### PR TITLE
Add organisation members to github-lens API

### DIFF
--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -32,6 +32,10 @@ export type GetTeamByNameResponse = GetResponseDataTypeFromEndpointMethod<
 export type TeamsResponse = GetResponseDataTypeFromEndpointMethod<
 	typeof octokit.teams.list
 >;
+export type OrgMembersResponse = GetResponseDataTypeFromEndpointMethod<
+	typeof octokit.orgs.listMembers
+>;
+export type MemberResponse = OrgMembersResponse[number]
 export type TeamRepoResponse = GetResponseDataTypeFromEndpointMethod<
 	typeof octokit.teams.listReposInOrg
 >;
@@ -110,6 +114,17 @@ export const getTeam = async (
 export const listTeams = async (client: Octokit): Promise<TeamsResponse> => {
 	return await client.paginate(
 		client.teams.list,
+		{
+			org: 'guardian',
+			per_page: defaultPageSize,
+		},
+		(response) => response.data,
+	);
+};
+
+export const listMembers = async (client: Octokit): Promise<OrgMembersResponse> => {
+	return await client.paginate(
+		client.orgs.listMembers,
 		{
 			org: 'guardian',
 			per_page: defaultPageSize,

--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -35,6 +35,9 @@ export type TeamsResponse = GetResponseDataTypeFromEndpointMethod<
 export type OrgMembersResponse = GetResponseDataTypeFromEndpointMethod<
 	typeof octokit.orgs.listMembers
 >;
+export type TeamMembersResponse = GetResponseDataTypeFromEndpointMethod<
+	typeof octokit.teams.listMembersInOrg
+>;
 export type MemberResponse = OrgMembersResponse[number]
 export type TeamRepoResponse = GetResponseDataTypeFromEndpointMethod<
 	typeof octokit.teams.listReposInOrg
@@ -117,6 +120,20 @@ export const listTeams = async (client: Octokit): Promise<TeamsResponse> => {
 		{
 			org: 'guardian',
 			per_page: defaultPageSize,
+		},
+		(response) => response.data,
+	);
+};
+
+export const listTeamMembers = async (
+	client: Octokit, 
+	teamName: string,
+): Promise<TeamMembersResponse> => {
+	return await client.paginate(
+		client.teams.listMembersInOrg,
+		{
+			org: 'guardian',
+			team_slug: teamName,
 		},
 		(response) => response.data,
 	);

--- a/packages/common/src/model/github.ts
+++ b/packages/common/src/model/github.ts
@@ -23,3 +23,10 @@ export interface Team {
 	slug: string;
 	repos: Repository[];
 }
+
+export interface Member {
+	name: string | undefined;
+    email: string | undefined;
+    login: string;
+    id: number;
+}

--- a/packages/common/src/model/github.ts
+++ b/packages/common/src/model/github.ts
@@ -25,7 +25,7 @@ export interface Team {
 }
 
 export interface Member {
-	name: string | undefined;
+    name: string | undefined;
     email: string | undefined;
     login: string;
     id: number;

--- a/packages/common/src/model/github.ts
+++ b/packages/common/src/model/github.ts
@@ -25,8 +25,8 @@ export interface Team {
 }
 
 export interface Member {
-    name: string | undefined;
-    login: string;
-    id: number;
+	name: string | undefined;
+	login: string;
+	id: number;
 	teams: string[];
 }

--- a/packages/common/src/model/github.ts
+++ b/packages/common/src/model/github.ts
@@ -26,7 +26,7 @@ export interface Team {
 
 export interface Member {
     name: string | undefined;
-    email: string | undefined;
     login: string;
     id: number;
+	teams: string[];
 }

--- a/packages/github-data-fetcher/src/handler.ts
+++ b/packages/github-data-fetcher/src/handler.ts
@@ -7,6 +7,7 @@ import {
 	getTeam,
 	listMembers,
 	listRepositories,
+	listTeamMembers,
 	listTeams,
 } from 'common/github/github';
 import { configureLogging, getLogLevel } from 'common/log/log';
@@ -17,9 +18,9 @@ import { asMember, asRepo, getAdminReposFromResponse } from './transformations';
 // Returns a map of repoName -> admins (a list of team slugs).
 const teamRepositories = async (
 	client: Octokit,
-	teamNames: string[],
+	teamSlugs: string[],
 ): Promise<Record<string, string[] | undefined>> => {
-	const teamRepositories = teamNames.map(async (teamName) => {
+	const teamRepositories = teamSlugs.map(async (teamName) => {
 		const teamRepos = await getReposForTeam(client, teamName);
 		const adminRepos: string[] = getAdminReposFromResponse(teamRepos);
 		return adminRepos.map((repoName) => ({
@@ -37,6 +38,28 @@ const teamRepositories = async (
 	}, {});
 };
 
+// Returns a map of memberName -> teamNames.
+const teamMembers = async (
+	client: Octokit,
+	teamSlugs: string[],
+): Promise<Record<string, string[] | undefined>> => {
+	const memberTeams = teamSlugs.map(async (teamSlug) => {
+		const teamMembers = await listTeamMembers(client, teamSlug);
+		return teamMembers.map((member) => ({
+			login: member.login,
+			teamSlug
+		}));
+	});
+
+	const flattened = (await Promise.all(memberTeams)).flat();
+
+	return flattened.reduce<Record<string, string[] | undefined>>((acc, member) => {
+		const existing = acc[member.login] ?? [];
+		acc[member.login] = existing.concat(member.teamSlug);
+		return acc;
+	}, {});
+};
+
 export interface TeamsAndRepositories {
 	teams: Team[];
 	repos: Repository[];
@@ -45,29 +68,32 @@ export interface TeamsAndRepositories {
 
 async function getGHData(
 	client: Octokit,
-	teamName?: string,
+	teamSlug?: string,
 ): Promise<TeamsAndRepositories> {
-	const teams = teamName
-		? [await getTeam(client, teamName)]
+	// Get all teams
+	const teams = teamSlug
+		? [await getTeam(client, teamSlug)]
 		: await listTeams(client);
-
 	console.log(`Found ${teams.length} github teams`);
 
+	// Get all repositories
 	const repositories = await listRepositories(client);
 	console.log(`Found ${repositories.length} github repos`);
 
+	// Get all organisation members
 	const members = await listMembers(client);
 	console.log(`Found ${members.length} organisation members`);
 
+	const teamSlugs = teams.map((_) => _.slug)
+
+	// Join members to teams
+	const membersOfTeams = await teamMembers(client, teamSlugs);
 	const membersOutput = members.map((member) =>
-		asMember(member),
+		asMember(member, membersOfTeams[member.login] ?? []),
 	);
 
-	const repositoriesToAdmins = await teamRepositories(
-		client,
-		teams.map((_) => _.slug),
-	);
-
+	// Join repositories to teams
+	const repositoriesToAdmins = await teamRepositories(client, teamSlugs);
 	const repositoriesOutput = repositories.map((repository) =>
 		asRepo(repository, repositoriesToAdmins[repository.name] ?? []),
 	);

--- a/packages/github-data-fetcher/src/transformations.ts
+++ b/packages/github-data-fetcher/src/transformations.ts
@@ -19,18 +19,14 @@ const parseDateString = (
 };
 
 export const asMember = (
-	member: MemberResponse
+	member: MemberResponse,
+	teams: string []
 ): Member => {
-	
-	const definedEmail: string = member.email ?? '';
-	const isGuardianEmail = definedEmail.includes('@guardian.co.uk') || definedEmail.includes('@theguardian.com');
-	
 	return {
 		id: member.id,
 		name: member.name ?? undefined,
 		login: member.login,
-		// Do not record a personal email address
-		email: isGuardianEmail ? definedEmail : undefined
+		teams
 	};
 }
 

--- a/packages/github-data-fetcher/src/transformations.ts
+++ b/packages/github-data-fetcher/src/transformations.ts
@@ -1,8 +1,9 @@
 import type {
+	MemberResponse,
 	RepositoryResponse,
 	TeamRepoResponse,
 } from 'common/github/github';
-import type { Repository } from 'common/model/github';
+import type { Member, Repository } from 'common/model/github';
 
 const parseDateString = (
 	dateString: string | null | undefined,
@@ -16,6 +17,22 @@ const parseDateString = (
 	}
 	return new Date(dateString);
 };
+
+export const asMember = (
+	member: MemberResponse
+): Member => {
+	
+	const definedEmail: string = member.email ?? '';
+	const isGuardianEmail = definedEmail.includes('@guardian.co.uk') || definedEmail.includes('@theguardian.com');
+	
+	return {
+		id: member.id,
+		name: member.name ?? undefined,
+		login: member.login,
+		// Do not record a personal email address
+		email: isGuardianEmail ? definedEmail : undefined
+	};
+}
 
 export const asRepo = (
 	repo: RepositoryResponse,

--- a/packages/github-lens-api/src/app.test.ts
+++ b/packages/github-lens-api/src/app.test.ts
@@ -1,21 +1,25 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access -- For body access which is always any */
-import type { RetrievedObject } from 'common/aws/s3';
-import type { Repository, Team } from 'common/model/github';
 import type { Express } from 'express';
 import request from 'supertest';
 import { buildApp } from './app';
+import type { GitHubData } from './data';
 
 describe('github-lens api lambda', () => {
 	let app: Express;
 
 	beforeEach(() => {
-		const repoData = Promise.resolve<RetrievedObject<Repository[]>>({
-			payload: [],
-		});
-		const teamData = Promise.resolve<RetrievedObject<Team[]>>({
-			payload: [],
-		});
-		app = buildApp(repoData, teamData);
+		const ghData = Promise.resolve<GitHubData>({
+			teams: {
+				payload: [],
+			},
+			members: {
+				payload: [],
+			},
+			repos: {
+				payload: [],
+			}
+		})
+		app = buildApp(ghData);
 	});
 
 	describe('GET /healthcheck', () => {

--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -29,6 +29,11 @@ export function buildApp(
 		'/repos',
 		asyncHandler(async (req: express.Request, res: express.Response) => {
 			const reposData = (await ghData).repos;
+			if (reposData === undefined) {
+				res.status(500).json({ error: 'Unable to retrieve repository data!'});
+				return;
+			}
+
 			if (typeof req.query.name !== 'undefined') {
 				const searchString:string = req.query.name.toString()
 				const jsonResponse = reposData.payload.filter((item) =>
@@ -50,6 +55,11 @@ export function buildApp(
 		'/repos/:name',
 		asyncHandler(async (req: express.Request, res: express.Response) => {
 			const reposData = (await ghData).repos;
+			if (reposData === undefined) {
+				res.status(500).json({ error: 'Unable to retrieve repository data!'});
+				return;
+			}
+
 			const jsonResponse = reposData.payload.filter(
 				(item) => item.name === req.params.name,
 			);
@@ -67,6 +77,11 @@ export function buildApp(
 		'/teams',
 		asyncHandler(async (req: express.Request, res: express.Response) => {
 			const teamsData = (await ghData).teams;
+			if (teamsData === undefined) {
+				res.status(500).json({ error: 'Unable to retrieve teams data!'});
+				return;
+			}
+
 			res.status(200).json(teamsData);
 		}),
 	);
@@ -75,6 +90,11 @@ export function buildApp(
 		'/teams/:slug',
 		asyncHandler(async (req: express.Request, res: express.Response) => {
 			const teamsData = (await ghData).teams;
+			if (teamsData === undefined) {
+				res.status(500).json({ error: 'Unable to retrieve teams data!'});
+				return;
+			}
+
 			const jsonResponse = teamsData.payload.filter(
 				(item) => item.slug === req.params.name,
 			);
@@ -92,6 +112,11 @@ export function buildApp(
 		'/members',
 		asyncHandler(async (req: express.Request, res: express.Response) => {
 			const membersData = (await ghData).members;
+			if (membersData === undefined) {
+				res.status(500).json({ error: 'Unable to retrieve members data!'});
+				return;
+			}
+
 			res.status(200).json(membersData);
 		}),
 	);
@@ -100,6 +125,11 @@ export function buildApp(
 		'/members/:login',
 		asyncHandler(async (req: express.Request, res: express.Response) => {
 			const membersData = (await ghData).members;
+			if (membersData === undefined) {
+				res.status(500).json({ error: 'Unable to retrieve members data!'});
+				return;
+			}
+
 			const jsonResponse = membersData.payload.filter(
 				(item) => item.login === req.params.login,
 			);

--- a/packages/github-lens-api/src/data.ts
+++ b/packages/github-lens-api/src/data.ts
@@ -1,0 +1,37 @@
+import path from 'path';
+import type { S3Client } from '@aws-sdk/client-s3';
+import type { RetrievedObject } from 'common/aws/s3';
+import { getObject  } from 'common/aws/s3';
+import type { Member, Repository, Team } from 'common/model/github';
+
+export interface GitHubData {
+	teams: RetrievedObject<Team[]>;
+	repos: RetrievedObject<Repository[]>;
+	members: RetrievedObject<Member[]>;
+}
+
+export const retrieveData = async (s3Client: S3Client, dataBucketName: string, dataKeyPrefix: string): Promise<GitHubData> => {
+	const repoFileLocation = path.join(dataKeyPrefix, 'repos.json');
+	const teamFileLocation = path.join(dataKeyPrefix, 'teams.json');
+	const memberFileLocation = path.join(dataKeyPrefix, 'members.json');
+	
+	const repos = await getObject<Repository[]>(
+		s3Client,
+		dataBucketName,
+		repoFileLocation,
+	);
+	
+	const teams = await getObject<Team[]>(
+		s3Client,
+		dataBucketName,
+		teamFileLocation,
+	);
+
+	const members = await getObject<Member[]>(
+		s3Client,
+		dataBucketName,
+		memberFileLocation,
+	);
+
+	return { teams, repos, members }
+}

--- a/packages/github-lens-api/src/handler.ts
+++ b/packages/github-lens-api/src/handler.ts
@@ -1,31 +1,17 @@
-import path from 'path';
-import { getObject, getS3Client } from 'common/aws/s3';
+
+import { getS3Client  } from 'common/aws/s3';
 import { configureLogging } from 'common/log/log';
-import type { Repository, Team } from 'common/model/github';
 import { buildApp } from './app';
 import { getConfig } from './config';
+import { retrieveData } from './data'
 
 const config = getConfig();
 const s3Client = getS3Client(config.region);
 
 configureLogging(config.logLevel);
 
-const repoFileLocation = path.join(config.dataKeyPrefix, 'repos.json');
-const teamFileLocation = path.join(config.dataKeyPrefix, 'teams.json');
-
-const repoData = getObject<Repository[]>(
-	s3Client,
-	config.dataBucketName,
-	repoFileLocation,
-);
-
-const teamData = getObject<Team[]>(
-	s3Client,
-	config.dataBucketName,
-	teamFileLocation,
-);
-
-const app = buildApp(repoData, teamData);
+const ghData = retrieveData(s3Client, config.dataBucketName, config.dataKeyPrefix);
+const app = buildApp(ghData);
 
 const PORT = process.env.PORT ?? '3232';
 app.listen(PORT, () => {


### PR DESCRIPTION
## What does this change?

This change retrieves organisation members from the GitHub API and makes that data available via the github-lens API.

<img width="436" alt="Screenshot 2022-11-26 at 14 35 37" src="https://user-images.githubusercontent.com/953792/204094254-e3122c13-888b-4736-94ee-5d064cea11d6.png">

## Why?

Organisation membership data is useful when associating staff members with their GitHub accounts and team membership in the services API (and potentially for auditing purposes / reproducing some of the functionality of gu-who).

