### PR TITLE
Updates the app name to "service catalogue"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Upload to riff-raff
         uses: guardian/actions-riff-raff@v2
         with:
-          app: github-lens
+          app: service-catalogue
           buildNumber: ${{ env.GITHUB_RUN_NUMBER }}
           projectName: deploy::github-lens
           configPath: packages/cdk/cdk.out/riff-raff.yaml

--- a/packages/cdk/lib/__snapshots__/cloudformation-lens.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudformation-lens.test.ts.snap
@@ -100,7 +100,7 @@ exports[`The CloudFormation Lens stack matches the snapshot 1`] = `
           {
             "Key": "gu:repo",
             "PropagateAtLaunch": true,
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "LogKinesisStreamName",
@@ -233,7 +233,7 @@ systemctl start cloudformation-lens
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -330,7 +330,7 @@ systemctl start cloudformation-lens
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -576,7 +576,7 @@ systemctl start cloudformation-lens
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -664,7 +664,7 @@ systemctl start cloudformation-lens
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -764,7 +764,7 @@ systemctl start cloudformation-lens
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -793,7 +793,7 @@ systemctl start cloudformation-lens
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -946,7 +946,7 @@ systemctl start cloudformation-lens
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -1105,7 +1105,7 @@ systemctl start cloudformation-lens
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -1157,7 +1157,7 @@ systemctl start cloudformation-lens
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",

--- a/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
@@ -122,7 +122,7 @@ exports[`The GithubLens stack matches the snapshot 1`] = `
           {
             "Key": "gu:repo",
             "PropagateAtLaunch": true,
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "LogKinesisStreamName",
@@ -258,7 +258,7 @@ systemctl start github-lens-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -372,7 +372,7 @@ systemctl start github-lens-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -621,7 +621,7 @@ systemctl start github-lens-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -672,7 +672,7 @@ systemctl start github-lens-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -755,7 +755,7 @@ systemctl start github-lens-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -855,7 +855,7 @@ systemctl start github-lens-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -884,7 +884,7 @@ systemctl start github-lens-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -1037,7 +1037,7 @@ systemctl start github-lens-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -1196,7 +1196,7 @@ systemctl start github-lens-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -1267,7 +1267,7 @@ systemctl start github-lens-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -1429,7 +1429,7 @@ systemctl start github-lens-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -1648,7 +1648,7 @@ systemctl start github-lens-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",

--- a/packages/cdk/lib/__snapshots__/services-api.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/services-api.test.ts.snap
@@ -105,7 +105,7 @@ exports[`The ServicesAPI stack matches the snapshot 1`] = `
           {
             "Key": "gu:repo",
             "PropagateAtLaunch": true,
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "LogKinesisStreamName",
@@ -241,7 +241,7 @@ systemctl start services-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -355,7 +355,7 @@ systemctl start services-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -601,7 +601,7 @@ systemctl start services-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -695,7 +695,7 @@ systemctl start services-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -795,7 +795,7 @@ systemctl start services-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -824,7 +824,7 @@ systemctl start services-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -977,7 +977,7 @@ systemctl start services-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",
@@ -1136,7 +1136,7 @@ systemctl start services-api
           },
           {
             "Key": "gu:repo",
-            "Value": "guardian/github-lens",
+            "Value": "guardian/service-catalogue",
           },
           {
             "Key": "Stack",


### PR DESCRIPTION
## What does this change?

Changes the app name to "service catalogue" so that riff-raff will call the project by its new name when deploying services. 

This should have no impact on the deployed services.

## Why?

To reduce confusion when the project has a different name than that deployed under.
