### PR TITLE
Updates the project name to "service catalogue"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           app: service-catalogue
           buildNumber: ${{ env.GITHUB_RUN_NUMBER }}
-          projectName: deploy::github-lens
+          projectName: deploy::service-catalogue
           configPath: packages/cdk/cdk.out/riff-raff.yaml
           contentDirectories: |
             cdk.out:


### PR DESCRIPTION
## What does this change?

This change https://github.com/guardian/service-catalogue/pull/64 doesn't really update the name riff-raff uses, we need to 

## Why?

To _really_ reduce confusion when the project has a different name than that deployed under.
