### PR TITLE
Fix for broken renaming of name -> slug

### DIFF
--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -96,7 +96,7 @@ export function buildApp(
 			}
 
 			const jsonResponse = teamsData.payload.filter(
-				(item) => item.slug === req.params.name,
+				(item) => item.slug === req.params.slug,
 			);
 			if (jsonResponse.length !== 0) {
 				res.status(200).json(jsonResponse);


### PR DESCRIPTION
## What does this change?

A previous PR updated to use the term "slug" (being more accurate than "name"), but broke the `teams/:slug` endpoint by failing to rename which request parameter it read from.

## Why?

Fix the `teams/:slug` endpoint.