### PR TITLE
Refactor to make routes in app.ts easier to grasp

### DIFF
--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -3,7 +3,11 @@ import cors from 'cors';
 import type { Express } from 'express';
 import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-import { getDescribeRouterHandler } from '../../common/src/expressRoutes';
+import {getRouteDescriptions} from "./controller/DescribeApiController";
+import {getHealthCheckHandler} from "./controller/HealthCheckController";
+import {getAllMembers, getRepoByLogin} from "./controller/MembersController";
+import {getAllRepos, getRepoByName} from "./controller/ReposController";
+import {getTeamBySlug} from "./controller/TeamsController";
 import type { GitHubData } from './data'
 
 export function buildApp(
@@ -21,9 +25,7 @@ export function buildApp(
 		}),
 	);
 
-	router.get('/healthcheck', (req: express.Request, res: express.Response) => {
-		res.status(200).json({ status: 'OK', stage: 'INFRA' });
-	});
+	router.get('/healthcheck', getHealthCheckHandler(router));
 
 	router.get(
 		'/repos',
@@ -33,21 +35,7 @@ export function buildApp(
 				res.status(500).json({ error: 'Unable to retrieve repository data!'});
 				return;
 			}
-
-			if (typeof req.query.name !== 'undefined') {
-				const searchString:string = req.query.name.toString()
-				const jsonResponse = reposData.payload.filter((item) =>
-					item.name.match(searchString),
-				);
-				if (jsonResponse.length !== 0) {
-					res.status(200).json(jsonResponse);
-				} else {
-					res
-						.status(200)
-						.json({ searchString: searchString, info: 'no results found in repos' });
-				}			} else {
-				res.status(200).json(reposData);
-			}
+				getAllRepos(req, res, reposData);
 		}),
 	);
 
@@ -59,17 +47,7 @@ export function buildApp(
 				res.status(500).json({ error: 'Unable to retrieve repository data!'});
 				return;
 			}
-
-			const jsonResponse = reposData.payload.filter(
-				(item) => item.name === req.params.name,
-			);
-			if (jsonResponse.length !== 0) {
-				res.status(200).json(jsonResponse);
-			} else {
-				res
-					.status(200)
-					.json({ repoName: req.params.name, info: 'Repository not found' });
-			}
+				getRepoByName(req, res, reposData);
 		}),
 	);
 
@@ -81,7 +59,6 @@ export function buildApp(
 				res.status(500).json({ error: 'Unable to retrieve teams data!'});
 				return;
 			}
-
 			res.status(200).json(teamsData);
 		}),
 	);
@@ -94,17 +71,7 @@ export function buildApp(
 				res.status(500).json({ error: 'Unable to retrieve teams data!'});
 				return;
 			}
-
-			const jsonResponse = teamsData.payload.filter(
-				(item) => item.slug === req.params.slug,
-			);
-			if (jsonResponse.length !== 0) {
-				res.status(200).json(jsonResponse);
-			} else {
-				res
-					.status(200)
-					.json({ teamSlug: req.params.slug, info: 'Team not found' });
-			}
+			getTeamBySlug(req, res, teamsData)
 		}),
 	);
 
@@ -116,8 +83,7 @@ export function buildApp(
 				res.status(500).json({ error: 'Unable to retrieve members data!'});
 				return;
 			}
-
-			res.status(200).json(membersData);
+			getAllMembers(req, res, membersData)
 		}),
 	);
 
@@ -129,54 +95,12 @@ export function buildApp(
 				res.status(500).json({ error: 'Unable to retrieve members data!'});
 				return;
 			}
-
-			const jsonResponse = membersData.payload.filter(
-				(item) => item.login === req.params.login,
-			);
-			if (jsonResponse.length !== 0) {
-				res.status(200).json(jsonResponse);
-			} else {
-				res
-					.status(200)
-					.json({ memberLogin: req.params.login, info: 'Member not found' });
-			}
+			getRepoByLogin(req, res, membersData)
 		}),
 	);
 
 	//handle all invalid routes by showing all available routes
-	router.get('*', getDescribeRouterHandler(router, (path: string) => {
-		let info = '';
-		switch (path) {
-			case '/healthcheck':
-				info = 'Display healthcheck';
-				break;
-			case '/repos':
-				info =
-					'Show all repos, with their team owners, optionally search by name with ?name=^repo-name-regex.*';
-				break;
-			case '/repos/:name':
-				info = 'Show repo and its team owners, if it exists';
-				break;
-			case '/teams':
-				info =
-					'Show all teams, with the repositories they own';
-				break;
-			case '/teams/:slug':
-				info = 'Show team and the repositories it owns, if it exists';
-				break;
-			case '/members':
-				info =
-					'Show member, with the teams they are in';
-				break;
-			case '/members/:login':
-				info = 'Show member and the teams they are in, if it exists';
-				break;
-			default:
-				info = 'No path info supplied';
-				break;
-		}
-		return info;
-	}));
+	router.get('*', getRouteDescriptions(router));
 
 	app.use('/', router);
 

--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -5,7 +5,7 @@ import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
 import {getRouteDescriptions} from "./controller/DescribeApiController";
 import {getHealthCheckHandler} from "./controller/HealthCheckController";
-import {getAllMembers, getRepoByLogin} from "./controller/MembersController";
+import {getMembers, getMembersByLogin} from "./controller/MembersController";
 import {getAllRepos, getRepoByName} from "./controller/ReposController";
 import {getTeamBySlug} from "./controller/TeamsController";
 import type { GitHubData } from './data'
@@ -25,7 +25,7 @@ export function buildApp(
 		}),
 	);
 
-	router.get('/healthcheck', getHealthCheckHandler(router));
+	router.get('/healthcheck', getHealthCheckHandler());
 
 	router.get(
 		'/repos',
@@ -83,7 +83,7 @@ export function buildApp(
 				res.status(500).json({ error: 'Unable to retrieve members data!'});
 				return;
 			}
-			getAllMembers(req, res, membersData)
+			getMembers(req, res, membersData)
 		}),
 	);
 
@@ -95,7 +95,7 @@ export function buildApp(
 				res.status(500).json({ error: 'Unable to retrieve members data!'});
 				return;
 			}
-			getRepoByLogin(req, res, membersData)
+			getMembersByLogin(req, res, membersData)
 		}),
 	);
 

--- a/packages/github-lens-api/src/controller/DescribeApiController.ts
+++ b/packages/github-lens-api/src/controller/DescribeApiController.ts
@@ -1,0 +1,63 @@
+import {getDescribeRouterHandler} from "common/expressRoutes";
+import type { Router } from 'express';
+import type express from 'express';
+
+interface InnerLayer {
+    method: string;
+}
+
+interface InnerRoute {
+    path: string;
+    stack: InnerLayer[];
+}
+
+interface RouterLayer {
+    route: InnerRoute | undefined;
+}
+
+function describeRoutes(path: string) {
+    let info = '';
+    switch (path) {
+        case '/healthcheck':
+            info = 'Display healthcheck';
+            break;
+        case '/repos':
+            info =
+                'Show all repos, with their team owners, optionally search by name with ?name=^repo-name-regex.*';
+            break;
+        case '/repos/:name':
+            info = 'Show repo and its team owners, if it exists';
+            break;
+        case '/archivedRepos':
+            info =
+                'Show all archived repos';
+            break;
+        case '/archivedReposNamesOnly':
+            info =
+                'Show all archived repos, names only (for tracker)';
+            break;
+        case '/teams':
+            info =
+                'Show all teams, with the repositories they own';
+            break;
+        case '/teams/:slug':
+            info = 'Show team and the repositories it owns, if it exists';
+            break;
+        case '/members':
+            info =
+                'Show member, with the teams they are in';
+            break;
+        case '/members/:login':
+            info = 'Show member and the teams they are in, if it exists';
+            break;
+        default:
+            info = 'No path info supplied';
+            break;
+    }
+    return info;
+}
+
+export const getRouteDescriptions = (router: Router) => {
+    return getDescribeRouterHandler(router, describeRoutes)
+};
+

--- a/packages/github-lens-api/src/controller/DescribeApiController.ts
+++ b/packages/github-lens-api/src/controller/DescribeApiController.ts
@@ -1,19 +1,5 @@
 import {getDescribeRouterHandler} from "common/expressRoutes";
 import type { Router } from 'express';
-import type express from 'express';
-
-interface InnerLayer {
-    method: string;
-}
-
-interface InnerRoute {
-    path: string;
-    stack: InnerLayer[];
-}
-
-interface RouterLayer {
-    route: InnerRoute | undefined;
-}
 
 function describeRoutes(path: string) {
     let info = '';

--- a/packages/github-lens-api/src/controller/HealthCheckController.ts
+++ b/packages/github-lens-api/src/controller/HealthCheckController.ts
@@ -1,0 +1,8 @@
+import type {Router} from "express";
+import type express from "express";
+
+export const getHealthCheckHandler = (router: Router) => {
+    return (req: express.Request, res: express.Response) => {
+        res.status(200).json({ status: 'OK', stage: 'INFRA' });
+    };
+};

--- a/packages/github-lens-api/src/controller/HealthCheckController.ts
+++ b/packages/github-lens-api/src/controller/HealthCheckController.ts
@@ -1,7 +1,6 @@
-import type {Router} from "express";
 import type express from "express";
 
-export const getHealthCheckHandler = (router: Router) => {
+export const getHealthCheckHandler = () => {
     return (req: express.Request, res: express.Response) => {
         res.status(200).json({ status: 'OK', stage: 'INFRA' });
     };

--- a/packages/github-lens-api/src/controller/MembersController.ts
+++ b/packages/github-lens-api/src/controller/MembersController.ts
@@ -1,12 +1,12 @@
 import type {RetrievedObject} from "common/aws/s3";
-import type {Member, Repository} from "common/model/github";
+import type {Member} from "common/model/github";
 import type express from "express";
 
-export const getAllMembers = (req: express.Request, res: express.Response, membersData: RetrievedObject<Member[]>) => {
+export const getMembers = (req: express.Request, res: express.Response, membersData: RetrievedObject<Member[]>) => {
     res.status(200).json(membersData);
 }
 
-export const getRepoByLogin = (req: express.Request, res: express.Response, membersData: RetrievedObject<Member[]>) => {
+export const getMembersByLogin = (req: express.Request, res: express.Response, membersData: RetrievedObject<Member[]>) => {
     const jsonResponse = membersData.payload.filter(
         (item) => item.login === req.params.login,
     );
@@ -14,7 +14,7 @@ export const getRepoByLogin = (req: express.Request, res: express.Response, memb
         res.status(200).json(jsonResponse);
     } else {
         res
-            .status(200)
+            .status(404)
             .json({ memberLogin: req.params.login, info: 'Member not found' });
     }
 }

--- a/packages/github-lens-api/src/controller/MembersController.ts
+++ b/packages/github-lens-api/src/controller/MembersController.ts
@@ -1,0 +1,20 @@
+import type {RetrievedObject} from "common/aws/s3";
+import type {Member, Repository} from "common/model/github";
+import type express from "express";
+
+export const getAllMembers = (req: express.Request, res: express.Response, membersData: RetrievedObject<Member[]>) => {
+    res.status(200).json(membersData);
+}
+
+export const getRepoByLogin = (req: express.Request, res: express.Response, membersData: RetrievedObject<Member[]>) => {
+    const jsonResponse = membersData.payload.filter(
+        (item) => item.login === req.params.login,
+    );
+    if (jsonResponse.length !== 0) {
+        res.status(200).json(jsonResponse);
+    } else {
+        res
+            .status(200)
+            .json({ memberLogin: req.params.login, info: 'Member not found' });
+    }
+}

--- a/packages/github-lens-api/src/controller/ReposController.ts
+++ b/packages/github-lens-api/src/controller/ReposController.ts
@@ -1,0 +1,33 @@
+import type {RetrievedObject} from "common/aws/s3";
+import type {Repository} from "common/model/github";
+import type express from "express";
+
+export const getAllRepos = (req: express.Request, res: express.Response, reposData: RetrievedObject<Repository[]>) => {
+    if (typeof req.query.name !== 'undefined') {
+        const searchString:string = req.query.name.toString()
+        const jsonResponse = reposData.payload.filter((item) =>
+            item.name.match(searchString),
+        );
+        if (jsonResponse.length !== 0) {
+            res.status(200).json(jsonResponse);
+        } else {
+            return res
+                .status(200)
+                .json({ searchString: searchString, info: 'no results found in repos' });
+        }			} else {
+        return res.status(200).json(reposData);
+    }
+}
+
+export const getRepoByName = (req: express.Request, res: express.Response, reposData: RetrievedObject<Repository[]>) => {
+    const jsonResponse = reposData.payload.filter(
+        (item) => item.name === req.params.name,
+    );
+    if (jsonResponse.length !== 0) {
+        return res.status(200).json(jsonResponse);
+    } else {
+        return res
+            .status(200)
+            .json({ repoName: req.params.name, info: 'Repository not found' });
+    }
+}

--- a/packages/github-lens-api/src/controller/ReposController.ts
+++ b/packages/github-lens-api/src/controller/ReposController.ts
@@ -27,7 +27,7 @@ export const getRepoByName = (req: express.Request, res: express.Response, repos
         return res.status(200).json(jsonResponse);
     } else {
         return res
-            .status(200)
+            .status(404)
             .json({ repoName: req.params.name, info: 'Repository not found' });
     }
 }

--- a/packages/github-lens-api/src/controller/TeamsController.ts
+++ b/packages/github-lens-api/src/controller/TeamsController.ts
@@ -1,0 +1,20 @@
+import type {RetrievedObject} from "common/aws/s3";
+import type {Team} from "common/model/github";
+import type express from "express";
+
+export const getAllTeams = (req: express.Request, res: express.Response, teamsData: RetrievedObject<Team[]>) => {
+    return res.status(200).json(teamsData);
+}
+
+export const getTeamBySlug = (req: express.Request, res: express.Response, teamsData: RetrievedObject<Team[]>) => {
+    const jsonResponse = teamsData.payload.filter(
+        (item) => item.slug === req.params.slug,
+    );
+    if (jsonResponse.length !== 0) {
+        res.status(200).json(jsonResponse);
+    } else {
+        res
+            .status(200)
+            .json({ teamSlug: req.params.slug, info: 'Team not found' });
+    }
+}

--- a/packages/github-lens-api/src/controller/TeamsController.ts
+++ b/packages/github-lens-api/src/controller/TeamsController.ts
@@ -14,7 +14,7 @@ export const getTeamBySlug = (req: express.Request, res: express.Response, teams
         res.status(200).json(jsonResponse);
     } else {
         res
-            .status(200)
+            .status(404)
             .json({ teamSlug: req.params.slug, info: 'Team not found' });
     }
 }


### PR DESCRIPTION
## What does this change?
Refactor to separate logic out of app.ts into controllers

## Why?
Keeping the routes separate for the implementation and the implementation in logical groups makes the code easier to understand und is good practice

## Further improvement
Maybe the calls to get the data could be moved too, but I ran into problems there and feel this refactor already adds worthwhile clarity.
