### PR TITLE
chore(prettier): Configure Prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "@guardian/eslint-config-typescript": "^2.0.0",
         "@guardian/prettier": "^2.1.5",
         "aws-sdk-client-mock": "^2.0.0",
-        "esbuild": "^0.15.16"
+        "esbuild": "^0.15.16",
+        "eslint-plugin-prettier": "^4.2.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7093,6 +7094,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
       "dev": true,
@@ -7382,6 +7404,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
@@ -9845,6 +9873,18 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/pretty-format": {
@@ -16884,6 +16924,15 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "dev": true,
@@ -17052,6 +17101,12 @@
       "version": "3.1.3",
       "dev": true,
       "peer": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.11",
@@ -18613,6 +18668,15 @@
       "version": "2.7.1",
       "dev": true,
       "peer": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-format": {
       "version": "29.3.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "@guardian/eslint-config-typescript": "^2.0.0",
     "@guardian/prettier": "^2.1.5",
     "aws-sdk-client-mock": "^2.0.0",
-    "esbuild": "^0.15.16"
+    "esbuild": "^0.15.16",
+    "eslint-plugin-prettier": "^4.2.1"
   },
   "dependencies": {
     "@types/jest": "^29.2.3",
@@ -33,7 +34,11 @@
     "typescript": "^4.9.3"
   },
   "eslintConfig": {
-    "extends": "@guardian/eslint-config-typescript"
+    "extends": "@guardian/eslint-config-typescript",
+    "plugins": ["prettier"],
+    "rules": {
+      "prettier/prettier": "error"
+    }
   },
   "eslintIgnore": [
     "packages/common/dist"

--- a/packages/common/src/expressRoutes.ts
+++ b/packages/common/src/expressRoutes.ts
@@ -14,7 +14,10 @@ interface RouterLayer {
 	route: InnerRoute | undefined;
 }
 
-export const getDescribeRouterHandler = (router: Router, describeRoutes: (path: string) => string) => {
+export const getDescribeRouterHandler = (
+	router: Router,
+	describeRoutes: (path: string) => string,
+) => {
 	return (req: express.Request, res: express.Response) => {
 		const urlProtocol = req.protocol + '://';
 		const urlHost = req.get('host') ?? 'localhost:3232';
@@ -26,7 +29,7 @@ export const getDescribeRouterHandler = (router: Router, describeRoutes: (path: 
 			.map((layer: RouterLayer) => {
 				const path = layer.route?.path ?? '';
 				const info = describeRoutes(path);
-				
+
 				return {
 					path: urlProtocol + urlHost + path,
 					methods: layer.route?.stack.map((innerStack) => innerStack.method),

--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -38,7 +38,7 @@ export type OrgMembersResponse = GetResponseDataTypeFromEndpointMethod<
 export type TeamMembersResponse = GetResponseDataTypeFromEndpointMethod<
 	typeof octokit.teams.listMembersInOrg
 >;
-export type MemberResponse = OrgMembersResponse[number]
+export type MemberResponse = OrgMembersResponse[number];
 export type TeamRepoResponse = GetResponseDataTypeFromEndpointMethod<
 	typeof octokit.teams.listReposInOrg
 >;
@@ -126,7 +126,7 @@ export const listTeams = async (client: Octokit): Promise<TeamsResponse> => {
 };
 
 export const listTeamMembers = async (
-	client: Octokit, 
+	client: Octokit,
 	teamName: string,
 ): Promise<TeamMembersResponse> => {
 	return await client.paginate(
@@ -139,7 +139,9 @@ export const listTeamMembers = async (
 	);
 };
 
-export const listMembers = async (client: Octokit): Promise<OrgMembersResponse> => {
+export const listMembers = async (
+	client: Octokit,
+): Promise<OrgMembersResponse> => {
 	return await client.paginate(
 		client.orgs.listMembers,
 		{

--- a/packages/github-data-fetcher/src/handler.ts
+++ b/packages/github-data-fetcher/src/handler.ts
@@ -47,17 +47,20 @@ const teamMembers = async (
 		const teamMembers = await listTeamMembers(client, teamSlug);
 		return teamMembers.map((member) => ({
 			login: member.login,
-			teamSlug
+			teamSlug,
 		}));
 	});
 
 	const flattened = (await Promise.all(memberTeams)).flat();
 
-	return flattened.reduce<Record<string, string[] | undefined>>((acc, member) => {
-		const existing = acc[member.login] ?? [];
-		acc[member.login] = existing.concat(member.teamSlug);
-		return acc;
-	}, {});
+	return flattened.reduce<Record<string, string[] | undefined>>(
+		(acc, member) => {
+			const existing = acc[member.login] ?? [];
+			acc[member.login] = existing.concat(member.teamSlug);
+			return acc;
+		},
+		{},
+	);
 };
 
 export interface TeamsAndRepositories {
@@ -84,7 +87,7 @@ async function getGHData(
 	const members = await listMembers(client);
 	console.log(`Found ${members.length} organisation members`);
 
-	const teamSlugs = teams.map((_) => _.slug)
+	const teamSlugs = teams.map((_) => _.slug);
 
 	// Join members to teams
 	const membersOfTeams = await teamMembers(client, teamSlugs);
@@ -145,10 +148,7 @@ export const main = async (): Promise<void> => {
 	const githubClient = getOctokit(config.github);
 	const s3Client = getS3Client(config.region);
 
-	const ghData = await getGHData(
-		githubClient,
-		config.github.teamToFetch,
-	);
+	const ghData = await getGHData(githubClient, config.github.teamToFetch);
 
 	const saveObject = async <T>(name: string, data: T) => {
 		const repoFileLocation = path.join(config.dataKeyPrefix, `${name}.json`);

--- a/packages/github-data-fetcher/src/transformations.ts
+++ b/packages/github-data-fetcher/src/transformations.ts
@@ -18,17 +18,14 @@ const parseDateString = (
 	return new Date(dateString);
 };
 
-export const asMember = (
-	member: MemberResponse,
-	teams: string []
-): Member => {
+export const asMember = (member: MemberResponse, teams: string[]): Member => {
 	return {
 		id: member.id,
 		name: member.name ?? undefined,
 		login: member.login,
-		teams
+		teams,
 	};
-}
+};
 
 export const asRepo = (
 	repo: RepositoryResponse,

--- a/packages/github-lens-api/src/app.test.ts
+++ b/packages/github-lens-api/src/app.test.ts
@@ -17,8 +17,8 @@ describe('github-lens api lambda', () => {
 			},
 			repos: {
 				payload: [],
-			}
-		})
+			},
+		});
 		app = buildApp(ghData);
 	});
 

--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -3,16 +3,14 @@ import cors from 'cors';
 import type { Express } from 'express';
 import express, { Router } from 'express';
 import asyncHandler from 'express-async-handler';
-import {getRouteDescriptions} from "./controller/DescribeApiController";
-import {getHealthCheckHandler} from "./controller/HealthCheckController";
-import {getMembers, getMembersByLogin} from "./controller/MembersController";
-import {getAllRepos, getRepoByName} from "./controller/ReposController";
-import {getTeamBySlug} from "./controller/TeamsController";
-import type { GitHubData } from './data'
+import { getRouteDescriptions } from './controller/DescribeApiController';
+import { getHealthCheckHandler } from './controller/HealthCheckController';
+import { getMembers, getMembersByLogin } from './controller/MembersController';
+import { getAllRepos, getRepoByName } from './controller/ReposController';
+import { getTeamBySlug } from './controller/TeamsController';
+import type { GitHubData } from './data';
 
-export function buildApp(
-	ghData: Promise<GitHubData>,
-): Express {
+export function buildApp(ghData: Promise<GitHubData>): Express {
 	const app = express();
 	const router = Router();
 
@@ -32,10 +30,10 @@ export function buildApp(
 		asyncHandler(async (req: express.Request, res: express.Response) => {
 			const reposData = (await ghData).repos;
 			if (reposData === undefined) {
-				res.status(500).json({ error: 'Unable to retrieve repository data!'});
+				res.status(500).json({ error: 'Unable to retrieve repository data!' });
 				return;
 			}
-				getAllRepos(req, res, reposData);
+			getAllRepos(req, res, reposData);
 		}),
 	);
 
@@ -44,10 +42,10 @@ export function buildApp(
 		asyncHandler(async (req: express.Request, res: express.Response) => {
 			const reposData = (await ghData).repos;
 			if (reposData === undefined) {
-				res.status(500).json({ error: 'Unable to retrieve repository data!'});
+				res.status(500).json({ error: 'Unable to retrieve repository data!' });
 				return;
 			}
-				getRepoByName(req, res, reposData);
+			getRepoByName(req, res, reposData);
 		}),
 	);
 
@@ -56,7 +54,7 @@ export function buildApp(
 		asyncHandler(async (req: express.Request, res: express.Response) => {
 			const teamsData = (await ghData).teams;
 			if (teamsData === undefined) {
-				res.status(500).json({ error: 'Unable to retrieve teams data!'});
+				res.status(500).json({ error: 'Unable to retrieve teams data!' });
 				return;
 			}
 			res.status(200).json(teamsData);
@@ -68,10 +66,10 @@ export function buildApp(
 		asyncHandler(async (req: express.Request, res: express.Response) => {
 			const teamsData = (await ghData).teams;
 			if (teamsData === undefined) {
-				res.status(500).json({ error: 'Unable to retrieve teams data!'});
+				res.status(500).json({ error: 'Unable to retrieve teams data!' });
 				return;
 			}
-			getTeamBySlug(req, res, teamsData)
+			getTeamBySlug(req, res, teamsData);
 		}),
 	);
 
@@ -80,10 +78,10 @@ export function buildApp(
 		asyncHandler(async (req: express.Request, res: express.Response) => {
 			const membersData = (await ghData).members;
 			if (membersData === undefined) {
-				res.status(500).json({ error: 'Unable to retrieve members data!'});
+				res.status(500).json({ error: 'Unable to retrieve members data!' });
 				return;
 			}
-			getMembers(req, res, membersData)
+			getMembers(req, res, membersData);
 		}),
 	);
 
@@ -92,10 +90,10 @@ export function buildApp(
 		asyncHandler(async (req: express.Request, res: express.Response) => {
 			const membersData = (await ghData).members;
 			if (membersData === undefined) {
-				res.status(500).json({ error: 'Unable to retrieve members data!'});
+				res.status(500).json({ error: 'Unable to retrieve members data!' });
 				return;
 			}
-			getMembersByLogin(req, res, membersData)
+			getMembersByLogin(req, res, membersData);
 		}),
 	);
 

--- a/packages/github-lens-api/src/controller/DescribeApiController.ts
+++ b/packages/github-lens-api/src/controller/DescribeApiController.ts
@@ -1,49 +1,44 @@
-import {getDescribeRouterHandler} from "common/expressRoutes";
+import { getDescribeRouterHandler } from 'common/expressRoutes';
 import type { Router } from 'express';
 
 function describeRoutes(path: string) {
-    let info = '';
-    switch (path) {
-        case '/healthcheck':
-            info = 'Display healthcheck';
-            break;
-        case '/repos':
-            info =
-                'Show all repos, with their team owners, optionally search by name with ?name=^repo-name-regex.*';
-            break;
-        case '/repos/:name':
-            info = 'Show repo and its team owners, if it exists';
-            break;
-        case '/archivedRepos':
-            info =
-                'Show all archived repos';
-            break;
-        case '/archivedReposNamesOnly':
-            info =
-                'Show all archived repos, names only (for tracker)';
-            break;
-        case '/teams':
-            info =
-                'Show all teams, with the repositories they own';
-            break;
-        case '/teams/:slug':
-            info = 'Show team and the repositories it owns, if it exists';
-            break;
-        case '/members':
-            info =
-                'Show member, with the teams they are in';
-            break;
-        case '/members/:login':
-            info = 'Show member and the teams they are in, if it exists';
-            break;
-        default:
-            info = 'No path info supplied';
-            break;
-    }
-    return info;
+	let info = '';
+	switch (path) {
+		case '/healthcheck':
+			info = 'Display healthcheck';
+			break;
+		case '/repos':
+			info =
+				'Show all repos, with their team owners, optionally search by name with ?name=^repo-name-regex.*';
+			break;
+		case '/repos/:name':
+			info = 'Show repo and its team owners, if it exists';
+			break;
+		case '/archivedRepos':
+			info = 'Show all archived repos';
+			break;
+		case '/archivedReposNamesOnly':
+			info = 'Show all archived repos, names only (for tracker)';
+			break;
+		case '/teams':
+			info = 'Show all teams, with the repositories they own';
+			break;
+		case '/teams/:slug':
+			info = 'Show team and the repositories it owns, if it exists';
+			break;
+		case '/members':
+			info = 'Show member, with the teams they are in';
+			break;
+		case '/members/:login':
+			info = 'Show member and the teams they are in, if it exists';
+			break;
+		default:
+			info = 'No path info supplied';
+			break;
+	}
+	return info;
 }
 
 export const getRouteDescriptions = (router: Router) => {
-    return getDescribeRouterHandler(router, describeRoutes)
+	return getDescribeRouterHandler(router, describeRoutes);
 };
-

--- a/packages/github-lens-api/src/controller/HealthCheckController.ts
+++ b/packages/github-lens-api/src/controller/HealthCheckController.ts
@@ -1,7 +1,7 @@
-import type express from "express";
+import type express from 'express';
 
 export const getHealthCheckHandler = () => {
-    return (req: express.Request, res: express.Response) => {
-        res.status(200).json({ status: 'OK', stage: 'INFRA' });
-    };
+	return (req: express.Request, res: express.Response) => {
+		res.status(200).json({ status: 'OK', stage: 'INFRA' });
+	};
 };

--- a/packages/github-lens-api/src/controller/MembersController.ts
+++ b/packages/github-lens-api/src/controller/MembersController.ts
@@ -1,20 +1,28 @@
-import type {RetrievedObject} from "common/aws/s3";
-import type {Member} from "common/model/github";
-import type express from "express";
+import type { RetrievedObject } from 'common/aws/s3';
+import type { Member } from 'common/model/github';
+import type express from 'express';
 
-export const getMembers = (req: express.Request, res: express.Response, membersData: RetrievedObject<Member[]>) => {
-    res.status(200).json(membersData);
-}
+export const getMembers = (
+	req: express.Request,
+	res: express.Response,
+	membersData: RetrievedObject<Member[]>,
+) => {
+	res.status(200).json(membersData);
+};
 
-export const getMembersByLogin = (req: express.Request, res: express.Response, membersData: RetrievedObject<Member[]>) => {
-    const jsonResponse = membersData.payload.filter(
-        (item) => item.login === req.params.login,
-    );
-    if (jsonResponse.length !== 0) {
-        res.status(200).json(jsonResponse);
-    } else {
-        res
-            .status(404)
-            .json({ memberLogin: req.params.login, info: 'Member not found' });
-    }
-}
+export const getMembersByLogin = (
+	req: express.Request,
+	res: express.Response,
+	membersData: RetrievedObject<Member[]>,
+) => {
+	const jsonResponse = membersData.payload.filter(
+		(item) => item.login === req.params.login,
+	);
+	if (jsonResponse.length !== 0) {
+		res.status(200).json(jsonResponse);
+	} else {
+		res
+			.status(404)
+			.json({ memberLogin: req.params.login, info: 'Member not found' });
+	}
+};

--- a/packages/github-lens-api/src/controller/ReposController.ts
+++ b/packages/github-lens-api/src/controller/ReposController.ts
@@ -1,33 +1,43 @@
-import type {RetrievedObject} from "common/aws/s3";
-import type {Repository} from "common/model/github";
-import type express from "express";
+import type { RetrievedObject } from 'common/aws/s3';
+import type { Repository } from 'common/model/github';
+import type express from 'express';
 
-export const getAllRepos = (req: express.Request, res: express.Response, reposData: RetrievedObject<Repository[]>) => {
-    if (typeof req.query.name !== 'undefined') {
-        const searchString:string = req.query.name.toString()
-        const jsonResponse = reposData.payload.filter((item) =>
-            item.name.match(searchString),
-        );
-        if (jsonResponse.length !== 0) {
-            res.status(200).json(jsonResponse);
-        } else {
-            return res
-                .status(200)
-                .json({ searchString: searchString, info: 'no results found in repos' });
-        }			} else {
-        return res.status(200).json(reposData);
-    }
-}
+export const getAllRepos = (
+	req: express.Request,
+	res: express.Response,
+	reposData: RetrievedObject<Repository[]>,
+) => {
+	if (typeof req.query.name !== 'undefined') {
+		const searchString: string = req.query.name.toString();
+		const jsonResponse = reposData.payload.filter((item) =>
+			item.name.match(searchString),
+		);
+		if (jsonResponse.length !== 0) {
+			res.status(200).json(jsonResponse);
+		} else {
+			return res.status(200).json({
+				searchString: searchString,
+				info: 'no results found in repos',
+			});
+		}
+	} else {
+		return res.status(200).json(reposData);
+	}
+};
 
-export const getRepoByName = (req: express.Request, res: express.Response, reposData: RetrievedObject<Repository[]>) => {
-    const jsonResponse = reposData.payload.filter(
-        (item) => item.name === req.params.name,
-    );
-    if (jsonResponse.length !== 0) {
-        return res.status(200).json(jsonResponse);
-    } else {
-        return res
-            .status(404)
-            .json({ repoName: req.params.name, info: 'Repository not found' });
-    }
-}
+export const getRepoByName = (
+	req: express.Request,
+	res: express.Response,
+	reposData: RetrievedObject<Repository[]>,
+) => {
+	const jsonResponse = reposData.payload.filter(
+		(item) => item.name === req.params.name,
+	);
+	if (jsonResponse.length !== 0) {
+		return res.status(200).json(jsonResponse);
+	} else {
+		return res
+			.status(404)
+			.json({ repoName: req.params.name, info: 'Repository not found' });
+	}
+};

--- a/packages/github-lens-api/src/controller/TeamsController.ts
+++ b/packages/github-lens-api/src/controller/TeamsController.ts
@@ -1,20 +1,26 @@
-import type {RetrievedObject} from "common/aws/s3";
-import type {Team} from "common/model/github";
-import type express from "express";
+import type { RetrievedObject } from 'common/aws/s3';
+import type { Team } from 'common/model/github';
+import type express from 'express';
 
-export const getAllTeams = (req: express.Request, res: express.Response, teamsData: RetrievedObject<Team[]>) => {
-    return res.status(200).json(teamsData);
-}
+export const getAllTeams = (
+	req: express.Request,
+	res: express.Response,
+	teamsData: RetrievedObject<Team[]>,
+) => {
+	return res.status(200).json(teamsData);
+};
 
-export const getTeamBySlug = (req: express.Request, res: express.Response, teamsData: RetrievedObject<Team[]>) => {
-    const jsonResponse = teamsData.payload.filter(
-        (item) => item.slug === req.params.slug,
-    );
-    if (jsonResponse.length !== 0) {
-        res.status(200).json(jsonResponse);
-    } else {
-        res
-            .status(404)
-            .json({ teamSlug: req.params.slug, info: 'Team not found' });
-    }
-}
+export const getTeamBySlug = (
+	req: express.Request,
+	res: express.Response,
+	teamsData: RetrievedObject<Team[]>,
+) => {
+	const jsonResponse = teamsData.payload.filter(
+		(item) => item.slug === req.params.slug,
+	);
+	if (jsonResponse.length !== 0) {
+		res.status(200).json(jsonResponse);
+	} else {
+		res.status(404).json({ teamSlug: req.params.slug, info: 'Team not found' });
+	}
+};

--- a/packages/github-lens-api/src/data.ts
+++ b/packages/github-lens-api/src/data.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import type { S3Client } from '@aws-sdk/client-s3';
 import type { RetrievedObject } from 'common/aws/s3';
-import { getObject  } from 'common/aws/s3';
+import { getObject } from 'common/aws/s3';
 import type { Member, Repository, Team } from 'common/model/github';
 
 export interface GitHubData {
@@ -10,24 +10,26 @@ export interface GitHubData {
 	members?: RetrievedObject<Member[]>;
 }
 
-export const retrieveData = async (s3Client: S3Client, dataBucketName: string, dataKeyPrefix: string): Promise<GitHubData> => {
+export const retrieveData = async (
+	s3Client: S3Client,
+	dataBucketName: string,
+	dataKeyPrefix: string,
+): Promise<GitHubData> => {
 	const getRetrievedData = async <T>(objectName: string) => {
 		const fileLocation = path.join(dataKeyPrefix, `${objectName}.json`);
-		return await getObject<T>(
-			s3Client,
-			dataBucketName,
-			fileLocation,
-		).catch((error) => {
-			const message = error instanceof Error ? error.message : String(error);
-			console.error(message);
+		return await getObject<T>(s3Client, dataBucketName, fileLocation).catch(
+			(error) => {
+				const message = error instanceof Error ? error.message : String(error);
+				console.error(message);
 
-			return Promise.resolve(undefined);
-		})
-	}
+				return Promise.resolve(undefined);
+			},
+		);
+	};
 
 	return {
 		repos: await getRetrievedData<Repository[]>('repos'),
 		teams: await getRetrievedData<Team[]>('teams'),
 		members: await getRetrievedData<Member[]>('members'),
-	}
-}
+	};
+};

--- a/packages/github-lens-api/src/handler.ts
+++ b/packages/github-lens-api/src/handler.ts
@@ -1,16 +1,19 @@
-
-import { getS3Client  } from 'common/aws/s3';
+import { getS3Client } from 'common/aws/s3';
 import { configureLogging } from 'common/log/log';
 import { buildApp } from './app';
 import { getConfig } from './config';
-import { retrieveData } from './data'
+import { retrieveData } from './data';
 
 const config = getConfig();
 const s3Client = getS3Client(config.region);
 
 configureLogging(config.logLevel);
 
-const ghData = retrieveData(s3Client, config.dataBucketName, config.dataKeyPrefix);
+const ghData = retrieveData(
+	s3Client,
+	config.dataBucketName,
+	config.dataKeyPrefix,
+);
 const app = buildApp(ghData);
 
 const PORT = process.env.PORT ?? '3232';

--- a/packages/services-api/src/app.ts
+++ b/packages/services-api/src/app.ts
@@ -85,29 +85,30 @@ export function buildApp(config: Config): Express {
 	);
 
 	//handle all invalid routes by showing all available routes
-	router.get('*', getDescribeRouterHandler(router, (path: string) => {
-		let info = '';
-		switch (path) {
-			case '/healthcheck':
-				info = 'Display healthcheck';
-				break;
-			case '/teams':
-				info =
-					'Show all P&E teams, with the services they own';
-				break;
-			case '/teams/:name':
-				info = 'Show team and the services it owns, if it exists';
-				break;
-			case '/people':
-				info =
-					'Show all P&E people, with their role & GitHub username';
-				break;
-			default:
-				info = 'No path info supplied';
-				break;
-		}
-		return info;
-	}));
+	router.get(
+		'*',
+		getDescribeRouterHandler(router, (path: string) => {
+			let info = '';
+			switch (path) {
+				case '/healthcheck':
+					info = 'Display healthcheck';
+					break;
+				case '/teams':
+					info = 'Show all P&E teams, with the services they own';
+					break;
+				case '/teams/:name':
+					info = 'Show team and the services it owns, if it exists';
+					break;
+				case '/people':
+					info = 'Show all P&E people, with their role & GitHub username';
+					break;
+				default:
+					info = 'No path info supplied';
+					break;
+			}
+			return info;
+		}),
+	);
 
 	app.use('/', router);
 


### PR DESCRIPTION
## What does this change?
Since @guardian/eslint-config v2.0.0 we have to run Prettier ourselves.

In this change, we configure ESlint to run Prettier.

See:
  - https://github.com/guardian/csnx/releases/tag/%40guardian%2Feslint-config%402.0.0
  - https://github.com/prettier/eslint-plugin-prettier

## Why?
Prettier is an opinionated formatter... so we don't have to be! It produces a consistent code style.

It takes care of decisions on quite mark style (`"` or `'`), tabs vs spaces, trailing commas on objects, etc.