### PR TITLE
chore: Add IDE configuration to format files on save

### DIFF
--- a/.idea/jsLinters/eslint.xml
+++ b/.idea/jsLinters/eslint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EslintConfiguration">
+    <option name="fix-on-save" value="true" />
+  </component>
+</project>

--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PrettierConfiguration">
+    <option name="myRunOnSave" value="true" />
+  </component>
+</project>

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+      "esbenp.prettier-vscode",
+      "editorconfig.editorconfig",
+      "dbaeumer.vscode-eslint",
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+      "source.fixAll": true
+  }
+}


### PR DESCRIPTION
Follows https://github.com/guardian/service-catalogue/pull/83.

## What does this change?
We run ESLint in CI. In an effort to reduce the chance of a build failing for violating ESLint rules, add some IDE configuration files to format files on save.

Config added for VS Code and IntelliJ.

## Why?
An attempt to reduce friction and improve local DX.

## How to test
- Checkout the branch
- Open the repository in IntelliJ
- Add `const message = "hello"` to a file
- Save and witness it being rewritten to `const message = 'hello';` (single quotes, trailing semicolon)
- Repeat for VS Code