### PR TITLE
feat(data-fetcher): Store the languages of a repository

### DIFF
--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -166,3 +166,40 @@ export const getReposForTeam = async (
 		(response) => response.data,
 	);
 };
+
+export async function getLanguagesForRepositories(
+	client: Octokit,
+	repositories: RepositoriesResponse,
+): Promise<Record<string, string[]>> {
+	const data = await Promise.all(
+		repositories.map(async ({ name }) => {
+			const languages = await getRepositoryLanguages(client, name);
+			return {
+				repository: name,
+				languages,
+			};
+		}),
+	);
+
+	return data.reduce((acc, { repository, languages }) => {
+		return {
+			...acc,
+			[repository]: languages,
+		};
+	}, {});
+}
+
+async function getRepositoryLanguages(
+	client: Octokit,
+	repositoryName: string,
+): Promise<string[]> {
+	const response = await client.repos.listLanguages({
+		owner: 'guardian',
+		repo: repositoryName,
+	});
+	const languages = Object.keys(response.data);
+	console.log(
+		`Repository ${repositoryName} uses languages: ${languages.join(', ')}`,
+	);
+	return languages;
+}

--- a/packages/common/src/model/github.ts
+++ b/packages/common/src/model/github.ts
@@ -8,7 +8,7 @@ export interface Repository {
 	updated_at: Date | null;
 	pushed_at: Date | null;
 	size: number | undefined;
-	language: string | null | undefined;
+	languages: string[];
 	archived: boolean | undefined;
 	open_issues_count: number | undefined;
 	is_template: boolean | undefined;

--- a/packages/github-data-fetcher/src/transformations.test.ts
+++ b/packages/github-data-fetcher/src/transformations.test.ts
@@ -25,8 +25,9 @@ describe('repository owners', function () {
 describe('repository objects', function () {
 	it('should combine a RepositoryResponse with a list of owners', function () {
 		const owners = ['team3', 'team4'];
+		const languages = ['Scala', 'Go'];
 		const repo: RepositoryResponse = mockRepo;
-		const finalRepoObject: Repository = asRepo(repo, owners);
+		const finalRepoObject: Repository = asRepo(repo, owners, languages);
 
 		expect(finalRepoObject.owners).toStrictEqual(['team3', 'team4']);
 		expect(finalRepoObject.name).toStrictEqual('repo-name');

--- a/packages/github-data-fetcher/src/transformations.ts
+++ b/packages/github-data-fetcher/src/transformations.ts
@@ -29,7 +29,8 @@ export const asMember = (member: MemberResponse, teams: string[]): Member => {
 
 export const asRepo = (
 	repo: RepositoryResponse,
-	owners?: string[],
+	owners: string[],
+	languages: string[],
 ): Repository => {
 	return {
 		id: repo.id,
@@ -41,13 +42,13 @@ export const asRepo = (
 		updated_at: parseDateString(repo.updated_at),
 		pushed_at: parseDateString(repo.pushed_at),
 		size: repo.size,
-		language: repo.language,
 		archived: repo.archived,
 		open_issues_count: repo.open_issues_count,
 		is_template: repo.is_template,
 		topics: repo.topics,
 		default_branch: repo.default_branch,
-		owners: owners ? owners : [],
+		owners,
+		languages,
 	};
 };
 


### PR DESCRIPTION
## What does this change?
The `language` property of a repository is a single item - the primary language used. In this change, we store the entire set of languages used (ordered by frequency).

### Example response

```json
[
  {
    "id": 13386075,
    "name": "prism",
    "full_name": "guardian/prism",
    "private": false,
    "description": "Tool for collecting live data about infrastructure so it can be easily queried by users and automated tooling",
    "created_at": "2013-10-07T14:32:02.000Z",
    "updated_at": "2022-06-10T10:45:05.000Z",
    "pushed_at": "2022-11-28T13:04:52.000Z",
    "size": 2495,
    "languages": [
      "Scala",
      "Ruby",
      "TypeScript",
      "HTML",
      "JavaScript",
      "Shell"
    ],
    "archived": false,
    "open_issues_count": 5,
    "is_template": false,
    "topics": [
      "production"
    ],
    "default_branch": "main",
    "owners": [
      "devx-operations"
    ]
  }
]
```

## Why?
Knowing all the languages allows us to check for complete Snyk integration, for example.