### PR TITLE
chore: Use departmental tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@guardian/eslint-config-typescript": "^2.0.0",
         "@guardian/prettier": "^2.1.5",
+        "@guardian/tsconfig": "^0.2.0",
         "aws-sdk-client-mock": "^2.0.0",
         "esbuild": "^0.15.16",
         "eslint-plugin-prettier": "^4.2.1"
@@ -4187,6 +4188,12 @@
       "peerDependencies": {
         "prettier": "^2.4.0"
       }
+    },
+    "node_modules/@guardian/tsconfig": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@guardian/tsconfig/-/tsconfig-0.2.0.tgz",
+      "integrity": "sha512-RauppalK+cQZDRK6IssVmDSnU/VyqMNuVOxPxhmI03kVRxEdwcmBuRqexHwDbnClVUxW/N9hYLbFNuAb9V/p+A==",
+      "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.7",
@@ -14784,6 +14791,12 @@
       "version": "2.1.5",
       "dev": true,
       "requires": {}
+    },
+    "@guardian/tsconfig": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@guardian/tsconfig/-/tsconfig-0.2.0.tgz",
+      "integrity": "sha512-RauppalK+cQZDRK6IssVmDSnU/VyqMNuVOxPxhmI03kVRxEdwcmBuRqexHwDbnClVUxW/N9hYLbFNuAb9V/p+A==",
+      "dev": true
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.7",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@guardian/eslint-config-typescript": "^2.0.0",
     "@guardian/prettier": "^2.1.5",
+    "@guardian/tsconfig": "^0.2.0",
     "aws-sdk-client-mock": "^2.0.0",
     "esbuild": "^0.15.16",
     "eslint-plugin-prettier": "^4.2.1"
@@ -35,7 +36,9 @@
   },
   "eslintConfig": {
     "extends": "@guardian/eslint-config-typescript",
-    "plugins": ["prettier"],
+    "plugins": [
+      "prettier"
+    ],
     "rules": {
       "prettier/prettier": "error"
     }

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -1,8 +1,8 @@
-import 'source-map-support/register';
-import { GuRootExperimental } from '@guardian/cdk/lib/experimental/constructs/root';
-import { CloudFormationLens } from '../lib/cloudformation-lens';
-import { GithubLens } from '../lib/github-lens';
-import { ServicesApi } from '../lib/services-api';
+import 'source-map-support/register.js';
+import { GuRootExperimental } from '@guardian/cdk/lib/experimental/constructs/root.js';
+import { CloudFormationLens } from '../lib/cloudformation-lens.js';
+import { GithubLens } from '../lib/github-lens.js';
+import { ServicesApi } from '../lib/services-api.js';
 
 const app = new GuRootExperimental();
 

--- a/packages/cdk/lib/cloudformation-lens.ts
+++ b/packages/cdk/lib/cloudformation-lens.ts
@@ -1,12 +1,12 @@
-import { AccessScope } from '@guardian/cdk/lib/constants';
-import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { AccessScope } from '@guardian/cdk/lib/constants/index.js';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core/index.js';
 import {
 	GuAnghammaradTopicParameter,
 	GuDistributionBucketParameter,
 	GuStack,
-} from '@guardian/cdk/lib/constructs/core';
-import { GuCname } from '@guardian/cdk/lib/constructs/dns';
-import { GuEc2App } from '@guardian/cdk/lib/patterns/ec2-app';
+} from '@guardian/cdk/lib/constructs/core/index.js';
+import { GuCname } from '@guardian/cdk/lib/constructs/dns/index.js';
+import { GuEc2App } from '@guardian/cdk/lib/patterns/ec2-app/index.js';
 import { Duration } from 'aws-cdk-lib';
 import type { App } from 'aws-cdk-lib';
 import {

--- a/packages/cdk/lib/github-lens.ts
+++ b/packages/cdk/lib/github-lens.ts
@@ -1,15 +1,15 @@
-import { AccessScope } from '@guardian/cdk/lib/constants';
+import { AccessScope } from '@guardian/cdk/lib/constants/index.js';
 import {
 	GuAnghammaradTopicParameter,
 	GuDistributionBucketParameter,
 	GuStack,
 	GuStringParameter,
-} from '@guardian/cdk/lib/constructs/core';
-import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
-import { GuCname } from '@guardian/cdk/lib/constructs/dns';
-import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
-import { GuEc2App } from '@guardian/cdk/lib/patterns/ec2-app';
-import { GuScheduledLambda } from '@guardian/cdk/lib/patterns/scheduled-lambda';
+} from '@guardian/cdk/lib/constructs/core/index.js';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core/index.js';
+import { GuCname } from '@guardian/cdk/lib/constructs/dns/index.js';
+import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3/index.js';
+import { GuEc2App } from '@guardian/cdk/lib/patterns/ec2-app/index.js';
+import { GuScheduledLambda } from '@guardian/cdk/lib/patterns/scheduled-lambda.js';
 import { Duration } from 'aws-cdk-lib';
 import type { App } from 'aws-cdk-lib';
 import {

--- a/packages/cdk/lib/services-api.ts
+++ b/packages/cdk/lib/services-api.ts
@@ -1,12 +1,12 @@
-import { AccessScope } from '@guardian/cdk/lib/constants';
+import { AccessScope } from '@guardian/cdk/lib/constants/index.js';
 import {
 	GuAnghammaradTopicParameter,
 	GuDistributionBucketParameter,
 	GuStack,
-} from '@guardian/cdk/lib/constructs/core';
-import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
-import { GuCname } from '@guardian/cdk/lib/constructs/dns';
-import { GuEc2App } from '@guardian/cdk/lib/patterns/ec2-app';
+} from '@guardian/cdk/lib/constructs/core/index.js';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core/index.js';
+import { GuCname } from '@guardian/cdk/lib/constructs/dns/index.js';
+import { GuEc2App } from '@guardian/cdk/lib/patterns/ec2-app/index.js';
 import { CfnParameter, Duration } from 'aws-cdk-lib';
 import type { App } from 'aws-cdk-lib';
 import {

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -1,5 +1,6 @@
 {
   "name": "cdk",
+  "type": "module",
   "version": "1.0.0",
   "scripts": {
     "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects cdk",

--- a/packages/common/src/aws/kms.test.ts
+++ b/packages/common/src/aws/kms.test.ts
@@ -22,14 +22,4 @@ describe('decrypt', function () {
 
 		expect(actualOutput).toBe(expectedOutput);
 	});
-
-	it('returns undefined if the decrypt operation fails', async function () {
-		const expectedOutput = 'plaintext';
-
-		kmsMock.on(DecryptCommand).rejects();
-
-		const actualOutput = await decrypt('keyId', expectedOutput);
-
-		expect(actualOutput).toBe(undefined);
-	});
 });

--- a/packages/common/src/aws/kms.ts
+++ b/packages/common/src/aws/kms.ts
@@ -8,7 +8,7 @@ const kmsClient = new KMSClient({
 export const decrypt = async (
 	cipherText: string,
 	keyId: string,
-): Promise<string | undefined> => {
+): Promise<string> => {
 	const decryptCommand = new DecryptCommand({
 		CiphertextBlob: Buffer.from(cipherText, 'base64'),
 		KeyId: keyId,
@@ -18,14 +18,18 @@ export const decrypt = async (
 		const { Plaintext } = await kmsClient.send(decryptCommand);
 		console.log('Decrypt command sent successfully');
 
-		if (Plaintext) {
-			console.log('Ciphertext successfully decrypted');
-			const plaintextString = Buffer.from(Plaintext).toString();
-			return plaintextString;
-		} else {
-			console.error('Plaintext is missing from DecryptCommandOutput!');
+		if (!Plaintext) {
+			// should not happen, AWS's types are just a bit odd
+			const message = 'Plaintext is missing from DecryptCommandOutput!';
+			console.error(message);
+			return message;
 		}
+
+		console.log('Ciphertext successfully decrypted');
+		return Buffer.from(Plaintext).toString();
 	} catch (e) {
-		console.error(`Decryption failed: ${(e as Error).message}`);
+		const message = `Decryption failed: ${(e as Error).message}`;
+		console.error(message);
+		throw new Error(message);
 	}
 };

--- a/packages/common/src/aws/s3.test.ts
+++ b/packages/common/src/aws/s3.test.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import { Readable } from 'stream';
 import {
 	GetObjectCommand,
@@ -57,6 +58,9 @@ describe('putObject', function () {
 
 		const s3PutObjectStub = s3Mock.commandCalls(PutObjectCommand);
 
+		assert(s3PutObjectStub.length > 0);
+
+		// @ts-expect-error -- length asserted above
 		expect(s3PutObjectStub[0].args[0].input).toEqual({
 			Bucket: 'bucket',
 			Key: 'key',

--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -69,6 +69,8 @@ export const getOctokit = (config: GitHubConfig): Octokit => {
 					console.log(`Retrying after ${retryAfter} seconds!`);
 					return true;
 				}
+
+				return false;
 			},
 			onAbuseLimit: async (retryAfter: number, options: Options) => {
 				// does not retry, only logs a warning
@@ -82,6 +84,8 @@ export const getOctokit = (config: GitHubConfig): Octokit => {
 					await sleep(60000);
 					return true;
 				}
+
+				return false;
 			},
 		},
 	});

--- a/packages/github-data-fetcher/src/handler.ts
+++ b/packages/github-data-fetcher/src/handler.ts
@@ -107,7 +107,7 @@ async function getGHData(
 		return asRepo(
 			repository,
 			repositoriesToAdmins[repository.name] ?? [],
-			repositoryLanguages[repository.name],
+			repositoryLanguages[repository.name] ?? [],
 		);
 	});
 
@@ -118,7 +118,7 @@ async function getGHData(
 		const repo = asRepo(
 			repository,
 			repositoriesToAdmins[repository.name] ?? [],
-			repositoryLanguages[repository.name],
+			repositoryLanguages[repository.name] ?? [],
 		);
 
 		adminTeamSlugs.forEach((adminSlug: string) => {

--- a/packages/github-lens-api/src/controller/repos.ts
+++ b/packages/github-lens-api/src/controller/repos.ts
@@ -7,21 +7,21 @@ export const getAllRepos = (
 	res: express.Response,
 	reposData: RetrievedObject<Repository[]>,
 ) => {
-	if (typeof req.query.name !== 'undefined') {
-		const searchString: string = req.query.name.toString();
-		const jsonResponse = reposData.payload.filter((item) =>
-			item.name.match(searchString),
-		);
-		if (jsonResponse.length !== 0) {
-			res.status(200).json(jsonResponse);
-		} else {
-			return res.status(200).json({
-				searchString: searchString,
-				info: 'no results found in repos',
-			});
-		}
-	} else {
+	if (typeof req.query.name === 'undefined') {
 		return res.status(200).json(reposData);
+	}
+
+	const searchString: string = req.query.name.toString();
+	const jsonResponse = reposData.payload.filter((item) =>
+		item.name.match(searchString),
+	);
+	if (jsonResponse.length !== 0) {
+		return res.status(200).json(jsonResponse);
+	} else {
+		return res.status(200).json({
+			searchString: searchString,
+			info: 'no results found in repos',
+		});
 	}
 };
 

--- a/packages/services-api/src/app.ts
+++ b/packages/services-api/src/app.ts
@@ -67,13 +67,17 @@ export function buildApp(config: Config): Express {
 
 	router.get(
 		'/teams/:id',
-		asyncHandler(async (req: express.Request, res: express.Response) => {
-			const team = await galaxiesApi.getTeam(req.params.id);
-			const services = await servicesApi.forGithubOwner(team.primaryGithubTeam);
+		asyncHandler(
+			async (req: express.Request<{ id: string }>, res: express.Response) => {
+				const team = await galaxiesApi.getTeam(req.params.id);
+				const services = await servicesApi.forGithubOwner(
+					team.primaryGithubTeam,
+				);
 
-			const resp: TeamResponse = { ...team, services };
-			res.status(200).json(resp);
-		}),
+				const resp: TeamResponse = { ...team, services };
+				res.status(200).json(resp);
+			},
+		),
 	);
 
 	router.get(

--- a/packages/services-api/src/galaxies.ts
+++ b/packages/services-api/src/galaxies.ts
@@ -68,7 +68,7 @@ export class S3GalaxiesApi implements GalaxiesApi {
 		// Add the (for now) missing fields.
 		return people.map((person) => ({
 			...person,
-			githubUsername: peopleMapping[person.emailId],
+			githubUsername: peopleMapping[person.emailId] ?? 'unknown',
 		}));
 	}
 
@@ -89,12 +89,14 @@ export class S3GalaxiesApi implements GalaxiesApi {
 
 		const teamsMapping = mappingResp.payload;
 
-		// Add the (for now) missing fields.
-		return Object.keys(teams).map((teamId) => {
+		return Object.entries(teams).map(([id, team]) => {
 			return {
-				...teams[teamId],
-				id: teamId,
-				primaryGithubTeam: teamsMapping[teamId],
+				...team,
+
+				// Note, this doesn't (yet) exist in actual Galaxies.
+				// Add them (for now).
+				id,
+				primaryGithubTeam: teamsMapping[id] ?? 'unknown',
 			};
 		});
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,6 @@
 {
+  "extends": "@guardian/tsconfig/tsconfig.json",
   "compilerOptions": {
-    "target": "ES2021",
-    "module": "commonjs",
-    "lib": ["ES2021", "dom"],
-    "moduleResolution": "node",
-    "esModuleInterop": true,
-    "strict": true,
-    "noFallthroughCasesInSwitch": true,
-    "inlineSourceMap": true,
-    "inlineSources": true,
-    "experimentalDecorators": true,
     "baseUrl": ".",
     "paths": {
       "common": ["packages/common/src"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     }
   },
   "ts-node": {
+    "esm": true,
     "require": ["tsconfig-paths/register", "dotenv/config"]
   }
 }


### PR DESCRIPTION
## What does this change?
Use [@guardian/tsconfig](https://github.com/guardian/csnx/tree/main/libs/%40guardian/tsconfig) to reduce the amount of configuration.

This config has highlighted some code paths not returning expected values. These are also fixed.

## Why?
- Less config
- An easier path to ESM... I think!
- Makes it easier to use packages that are now published as ESM only (e.g. [node-fetch](https://github.com/guardian/service-catalogue/pull/87#discussion_r1036853767))