### PR TITLE
Add Repocop CDK test

### DIFF
--- a/packages/cdk/lib/__snapshots__/repocop.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/repocop.test.ts.snap
@@ -1,0 +1,375 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The Repocop stack matches the snapshot 1`] = `
+{
+  "Metadata": {
+    "gu:cdk:constructs": [
+      "GuDistributionBucketParameter",
+      "GuScheduledLambda",
+      "GuLambdaErrorPercentageAlarm",
+    ],
+    "gu:cdk:version": "TEST",
+  },
+  "Parameters": {
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "repocoplambdaB702A335": {
+      "DependsOn": [
+        "repocoplambdaServiceRoleDefaultPolicyCD286095",
+        "repocoplambdaServiceRole65643A09",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "deploy/INFRA/repocop/repocop.jar",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "repocop",
+            "STACK": "deploy",
+            "STAGE": "INFRA",
+          },
+        },
+        "Handler": "com.gu.repocop.main.main",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "repocoplambdaServiceRole65643A09",
+            "Arn",
+          ],
+        },
+        "Runtime": "java11",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "repocop",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "INFRA",
+          },
+        ],
+        "Timeout": 300,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "repocoplambdaErrorPercentageAlarmForLambda7BA16892": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":devx-alerts",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "repocoplambdaB702A335",
+              },
+              " exceeded 0% error rate",
+            ],
+          ],
+        },
+        "AlarmName": {
+          "Fn::Join": [
+            "",
+            [
+              "High error % from ",
+              {
+                "Ref": "repocoplambdaB702A335",
+              },
+              " lambda in INFRA",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "repocoplambdaB702A335",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "repocoplambdaB702A335",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "repocoplambdaB702A335",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "repocoplambdaServiceRole65643A09": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "repocop",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "INFRA",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "repocoplambdaServiceRoleDefaultPolicyCD286095": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/deploy/INFRA/repocop/repocop.jar",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/INFRA/deploy/repocop",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/INFRA/deploy/repocop/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "repocoplambdaServiceRoleDefaultPolicyCD286095",
+        "Roles": [
+          {
+            "Ref": "repocoplambdaServiceRole65643A09",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "repocoplambdarepocoplambdacron080759EAEC6": {
+      "Properties": {
+        "ScheduleExpression": "cron(0 8 * * ? *)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "repocoplambdaB702A335",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "repocoplambdarepocoplambdacron080AllowEventRuleGithubLensrepocoplambda6A711F8052BB5B42": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "repocoplambdaB702A335",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "repocoplambdarepocoplambdacron080759EAEC6",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+  },
+}
+`;

--- a/packages/cdk/lib/__snapshots__/repocop.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/repocop.test.ts.snap
@@ -351,7 +351,7 @@ exports[`The Repocop stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Events::Rule",
     },
-    "repocoplambdarepocoplambdacron080AllowEventRuleGithubLensrepocoplambda6A711F8052BB5B42": {
+    "repocoplambdarepocoplambdacron080AllowEventRuleRepocoprepocoplambdaD20097B3E7516549": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {

--- a/packages/cdk/lib/repocop.test.ts
+++ b/packages/cdk/lib/repocop.test.ts
@@ -1,0 +1,15 @@
+import { App } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { Repocop } from './repocop';
+
+describe('The Repocop stack', () => {
+	it('matches the snapshot', () => {
+		const app = new App();
+		const stack = new Repocop(app, 'GithubLens', {
+			stack: 'deploy',
+			stage: 'INFRA',
+		});
+		const template = Template.fromStack(stack);
+		expect(template.toJSON()).toMatchSnapshot();
+	});
+});

--- a/packages/cdk/lib/repocop.test.ts
+++ b/packages/cdk/lib/repocop.test.ts
@@ -5,7 +5,7 @@ import { Repocop } from './repocop';
 describe('The Repocop stack', () => {
 	it('matches the snapshot', () => {
 		const app = new App();
-		const stack = new Repocop(app, 'GithubLens', {
+		const stack = new Repocop(app, 'Repocop', {
 			stack: 'deploy',
 			stage: 'INFRA',
 		});


### PR DESCRIPTION
## What does this change?

Follows https://github.com/guardian/service-catalogue/pull/97, to add test coverage for Repocop CDK stack.

## Why?

So we notice and test infra changes in repocop.