### PR TITLE
chore: Ignore artifact files built by SBT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -335,3 +335,4 @@ dist
 ### Custom ###
 # Ignore zipped buildg artifacts
 *.zip
+target


### PR DESCRIPTION
## What does this change?
Ignores compile artifacts from VCS.

## Why?
We don't need them.