### PR TITLE
Revert esm changes

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -1,9 +1,9 @@
-import 'source-map-support/register.js';
-import { GuRootExperimental } from '@guardian/cdk/lib/experimental/constructs/root.js';
-import { CloudFormationLens } from '../lib/cloudformation-lens.js';
-import { GithubLens } from '../lib/github-lens.js';
-import { Repocop } from '../lib/repocop.js';
-import { ServicesApi } from '../lib/services-api.js';
+import 'source-map-support/register';
+import { GuRootExperimental } from '@guardian/cdk/lib/experimental/constructs/root';
+import { CloudFormationLens } from '../lib/cloudformation-lens';
+import { GithubLens } from '../lib/github-lens';
+import { Repocop } from '../lib/repocop';
+import { ServicesApi } from '../lib/services-api';
 
 const app = new GuRootExperimental();
 

--- a/packages/cdk/lib/cloudformation-lens.ts
+++ b/packages/cdk/lib/cloudformation-lens.ts
@@ -1,12 +1,12 @@
-import { AccessScope } from '@guardian/cdk/lib/constants/index.js';
-import type { GuStackProps } from '@guardian/cdk/lib/constructs/core/index.js';
+import { AccessScope } from '@guardian/cdk/lib/constants';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import {
 	GuAnghammaradTopicParameter,
 	GuDistributionBucketParameter,
 	GuStack,
-} from '@guardian/cdk/lib/constructs/core/index.js';
-import { GuCname } from '@guardian/cdk/lib/constructs/dns/index.js';
-import { GuEc2App } from '@guardian/cdk/lib/patterns/ec2-app/index.js';
+} from '@guardian/cdk/lib/constructs/core';
+import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import { GuEc2App } from '@guardian/cdk/lib/patterns/ec2-app';
 import { Duration } from 'aws-cdk-lib';
 import type { App } from 'aws-cdk-lib';
 import {

--- a/packages/cdk/lib/github-lens.ts
+++ b/packages/cdk/lib/github-lens.ts
@@ -1,15 +1,15 @@
-import { AccessScope } from '@guardian/cdk/lib/constants/index.js';
+import { AccessScope } from '@guardian/cdk/lib/constants';
 import {
 	GuAnghammaradTopicParameter,
 	GuDistributionBucketParameter,
 	GuStack,
 	GuStringParameter,
-} from '@guardian/cdk/lib/constructs/core/index.js';
-import type { GuStackProps } from '@guardian/cdk/lib/constructs/core/index.js';
-import { GuCname } from '@guardian/cdk/lib/constructs/dns/index.js';
-import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3/index.js';
-import { GuEc2App } from '@guardian/cdk/lib/patterns/ec2-app/index.js';
-import { GuScheduledLambda } from '@guardian/cdk/lib/patterns/scheduled-lambda.js';
+} from '@guardian/cdk/lib/constructs/core';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
+import { GuEc2App } from '@guardian/cdk/lib/patterns/ec2-app';
+import { GuScheduledLambda } from '@guardian/cdk/lib/patterns/scheduled-lambda';
 import { Duration } from 'aws-cdk-lib';
 import type { App } from 'aws-cdk-lib';
 import {

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -1,6 +1,6 @@
-import type { GuStackProps } from '@guardian/cdk/lib/constructs/core/index.js';
-import { GuStack } from '@guardian/cdk/lib/constructs/core/index.js';
-import { GuScheduledLambda } from '@guardian/cdk/lib/patterns/scheduled-lambda.js';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuScheduledLambda } from '@guardian/cdk/lib/patterns/scheduled-lambda';
 import type { App } from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
 import { Schedule } from 'aws-cdk-lib/aws-events';

--- a/packages/cdk/lib/services-api.ts
+++ b/packages/cdk/lib/services-api.ts
@@ -1,12 +1,12 @@
-import { AccessScope } from '@guardian/cdk/lib/constants/index.js';
+import { AccessScope } from '@guardian/cdk/lib/constants';
 import {
 	GuAnghammaradTopicParameter,
 	GuDistributionBucketParameter,
 	GuStack,
-} from '@guardian/cdk/lib/constructs/core/index.js';
-import type { GuStackProps } from '@guardian/cdk/lib/constructs/core/index.js';
-import { GuCname } from '@guardian/cdk/lib/constructs/dns/index.js';
-import { GuEc2App } from '@guardian/cdk/lib/patterns/ec2-app/index.js';
+} from '@guardian/cdk/lib/constructs/core';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import { GuEc2App } from '@guardian/cdk/lib/patterns/ec2-app';
 import { CfnParameter, Duration } from 'aws-cdk-lib';
 import type { App } from 'aws-cdk-lib';
 import {

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -1,6 +1,5 @@
 {
   "name": "cdk",
-  "type": "module",
   "version": "1.0.0",
   "scripts": {
     "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects cdk",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,13 @@
 {
   "extends": "@guardian/tsconfig/tsconfig.json",
   "compilerOptions": {
+
+    "module": "commonjs",
+    "esModuleInterop": true,
+
+
+
+
     "baseUrl": ".",
     "paths": {
       "common": ["packages/common/src"],
@@ -8,7 +15,6 @@
     }
   },
   "ts-node": {
-    "esm": true,
     "require": ["tsconfig-paths/register", "dotenv/config"]
   }
 }


### PR DESCRIPTION
Change tsconfig to be able to run locally without errors, revert currently unneeded js extentions

Co-authored-by: Akash <akash1810@users.noreply.github.com>

## Why?

https://github.com/guardian/service-catalogue/pull/89
did introduce the problem that running locally did not work 
