### PR TITLE
Target the dependency-updates branch for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    target-branch: "dependency-updates"
     ignore:
       # The version of AWS CDK libraries must match those from @guardian/cdk.
       # We'd never be able to update them here independently, so just ignore them.


### PR DESCRIPTION
## What does this change?

Target the existing `dependency-updates` branch that Scala Steward is adding updates to.

## Why?

Simplify the process of merging regular dependency updates
