### PR TITLE
Data Fetcher should run before Repocop

### DIFF
--- a/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
@@ -1587,7 +1587,7 @@ systemctl start github-lens-api
       },
       "Type": "AWS::IAM::Policy",
     },
-    "githubdatafetcherlambdagithubdatafetcherlambdacron080AllowEventRuleGithubLensgithubdatafetcherlambdaE2220E44970E0DB1": {
+    "githubdatafetcherlambdagithubdatafetcherlambdacron070AllowEventRuleGithubLensgithubdatafetcherlambdaE2220E443EEB0D75": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -1599,16 +1599,16 @@ systemctl start github-lens-api
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "githubdatafetcherlambdagithubdatafetcherlambdacron080DB012BEB",
+            "githubdatafetcherlambdagithubdatafetcherlambdacron070E752734E",
             "Arn",
           ],
         },
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "githubdatafetcherlambdagithubdatafetcherlambdacron080DB012BEB": {
+    "githubdatafetcherlambdagithubdatafetcherlambdacron070E752734E": {
       "Properties": {
-        "ScheduleExpression": "cron(0 8 * * ? *)",
+        "ScheduleExpression": "cron(0 7 * * ? *)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/packages/cdk/lib/github-lens.ts
+++ b/packages/cdk/lib/github-lens.ts
@@ -159,7 +159,7 @@ systemctl start ${apiApp}
 					toleratedErrorPercentage: 0,
 					snsTopicName: 'devx-alerts',
 				},
-				rules: [{ schedule: Schedule.cron({ minute: '0', hour: '8' }) }],
+				rules: [{ schedule: Schedule.cron({ minute: '0', hour: '7' }) }],
 				timeout: Duration.seconds(300),
 				environment: {
 					STAGE: this.stage,


### PR DESCRIPTION
## What does this change?

Before, the data fetcher and repocop both ran at 8am
Now, the data fetcher runs at 7.

## Why?
Repocop is less likely to be using stale data, if datafetcher hasn't finished in time