### PR TITLE
Update filters to work more generally on API endpoints

### DIFF
--- a/packages/github-lens-api/src/app.ts
+++ b/packages/github-lens-api/src/app.ts
@@ -7,7 +7,7 @@ import { getRouteDescriptions } from './controller/describe';
 import { getHealthCheckHandler } from './controller/healthcheck';
 import { getMembers, getMembersByLogin } from './controller/members';
 import { getAllRepos, getRepoByName } from './controller/repos';
-import { getTeamBySlug } from './controller/teams';
+import { getAllTeams, getTeamBySlug } from './controller/teams';
 import type { GitHubData } from './data';
 
 export function buildApp(ghData: Promise<GitHubData>): Express {
@@ -57,7 +57,7 @@ export function buildApp(ghData: Promise<GitHubData>): Express {
 				res.status(500).json({ error: 'Unable to retrieve teams data!' });
 				return;
 			}
-			res.status(200).json(teamsData);
+			getAllTeams(req, res, teamsData);
 		}),
 	);
 

--- a/packages/github-lens-api/src/controller/describe.ts
+++ b/packages/github-lens-api/src/controller/describe.ts
@@ -5,7 +5,7 @@ function describeRoutes(path: string): string {
 	const infoByRoute: Record<string, string> = {
 		'/healthcheck': 'Display healthcheck',
 		'/repos':
-			'Show all repos, with their team owners, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived, ?repoIsNotArchived',
+			'Show all repos, with their team owners, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived, ?repoIsNotArchived, ?repoNotOwned',
 		'/repos/:name': 'Show repo and its team owners, if it exists',
 		'/teams':
 			'Show all teams, with the repositories they own, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived, ?repoIsNotArchived',

--- a/packages/github-lens-api/src/controller/describe.ts
+++ b/packages/github-lens-api/src/controller/describe.ts
@@ -5,10 +5,12 @@ function describeRoutes(path: string): string {
 	const infoByRoute: Record<string, string> = {
 		'/healthcheck': 'Display healthcheck',
 		'/repos':
-			'Show all repos, with their team owners, optionally search by name with ?name=^repo-name-regex.* and filter for ?isArchived',
+			'Show all repos, with their team owners, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived, ?repoIsNotArchived',
 		'/repos/:name': 'Show repo and its team owners, if it exists',
-		'/teams': 'Show all teams, with the repositories they own',
-		'/teams/:slug': 'Show team with info, if it exists',
+		'/teams':
+			'Show all teams, with the repositories they own, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived, ?repoIsNotArchived',
+		'/teams/:slug':
+			'Show team with info, if it exists, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived, ?repoIsNotArchived',
 		'/members': 'Show member, with the teams they are in',
 		'/members/:login': 'Show member and the teams they are in, if it exists',
 	};

--- a/packages/github-lens-api/src/controller/repos.ts
+++ b/packages/github-lens-api/src/controller/repos.ts
@@ -1,36 +1,14 @@
 import type { RetrievedObject } from 'common/aws/s3';
 import type { Repository } from 'common/model/github';
 import type express from 'express';
-
-interface Filter {
-	paramName: string;
-	fn: (r: Repository, paramValue: string) => boolean;
-}
+import { filterRepos } from '../filters';
 
 export const getAllRepos = (
 	req: express.Request,
 	res: express.Response,
 	reposData: RetrievedObject<Repository[]>,
 ) => {
-	const filters: Filter[] = [
-		{
-			paramName: 'name',
-			fn: (repo: Repository, paramValue: string) =>
-				!!repo.name.match(paramValue),
-		},
-		{
-			paramName: 'isArchived',
-			fn: (repo: Repository) => repo.archived ?? false,
-		},
-	];
-
-	const repos = reposData.payload.filter((repo) => {
-		return filters.every((filter) => {
-			const paramValue = req.query[filter.paramName];
-			if (paramValue === undefined) return true; // ignore filter fn if param unset
-			return filter.fn(repo, paramValue.toString());
-		});
-	});
+	const repos = filterRepos(req, reposData.payload);
 
 	res.status(200).json({ ...reposData, payload: repos });
 };

--- a/packages/github-lens-api/src/controller/teams.ts
+++ b/packages/github-lens-api/src/controller/teams.ts
@@ -1,13 +1,20 @@
 import type { RetrievedObject } from 'common/aws/s3';
 import type { Team } from 'common/model/github';
 import type express from 'express';
+import { filterRepos } from '../filters';
 
 export const getAllTeams = (
 	req: express.Request,
 	res: express.Response,
 	teamsData: RetrievedObject<Team[]>,
 ) => {
-	return res.status(200).json(teamsData);
+	const filteredTeams = teamsData.payload.map((team) => {
+		return { ...team, repos: filterRepos(req, team.repos) };
+	});
+
+	const filteredTeamsData = { ...teamsData, payload: filteredTeams };
+
+	res.status(200).json(filteredTeamsData);
 };
 
 export const getTeamBySlug = (
@@ -16,8 +23,11 @@ export const getTeamBySlug = (
 	teamsData: RetrievedObject<Team[]>,
 ) => {
 	const team = teamsData.payload.find((item) => item.slug === req.params.slug);
+
 	if (team) {
-		res.status(200).json({ ...teamsData, payload: team });
+		const filteredTeam = { ...team, repos: filterRepos(req, team.repos) };
+
+		res.status(200).json({ ...teamsData, payload: filteredTeam });
 	} else {
 		res.status(404).json({ teamSlug: req.params.slug, info: 'Team not found' });
 	}

--- a/packages/github-lens-api/src/filters.ts
+++ b/packages/github-lens-api/src/filters.ts
@@ -1,0 +1,48 @@
+import type { Repository } from 'common/model/github';
+import type express from 'express';
+
+export interface RepoFilter {
+	paramName: string;
+	fn: (r: Repository, paramValue: string) => boolean;
+}
+
+export const repoFilters: RepoFilter[] = [
+	{
+		paramName: 'repoName',
+		fn: (repo: Repository, paramValue: string) => !!repo.name.match(paramValue),
+	},
+	{
+		paramName: 'repoIsArchived',
+		fn: (repo: Repository) => repo.archived ?? false,
+	},
+	{
+		paramName: 'repoIsNotArchived',
+		fn: (repo: Repository) => !(repo.archived ?? false),
+	},
+];
+
+export const filterRepos = (
+	req: express.Request,
+	repos: Repository[],
+): Repository[] => {
+	return repos.filter((repo) => {
+		return repoFilters.every((filter) => {
+			const paramValue = req.query[filter.paramName];
+			if (paramValue === undefined) return true; // ignore filter fn if param unset
+			return filter.fn(repo, paramValue.toString());
+		});
+	});
+};
+
+// TODO: If we add further filters, suggest this format
+// export interface TeamFilter {
+// 	paramName: string;
+// 	fn: (r: Team, paramValue: string) => boolean;
+// }
+
+// export const teamFilters: TeamFilter[] = [
+// 	{
+// 		paramName: 'teamName',
+// 		fn: (team: Team, paramValue: string) => true,
+// 	},
+// ];

--- a/packages/github-lens-api/src/filters.ts
+++ b/packages/github-lens-api/src/filters.ts
@@ -12,6 +12,10 @@ export const repoFilters: RepoFilter[] = [
 		fn: (repo: Repository, paramValue: string) => !!repo.name.match(paramValue),
 	},
 	{
+		paramName: 'repoNotOwned',
+		fn: (repo: Repository) => repo.owners.length === 0,
+	},
+	{
 		paramName: 'repoIsArchived',
 		fn: (repo: Repository) => repo.archived ?? false,
 	},


### PR DESCRIPTION
## What does this change?

Updates the way filters work so they can be applied across multiple endpoints. This change allows filtering of repository data on the following endpoints:

- `/teams/:slug`
- `/teams`

It renames the filter parameters to refer to specifically the type of data they are filtering on the API responses, i.e.

- `name` -> `repoName`
- `isArchived` -> `repoIsArchived`

It also adds the following filter that can be applied across the existing endpoints;

- `repoIsNotArchived`: Display only repositories not archived.
- `repoNotOwned`: Display only repositories with no owners.

## Why?

Generalises the use of filters in a (hopefully) sensible way, and provides utility to other services wanting to consume this data.
