### PR TITLE
Adds team filters

### DIFF
--- a/packages/github-lens-api/src/controller/describe.ts
+++ b/packages/github-lens-api/src/controller/describe.ts
@@ -8,9 +8,9 @@ function describeRoutes(path: string): string {
 			'Show all repos, with their team owners, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived, ?repoIsNotArchived, ?repoNotOwned',
 		'/repos/:name': 'Show repo and its team owners, if it exists',
 		'/teams':
-			'Show all teams, with the repositories they own, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived, ?repoIsNotArchived',
+			'Show all teams, with the repositories they own, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived, ?repoIsNotArchived, ?teamIsEngineering, ?teamIsValid',
 		'/teams/:slug':
-			'Show team with info, if it exists, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived, ?repoIsNotArchived',
+			'Show team with info, if it exists, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived, ?repoIsNotArchived, ?teamIsEngineering, ?teamIsValid',
 		'/members': 'Show member, with the teams they are in',
 		'/members/:login': 'Show member and the teams they are in, if it exists',
 	};

--- a/packages/github-lens-api/src/controller/teams.ts
+++ b/packages/github-lens-api/src/controller/teams.ts
@@ -1,7 +1,7 @@
 import type { RetrievedObject } from 'common/aws/s3';
 import type { Team } from 'common/model/github';
 import type express from 'express';
-import { filterRepos } from '../filters';
+import { filterRepos, filterTeams } from '../filters';
 
 export const getAllTeams = (
 	req: express.Request,
@@ -12,7 +12,10 @@ export const getAllTeams = (
 		return { ...team, repos: filterRepos(req, team.repos) };
 	});
 
-	const filteredTeamsData = { ...teamsData, payload: filteredTeams };
+	const filteredTeamsData = {
+		...teamsData,
+		payload: filterTeams(req, filteredTeams),
+	};
 
 	res.status(200).json(filteredTeamsData);
 };

--- a/packages/github-lens-api/src/validGithubTeams.ts
+++ b/packages/github-lens-api/src/validGithubTeams.ts
@@ -64,3 +64,14 @@ export const validGithubTeams = [
 	{ name: 'it-australia', engineering: false },
 	{ name: 'glabs-au', engineering: false },
 ];
+
+export const engineeringTeamSlugs = validGithubTeams
+	.filter((team) => team.engineering)
+	.map((team) => {
+		const { name } = team;
+		return name;
+	});
+
+export const validTeamSlugs = validGithubTeams.map((team) => {
+	return team.name;
+});


### PR DESCRIPTION
## What does this change?

This change adds the ability to filter the teams endpoints for valid / engineering teams based on the `validGithubTeams.ts` data.

## Why?

To allow this data to be used by repocop.
