### PR TITLE
chore(deps): `dotenv` is a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
       "dependencies": {
         "@types/jest": "^29.2.3",
         "@types/node": "^18.11.11",
-        "dotenv": "^16.0.1",
         "jest": "^29.3.1",
         "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
@@ -24,6 +23,7 @@
         "@guardian/prettier": "^2.1.5",
         "@guardian/tsconfig": "^0.2.0",
         "aws-sdk-client-mock": "^2.0.0",
+        "dotenv": "^16.0.1",
         "esbuild": "^0.15.16",
         "eslint-plugin-prettier": "^4.2.1"
       }
@@ -4797,6 +4797,7 @@
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
       "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -8746,6 +8747,7 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10244,8 +10246,7 @@
         "@octokit/auth-app": "^4.0.4",
         "@octokit/core": "^4.0.4",
         "@octokit/plugin-throttling": "^4.3.2",
-        "@octokit/rest": "^19.0.3",
-        "dotenv": "^16.0.1"
+        "@octokit/rest": "^19.0.3"
       }
     },
     "packages/github-lens-api": {
@@ -10253,7 +10254,6 @@
       "dependencies": {
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
-        "dotenv": "^10.0.0",
         "express": "^4.17.1",
         "express-async-handler": "^1.2.0"
       },
@@ -10263,13 +10263,6 @@
         "@types/express": "^4.17.12",
         "@types/supertest": "^2.0.11",
         "supertest": "^6.3.1"
-      }
-    },
-    "packages/github-lens-api/node_modules/dotenv": {
-      "version": "10.0.0",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=10"
       }
     },
     "packages/repocop": {
@@ -10282,7 +10275,6 @@
         "axios": "^1.2.1",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
-        "dotenv": "^10.0.0",
         "express": "^4.17.1",
         "express-async-handler": "^1.2.0"
       },
@@ -10292,13 +10284,6 @@
         "@types/express": "^4.17.12",
         "@types/supertest": "^2.0.11",
         "supertest": "^6.3.1"
-      }
-    },
-    "packages/services-api/node_modules/dotenv": {
-      "version": "10.0.0",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=10"
       }
     }
   },
@@ -14072,7 +14057,8 @@
     "dotenv": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "dev": true
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -15154,8 +15140,7 @@
         "@octokit/auth-app": "^4.0.4",
         "@octokit/core": "^4.0.4",
         "@octokit/plugin-throttling": "^4.3.2",
-        "@octokit/rest": "^19.0.3",
-        "dotenv": "^16.0.1"
+        "@octokit/rest": "^19.0.3"
       }
     },
     "github-lens-api": {
@@ -15167,15 +15152,9 @@
         "@types/supertest": "^2.0.11",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
-        "dotenv": "^10.0.0",
         "express": "^4.17.1",
         "express-async-handler": "^1.2.0",
         "supertest": "^6.3.1"
-      },
-      "dependencies": {
-        "dotenv": {
-          "version": "10.0.0"
-        }
       }
     },
     "glob": {
@@ -16962,7 +16941,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "qs": {
       "version": "6.11.0",
@@ -17276,15 +17256,9 @@
         "axios": "^1.2.1",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
-        "dotenv": "^10.0.0",
         "express": "^4.17.1",
         "express-async-handler": "^1.2.0",
         "supertest": "^6.3.1"
-      },
-      "dependencies": {
-        "dotenv": {
-          "version": "10.0.0"
-        }
       }
     },
     "setprototypeof": {

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "@guardian/prettier": "^2.1.5",
     "@guardian/tsconfig": "^0.2.0",
     "aws-sdk-client-mock": "^2.0.0",
+    "dotenv": "^16.0.1",
     "esbuild": "^0.15.16",
     "eslint-plugin-prettier": "^4.2.1"
   },
   "dependencies": {
     "@types/jest": "^29.2.3",
     "@types/node": "^18.11.11",
-    "dotenv": "^16.0.1",
     "jest": "^29.3.1",
     "ts-jest": "^29.0.3",
     "ts-node": "^10.9.1",

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -1,7 +1,4 @@
-import * as dotenv from 'dotenv';
 import { decrypt } from './aws/kms';
-
-dotenv.config({ path: `${__dirname}/../../../.env` });
 
 export type Stage = `INFRA` | 'DEV';
 

--- a/packages/github-data-fetcher/package.json
+++ b/packages/github-data-fetcher/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects github-data-fetcher",
     "build": "esbuild src/handler.ts --bundle --outdir=dist --platform=node --target=node16 --external:aws-sdk",
-    "dev": "ts-node ./src/handler",
+    "dev": "DOTENV_CONFIG_PATH=../../.env ts-node ./src/handler.ts",
     "typecheck": "tsc -noEmit"
   },
   "dependencies": {
@@ -14,7 +14,6 @@
     "@octokit/auth-app": "^4.0.4",
     "@octokit/core": "^4.0.4",
     "@octokit/plugin-throttling": "^4.3.2",
-    "@octokit/rest": "^19.0.3",
-    "dotenv": "^16.0.1"
+    "@octokit/rest": "^19.0.3"
   }
 }

--- a/packages/github-lens-api/package.json
+++ b/packages/github-lens-api/package.json
@@ -6,7 +6,7 @@
     "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects github-lens-api",
     "prebuild": "rm -rf dist",
     "build": "esbuild src/handler.ts --bundle --outdir=dist --platform=node --target=node16 --external:aws-sdk",
-    "dev": "LOCAL=true ts-node ./src/handler",
+    "dev": "DOTENV_CONFIG_PATH=../../.env ts-node ./src/handler.ts",
     "start": "npm run dev",
     "typecheck": "tsc -noEmit"
   },
@@ -20,7 +20,6 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
-    "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "express-async-handler": "^1.2.0"
   }

--- a/packages/services-api/package.json
+++ b/packages/services-api/package.json
@@ -6,7 +6,7 @@
     "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects services-api",
     "prebuild": "rm -rf dist",
     "build": "esbuild src/handler.ts --bundle --outdir=dist --platform=node --target=node16 --external:aws-sdk",
-    "dev": "LOCAL=true ts-node ./src/handler",
+    "dev": "DOTENV_CONFIG_PATH=../../.env ts-node ./src/handler.ts",
     "start": "npm run dev",
     "typecheck": "tsc -noEmit"
   },
@@ -22,7 +22,6 @@
     "axios": "^1.2.1",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
-    "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "express-async-handler": "^1.2.0"
   }


### PR DESCRIPTION
## What does this change?
We achieve configuration via environment variables (env vars).

Locally, we use the [`dotenv`](https://github.com/motdotla/dotenv) package to read env vars from disk (the `.env` file). In production, we set env vars via IaC.

This change:
  - Removes `dotenv` as an individual dependency from each project, favouring 1 version at the root
  - [Preloads](https://github.com/motdotla/dotenv#preload) `.env` via `DOTENV_CONFIG_PATH`, to remove any imports from `dotenv` in production code
  - Moves `dotenv` to `devDependencies` in the root `package.json`. This makes dependency management much easier too!

## Why?
Simplifies the repository.