### PR TITLE
chore: Quieten production logs

### DIFF
--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -202,7 +202,7 @@ async function getRepositoryLanguages(
 		repo: repositoryName,
 	});
 	const languages = Object.keys(response.data);
-	console.log(
+	console.debug(
 		`Repository ${repositoryName} uses languages: ${languages.join(', ')}`,
 	);
 	return languages;


### PR DESCRIPTION
## What does this change?
Convert the repo language log line to `debug`, to reduce volume of logs seen in production (as we don't log at debug level in production).

## Why?
Less noise makes it easier to find things.