### PR TITLE
fix: Correct valid values of `Stage`

### DIFF
--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -3,7 +3,7 @@ import { decrypt } from './aws/kms';
 
 dotenv.config({ path: `${__dirname}/../../../.env` });
 
-export type Stage = 'PROD' | 'CODE' | 'DEV';
+export type Stage = `INFRA` | 'DEV';
 
 export const mandatoryEncrypted = async (
 	item: string,


### PR DESCRIPTION
## What does this change?
- `DEV` when running locally
- [`INFRA` when running in AWS](https://github.com/guardian/service-catalogue/blob/main/packages/cdk/bin/cdk.ts)

## Why?
Because it's correct...

![img](https://media.giphy.com/media/1AeQ2tgUnqtswSuHQx/giphy.gif)