### PR TITLE
Make filter params accept boolean values

### DIFF
--- a/packages/github-lens-api/src/controller/describe.ts
+++ b/packages/github-lens-api/src/controller/describe.ts
@@ -5,12 +5,12 @@ function describeRoutes(path: string): string {
 	const infoByRoute: Record<string, string> = {
 		'/healthcheck': 'Display healthcheck',
 		'/repos':
-			'Show all repos, with their team owners, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived, ?repoIsNotArchived, ?repoNotOwned',
+			'Show all repos, with their team owners, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived=true|false, ?repoIsOwned=true|false',
 		'/repos/:name': 'Show repo and its team owners, if it exists',
 		'/teams':
-			'Show all teams, with the repositories they own, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived, ?repoIsNotArchived, ?teamIsEngineering, ?teamIsValid',
+			'Show all teams, with the repositories they own, optionally filter repositories ?repoName=^repo-name-regex.*, ?teamName=^repo-name-regex.*, ?repoIsArchived=true|false, ?repoIsOwned=true|false ?teamIsEngineering=true|false, ?teamIsValid=true|false',
 		'/teams/:slug':
-			'Show team with info, if it exists, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived, ?repoIsNotArchived, ?teamIsEngineering, ?teamIsValid',
+			'Show team with info, if it exists, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoName=^repo-name-regex.*, ?teamName=^repo-name-regex.*, ?repoIsArchived=true|false, ?repoIsOwned=true|false ?teamIsEngineering=true|false, ?teamIsValid=true|false',
 		'/members': 'Show member, with the teams they are in',
 		'/members/:login': 'Show member and the teams they are in, if it exists',
 	};

--- a/packages/github-lens-api/src/filters.ts
+++ b/packages/github-lens-api/src/filters.ts
@@ -33,14 +33,14 @@ export const repoFilters: RepoFilter[] = [
 		paramName: 'repoIsOwned',
 		fn: (repo: Repository, paramValue: string) => {
 			const repoIsOwned = repo.owners.length !== 0;
-			return paramValue === 'true' ? repoIsOwned : !repoIsOwned;
+			return paramValue === 'false' ? !repoIsOwned : repoIsOwned;
 		},
 	},
 	{
 		paramName: 'repoIsArchived',
 		fn: (repo: Repository, paramValue: string) => {
 			const repoIsArchived = repo.archived ?? false;
-			return paramValue === 'true' ? repoIsArchived : !repoIsArchived;
+			return paramValue === 'false' ? !repoIsArchived : repoIsArchived;
 		},
 	},
 ];
@@ -54,14 +54,14 @@ export const teamFilters: TeamFilter[] = [
 		paramName: 'teamIsEngineering',
 		fn: (team: Team, paramValue: string) => {
 			const teamIsEngineering = engineeringTeamSlugs.includes(team.slug);
-			return paramValue === 'true' ? teamIsEngineering : !teamIsEngineering;
+			return paramValue === 'false' ? !teamIsEngineering : teamIsEngineering;
 		},
 	},
 	{
 		paramName: 'teamIsValid',
 		fn: (team: Team, paramValue: string) => {
 			const teamIsValid = validTeamSlugs.includes(team.slug);
-			return paramValue === 'true' ? teamIsValid : !teamIsValid;
+			return paramValue === 'false' ? !teamIsValid : teamIsValid;
 		},
 	},
 ];

--- a/packages/github-lens-api/src/filters.ts
+++ b/packages/github-lens-api/src/filters.ts
@@ -30,16 +30,18 @@ export const repoFilters: RepoFilter[] = [
 		fn: (repo: Repository, paramValue: string) => !!repo.name.match(paramValue),
 	},
 	{
-		paramName: 'repoNotOwned',
-		fn: (repo: Repository) => repo.owners.length === 0,
+		paramName: 'repoIsOwned',
+		fn: (repo: Repository, paramValue: string) => {
+			const repoIsOwned = repo.owners.length !== 0;
+			return paramValue === 'true' ? repoIsOwned : !repoIsOwned;
+		},
 	},
 	{
 		paramName: 'repoIsArchived',
-		fn: (repo: Repository) => repo.archived ?? false,
-	},
-	{
-		paramName: 'repoIsNotArchived',
-		fn: (repo: Repository) => !(repo.archived ?? false),
+		fn: (repo: Repository, paramValue: string) => {
+			const repoIsArchived = repo.archived ?? false;
+			return paramValue === 'true' ? repoIsArchived : !repoIsArchived;
+		},
 	},
 ];
 
@@ -50,11 +52,17 @@ export const teamFilters: TeamFilter[] = [
 	},
 	{
 		paramName: 'teamIsEngineering',
-		fn: (team: Team) => engineeringTeamSlugs.includes(team.slug),
+		fn: (team: Team, paramValue: string) => {
+			const teamIsEngineering = engineeringTeamSlugs.includes(team.slug);
+			return paramValue === 'true' ? teamIsEngineering : !teamIsEngineering;
+		},
 	},
 	{
 		paramName: 'teamIsValid',
-		fn: (team: Team) => validTeamSlugs.includes(team.slug),
+		fn: (team: Team, paramValue: string) => {
+			const teamIsValid = validTeamSlugs.includes(team.slug);
+			return paramValue === 'true' ? teamIsValid : !teamIsValid;
+		},
 	},
 ];
 


### PR DESCRIPTION
## What does this change?

Allow some of the existing parameters to take a boolean value, so we can have fewer parameters and they are used in a less surprising way. The implementation naively looks for the addition of `=false` to the param, and uses only positive language so that the original param without the addition of boolean also works.

e.g.

- `/repos?repoIsArchived=false`: returns all repos where archived is false
- `/repos?repoIsArchived=true`: returns all repos where archived is true
- `/repos?repoIsArchived`: returns all repos where archived is true
- `/repos?repoIsArchived=purplehippos`: _also_ returns all repos where archived is true

Although this is _a bit weird_ I think it is good enough for our purposes.

## Why?

Slightly less surprised developers! 😮 