### PR TITLE
refactor: Automatically add filters to route info

### DIFF
--- a/packages/github-lens-api/src/controller/describe.ts
+++ b/packages/github-lens-api/src/controller/describe.ts
@@ -1,16 +1,22 @@
 import { getDescribeRouterHandler } from 'common/expressRoutes';
 import type { Router } from 'express';
+import { repoFilters, teamFilters } from '../filters';
 
 function describeRoutes(path: string): string {
+	const availableRepoFilters = repoFilters.map((_) => _.paramName).join(', ');
+	const availableTeamFilters = [
+		availableRepoFilters,
+		teamFilters.map((_) => _.paramName),
+	]
+		.flat()
+		.join(', ');
+
 	const infoByRoute: Record<string, string> = {
 		'/healthcheck': 'Display healthcheck',
-		'/repos':
-			'Show all repos, with their team owners, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived=true|false, ?repoIsOwned=true|false',
+		'/repos': `Show all repos, with their team owners. Available filters (applied as query strings): ${availableRepoFilters}`,
 		'/repos/:name': 'Show repo and its team owners, if it exists',
-		'/teams':
-			'Show all teams, with the repositories they own, optionally filter repositories ?repoName=^repo-name-regex.*, ?teamName=^repo-name-regex.*, ?repoIsArchived=true|false, ?repoIsOwned=true|false ?teamIsEngineering=true|false, ?teamIsValid=true|false',
-		'/teams/:slug':
-			'Show team with info, if it exists, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoName=^repo-name-regex.*, ?teamName=^repo-name-regex.*, ?repoIsArchived=true|false, ?repoIsOwned=true|false ?teamIsEngineering=true|false, ?teamIsValid=true|false',
+		'/teams': `Show all teams, with the repositories they own. Available filters (applied as query strings): ${availableTeamFilters}`,
+		'/teams/:slug': `Show team with info, if it exists. Available filters (applied as query strings): ${availableTeamFilters}`,
 		'/members': 'Show member, with the teams they are in',
 		'/members/:login': 'Show member and the teams they are in, if it exists',
 	};

--- a/packages/github-lens-api/src/filters.ts
+++ b/packages/github-lens-api/src/filters.ts
@@ -2,12 +2,25 @@ import type { Repository, Team } from 'common/model/github';
 import type express from 'express';
 import { engineeringTeamSlugs, validTeamSlugs } from './validGithubTeams';
 
-interface TFilter<T> {
+interface TFilter<T extends Team | Repository> {
+	/**
+	 * The URL query string to observe to activate the filter.
+	 *
+	 * Currently, the value will always come in as a `string`.
+	 * Try to denote the type in the name. For example `isX` or `hasX` for boolean.
+	 */
 	paramName: string;
-	fn: (r: T, paramValue: string) => boolean;
+
+	/**
+	 * A function that returns `true` if the entity matches the filter, `false` otherwise.
+	 *
+	 * @param entity what to filter on
+	 * @param paramValue the (raw) value of the query string
+	 */
+	fn: (entity: T, paramValue: string) => boolean;
 }
 
-const filterT = <T>(
+const filterT = <T extends Team | Repository>(
 	req: express.Request,
 	t: T[],
 	filters: Array<TFilter<T>>,


### PR DESCRIPTION
## What does this change?
Automatically add the available filters to the index page. This makes it easier to keep the two in-sync, at the cost of removing the `type` description. However, the type could/should be implied by the name (e.g. `isX` is a boolean).

### Before
```json
[
  {
    "path": "http://localhost:3232/healthcheck",
    "methods": [
      "get"
    ],
    "info": "Display healthcheck"
  },
  {
    "path": "http://localhost:3232/repos",
    "methods": [
      "get"
    ],
    "info": "Show all repos, with their team owners, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoIsArchived=true|false, ?repoIsOwned=true|false"
  },
  {
    "path": "http://localhost:3232/repos/:name",
    "methods": [
      "get"
    ],
    "info": "Show repo and its team owners, if it exists"
  },
  {
    "path": "http://localhost:3232/teams",
    "methods": [
      "get"
    ],
    "info": "Show all teams, with the repositories they own, optionally filter repositories ?repoName=^repo-name-regex.*, ?teamName=^repo-name-regex.*, ?repoIsArchived=true|false, ?repoIsOwned=true|false ?teamIsEngineering=true|false, ?teamIsValid=true|false"
  },
  {
    "path": "http://localhost:3232/teams/:slug",
    "methods": [
      "get"
    ],
    "info": "Show team with info, if it exists, optionally filter repositories ?repoName=^repo-name-regex.*, ?repoName=^repo-name-regex.*, ?teamName=^repo-name-regex.*, ?repoIsArchived=true|false, ?repoIsOwned=true|false ?teamIsEngineering=true|false, ?teamIsValid=true|false"
  },
  {
    "path": "http://localhost:3232/members",
    "methods": [
      "get"
    ],
    "info": "Show member, with the teams they are in"
  },
  {
    "path": "http://localhost:3232/members/:login",
    "methods": [
      "get"
    ],
    "info": "Show member and the teams they are in, if it exists"
  }
]
```

### After
```json
[
  {
    "path": "http://localhost:3232/healthcheck",
    "methods": [
      "get"
    ],
    "info": "Display healthcheck"
  },
  {
    "path": "http://localhost:3232/repos",
    "methods": [
      "get"
    ],
    "info": "Show all repos, with their team owners. Available filters (applied as query strings): repoName, repoIsOwned, repoIsArchived"
  },
  {
    "path": "http://localhost:3232/repos/:name",
    "methods": [
      "get"
    ],
    "info": "Show repo and its team owners, if it exists"
  },
  {
    "path": "http://localhost:3232/teams",
    "methods": [
      "get"
    ],
    "info": "Show all teams, with the repositories they own. Available filters (applied as query strings): repoName, repoIsOwned, repoIsArchived, teamName, teamIsEngineering, teamIsValid"
  },
  {
    "path": "http://localhost:3232/teams/:slug",
    "methods": [
      "get"
    ],
    "info": "Show team with info, if it exists. Available filters (applied as query strings): repoName, repoIsOwned, repoIsArchived, teamName, teamIsEngineering, teamIsValid"
  },
  {
    "path": "http://localhost:3232/members",
    "methods": [
      "get"
    ],
    "info": "Show member, with the teams they are in"
  },
  {
    "path": "http://localhost:3232/members/:login",
    "methods": [
      "get"
    ],
    "info": "Show member and the teams they are in, if it exists"
  }
]
```

## Why?
Fewer things to remember to keep up to date.

## How has it been verified?
By running locally.