### PR TITLE
Add last commit to repos endpoint

### DIFF
--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { createAppAuth } from '@octokit/auth-app';
 import { throttling } from '@octokit/plugin-throttling';
 import { Octokit } from '@octokit/rest';
@@ -176,6 +177,7 @@ export async function getLanguagesForRepositories(
 	client: Octokit,
 	repositories: RepositoriesResponse,
 ): Promise<Record<string, string[]>> {
+	console.log('Get repo languages');
 	const data = await Promise.all(
 		repositories.map(async ({ name }) => {
 			const languages = await getRepositoryLanguages(client, name);
@@ -213,10 +215,16 @@ export async function getLastCommitForRepositories(
 	client: Octokit,
 	repositories: RepositoriesResponse,
 ): Promise<Record<string, Commit>> {
+	console.log('Get last commits for repos');
 	const data = await Promise.all(
 		repositories
 			.filter((repository) => {
 				const repositoryIsEmpty = repository.size === 0;
+				if (repositoryIsEmpty) {
+					console.log(
+						`Repository ${repository.name} is empty so there is also no last commit`,
+					);
+				}
 				const hasDefaultBranch = repository.default_branch !== undefined;
 				if (!hasDefaultBranch) {
 					console.log(

--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -246,27 +246,22 @@ export async function getLastCommitForRepositories(
 	}, {});
 }
 
-async function getRepositoryLastCommit(
+export async function getRepositoryLastCommit(
 	client: Octokit,
 	repositoryName: string,
 	defaultBranch: string,
 ): Promise<Commit | undefined> {
-	try {
-		const response = await client.repos.getCommit({
-			owner: 'guardian',
-			repo: repositoryName,
-			per_page: 1,
-			ref: defaultBranch,
-		});
-		const lastCommit = response.data;
-		return {
-			message: lastCommit.commit.message,
-			author: lastCommit.commit.author?.name,
-			date: lastCommit.commit.author?.date,
-			sha: lastCommit.sha,
-		};
-	} catch {
-		console.log('Repository ' + repositoryName + ' has no commits');
-		return undefined;
-	}
+	const response = await client.repos.getCommit({
+		owner: 'guardian',
+		repo: repositoryName,
+		per_page: 1,
+		ref: defaultBranch,
+	});
+	const lastCommit = response.data;
+	return {
+		message: lastCommit.commit.message,
+		author: lastCommit.commit.author?.name,
+		date: lastCommit.commit.author?.date,
+		sha: lastCommit.sha,
+	};
 }

--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -246,7 +246,7 @@ export async function getLastCommitForRepositories(
 	}, {});
 }
 
-export async function getRepositoryLastCommit(
+async function getRepositoryLastCommit(
 	client: Octokit,
 	repositoryName: string,
 	defaultBranch: string,

--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { createAppAuth } from '@octokit/auth-app';
 import { throttling } from '@octokit/plugin-throttling';
 import { Octokit } from '@octokit/rest';

--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -2,8 +2,8 @@ import { createAppAuth } from '@octokit/auth-app';
 import { throttling } from '@octokit/plugin-throttling';
 import { Octokit } from '@octokit/rest';
 import type { GetResponseDataTypeFromEndpointMethod } from '@octokit/types';
+import type { Commit } from 'common/model/github';
 import { sleep } from '../sleep';
-import { Commit } from 'common/model/github';
 
 const ThrottledOctokit = Octokit.plugin(throttling);
 const defaultPageSize = 100;
@@ -236,7 +236,7 @@ async function getRepositoryLastCommit(
 	repositoryName: string,
 ): Promise<Commit | undefined> {
 	try {
-		let response = await client.request(`GET /repos/{owner}/{repo}/commits`, {
+		const response = await client.request(`GET /repos/{owner}/{repo}/commits`, {
 			owner: 'guardian',
 			repo: repositoryName,
 			per_page: 1,

--- a/packages/common/src/model/github.ts
+++ b/packages/common/src/model/github.ts
@@ -15,6 +15,7 @@ export interface Repository {
 	topics: string[] | undefined;
 	default_branch: string | undefined;
 	owners: string[];
+	lastCommit: string[];
 }
 
 export interface Team {

--- a/packages/common/src/model/github.ts
+++ b/packages/common/src/model/github.ts
@@ -15,7 +15,7 @@ export interface Repository {
 	topics: string[] | undefined;
 	default_branch: string | undefined;
 	owners: string[];
-	lastCommit: string[];
+	lastCommit?: Commit;
 }
 
 export interface Team {
@@ -23,6 +23,13 @@ export interface Team {
 	name: string;
 	slug: string;
 	repos: Repository[];
+}
+
+export interface Commit {
+	message: string;
+	author?: string;
+	date?: string;
+	sha?: string;
 }
 
 export interface Member {

--- a/packages/github-data-fetcher/src/handler.ts
+++ b/packages/github-data-fetcher/src/handler.ts
@@ -6,7 +6,6 @@ import {
 	getLastCommitForRepositories,
 	getOctokit,
 	getReposForTeam,
-	getRepositoryLastCommit,
 	getTeam,
 	listMembers,
 	listRepositories,
@@ -85,6 +84,9 @@ async function getGHData(
 	// Get all repositories
 	let repositories = await listRepositories(client);
 
+	//TODO implement better way to test on dev
+	//repositories = repositories.slice(0, 10);
+
 	console.log(`Found ${repositories.length} github repos`);
 
 	// Get all organisation members
@@ -119,7 +121,7 @@ async function getGHData(
 			repository,
 			repositoriesToAdmins[repository.name] ?? [],
 			repositoryLanguages[repository.name] ?? [],
-			repositoryLastCommit[repository.name] ?? [],
+			repositoryLastCommit[repository.name],
 		);
 	});
 	console.log('Join repositories to teams');
@@ -132,7 +134,7 @@ async function getGHData(
 			repository,
 			repositoriesToAdmins[repository.name] ?? [],
 			repositoryLanguages[repository.name] ?? [],
-			repositoryLastCommit[repository.name] ?? [],
+			repositoryLastCommit[repository.name],
 		);
 
 		adminTeamSlugs.forEach((adminSlug: string) => {
@@ -173,16 +175,7 @@ export const main = async (): Promise<void> => {
 	const githubClient = getOctokit(config.github);
 	const s3Client = getS3Client(config.region);
 
-	const lastCommitRiffRaff = getRepositoryLastCommit(githubClient, 'riff-raff');
-	console.log(lastCommitRiffRaff);
-
 	const ghData = await getGHData(githubClient, config.github.teamToFetch);
-
-	const lastCommit = getRepositoryLastCommit(
-		githubClient,
-		'test-interactive-repo',
-	);
-	console.log(lastCommit);
 
 	const saveObject = async <T>(name: string, data: T) => {
 		const repoFileLocation = path.join(config.dataKeyPrefix, `${name}.json`);

--- a/packages/github-data-fetcher/src/handler.ts
+++ b/packages/github-data-fetcher/src/handler.ts
@@ -82,7 +82,7 @@ async function getGHData(
 	console.log(`Found ${teams.length} github teams`);
 
 	// Get all repositories
-	let repositories = await listRepositories(client);
+	const repositories = await listRepositories(client);
 
 	//TODO implement better way to test on dev
 	//repositories = repositories.slice(0, 10);

--- a/packages/github-data-fetcher/src/handler.ts
+++ b/packages/github-data-fetcher/src/handler.ts
@@ -106,13 +106,11 @@ async function getGHData(
 		client,
 		repositories,
 	);
-	console.log('Get repo languages');
 
 	const repositoryLastCommit = await getLastCommitForRepositories(
 		client,
 		repositories,
 	);
-	console.log('Get last commits for repos');
 
 	// Join repositories to teams
 	const repositoriesToAdmins = await teamRepositories(client, teamSlugs);

--- a/packages/github-data-fetcher/src/transformations.ts
+++ b/packages/github-data-fetcher/src/transformations.ts
@@ -3,7 +3,7 @@ import type {
 	RepositoryResponse,
 	TeamRepoResponse,
 } from 'common/github/github';
-import type { Member, Repository } from 'common/model/github';
+import type { Commit, Member, Repository } from 'common/model/github';
 
 const parseDateString = (
 	dateString: string | null | undefined,
@@ -31,7 +31,7 @@ export const asRepo = (
 	repo: RepositoryResponse,
 	owners: string[],
 	languages: string[],
-	lastCommit: string[],
+	lastCommit?: Commit,
 ): Repository => {
 	return {
 		id: repo.id,

--- a/packages/github-data-fetcher/src/transformations.ts
+++ b/packages/github-data-fetcher/src/transformations.ts
@@ -31,6 +31,7 @@ export const asRepo = (
 	repo: RepositoryResponse,
 	owners: string[],
 	languages: string[],
+	lastCommit: string[],
 ): Repository => {
 	return {
 		id: repo.id,
@@ -49,6 +50,7 @@ export const asRepo = (
 		default_branch: repo.default_branch,
 		owners,
 		languages,
+		lastCommit,
 	};
 };
 


### PR DESCRIPTION
Add last commit to repos endpoint

## What does this change?
Adds info about last commit to repos api endpoint (if there are any)

It now works for all repos

## Why?
For Repocop: Natasha: When we run snyk we send the commit hash with it to tag the project. If we can see that the hash snyk has matches the one github has at the head of the default branch (which is only mostly called main, it could be called something else), then we know that it's up to date

## How has it been verified?
Paired with Nic added sha and cleaned up code
Turned out my problems were rate limit related outside of scope of this PR.

There are repos without commits.

Paired with Akash to fix issue with repos with master branch

Repository test-interactive-repo has no commits
Repository interactive-rooney-england-goals has no commits
Repository newgreekdebt2 has no commits
Repository gdn-style-guide-scraper has no commits
Repository interactive-nhs-budget has no commits
Repository pluto_image_uploader has no commits
Repository transfer-tree-2016 has no commits
Repository r2-archive-platform has no commits
Repository interactive-leicester-season-table has no commits
Repository interactive-feedback has no commits
Repository we-should-protect-things has no commits
Repository interactive-euro-2016-wallchart has no commits
Repository euro-2016-wallchart has no commits
Repository interactive-euro2016-wallchart has no commits
Repository print-referendum has no commits
Repository team-gb-gallery has no commits
Repository funnel has no commits
Repository interactive-vertical-slideshow has no commits
Repository interactive-vertical-slideshow-tool has no commits
Repository interactive-nhs-deficit has no commits
Repository interactive-cricket-match has no commits
Repository interactive-fsa has no commits
Repository interactive-fsa-map has no commits
Repository interactive-yemen-airstrikes has no commits
Repository interactive-inline-video-loop has no commits
Repository interactive-membership-page-enhancer has no commits
Repository testaagain has no commits
Repository interactive-retirement-enhancements has no commits
Repository interactive-atom-parkour has no commits
Repository interactive-french-elex-cards-all has no commits
Repository page-enhancer-back-to-top-btn has no commits
Repository fulfilment-uploader-lambda has no commits
Repository interactive-page-tidy-text has no commits
Repository visuals-documentation has no commits
Repository interactive-atom-th has no commits
Repository interactive-brexit-comparison has no commits
Repository interactive-stranger-things has no commits
Repository 2016-aus-election-results has no commits
Repository aus-mdb-river-2018 has no commits
Repository interactive-player-ratings-analysis has no commits
Repository interactive-generic-maps has no commits
Repository kee has no commits
Repository testtest has no commits
Repository duplo has no commits
Repository aus-lobbyists-2018 has no commits
Repository tools-dashboard has no commits
Repository au-macos-1013 has no commits
Repository interactive-test has no commits
Repository theguardian.engineering has no commits
Repository interactive-populism-scatterplots has no commits
Repository interactive-deforestation has no commits
Repository interactive-ep-elex-2019 has no commits
Repository guardian-essential-poll-tables has no commits
Repository interactive-atom-leader-2019 has no commits
Repository interactive-test-enhancer has no commits
Repository interactive-atom-design-3 has no commits
Repository interactive-flightradar has no commits
Repository braze-diff-publisher has no commits
Repository interactive-covid-stock-markets has no commits
Repository interactive-biodiversity has no commits
Repository interactive-covid-uk-estimated-areas has no commits
Repository interactive-congestion-tiles has no commits
Repository rendering has no commits
Repository interactive-atom-200-fonts has no commits
Repository interactive-french-poll-fetcher has no commits
Repository interactive-airbnb has no commits
Repository infosec-thehive has no commits
Repository infosec-central-gam has no commits
Repository interactive-supply-chain-map has no commits
Repository membership-platform has no commits
Repository Personalisation has no commits
Repository maplibre-terrain-example has no commits
Repository 2022-aus-census-analysis has no commits


