### PR TITLE
simplify hook setup

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,12 +1,20 @@
 #!/bin/zsh
 
+MSG='
+RepoCop changes detected"
+
+Running markdown snapshot test. If this fails, regenerate the markdown file, stage the changes, and commit again
+Run
+    sbt "runMain com.gu.repocop.markdown"
+from the repocop root.
+It can take several seconds for sbt to start up. Sit tight...
+'
 
 REPOCOP_CHANGES=$(git status --short packages/repocop/)
 if [[ -n "$REPOCOP_CHANGES" ]]
 then
-    printf "RepoCop changes detected"
-    printf "\n\nRunning markdown snapshot test. If this fails, regenerate the markdown file, stage the changes, and commit again"
-    printf "\nIt can take several seconds for sbt to start up. Sit tight...\n\n"
+    # shellcheck disable=SC2090
+    echo "${MSG}"
     (cd packages/repocop && sbt "testOnly *MarkdownSpec")
 else
     echo "No repocop changes detected, skipping git hook"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/zsh
+
+
+REPOCOP_CHANGES=$(git status --short packages/repocop/)
+if [[ -n "$REPOCOP_CHANGES" ]]
+then
+    printf "RepoCop changes detected"
+    printf "\n\nRunning markdown snapshot test. If this fails, regenerate the markdown file, stage the changes, and commit again"
+    printf "\nIt can take several seconds for sbt to start up. Sit tight...\n\n"
+    (cd packages/repocop && sbt "testOnly *MarkdownSpec")
+else
+    echo "No repocop changes detected, skipping git hook"
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,20 +11,7 @@ STACK=deploy
 
 setup_git_hook() {
   echo "Setting up repocop pre-commit hook"
-  printf '#!/bin/sh
-
-
-REPOCOP_CHANGES=$(git status --short packages/repocop/)
-if [[ -n "$REPOCOP_CHANGES" ]]
-then
-    printf "RepoCop changes detected"
-    printf "\n\nRunning markdown snapshot test. If this fails, regenerate the markdown file, stage the changes, and commit again"
-    printf "\nIt can take several seconds for sbt to start up. Sit tight...\n\n"
-    (cd packages/repocop && sbt "testOnly *MarkdownSpec")
-else
-    echo "No repocop changes detected, skipping git hook"
-fi
-' > "${ROOT_DIR}/.git/hooks/pre-commit"
+  cp "${ROOT_DIR}/scripts/pre-commit" "${ROOT_DIR}/.git/hooks/pre-commit"
 
 chmod +x "${ROOT_DIR}/.git/hooks/pre-commit"
 }


### PR DESCRIPTION
## What does this change?

extracts pre hook commit to its own file

## Why?

easier to read, easier to test

## How has it been verified?

deleted the hook from .git, reran the setup script, verified that the hook still works.
