### PR TITLE
Reduce requests made to github

### DIFF
--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -221,17 +221,7 @@ export async function getLastCommitForRepositories(
 		repositories
 			.filter((repository) => {
 				const repositoryIsEmpty = repository.size === 0;
-				if (repositoryIsEmpty) {
-					console.log(
-						`Repository ${repository.name} is empty so there is also no last commit`,
-					);
-				}
 				const hasDefaultBranch = repository.default_branch !== undefined;
-				if (!hasDefaultBranch) {
-					console.log(
-						`Repository ${repository.name} has no default branch so there is also no last commit`,
-					);
-				}
 				return hasDefaultBranch && !repositoryIsEmpty;
 			})
 			.map(async ({ name, default_branch }) => {

--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -94,7 +94,7 @@ export const getOctokit = (config: GitHubConfig): Octokit => {
 	return _octokit;
 };
 
-export const listRepositories = async (
+export const getReposFromGitHub = async (
 	client: Octokit,
 ): Promise<RepositoriesResponse> => {
 	return await client.paginate(

--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -97,7 +97,7 @@ export const getOctokit = (config: GitHubConfig): Octokit => {
 export const getReposFromGitHub = async (
 	client: Octokit,
 ): Promise<RepositoriesResponse> => {
-	return await client.paginate(
+	const repos: RepositoriesResponse = await client.paginate(
 		client.repos.listForOrg,
 		{
 			org: 'guardian',
@@ -105,6 +105,8 @@ export const getReposFromGitHub = async (
 		},
 		(response) => response.data,
 	);
+	console.log(`Found ${repos.length} repositories on Github`);
+	return repos;
 };
 
 export const getTeam = async (

--- a/packages/github-data-fetcher/src/handler.ts
+++ b/packages/github-data-fetcher/src/handler.ts
@@ -179,35 +179,6 @@ export const main = async (): Promise<void> => {
 	const config = await getConfig();
 	configureLogging(getLogLevel(config.logLevel));
 
-	function timestampsMatch(
-		oldRepo: Repository,
-		newRepo: RepositoryResponse,
-	): boolean {
-		if (newRepo.updated_at && newRepo.pushed_at) {
-			const matchingUpdateTime =
-				new Date(newRepo.updated_at) === oldRepo.updated_at;
-			const matchingPushTime =
-				new Date(newRepo.pushed_at) === oldRepo.pushed_at;
-			return matchingPushTime && matchingUpdateTime;
-		} else {
-			return false;
-		}
-	}
-
-	function foundUnchangedMatchOnGithub(
-		oldRepo: Repository,
-		newRepos: RepositoriesResponse,
-	): boolean {
-		const matchingRepo: RepositoryResponse | undefined = newRepos.find(
-			(newRepo) => newRepo.name === oldRepo.name,
-		);
-		if (matchingRepo) {
-			return timestampsMatch(oldRepo, matchingRepo);
-		} else {
-			return false;
-		}
-	}
-
 	console.log('Starting github-data-fetcher');
 
 	const githubClient = getOctokit(config.github);

--- a/packages/github-data-fetcher/src/repoMatching.test.ts
+++ b/packages/github-data-fetcher/src/repoMatching.test.ts
@@ -1,12 +1,12 @@
 import type { RepositoryResponse } from 'common/github/github';
 import { mockRepo } from './mockRepo';
-import { foundUnchangedMatchOnGithub } from './repoMatching';
+import { isCachedRepositoryStale } from './repoMatching';
 import { asRepo } from './transformations';
 
 describe('a positive date match', function () {
 	it('should be confirmed if dates match up exactly', function () {
 		const finalRepoObject = asRepo(mockRepo, [], []);
-		const actual = foundUnchangedMatchOnGithub(finalRepoObject, [mockRepo]);
+		const actual = isCachedRepositoryStale(finalRepoObject, [mockRepo]);
 		const expected = true;
 		expect(actual).toStrictEqual(expected);
 	});
@@ -14,7 +14,7 @@ describe('a positive date match', function () {
 		const GHRepo: RepositoryResponse = mockRepo;
 		GHRepo.updated_at = null;
 		const s3Repo = asRepo(GHRepo, [], []);
-		const actual = foundUnchangedMatchOnGithub(s3Repo, [GHRepo]);
+		const actual = isCachedRepositoryStale(s3Repo, [GHRepo]);
 		const expected = false;
 		expect(actual).toStrictEqual(expected);
 	});
@@ -24,7 +24,7 @@ describe('a positive date match', function () {
 		const s3Repo = asRepo(GHRepo, [], []);
 		s3Repo.updated_at = new Date('1989-10-10');
 
-		const actual = foundUnchangedMatchOnGithub(s3Repo, [GHRepo]);
+		const actual = isCachedRepositoryStale(s3Repo, [GHRepo]);
 		const expected = false;
 		expect(actual).toStrictEqual(expected);
 	});

--- a/packages/github-data-fetcher/src/repoMatching.test.ts
+++ b/packages/github-data-fetcher/src/repoMatching.test.ts
@@ -1,0 +1,16 @@
+import { mockRepo } from './mockRepo';
+import { foundUnchangedMatchOnGithub } from './repoMatching';
+import { asRepo } from './transformations';
+
+describe('a positive date match', function () {
+	it('should be confirmed if dates match up exactly', function () {
+		const finalRepoObject = asRepo(mockRepo, [], []);
+
+		expect(
+			foundUnchangedMatchOnGithub(finalRepoObject, [mockRepo]),
+		).toStrictEqual(true);
+	});
+	it('should not be confirmed if any date returned is a null', function () {
+		expect(true).toStrictEqual(true);
+	});
+});

--- a/packages/github-data-fetcher/src/repoMatching.test.ts
+++ b/packages/github-data-fetcher/src/repoMatching.test.ts
@@ -1,3 +1,4 @@
+import type { RepositoryResponse } from 'common/github/github';
 import { mockRepo } from './mockRepo';
 import { foundUnchangedMatchOnGithub } from './repoMatching';
 import { asRepo } from './transformations';
@@ -5,12 +6,26 @@ import { asRepo } from './transformations';
 describe('a positive date match', function () {
 	it('should be confirmed if dates match up exactly', function () {
 		const finalRepoObject = asRepo(mockRepo, [], []);
-
-		expect(
-			foundUnchangedMatchOnGithub(finalRepoObject, [mockRepo]),
-		).toStrictEqual(true);
+		const actual = foundUnchangedMatchOnGithub(finalRepoObject, [mockRepo]);
+		const expected = true;
+		expect(actual).toStrictEqual(expected);
 	});
-	it('should not be confirmed if any date returned is a null', function () {
-		expect(true).toStrictEqual(true);
+	it('should not be confirmed if there are matching nulls', function () {
+		const GHRepo: RepositoryResponse = mockRepo;
+		GHRepo.updated_at = null;
+		const s3Repo = asRepo(GHRepo, [], []);
+		const actual = foundUnchangedMatchOnGithub(s3Repo, [GHRepo]);
+		const expected = false;
+		expect(actual).toStrictEqual(expected);
+	});
+	it('should not be confirmed if some dates are different', function () {
+		const GHRepo: RepositoryResponse = mockRepo;
+		GHRepo.updated_at = '2020-01-01';
+		const s3Repo = asRepo(GHRepo, [], []);
+		s3Repo.updated_at = new Date('1989-10-10');
+
+		const actual = foundUnchangedMatchOnGithub(s3Repo, [GHRepo]);
+		const expected = false;
+		expect(actual).toStrictEqual(expected);
 	});
 });

--- a/packages/github-data-fetcher/src/repoMatching.ts
+++ b/packages/github-data-fetcher/src/repoMatching.ts
@@ -1,0 +1,45 @@
+import type {
+	RepositoriesResponse,
+	RepositoryResponse,
+} from 'common/github/github';
+import type { Repository } from 'common/model/github';
+
+function timestampsMatch(
+	oldRepo: Repository,
+	newRepo: RepositoryResponse,
+): boolean {
+	if (
+		newRepo.updated_at &&
+		newRepo.pushed_at &&
+		oldRepo.updated_at &&
+		oldRepo.pushed_at
+	) {
+		const newUpdate: number = new Date(newRepo.updated_at).getTime();
+		const oldUpdate: number = new Date(oldRepo.updated_at).getTime();
+		const newPush: number = new Date(newRepo.pushed_at).getTime();
+		const oldPush: number = new Date(oldRepo.pushed_at).getTime();
+		const matchingUpdateTime = newUpdate == oldUpdate;
+		const matchingPushTime = newPush == oldPush;
+		return matchingPushTime && matchingUpdateTime;
+	} else {
+		return false;
+	}
+}
+
+export function foundUnchangedMatchOnGithub(
+	oldRepo: Repository,
+	newRepos: RepositoriesResponse,
+): boolean {
+	const matchingRepo: RepositoryResponse | undefined = newRepos.find(
+		(newRepo) => newRepo.name === oldRepo.name,
+	);
+	if (matchingRepo) {
+		const matchFound: boolean = timestampsMatch(oldRepo, matchingRepo);
+		if (matchFound) {
+			console.log(`match found! ${oldRepo.name}`);
+		}
+		return matchFound;
+	} else {
+		return false;
+	}
+}

--- a/packages/github-data-fetcher/src/repoMatching.ts
+++ b/packages/github-data-fetcher/src/repoMatching.ts
@@ -18,15 +18,15 @@ function timestampsMatch(
 		const oldUpdate: number = new Date(oldRepo.updated_at).getTime();
 		const newPush: number = new Date(newRepo.pushed_at).getTime();
 		const oldPush: number = new Date(oldRepo.pushed_at).getTime();
-		const matchingUpdateTime = newUpdate == oldUpdate;
-		const matchingPushTime = newPush == oldPush;
+		const matchingUpdateTime = newUpdate === oldUpdate;
+		const matchingPushTime = newPush === oldPush;
 		return matchingPushTime && matchingUpdateTime;
 	} else {
 		return false;
 	}
 }
 
-export function foundUnchangedMatchOnGithub(
+export function isCachedRepositoryStale(
 	oldRepo: Repository,
 	newRepos: RepositoriesResponse,
 ): boolean {

--- a/packages/github-data-fetcher/src/repoMatching.ts
+++ b/packages/github-data-fetcher/src/repoMatching.ts
@@ -34,11 +34,7 @@ export function foundUnchangedMatchOnGithub(
 		(newRepo) => newRepo.name === oldRepo.name,
 	);
 	if (matchingRepo) {
-		const matchFound: boolean = timestampsMatch(oldRepo, matchingRepo);
-		if (matchFound) {
-			console.log(`match found! ${oldRepo.name}`);
-		}
-		return matchFound;
+		return timestampsMatch(oldRepo, matchingRepo);
 	} else {
 		return false;
 	}


### PR DESCRIPTION
## What does this change?

Affected GitHub requests, assuming ~3000 repos
Previously, we were making multiple requests for every repository to gather all the metadata fresh. Now, we run the initial requests to get the basic metadata, and only make further requests for information if we detect that the repo has been updated.

With a several day gap between successful runs, the calls to the language and commit endpoints have been reduced from about 3200 each to about 80 each, a reduction of about 98% 🥳🥳🥳. **n.b no changes have been made do how we interact with other endpoints. I'd guesstimate that it would be closer to 90% once all unchanged requests have been factored in**

## Why?

The data fetcher has been failing for the last few days as recent changes mean we are now exceeding the rate limit. This had not been detected previously as the local config runs only a subset of the repositories. Only making additional requests for a subset of repositories keeps us under the limit, and greatly reduces the running time of the lambda.

## How has it been verified?

Unit tests have been written to verify that timestamp matching works. Extra logging has been added to the handler so users can sense check the number of modified repos.
