### PR TITLE
Sets a timeout for the CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
       - main
 jobs:
   CI:
+    timeout-minutes: 1
     runs-on: ubuntu-latest
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
       - main
 jobs:
   CI:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
       - main
 jobs:
   CI:
-    timeout-minutes: 1
+    timeout-minutes: 10
     runs-on: ubuntu-latest
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token


### PR DESCRIPTION
Co-authored-by: @tjsilver 

## What does this change?

The default timeout for a GHA is 360 minutes (6 hours). Normally this step completes in about 5 minutes, so we've lowered the timeout

## Why?

6 hours seemed like too many.

I think this could be rolled out to other actions too.

## How has it been verified?

Initially the timeout was set to 1 minute, which failed as there was not enough time for the process complete. It was then set to 10 minutes, and passed.
<img width="1204" alt="Screenshot 2023-02-20 at 16 05 18" src="https://user-images.githubusercontent.com/67543397/220154377-7852b66f-98a7-4c58-bd8b-ea903962316c.png">
