### PR TITLE
chore(cloudformation-lens): Use `arm64-focal-java11-deploy-infrastructure` based AMI

### DIFF
--- a/packages/cdk/lib/cloudformation-lens.ts
+++ b/packages/cdk/lib/cloudformation-lens.ts
@@ -71,7 +71,7 @@ systemctl start ${name}
 			certificateProps: { domainName },
 			scaling: { minimumInstances: 1, maximumInstances: 2 },
 			userData: userData,
-			imageRecipe: 'arm64-bionic-java11-deploy-infrastructure', // TODO should we create a minimal Amigo recipe for this?
+			imageRecipe: 'arm64-focal-java11-deploy-infrastructure', // TODO should we create a minimal Amigo recipe for this?
 			applicationLogging: { enabled: true },
 		});
 


### PR DESCRIPTION
## What does this change?
Use the AMIgo recipe `arm64-focal-java11-deploy-infrastructure` for the cloudformation-lens service.

## Why?
The [previous recipe](https://amigo.gutools.co.uk/recipes/arm64-focal-java11-deploy-infrastructure) is based on Ubuntu 18.04 which leaves [standard support](https://ubuntu.com/about/release-cycle) in April 2023.

This [new recipe](https://amigo.gutools.co.uk/recipes/arm64-bionic-java11-deploy-infrastructure) is based on Ubuntu 20.04.

## How has it been verified?
1. [Deploy](https://riffraff.gutools.co.uk/deployment/view/5410401a-91be-433a-afd7-0775aba8673d) this branch (there is only one stage, INFRA)
2. The AMI used should be based on focal. Check using [SSM](https://github.com/guardian/ssm-scala):
   
   ```sh
   ssm cmd -p deployTools -t cloudformation-lens,deploy,INFRA --cmd "cat /etc/lsb-release"
   ```
   ```console
   ➜ ssm cmd -p deployTools -t cloudformation-lens,deploy,INFRA --cmd "cat /etc/lsb-release"
   ========= i-0c602bf1199378dce =========
   STDOUT:
   DISTRIB_ID=Ubuntu
   DISTRIB_RELEASE=20.04
   DISTRIB_CODENAME=focal
   DISTRIB_DESCRIPTION="Ubuntu 20.04.5 LTS"
   
   STDERR:
   
   
   ```