### PR TITLE
Remove non-null assertion

### DIFF
--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -228,7 +228,7 @@ export async function getLastCommitForRepositories(
 				const lastCommits = await getRepositoryLastCommit(
 					client,
 					name,
-					default_branch!,
+					default_branch,
 				);
 				return {
 					repository: name,


### PR DESCRIPTION
Co-authored-by: @NovemberTang 

## What does this change?

Removes the non-null assertion for `default_branch`  in the map function.

## Why?

This assertion is not required because the previous filter function should only pass in default branches that exist. The linter wasn't happy with the non-null assertion.

## How has it been verified?

It hasn't yet - but will be run locally. 