### PR TITLE
Nt/tidyandtest

### DIFF
--- a/packages/common/src/github/github.ts
+++ b/packages/common/src/github/github.ts
@@ -225,27 +225,30 @@ export async function getLastCommitForRepositories(
 				return hasDefaultBranch && !repositoryIsEmpty;
 			})
 			.map(async ({ name, default_branch }) => {
-				const lastCommits = await getRepositoryLastCommit(
+				const lastMainBranchCommit = await getLastCommitFromBranch(
 					client,
 					name,
 					default_branch!,
 				);
 				return {
 					repository: name,
-					lastCommits,
+					lastMainBranchCommit,
 				};
 			}),
 	);
-
-	return data.reduce((acc, { repository, lastCommits }) => {
-		return {
-			...acc,
-			[repository]: lastCommits,
-		};
-	}, {});
+	const lastCommits: Record<string, Commit> = data.reduce(
+		(acc, { repository, lastMainBranchCommit: lastMainBranchCommit }) => {
+			return {
+				...acc,
+				[repository]: lastMainBranchCommit,
+			};
+		},
+		{},
+	);
+	return lastCommits;
 }
 
-async function getRepositoryLastCommit(
+async function getLastCommitFromBranch(
 	client: Octokit,
 	repositoryName: string,
 	defaultBranch: string,

--- a/packages/common/src/model/github.ts
+++ b/packages/common/src/model/github.ts
@@ -15,7 +15,7 @@ export interface Repository {
 	topics: string[] | undefined;
 	default_branch: string | undefined;
 	owners: string[];
-	lastCommit?: Commit;
+	last_commit?: Commit;
 }
 
 export interface Team {

--- a/packages/github-data-fetcher/src/transformations.test.ts
+++ b/packages/github-data-fetcher/src/transformations.test.ts
@@ -1,8 +1,12 @@
 import type { RepositoryResponse } from 'common/github/github';
-import type { Repository } from 'common/model/github';
+import type { Commit, Repository } from 'common/model/github';
 import { mockRepo } from './mockRepo';
 import type { RepoAndOwner } from './transformations';
 import { asRepo, findOwnersOfRepo } from './transformations';
+
+const emptyCommit: Commit = {
+	message: '',
+};
 
 describe('repository owners', function () {
 	it('should not be returned if none exist for that repo', function () {
@@ -31,5 +35,38 @@ describe('repository objects', function () {
 
 		expect(finalRepoObject.owners).toStrictEqual(['team3', 'team4']);
 		expect(finalRepoObject.name).toStrictEqual('repo-name');
+	});
+	it('should combine a RepositoryResponse with the most recent commit', function () {
+		const commit = { ...emptyCommit, message: 'hello' };
+		const repo: RepositoryResponse = mockRepo;
+		const finalRepoObject: Repository = asRepo(repo, [], [], commit);
+
+		expect(finalRepoObject.last_commit?.message).toStrictEqual('hello');
+		expect(finalRepoObject.name).toStrictEqual('repo-name');
+	});
+});
+
+describe('date strings', function () {
+	const repo = { ...mockRepo, updated_at: '2015-01-25T08:09:10Z' };
+	it('should convert to date objects if they exist', function () {
+		const actualDate = asRepo(repo, [], [], emptyCommit).updated_at;
+		const expectedDate = new Date(2015, 0, 25, 8, 9, 10);
+		expect(actualDate).toEqual(expectedDate);
+	});
+	it('should return a null if there is no date', function () {
+		const actualDate = asRepo(
+			{ ...mockRepo, updated_at: '' },
+			[],
+			[],
+			emptyCommit,
+		).updated_at;
+		expect(actualDate).toEqual(null);
+		const actualDate2 = asRepo(
+			{ ...mockRepo, updated_at: undefined },
+			[],
+			[],
+			emptyCommit,
+		).updated_at;
+		expect(actualDate2).toEqual(null);
 	});
 });

--- a/packages/github-data-fetcher/src/transformations.ts
+++ b/packages/github-data-fetcher/src/transformations.ts
@@ -50,7 +50,7 @@ export const asRepo = (
 		default_branch: repo.default_branch,
 		owners,
 		languages,
-		lastCommit,
+		last_commit: lastCommit,
 	};
 };
 


### PR DESCRIPTION
## What does this change?

Renamed some fields, added a test for including the most recent commit, and for date verification

## Why?

Renaming - consistency and accuracy
Testing - though the logic is pretty simple, more test coverage is rarely a bad thing. It would be interesting to run the service catalogue through a code coverage tool at some point...

## How has it been verified?

The unit tests pass
