### PR TITLE
Introduce Cloudquery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
               - packages/cloudformation-lens/cloudformation-lens
             repocop:
               - packages/repocop/target/scala-3.2.1/repocop.jar
+            cloudquery:
+              - packages/cdk/lib/cloudquery/bootstrap.py
 
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -7,10 +7,36 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       "GuVpcParameter",
       "GuSubnetListParameter",
       "GuSecurityGroup",
+      "GuAmiParameter",
+      "GuInstanceRole",
+      "GuSSMRunCommandPolicy",
+      "GuDescribeEC2Policy",
+      "GuLoggingStreamNameParameter",
+      "GuLogShippingPolicy",
+      "GuDistributionBucketParameter",
+      "GuGetDistributablePolicy",
+      "GuParameterStoreReadPolicy",
+      "GuHttpsEgressSecurityGroup",
+      "GuAutoScalingGroup",
+      "GuWazuhAccess",
     ],
     "gu:cdk:version": "TEST",
   },
   "Parameters": {
+    "AMICloudquery": {
+      "Description": "Amazon Machine Image ID for the app cloudquery. Use this in conjunction with AMIgo to keep AMIs up to date.",
+      "Type": "AWS::EC2::Image::Id",
+    },
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "LoggingStreamName": {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "VpcId": {
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
@@ -23,6 +49,296 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "DescribeEC2PolicyFF5F9295": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCloudquery54F86B54",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GetDistributablePolicyCloudquery19347D25": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/deploy/TEST/cloudquery/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicyCloudquery19347D25",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCloudquery54F86B54",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuHttpsEgressSecurityGroupCloudquery3AE9FC4C": {
+      "Properties": {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cloudquery",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuLogShippingPolicy981BFE5A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:kinesis:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCloudquery54F86B54",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "InstanceRoleCloudquery54F86B54": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ec2.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        ],
+        "Path": "/",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cloudquery",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "InstanceRoleCloudqueryDefaultPolicyBCEDADAD": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "cloudformation:GetTemplate",
+                "dynamodb:GetItem",
+                "dynamodb:BatchGetItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "ec2:GetConsoleOutput",
+                "ec2:GetConsoleScreenshot",
+                "ecr:BatchGetImage",
+                "ecr:GetAuthorizationToken",
+                "ecr:GetDownloadUrlForLayer",
+                "kinesis:Get*",
+                "lambda:GetFunction",
+                "logs:GetLogEvents",
+                "s3:GetObject",
+                "sdb:Select*",
+                "sqs:ReceiveMessage",
+              ],
+              "Effect": "Deny",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "InstanceRoleCloudqueryDefaultPolicyBCEDADAD",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCloudquery54F86B54",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ParameterStoreReadCloudqueryA859D391": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/cloudquery",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/cloudquery/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCloudquery54F86B54",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "PostgresAccessSecurityGroupCloudqueryE959A23F": {
       "Properties": {
         "GroupDescription": "CloudQuery/PostgresAccessSecurityGroupCloudquery",
@@ -285,6 +601,362 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::RDS::DBSubnetGroup",
+    },
+    "SSMRunCommandPolicy244E1613": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ssm-run-command-policy",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCloudquery54F86B54",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "WazuhSecurityGroup": {
+      "Properties": {
+        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh event logging",
+            "FromPort": 1514,
+            "IpProtocol": "tcp",
+            "ToPort": 1514,
+          },
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh agent registration",
+            "FromPort": 1515,
+            "IpProtocol": "tcp",
+            "ToPort": 1515,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "asgCloudqueryASG40AB7667": {
+      "Properties": {
+        "LaunchConfigurationName": {
+          "Ref": "asgCloudqueryLaunchConfigEECD8C1E",
+        },
+        "MaxSize": "2",
+        "MinSize": "1",
+        "Tags": [
+          {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "cloudquery",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "PropagateAtLaunch": true,
+            "Value": "CloudQuery/asgCloudquery",
+          },
+          {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+        ],
+        "VPCZoneIdentifier": {
+          "Ref": "cloudqueryPrivateSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "asgCloudqueryInstanceProfileD6927F3E": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCloudquery54F86B54",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "asgCloudqueryLaunchConfigEECD8C1E": {
+      "DependsOn": [
+        "InstanceRoleCloudqueryDefaultPolicyBCEDADAD",
+        "InstanceRoleCloudquery54F86B54",
+      ],
+      "Properties": {
+        "IamInstanceProfile": {
+          "Ref": "asgCloudqueryInstanceProfileD6927F3E",
+        },
+        "ImageId": {
+          "Ref": "AMICloudquery",
+        },
+        "InstanceType": "t4g.small",
+        "MetadataOptions": {
+          "HttpTokens": "required",
+        },
+        "SecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "GuHttpsEgressSecurityGroupCloudquery3AE9FC4C",
+              "GroupId",
+            ],
+          },
+          {
+            "Fn::GetAtt": [
+              "WazuhSecurityGroup",
+              "GroupId",
+            ],
+          },
+          {
+            "Fn::GetAtt": [
+              "PostgresAccessSecurityGroupCloudqueryE959A23F",
+              "GroupId",
+            ],
+          },
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "#!/bin/bash
+# Install Cloudquery
+set -xe
+curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.1/cloudquery_linux_arm64 -o cloudquery
+chmod a+x cloudquery
+# Add configuration files
+cat > aws.yaml << EOL
+kind: source
+spec:
+  name: 'aws'
+  path: 'cloudquery/aws'
+  version: 'v15.4.0'
+  # tables: ["*"]
+  destinations: ['postgresql']
+  skip_tables:
+    - aws_ec2_vpc_endpoint_services # this resource includes services that are available from AWS as well as other AWS Accounts
+    - aws_cloudtrail_events
+    - aws_docdb_cluster_parameter_groups
+    - aws_docdb_engine_versions
+    - aws_ec2_instance_types
+    - aws_elasticache_engine_versions
+    - aws_elasticache_parameter_groups
+    - aws_elasticache_reserved_cache_nodes_offerings
+    - aws_elasticache_service_updates
+    - aws_neptune_cluster_parameter_groups
+    - aws_neptune_db_parameter_groups
+    - aws_rds_cluster_parameter_groups
+    - aws_rds_db_parameter_groups
+    - aws_rds_engine_versions
+    - aws_servicequotas_services
+  spec:
+    regions:
+      - eu-west-1
+    accounts:
+      - id: deployTools
+        local_profile: deployTools
+
+EOL
+cat > postgresql.yaml << EOL
+kind: destination
+spec:
+  name: 'postgresql'
+  registry: 'github'
+  path: 'cloudquery/postgresql'
+  version: 'v3.0.0'
+  spec:
+    #TODO put credentials and adress later
+    connection_string: 'postgresql://postgres:£PASSWORD@£HOST:5432/postgres?sslmode=disable'
+
+EOL
+# Replace password + db host
+HOST=$(aws secretsmanager get-secret-value --secret-id ",
+                {
+                  "Fn::Join": [
+                    "-",
+                    [
+                      {
+                        "Fn::Select": [
+                          0,
+                          {
+                            "Fn::Split": [
+                              "-",
+                              {
+                                "Fn::Select": [
+                                  6,
+                                  {
+                                    "Fn::Split": [
+                                      ":",
+                                      {
+                                        "Ref": "PostgresInstance1Secret7FA1A24B",
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        "Fn::Select": [
+                          1,
+                          {
+                            "Fn::Split": [
+                              "-",
+                              {
+                                "Fn::Select": [
+                                  6,
+                                  {
+                                    "Fn::Split": [
+                                      ":",
+                                      {
+                                        "Ref": "PostgresInstance1Secret7FA1A24B",
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  ],
+                },
+                " --region ",
+                {
+                  "Ref": "AWS::Region",
+                },
+                " | jq -r '.SecretString|fromjson|.host')
+sed -i "s/£HOST/$HOST/g" postgresql.yaml
+PASSWORD=$(aws secretsmanager get-secret-value --secret-id ",
+                {
+                  "Fn::Join": [
+                    "-",
+                    [
+                      {
+                        "Fn::Select": [
+                          0,
+                          {
+                            "Fn::Split": [
+                              "-",
+                              {
+                                "Fn::Select": [
+                                  6,
+                                  {
+                                    "Fn::Split": [
+                                      ":",
+                                      {
+                                        "Ref": "PostgresInstance1Secret7FA1A24B",
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        "Fn::Select": [
+                          1,
+                          {
+                            "Fn::Split": [
+                              "-",
+                              {
+                                "Fn::Select": [
+                                  6,
+                                  {
+                                    "Fn::Split": [
+                                      ":",
+                                      {
+                                        "Ref": "PostgresInstance1Secret7FA1A24B",
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  ],
+                },
+                " --region ",
+                {
+                  "Ref": "AWS::Region",
+                },
+                " | jq -r '.SecretString|fromjson|.password|@uri')
+sed -i "s/£PASSWORD/$PASSWORD/g" postgresql.yaml
+echo "#!/bin/sh
+/cloudquery sync /aws.yaml /postgresql.yaml" > /etc/cron.daily/cloudQuery
+chmod +x /etc/cron.daily/cloudQuery",
+              ],
+            ],
+          },
+        },
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
   },
 }

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import type { GuAutoScalingGroupProps } from '@guardian/cdk/lib/constructs/autoscaling';
+import { GuAutoScalingGroup } from '@guardian/cdk/lib/constructs/autoscaling';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import {
@@ -11,7 +14,9 @@ import {
 	InstanceSize,
 	InstanceType,
 	Port,
+	UserData,
 } from 'aws-cdk-lib/aws-ec2';
+import { Effect, ManagedPolicy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import type { DatabaseInstanceProps } from 'aws-cdk-lib/aws-rds';
 import { DatabaseInstance, DatabaseInstanceEngine } from 'aws-cdk-lib/aws-rds';
 import {
@@ -45,6 +50,11 @@ export class CloudQuery extends GuStack {
 		};
 
 		const db = new DatabaseInstance(this, 'PostgresInstance1', dbProps);
+		const dbSecret = db.secret?.secretName;
+
+		if (!dbSecret) {
+			throw new Error('DB Secret is missing');
+		}
 
 		const applicationToPostgresSecurityGroup = new GuSecurityGroup(
 			this,
@@ -52,6 +62,7 @@ export class CloudQuery extends GuStack {
 			{ app, vpc },
 		);
 
+		// Used by downstream services that read CloudQuery data, namely Grafana.
 		new StringParameter(this, 'PostgresAccessSecurityGroupParam', {
 			parameterName: `/${stage}/${stack}/${app}/postgres-access-security-group`,
 			simpleName: false,
@@ -64,5 +75,88 @@ export class CloudQuery extends GuStack {
 			applicationToPostgresSecurityGroup,
 			Port.tcp(port),
 		);
+
+		const userData = UserData.forLinux();
+
+		const awsYaml = fs.readFileSync(__dirname + '/cloudquery/aws.yaml', {
+			encoding: 'utf-8',
+		});
+		const postgresqlYaml = fs.readFileSync(
+			__dirname + '/cloudquery/postgresql.yaml',
+			{
+				encoding: 'utf-8',
+			},
+		);
+
+		userData.addCommands(
+			'# Install Cloudquery',
+			`set -xe`,
+			`curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.1/cloudquery_linux_arm64 -o cloudquery`,
+			`chmod a+x cloudquery`,
+			'# Add configuration files',
+			`cat > aws.yaml << EOL
+${awsYaml}
+EOL`,
+			`cat > postgresql.yaml << EOL
+${postgresqlYaml}
+EOL`,
+			`# Replace password + db host`,
+			`HOST=$(aws secretsmanager get-secret-value --secret-id ${dbSecret} --region ${this.region} | jq -r '.SecretString|fromjson|.host')`,
+			`sed -i "s/£HOST/$HOST/g" postgresql.yaml`,
+			`PASSWORD=$(aws secretsmanager get-secret-value --secret-id ${dbSecret} --region ${this.region} | jq -r '.SecretString|fromjson|.password|@uri')`,
+			`sed -i "s/£PASSWORD/$PASSWORD/g" postgresql.yaml`,
+			`echo "#!/bin/sh\n/cloudquery sync /aws.yaml /postgresql.yaml" > /etc/cron.daily/cloudQuery`,
+			`chmod +x /etc/cron.daily/cloudQuery`, // TODO ship logs.
+		);
+
+		const asgProps: GuAutoScalingGroupProps = {
+			app,
+			vpc: vpc,
+			vpcSubnets: { subnets: privateSubnets },
+			minimumInstances: 1,
+			userData: userData,
+			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+			imageRecipe: 'arm64-jammy-java11-deploy-infrastructure',
+			additionalSecurityGroups: [applicationToPostgresSecurityGroup],
+		};
+
+		const asg = new GuAutoScalingGroup(this, 'asg', asgProps);
+
+		asg.role.addManagedPolicy(
+			ManagedPolicy.fromManagedPolicyArn(
+				this,
+				'read-all-policy',
+				'arn:aws:iam::aws:policy/ReadOnlyAccess',
+			),
+		);
+
+		// See https://github.com/cloudquery/iam-for-aws-orgs/ and
+		// https://github.com/cloudquery/iam-for-aws-orgs/blob/d44ffe5509ba8a6c84c31dcc1dac7f475a5099e3/template.yml#L95.
+		asg.addToRolePolicy(
+			new PolicyStatement({
+				effect: Effect.DENY,
+				resources: ['*'],
+				actions: [
+					'cloudformation:GetTemplate',
+					'dynamodb:GetItem',
+					'dynamodb:BatchGetItem',
+					'dynamodb:Query',
+					'dynamodb:Scan',
+					'ec2:GetConsoleOutput',
+					'ec2:GetConsoleScreenshot',
+					'ecr:BatchGetImage',
+					'ecr:GetAuthorizationToken',
+					'ecr:GetDownloadUrlForLayer',
+					'kinesis:Get*',
+					'lambda:GetFunction',
+					'logs:GetLogEvents',
+					's3:GetObject',
+					'sdb:Select*',
+					'sqs:ReceiveMessage',
+				],
+			}),
+		);
+
+		db.secret.grantRead(asg);
 	}
 }

--- a/packages/cdk/lib/cloudquery/aws.yaml
+++ b/packages/cdk/lib/cloudquery/aws.yaml
@@ -1,0 +1,29 @@
+kind: source
+spec:
+  name: 'aws'
+  path: 'cloudquery/aws'
+  version: 'v15.4.0'
+  # tables: ["*"]
+  destinations: ['postgresql']
+  skip_tables:
+    - aws_ec2_vpc_endpoint_services # this resource includes services that are available from AWS as well as other AWS Accounts
+    - aws_cloudtrail_events
+    - aws_docdb_cluster_parameter_groups
+    - aws_docdb_engine_versions
+    - aws_ec2_instance_types
+    - aws_elasticache_engine_versions
+    - aws_elasticache_parameter_groups
+    - aws_elasticache_reserved_cache_nodes_offerings
+    - aws_elasticache_service_updates
+    - aws_neptune_cluster_parameter_groups
+    - aws_neptune_db_parameter_groups
+    - aws_rds_cluster_parameter_groups
+    - aws_rds_db_parameter_groups
+    - aws_rds_engine_versions
+    - aws_servicequotas_services
+  spec:
+    regions:
+      - eu-west-1
+    accounts:
+      - id: deployTools
+        local_profile: deployTools

--- a/packages/cdk/lib/cloudquery/bootstrap.py
+++ b/packages/cdk/lib/cloudquery/bootstrap.py
@@ -1,0 +1,1 @@
+# TODO: replace user data bash stuff with this to be create python script

--- a/packages/cdk/lib/cloudquery/postgresql.yaml
+++ b/packages/cdk/lib/cloudquery/postgresql.yaml
@@ -1,0 +1,9 @@
+kind: destination
+spec:
+  name: 'postgresql'
+  registry: 'github'
+  path: 'cloudquery/postgresql'
+  version: 'v3.0.0'
+  spec:
+    #TODO put credentials and adress later
+    connection_string: 'postgresql://postgres:£PASSWORD@£HOST:5432/postgres?sslmode=disable'


### PR DESCRIPTION
## What does this change?

Cloudquery is a great way to collect AWS, and other, sources of data and push it into a destination - in this case Postgres.

This commit represents an initial spike and there will be plenty of follow up work to tidy things up and broaden its behaviour, e.g. by targeting additional accounts.

See also:

https://www.cloudquery.io/

## Why?

The initial aims is to validate that we can successfully run Cloudquery
[See trello card about spike](https://trello.com/c/1bMquzu6/1813-spike-cloudquery)

Even from some initial queries it is clear that this tool can help us replace some of our custom tracking code.