### PR TITLE
Allow things to talk to CloudQuery database

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -6,6 +6,7 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
     "gu:cdk:constructs": [
       "GuVpcParameter",
       "GuSubnetListParameter",
+      "GuSecurityGroup",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -22,6 +23,65 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "PostgresAccessSecurityGroupCloudqueryE959A23F": {
+      "Properties": {
+        "GroupDescription": "CloudQuery/PostgresAccessSecurityGroupCloudquery",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cloudquery",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "PostgresAccessSecurityGroupParam38DFE001": {
+      "Properties": {
+        "DataType": "text",
+        "Name": "/TEST/deploy/cloudquery/postgres-access-security-group",
+        "Tags": {
+          "Stack": "deploy",
+          "Stage": "TEST",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/service-catalogue",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": {
+          "Fn::GetAtt": [
+            "PostgresAccessSecurityGroupCloudqueryE959A23F",
+            "GroupId",
+          ],
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "PostgresInstance16DE4286E": {
       "DeletionPolicy": "Snapshot",
       "Properties": {
@@ -57,6 +117,7 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
             ],
           ],
         },
+        "Port": "5432",
         "PubliclyAccessible": false,
         "StorageType": "gp2",
         "Tags": [
@@ -177,15 +238,10 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "PostgresInstance1SecurityGroupfromCloudQueryPostgresInstance1SecurityGroupE406EBD1IndirectPortD7FF4792": {
+    "PostgresInstance1SecurityGroupfromCloudQueryPostgresAccessSecurityGroupCloudqueryAE627D465432AE3168F5": {
       "Properties": {
-        "Description": "from CloudQueryPostgresInstance1SecurityGroupE406EBD1:{IndirectPort}",
-        "FromPort": {
-          "Fn::GetAtt": [
-            "PostgresInstance16DE4286E",
-            "Endpoint.Port",
-          ],
-        },
+        "Description": "from CloudQueryPostgresAccessSecurityGroupCloudqueryAE627D46:5432",
+        "FromPort": 5432,
         "GroupId": {
           "Fn::GetAtt": [
             "PostgresInstance1SecurityGroupFA28C3C0",
@@ -195,16 +251,11 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": {
           "Fn::GetAtt": [
-            "PostgresInstance1SecurityGroupFA28C3C0",
+            "PostgresAccessSecurityGroupCloudqueryE959A23F",
             "GroupId",
           ],
         },
-        "ToPort": {
-          "Fn::GetAtt": [
-            "PostgresInstance16DE4286E",
-            "Endpoint.Port",
-          ],
-        },
+        "ToPort": 5432,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -1,24 +1,43 @@
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
-import { GuVpc, SubnetType } from '@guardian/cdk/lib/constructs/ec2';
+import {
+	GuSecurityGroup,
+	GuVpc,
+	SubnetType,
+} from '@guardian/cdk/lib/constructs/ec2';
 import type { App } from 'aws-cdk-lib';
-import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
+import {
+	InstanceClass,
+	InstanceSize,
+	InstanceType,
+	Port,
+} from 'aws-cdk-lib/aws-ec2';
 import type { DatabaseInstanceProps } from 'aws-cdk-lib/aws-rds';
 import { DatabaseInstance, DatabaseInstanceEngine } from 'aws-cdk-lib/aws-rds';
+import {
+	ParameterDataType,
+	ParameterTier,
+	StringParameter,
+} from 'aws-cdk-lib/aws-ssm';
 
 export class CloudQuery extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
 		super(scope, id, props);
 
+		const { stage, stack } = this;
 		const app = props.app ?? 'cloudquery';
+
 		const vpc = GuVpc.fromIdParameter(this, 'vpc');
 		const privateSubnets = GuVpc.subnetsFromParameter(this, {
 			type: SubnetType.PRIVATE,
 			app,
 		});
 
+		const port = 5432;
+
 		const dbProps: DatabaseInstanceProps = {
 			engine: DatabaseInstanceEngine.POSTGRES,
+			port,
 			vpc,
 			vpcSubnets: { subnets: privateSubnets },
 			iamAuthentication: true,
@@ -27,6 +46,23 @@ export class CloudQuery extends GuStack {
 
 		const db = new DatabaseInstance(this, 'PostgresInstance1', dbProps);
 
-		db.connections.allowDefaultPortInternally();
+		const applicationToPostgresSecurityGroup = new GuSecurityGroup(
+			this,
+			'PostgresAccessSecurityGroup',
+			{ app, vpc },
+		);
+
+		new StringParameter(this, 'PostgresAccessSecurityGroupParam', {
+			parameterName: `/${stage}/${stack}/${app}/postgres-access-security-group`,
+			simpleName: false,
+			stringValue: applicationToPostgresSecurityGroup.securityGroupId,
+			tier: ParameterTier.STANDARD,
+			dataType: ParameterDataType.TEXT,
+		});
+
+		db.connections.allowFrom(
+			applicationToPostgresSecurityGroup,
+			Port.tcp(port),
+		);
 	}
 }


### PR DESCRIPTION
## What does this change?
There are two things that need to talk to the CloudQuery database:
  1. CloudQuery itself (write)
  2. Grafana (read)

This change creates a Security Group that allows connection to the database, and places its ID in an SSM Parameter to allow Grafana to easily obtain it.

This follows on from the changes in #149.