### PR TITLE
Add us-east-1 to CloudQuery regions scanned

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -823,6 +823,7 @@ spec:
   spec:
     regions:
       - eu-west-1
+      - us-east-1
     accounts:
       - id: deployTools
         role_arn: arn:aws:iam::£DEPLOY_TOOLS_ACCOUNT_ID:role/cloudquery-access

--- a/packages/cdk/lib/cloudquery/aws.yaml
+++ b/packages/cdk/lib/cloudquery/aws.yaml
@@ -24,6 +24,7 @@ spec:
   spec:
     regions:
       - eu-west-1
+      - us-east-1
     accounts:
       - id: deployTools
         role_arn: arn:aws:iam::£DEPLOY_TOOLS_ACCOUNT_ID:role/cloudquery-access


### PR DESCRIPTION
## What does this change?

Add `us-east-1` to CloudQuery regions scanned

## Why?

Some tables such as `aws_organizations_accounts` and `aws_waf_web_acls` the services for which are "global" will not get filled out unless you specify to query the magic original `us-east-1` region. This is necessary to get a good complete view of our infrastructure.

## How has it been verified?

Tested configuration with `cloudquery` locally.
