### PR TITLE
feat(cloudquery): Ship logs to Central ELK

### DIFF
--- a/config/cloudquery/cloudquery.service
+++ b/config/cloudquery/cloudquery.service
@@ -2,7 +2,7 @@
 Description=CloudQuery
 
 [Service]
-ExecStart=/cloudquery sync /aws.yaml /postgresql.yaml
+ExecStart=/cloudquery sync --log-format json --log-console /aws.yaml /postgresql.yaml
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -737,6 +737,13 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "LogKinesisStreamName",
+            "PropagateAtLaunch": true,
+            "Value": {
+              "Ref": "LoggingStreamName",
+            },
+          },
+          {
             "Key": "Name",
             "PropagateAtLaunch": true,
             "Value": "CloudQuery/asgCloudquery",
@@ -750,6 +757,11 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
             "Key": "Stage",
             "PropagateAtLaunch": true,
             "Value": "TEST",
+          },
+          {
+            "Key": "SystemdUnit",
+            "PropagateAtLaunch": true,
+            "Value": "cloudquery.service",
           },
         ],
         "VPCZoneIdentifier": {


### PR DESCRIPTION
## What does this change?
Since #156, CloudQuery's logs are available in `journald`.

In this change we [configure CloudQuery](https://www.cloudquery.io/docs/reference/cli/cloudquery) to produce logs in JSON format. We also add the `LogKinesisStreamName`, `SystemdUnit` tags to the autoscaling group.

With these three changes, we can take advantage of [devx-logs](https://github.com/guardian/devx-logs) - devx-logs will automatically[^1] produce some configuration for [fluentbit](https://fluentbit.io/) to forward our logs on to Kinesis, allowing them to be ingested into the Central ELK stack.

## Why?
Having logs shipped to Central ELK increase our visibility[^2].

## How has it been verified?
- Deploy it ([done](https://riffraff.gutools.co.uk/deployment/view/7149a5c5-b352-4b91-8e31-654f181e4a12))
- View [logs in Central ELK](https://logs.gutools.co.uk/s/devx/goto/d6d28b20-cfeb-11ed-9d78-d12928f91852) (see screenshot below)

![image](https://user-images.githubusercontent.com/836140/229187050-d0586ab6-7eed-4662-981e-dc2b2371736e.png)

[^1]: devx-logs will [tail logs from journald, and expects the logs to be in JSON format](https://github.com/guardian/devx-logs/blob/ee2b0b9b3423eb6c86e2de3f875e7aa2da0b6949/fluentbit/application-logs.conf)
[^2]: It's shown immediate value too! From the screenshot, we can see CloudQuery is erroring!