### PR TITLE
Cache go deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,8 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version: '1.20'
+          cache-dependency-path: packages/cloudformation-lens/go.sum
 
       - name: Run script/ci
         run: ./scripts/ci.sh


### PR DESCRIPTION
## What does this change?

Attempts to fix Go build caching. See: https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs.

## Why?

To speed up the build.

Note, this is likely to see at best a 30s improvement.

## How has it been verified?

TODO - will run a few times and compare.