### PR TITLE
Implement RDS IAM auth for Cloudquery

### DIFF
--- a/config/cloudquery/cloudquery.service
+++ b/config/cloudquery/cloudquery.service
@@ -2,7 +2,7 @@
 Description=CloudQuery
 
 [Service]
-ExecStart=/cloudquery sync --log-format json --log-console /aws.yaml /postgresql.yaml
+ExecStart=/cloudquery.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/config/cloudquery/cloudquery.sh
+++ b/config/cloudquery/cloudquery.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+/cloudquery --log-format json --log-console sync /aws.yaml /postgresql.yaml

--- a/config/cloudquery/cloudquery.sh
+++ b/config/cloudquery/cloudquery.sh
@@ -15,7 +15,8 @@ PG_PASSWORD="$(aws rds generate-db-auth-token --hostname $RDS_HOST --port 5432 -
 # See `postgresql.yaml`
 # See https://www.postgresql.org/docs/11/libpq-connect.html#LIBPQ-CONNECT-SSLMODE for sslmode options
 # See https://www.cloudquery.io/docs/advanced-topics/environment-variable-substitution
-export PG_CONNECTION_STRING="postgresql://cloudquery:$PG_PASSWORD@$RDS_HOST:5432/postgres?sslmode=verify-full"  > /connection_string
+echo "user=cloudquery password=$PG_PASSWORD host=$RDS_HOST port=5432 dbname=postgres sslmode=verify-full" > /connection_string
+
 
 # Run cloudquery
 /cloudquery --log-format json --log-console sync /aws.yaml /postgresql.yaml

--- a/config/cloudquery/cloudquery.sh
+++ b/config/cloudquery/cloudquery.sh
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
 
 set -e
+# This is created in the Cloudformation
+# TODO: At the moment this is hard-coded, but if we want multiple stages in the future we would need to change this
+SSM_PATH=/INFRA/deploy/cloudquery/postgres-instance-endpoint-address
 
-# NOTE: The `RDS_HOST` env var is set in userdata
+# Get the address of the postgres instance endpoint from SSM, because it's more secure and future-proof
+RDS_HOST="$(aws ssm get-parameter --name $SSM_PATH --region eu-west-1 | jq .Parameter.Value -r)"
 
 # Generate temp credentials
-export PG_PASSWORD="$(aws rds generate-db-auth-token --hostname $RDS_HOST --port 5432 --region eu-west-1 --username cloudquery)"
+PG_PASSWORD="$(aws rds generate-db-auth-token --hostname $RDS_HOST --port 5432 --region eu-west-1 --username cloudquery)"
 
-# Build connection string
+# Build connection string on disk for CloudQuery to read
+# See `postgresql.yaml`
 # See https://www.postgresql.org/docs/11/libpq-connect.html#LIBPQ-CONNECT-SSLMODE for sslmode options
-export PG_CONNECTION_STRING="postgresql://cloudquery:$PG_PASSWORD@$RDS_HOST:5432/postgres?sslmode=verify-full"
+# See https://www.cloudquery.io/docs/advanced-topics/environment-variable-substitution
+export PG_CONNECTION_STRING="postgresql://cloudquery:$PG_PASSWORD@$RDS_HOST:5432/postgres?sslmode=verify-full"  > /connection_string
 
 # Run cloudquery
 /cloudquery --log-format json --log-console sync /aws.yaml /postgresql.yaml

--- a/config/cloudquery/cloudquery.sh
+++ b/config/cloudquery/cloudquery.sh
@@ -2,4 +2,14 @@
 
 set -e
 
+# NOTE: The `RDS_HOST` env var is set in userdata
+
+# Generate temp credentials
+export PG_PASSWORD="$(aws rds generate-db-auth-token --hostname $RDS_HOST --port 5432 --region eu-west-1 --username cloudquery)"
+
+# Build connection string
+# See https://www.postgresql.org/docs/11/libpq-connect.html#LIBPQ-CONNECT-SSLMODE for sslmode options
+export PG_CONNECTION_STRING="postgresql://cloudquery:$PG_PASSWORD@$RDS_HOST:5432/postgres?sslmode=verify-full"
+
+# Run cloudquery
 /cloudquery --log-format json --log-console sync /aws.yaml /postgresql.yaml

--- a/config/cloudquery/postgresql.yaml
+++ b/config/cloudquery/postgresql.yaml
@@ -4,13 +4,11 @@ spec:
   registry: 'github'
   path: 'cloudquery/postgresql'
   version: 'v3.0.0'
-  
+
   # Automatically apply migrations whenever plugins are updated.
   # Note: This is not encouraged if risk averse, so we should consider removing this once fully in production.
   # See: https://www.cloudquery.io/docs/advanced-topics/managing-versions#managing-plugin-versions
   migrate_mode: 'forced'
-  
+
   spec:
-    #TODO put credentials and adress later
-    # See https://www.postgresql.org/docs/11/libpq-connect.html#LIBPQ-CONNECT-SSLMODE for sslmode options
-    connection_string: 'postgresql://postgres:£PASSWORD@£HOST:5432/postgres?sslmode=verify-full'
+    connection_string: ${PG_CONNECTION_STRING}

--- a/config/cloudquery/postgresql.yaml
+++ b/config/cloudquery/postgresql.yaml
@@ -11,4 +11,4 @@ spec:
   migrate_mode: 'forced'
 
   spec:
-    connection_string: ${PG_CONNECTION_STRING}
+    connection_string: ${file:/connection_string}

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -846,10 +846,17 @@ aws s3 cp 's3://",
                   "Ref": "DistributionBucketName",
                 },
                 "/deploy/TEST/cloudquery/cloudquery.timer' '/etc/systemd/system/cloudquery.timer'
+mkdir -p $(dirname '/cloudquery.sh')
+aws s3 cp 's3://",
+                {
+                  "Ref": "DistributionBucketName",
+                },
+                "/deploy/TEST/cloudquery/cloudquery.sh' '/cloudquery.sh'
 # Install Cloudquery
 set -xe
 curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.1/cloudquery_linux_arm64 -o cloudquery
 chmod a+x cloudquery
+chmod a+x /cloudquery.sh
 # Set target accounts - temp until we use OUs
 sed -i "s/£DEPLOY_TOOLS_ACCOUNT_ID/",
                 {

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -661,6 +661,27 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       },
       "Type": "AWS::RDS::DBSubnetGroup",
     },
+    "PostgresInstanceEndpointAddress6E14162C": {
+      "Properties": {
+        "DataType": "text",
+        "Name": "/TEST/deploy/cloudquery/postgres-instance-endpoint-address",
+        "Tags": {
+          "Stack": "deploy",
+          "Stage": "TEST",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/service-catalogue",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": {
+          "Fn::GetAtt": [
+            "PostgresInstance16DE4286E",
+            "Endpoint.Address",
+          ],
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "SSMRunCommandPolicy244E1613": {
       "Properties": {
         "PolicyDocument": {
@@ -895,14 +916,6 @@ sed -i "s/£DEV_PLAYGROUND_ACCOUNT_ID/",
                   "Ref": "devPlaygroundAccountIDParam",
                 },
                 "/g" aws.yaml
-export RDS_HOST=",
-                {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-                "
 curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/ca-certificates/rds-ca-2019-root.crt
 update-ca-certificates
 systemctl enable cloudquery.timer

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -291,6 +291,33 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
               "Resource": "arn:aws:iam::*:role/cloudquery-access",
             },
             {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/cloudquery",
+                  ],
+                ],
+              },
+            },
+            {
               "Action": [
                 "secretsmanager:GetSecretValue",
                 "secretsmanager:DescribeSecret",
@@ -868,127 +895,14 @@ sed -i "s/£DEV_PLAYGROUND_ACCOUNT_ID/",
                   "Ref": "devPlaygroundAccountIDParam",
                 },
                 "/g" aws.yaml
-# Replace password + db host
-HOST=$(aws secretsmanager get-secret-value --secret-id ",
+export RDS_HOST=",
                 {
-                  "Fn::Join": [
-                    "-",
-                    [
-                      {
-                        "Fn::Select": [
-                          0,
-                          {
-                            "Fn::Split": [
-                              "-",
-                              {
-                                "Fn::Select": [
-                                  6,
-                                  {
-                                    "Fn::Split": [
-                                      ":",
-                                      {
-                                        "Ref": "PostgresInstance1Secret7FA1A24B",
-                                      },
-                                    ],
-                                  },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                      {
-                        "Fn::Select": [
-                          1,
-                          {
-                            "Fn::Split": [
-                              "-",
-                              {
-                                "Fn::Select": [
-                                  6,
-                                  {
-                                    "Fn::Split": [
-                                      ":",
-                                      {
-                                        "Ref": "PostgresInstance1Secret7FA1A24B",
-                                      },
-                                    ],
-                                  },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
+                  "Fn::GetAtt": [
+                    "PostgresInstance16DE4286E",
+                    "Endpoint.Address",
                   ],
                 },
-                " --region ",
-                {
-                  "Ref": "AWS::Region",
-                },
-                " | jq -r '.SecretString|fromjson|.host')
-sed -i "s/£HOST/$HOST/g" postgresql.yaml
-PASSWORD=$(aws secretsmanager get-secret-value --secret-id ",
-                {
-                  "Fn::Join": [
-                    "-",
-                    [
-                      {
-                        "Fn::Select": [
-                          0,
-                          {
-                            "Fn::Split": [
-                              "-",
-                              {
-                                "Fn::Select": [
-                                  6,
-                                  {
-                                    "Fn::Split": [
-                                      ":",
-                                      {
-                                        "Ref": "PostgresInstance1Secret7FA1A24B",
-                                      },
-                                    ],
-                                  },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                      {
-                        "Fn::Select": [
-                          1,
-                          {
-                            "Fn::Split": [
-                              "-",
-                              {
-                                "Fn::Select": [
-                                  6,
-                                  {
-                                    "Fn::Split": [
-                                      ":",
-                                      {
-                                        "Ref": "PostgresInstance1Secret7FA1A24B",
-                                      },
-                                    ],
-                                  },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  ],
-                },
-                " --region ",
-                {
-                  "Ref": "AWS::Region",
-                },
-                " | jq -r '.SecretString|fromjson|.password|@uri')
-sed -i "s/£PASSWORD/$PASSWORD/g" postgresql.yaml
+                "
 curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/ca-certificates/rds-ca-2019-root.crt
 update-ca-certificates
 systemctl enable cloudquery.timer

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -132,11 +132,20 @@ export class CloudQuery extends GuStack {
 			localFile: '/etc/systemd/system/cloudquery.timer',
 		});
 
+		userData.addS3DownloadCommand({
+			bucket: bucket,
+			bucketKey: `${stack}/${stage}/${app}/cloudquery.sh`,
+			localFile: '/cloudquery.sh',
+		});
+
 		userData.addCommands(
 			'# Install Cloudquery',
 			`set -xe`,
 			`curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.1/cloudquery_linux_arm64 -o cloudquery`,
 			`chmod a+x cloudquery`,
+
+			// Set permission to execute cloudquery.sh
+			`chmod a+x /cloudquery.sh`,
 
 			`# Set target accounts - temp until we use OUs`,
 			`sed -i "s/£DEPLOY_TOOLS_ACCOUNT_ID/${deployToolsAccountID.valueAsString}/g" aws.yaml`,

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -76,6 +76,13 @@ export class CloudQuery extends GuStack {
 			tier: ParameterTier.STANDARD,
 			dataType: ParameterDataType.TEXT,
 		});
+		new StringParameter(this, 'PostgresInstanceEndpointAddress', {
+			parameterName: `/${stage}/${stack}/${app}/postgres-instance-endpoint-address`,
+			simpleName: false,
+			stringValue: db.dbInstanceEndpointAddress,
+			tier: ParameterTier.STANDARD,
+			dataType: ParameterDataType.TEXT,
+		});
 
 		db.connections.allowFrom(
 			applicationToPostgresSecurityGroup,
@@ -150,8 +157,6 @@ export class CloudQuery extends GuStack {
 			`# Set target accounts - temp until we use OUs`,
 			`sed -i "s/£DEPLOY_TOOLS_ACCOUNT_ID/${deployToolsAccountID.valueAsString}/g" aws.yaml`,
 			`sed -i "s/£DEV_PLAYGROUND_ACCOUNT_ID/${devPlaygroundAccountID.valueAsString}/g" aws.yaml`,
-
-			`export RDS_HOST=${db.dbInstanceEndpointAddress}`,
 
 			// Install RDS certificate
 			'curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/ca-certificates/rds-ca-2019-root.crt',

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -22,7 +22,7 @@ import {
 	UserData,
 } from 'aws-cdk-lib/aws-ec2';
 import { Effect, ManagedPolicy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import type { DatabaseInstanceProps } from 'aws-cdk-lib/aws-rds';
+import type { CfnDBInstance, DatabaseInstanceProps } from 'aws-cdk-lib/aws-rds';
 import { DatabaseInstance, DatabaseInstanceEngine } from 'aws-cdk-lib/aws-rds';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import {
@@ -151,11 +151,7 @@ export class CloudQuery extends GuStack {
 			`sed -i "s/£DEPLOY_TOOLS_ACCOUNT_ID/${deployToolsAccountID.valueAsString}/g" aws.yaml`,
 			`sed -i "s/£DEV_PLAYGROUND_ACCOUNT_ID/${devPlaygroundAccountID.valueAsString}/g" aws.yaml`,
 
-			`# Replace password + db host`,
-			`HOST=$(aws secretsmanager get-secret-value --secret-id ${dbSecret} --region ${this.region} | jq -r '.SecretString|fromjson|.host')`,
-			`sed -i "s/£HOST/$HOST/g" postgresql.yaml`,
-			`PASSWORD=$(aws secretsmanager get-secret-value --secret-id ${dbSecret} --region ${this.region} | jq -r '.SecretString|fromjson|.password|@uri')`,
-			`sed -i "s/£PASSWORD/$PASSWORD/g" postgresql.yaml`,
+			`export RDS_HOST=${db.dbInstanceEndpointAddress}`,
 
 			// Install RDS certificate
 			'curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/ca-certificates/rds-ca-2019-root.crt',
@@ -239,6 +235,18 @@ export class CloudQuery extends GuStack {
 				effect: Effect.ALLOW,
 				resources: ['arn:aws:iam::*:role/cloudquery-access'],
 				actions: ['sts:AssumeRole'],
+			}),
+		);
+
+		const { attrDbiResourceId } = db.node.defaultChild as CfnDBInstance;
+
+		asg.addToRolePolicy(
+			new PolicyStatement({
+				effect: Effect.ALLOW,
+				resources: [
+					`arn:aws:rds-db:${this.region}:${this.account}:dbuser:${attrDbiResourceId}/cloudquery`,
+				],
+				actions: ['rds-db:connect'],
 			}),
 		);
 


### PR DESCRIPTION
> **Note**
> It might be easiest to review [commit by commit](https://github.com/guardian/service-catalogue/pull/159/commits).

## What does this change?
Switches to use [IAM authentication](https://repost.aws/knowledge-center/rds-postgresql-connect-using-iam) when connecting to the Postgres database. IAM authentication is preferred as it produces temporary credentials (valid for 15 minutes), in place of long-lived credentials.

As the credentials are temporary, we issue them each time the CloudQuery scheduled task runs. If we were to only issue them in the user data, they would have expired by the time CloudQuery would run.

## Why?
Use of the root credentials is not best practice. With this change, we're using temporary credentials, for a dedicated user.

## How has it been verified?
The branch has been deployed, and CloudQuery has successfully run and written to the database.