### PR TITLE
chore(deps): Update CloudQuery AWS source to 15.7.0

### DIFF
--- a/config/cloudquery/aws.yaml
+++ b/config/cloudquery/aws.yaml
@@ -2,7 +2,7 @@ kind: source
 spec:
   name: 'aws'
   path: 'cloudquery/aws'
-  version: 'v15.4.0'
+  version: 'v15.7.0'
   # tables: ["*"]
   destinations: ['postgresql']
   skip_tables:


### PR DESCRIPTION
## What does this change?
Updates the [AWS source plugin for CloudQuery to 15.7.0](https://github.com/cloudquery/cloudquery/releases/tag/plugins-source-aws-v15.7.0) to resolve an issue spotted in https://github.com/guardian/service-catalogue/pull/157:

```log
operation error EC2: DescribeImageAttribute, https response error StatusCode: 400, RequestID: REDACTED, api error AuthFailure: Not authorized for image:ami-REDACTED
```

See:
  - https://github.com/cloudquery/cloudquery/issues/9403
  - https://github.com/cloudquery/cloudquery/pull/9406

## Why?
Fewer errors!

## How has it been verified?
- Deploy the branch
- Observe fewer errors in the logs