### PR TITLE
feat(cloudquery): Verify RDS SSL certificate

### DIFF
--- a/config/cloudquery/postgresql.yaml
+++ b/config/cloudquery/postgresql.yaml
@@ -12,4 +12,5 @@ spec:
   
   spec:
     #TODO put credentials and adress later
-    connection_string: 'postgresql://postgres:£PASSWORD@£HOST:5432/postgres?sslmode=disable'
+    # See https://www.postgresql.org/docs/11/libpq-connect.html#LIBPQ-CONNECT-SSLMODE for sslmode options
+    connection_string: 'postgresql://postgres:£PASSWORD@£HOST:5432/postgres?sslmode=verify-full'

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -982,6 +982,8 @@ PASSWORD=$(aws secretsmanager get-secret-value --secret-id ",
                 },
                 " | jq -r '.SecretString|fromjson|.password|@uri')
 sed -i "s/£PASSWORD/$PASSWORD/g" postgresql.yaml
+curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/ca-certificates/rds-ca-2019-root.crt
+update-ca-certificates
 systemctl enable cloudquery.timer
 systemctl start cloudquery.timer",
               ],

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -148,6 +148,10 @@ export class CloudQuery extends GuStack {
 			`PASSWORD=$(aws secretsmanager get-secret-value --secret-id ${dbSecret} --region ${this.region} | jq -r '.SecretString|fromjson|.password|@uri')`,
 			`sed -i "s/£PASSWORD/$PASSWORD/g" postgresql.yaml`,
 
+			// Install RDS certificate
+			'curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/ca-certificates/rds-ca-2019-root.crt',
+			'update-ca-certificates',
+
 			'systemctl enable cloudquery.timer',
 			'systemctl start cloudquery.timer',
 		);


### PR DESCRIPTION
## What does this change?
Verify the full SSL certificate on the RDS connection.

To achieve this, we download and add the signing certificate authority (CA) to the OS trust store. This means the CA is trusted OS wide.

An alternative to this could be to set the [`sslrootcert`](https://www.postgresql.org/docs/11/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT) value in the postgres connection string. Opted against that because it means we have to remember a file path, which is fragile. For example, when we move to an AMIgo recipe, we'd need to ensure these two paths line up, and stay in sync.

## Why?
Security!

From https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html:

> You can use Secure Socket Layer (SSL) or Transport Layer Security (TLS) from your application to encrypt a connection to a DB instance running MariaDB, Microsoft SQL Server, MySQL, Oracle, or PostgreSQL.
> 
> SSL/TLS connections provide one layer of security by encrypting data that moves between your client and a DB instance. Using a server certificate provides an extra layer of security by validating that the connection is being made to an Amazon RDS DB instance. It does so by checking the server certificate that is automatically installed on all DB instances that you provision.

## How has it been verified?
- Deploy it ([done](https://riffraff.gutools.co.uk/deployment/view/49f86e98-0c4b-4767-82d3-ce785819c5c1))
- Start cloudquery (`sudo systemctl start cloudquery`)
- Observe the logs showing postgres is being written to (`sudo journalctl -f -u cloudquery` OR look in Central ELK)