### PR TITLE
fix(cloudquery): Automatically apply database migration

### DIFF
--- a/config/cloudquery/postgresql.yaml
+++ b/config/cloudquery/postgresql.yaml
@@ -4,6 +4,12 @@ spec:
   registry: 'github'
   path: 'cloudquery/postgresql'
   version: 'v3.0.0'
+  
+  # Automatically apply migrations whenever plugins are updated.
+  # Note: This is not encouraged if risk averse, so we should consider removing this once fully in production.
+  # See: https://www.cloudquery.io/docs/advanced-topics/managing-versions#managing-plugin-versions
+  migrate_mode: 'forced'
+  
   spec:
     #TODO put credentials and adress later
     connection_string: 'postgresql://postgres:£PASSWORD@£HOST:5432/postgres?sslmode=disable'


### PR DESCRIPTION
## What does this change?
In #160 we performed a plugin update, however we did not perform [the necessary migration](https://www.cloudquery.io/docs/advanced-topics/managing-versions#managing-plugin-versions). This is resulting in the following messages being witnessed in the logs:

```log
failed to sync v1 source aws: failed to write for aws (v15.7.0) -> postgresql (v3.0.0): failed to CloseAndRecv client: rpc error: code = Internal desc = Context done: context canceled and failed to wait for plugin: table aws_accessanalyzer_analyzers not found in postgres. make sure to run migrate
```

We _could_ manually perform a migration, however whilst we're still rolling out to production, let's [automatically migrate](https://www.cloudquery.io/docs/reference/destination-spec#migrate_mode) for ease.

Though undesired, a failing migration isn't too bad, as we should be able to clear the database, and re-crawl to fill it back up.

## Why?
Migrations are necessary when updating CloudQuery elements.

## How has it been verified?
1. Deploy `main`
2. Run CloudQuery, and observe the above log
3. Deploy this branch ([done](https://riffraff.gutools.co.uk/deployment/view/69c9cc16-ac94-4ac6-9a63-1734de92619f))
4. Run CloudQuery, and observe quieter logs (i.e. fixing the issue)
5. Deploy `main`
6. Run CloudQuery, and observe it completing (as the migration is been performed)

The the above can only be done once, and I've done it!