### PR TITLE
Remove reading of secret by Cloudquery database

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -317,16 +317,6 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
                 ],
               },
             },
-            {
-              "Action": [
-                "secretsmanager:GetSecretValue",
-                "secretsmanager:DescribeSecret",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
-              },
-            },
           ],
           "Version": "2012-10-17",
         },

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -254,7 +254,5 @@ export class CloudQuery extends GuStack {
 				actions: ['rds-db:connect'],
 			}),
 		);
-
-		db.secret.grantRead(asg);
 	}
 }


### PR DESCRIPTION
We are now using IAM auth so reading the secret is redundant.

## What does this change?
Further to #159, this is a follow up to remove the reading of the secret by the database, [as mentioned here](https://github.com/guardian/service-catalogue/pull/159#discussion_r1162482201). 

## Why?
IAM auth has now been implement for the Cloudquery database, so this is no longer required.

## How has it been verified?
The branch was deployed and tested on the instance. We confirmed that Cloudquery was still able to talk to the database.