### PR TITLE
refactor(cloudquery): Use `/opt/cloudquery` rather than `/` as base directory

### DIFF
--- a/config/cloudquery/cloudquery.service
+++ b/config/cloudquery/cloudquery.service
@@ -2,7 +2,7 @@
 Description=CloudQuery
 
 [Service]
-ExecStart=/cloudquery.sh
+ExecStart=/opt/cloudquery/cloudquery.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/config/cloudquery/cloudquery.sh
+++ b/config/cloudquery/cloudquery.sh
@@ -15,8 +15,13 @@ PG_PASSWORD="$(aws rds generate-db-auth-token --hostname $RDS_HOST --port 5432 -
 # See `postgresql.yaml`
 # See https://www.postgresql.org/docs/11/libpq-connect.html#LIBPQ-CONNECT-SSLMODE for sslmode options
 # See https://www.cloudquery.io/docs/advanced-topics/environment-variable-substitution
-echo "user=cloudquery password=$PG_PASSWORD host=$RDS_HOST port=5432 dbname=postgres sslmode=verify-full" > /connection_string
+echo "user=cloudquery password=$PG_PASSWORD host=$RDS_HOST port=5432 dbname=postgres sslmode=verify-full" > /opt/cloudquery/connection_string
 
 
 # Run cloudquery
-/cloudquery --log-format json --log-console sync /aws.yaml /postgresql.yaml
+/opt/cloudquery/cloudquery \
+  --log-format json \
+  --log-console \
+  sync \
+  /opt/cloudquery/aws.yaml \
+  /opt/cloudquery/postgresql.yaml

--- a/config/cloudquery/postgresql.yaml
+++ b/config/cloudquery/postgresql.yaml
@@ -11,4 +11,4 @@ spec:
   migrate_mode: 'forced'
 
   spec:
-    connection_string: ${file:/connection_string}
+    connection_string: ${file:/opt/cloudquery/connection_string}

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -860,18 +860,18 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
               "",
               [
                 "#!/bin/bash
-mkdir -p $(dirname '/aws.yaml')
+mkdir -p $(dirname '/opt/cloudquery/aws.yaml')
 aws s3 cp 's3://",
                 {
                   "Ref": "DistributionBucketName",
                 },
-                "/deploy/TEST/cloudquery/aws.yaml' '/aws.yaml'
-mkdir -p $(dirname '/postgresql.yaml')
+                "/deploy/TEST/cloudquery/aws.yaml' '/opt/cloudquery/aws.yaml'
+mkdir -p $(dirname '/opt/cloudquery/postgresql.yaml')
 aws s3 cp 's3://",
                 {
                   "Ref": "DistributionBucketName",
                 },
-                "/deploy/TEST/cloudquery/postgresql.yaml' '/postgresql.yaml'
+                "/deploy/TEST/cloudquery/postgresql.yaml' '/opt/cloudquery/postgresql.yaml'
 mkdir -p $(dirname '/etc/systemd/system/cloudquery.service')
 aws s3 cp 's3://",
                 {
@@ -884,28 +884,26 @@ aws s3 cp 's3://",
                   "Ref": "DistributionBucketName",
                 },
                 "/deploy/TEST/cloudquery/cloudquery.timer' '/etc/systemd/system/cloudquery.timer'
-mkdir -p $(dirname '/cloudquery.sh')
+mkdir -p $(dirname '/opt/cloudquery/cloudquery.sh')
 aws s3 cp 's3://",
                 {
                   "Ref": "DistributionBucketName",
                 },
-                "/deploy/TEST/cloudquery/cloudquery.sh' '/cloudquery.sh'
-# Install Cloudquery
+                "/deploy/TEST/cloudquery/cloudquery.sh' '/opt/cloudquery/cloudquery.sh'
 set -xe
-curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.1/cloudquery_linux_arm64 -o cloudquery
-chmod a+x cloudquery
-chmod a+x /cloudquery.sh
-# Set target accounts - temp until we use OUs
+curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.1/cloudquery_linux_arm64 -o /opt/cloudquery/cloudquery
+chmod a+x /opt/cloudquery/cloudquery
+chmod a+x /opt/cloudquery/cloudquery.sh
 sed -i "s/£DEPLOY_TOOLS_ACCOUNT_ID/",
                 {
                   "Ref": "deployToolsAccountIDParam",
                 },
-                "/g" aws.yaml
+                "/g" /opt/cloudquery/aws.yaml
 sed -i "s/£DEV_PLAYGROUND_ACCOUNT_ID/",
                 {
                   "Ref": "devPlaygroundAccountIDParam",
                 },
-                "/g" aws.yaml
+                "/g" /opt/cloudquery/aws.yaml
 curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/ca-certificates/rds-ca-2019-root.crt
 update-ca-certificates
 systemctl enable cloudquery.timer

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import { MetadataKeys } from '@guardian/cdk/lib/constants';
 import type { GuAutoScalingGroupProps } from '@guardian/cdk/lib/constructs/autoscaling';
 import { GuAutoScalingGroup } from '@guardian/cdk/lib/constructs/autoscaling';
@@ -115,16 +116,19 @@ export class CloudQuery extends GuStack {
 			GuDistributionBucketParameter.getInstance(this).valueAsString,
 		);
 
-		userData.addS3DownloadCommand({
+		const baseDirectory = '/opt/cloudquery';
+		const cloudqueryBinary = path.join(baseDirectory, 'cloudquery');
+
+		const awsYamlFile = userData.addS3DownloadCommand({
 			bucket: bucket,
 			bucketKey: `${stack}/${stage}/${app}/aws.yaml`,
-			localFile: '/aws.yaml',
+			localFile: path.join(baseDirectory, 'aws.yaml'),
 		});
 
 		userData.addS3DownloadCommand({
 			bucket: bucket,
 			bucketKey: `${stack}/${stage}/${app}/postgresql.yaml`,
-			localFile: '/postgresql.yaml',
+			localFile: path.join(baseDirectory, 'postgresql.yaml'),
 		});
 
 		userData.addS3DownloadCommand({
@@ -139,24 +143,24 @@ export class CloudQuery extends GuStack {
 			localFile: '/etc/systemd/system/cloudquery.timer',
 		});
 
-		userData.addS3DownloadCommand({
+		const cloudqueryScript = userData.addS3DownloadCommand({
 			bucket: bucket,
 			bucketKey: `${stack}/${stage}/${app}/cloudquery.sh`,
-			localFile: '/cloudquery.sh',
+			localFile: path.join(baseDirectory, 'cloudquery.sh'),
 		});
 
 		userData.addCommands(
-			'# Install Cloudquery',
+			// Install Cloudquery,
 			`set -xe`,
-			`curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.1/cloudquery_linux_arm64 -o cloudquery`,
-			`chmod a+x cloudquery`,
+			`curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.1/cloudquery_linux_arm64 -o ${cloudqueryBinary}`,
+			`chmod a+x ${cloudqueryBinary}`,
 
 			// Set permission to execute cloudquery.sh
-			`chmod a+x /cloudquery.sh`,
+			`chmod a+x ${cloudqueryScript}`,
 
-			`# Set target accounts - temp until we use OUs`,
-			`sed -i "s/£DEPLOY_TOOLS_ACCOUNT_ID/${deployToolsAccountID.valueAsString}/g" aws.yaml`,
-			`sed -i "s/£DEV_PLAYGROUND_ACCOUNT_ID/${devPlaygroundAccountID.valueAsString}/g" aws.yaml`,
+			// Set target accounts - temp until we use OUs
+			`sed -i "s/£DEPLOY_TOOLS_ACCOUNT_ID/${deployToolsAccountID.valueAsString}/g" ${awsYamlFile}`,
+			`sed -i "s/£DEV_PLAYGROUND_ACCOUNT_ID/${devPlaygroundAccountID.valueAsString}/g" ${awsYamlFile}`,
 
 			// Install RDS certificate
 			'curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/ca-certificates/rds-ca-2019-root.crt',


### PR DESCRIPTION
## What does this change, and why?
Download files to `/opt/cloudquery` rather than `/`. Downloading files to a dedicated directory makes things easier to manage, and differentiate system files from our files.

## How has it been verified?
- [Deployed the branch](https://riffraff.gutools.co.uk/deployment/view/204be484-3520-40d0-9a1a-253a8eae8ef4)
- Ran CloudQuery via `systemctl start cloudquery`
- Observed the logs showing CloudQuery continues to run successfully (`journalctl -f -u cloudquery`)