### PR TITLE
feat(cloudquery): Add encryption to database

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -484,6 +484,7 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
         },
         "Port": "5432",
         "PubliclyAccessible": false,
+        "StorageEncrypted": true,
         "StorageType": "gp2",
         "Tags": [
           {

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -53,6 +53,7 @@ export class CloudQuery extends GuStack {
 			vpcSubnets: { subnets: privateSubnets },
 			iamAuthentication: true,
 			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+			storageEncrypted: true,
 		};
 
 		const db = new DatabaseInstance(this, 'PostgresInstance1', dbProps);


### PR DESCRIPTION
## What does this change?
This PR adds encryption to the Cloudquery database.
Note: This will cause a database replacement, which will also mean re-creating the Cloudquery user on the instance.

## Why?

AWS Postgres databases are not encrypted by default, but it is preferable to have encryption.

## How has it been verified?

We deployed this branch and observed the encrypted database in the console. We've successfully run Cloudquery to make sure that we can still write to the database. We've also updated the data source in Grafana and observed the graphs being populated.