### PR TITLE
refactor(cloudquery)!: Define the database in its own construct

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -7,6 +7,7 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       "GuVpcParameter",
       "GuSubnetListParameter",
       "GuSecurityGroup",
+      "GuDatabase",
       "GuDistributionBucketParameter",
       "GuAmiParameter",
       "GuInstanceRole",
@@ -48,6 +49,65 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "DefaultSecurityGroupCloudquery39EED116": {
+      "Properties": {
+        "GroupDescription": "CloudQuery/DefaultSecurityGroupCloudquery",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cloudquery",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "DefaultSecurityGroupCloudqueryfromCloudQueryDefaultSecurityGroupCloudquery6925211454323690040A": {
+      "Properties": {
+        "Description": "from CloudQueryDefaultSecurityGroupCloudquery69252114:5432",
+        "FromPort": 5432,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "DefaultSecurityGroupCloudquery39EED116",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "DefaultSecurityGroupCloudquery39EED116",
+            "GroupId",
+          ],
+        },
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
     "DescribeEC2PolicyFF5F9295": {
       "Properties": {
         "PolicyDocument": {
@@ -315,7 +375,7 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
                     ":dbuser:",
                     {
                       "Fn::GetAtt": [
-                        "PostgresInstance16DE4286E",
+                        "PostgresInstance1Cloudquery223DB538",
                         "DbiResourceId",
                       ],
                     },
@@ -400,16 +460,48 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "PostgresAccessSecurityGroupCloudqueryE959A23F": {
+    "PostgresInstance1Cloudquery223DB538": {
+      "DeletionPolicy": "Snapshot",
       "Properties": {
-        "GroupDescription": "CloudQuery/PostgresAccessSecurityGroupCloudquery",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
+        "AllocatedStorage": "100",
+        "CACertificateIdentifier": "rds-ca-2019",
+        "CopyTagsToSnapshot": true,
+        "DBInstanceClass": "db.t4g.small",
+        "DBSubnetGroupName": {
+          "Ref": "PostgresInstance1CloudquerySubnetGroup1E0841E2",
+        },
+        "DeletionProtection": true,
+        "EnableIAMDatabaseAuthentication": true,
+        "Engine": "postgres",
+        "MasterUserPassword": {
+          "Fn::Join": [
+            "",
+            [
+              "{{resolve:secretsmanager:",
+              {
+                "Ref": "PostgresInstance1CloudquerySecret896B33F7",
+              },
+              ":SecretString:password::}}",
+            ],
+          ],
+        },
+        "MasterUsername": {
+          "Fn::Join": [
+            "",
+            [
+              "{{resolve:secretsmanager:",
+              {
+                "Ref": "PostgresInstance1CloudquerySecret896B33F7",
+              },
+              ":SecretString:username::}}",
+            ],
+          ],
+        },
+        "MultiAZ": true,
+        "Port": "5432",
+        "PubliclyAccessible": false,
+        "StorageEncrypted": true,
+        "StorageType": "gp2",
         "Tags": [
           {
             "Key": "App",
@@ -432,17 +524,24 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
             "Value": "TEST",
           },
         ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
+        "VPCSecurityGroups": [
+          {
+            "Fn::GetAtt": [
+              "DefaultSecurityGroupCloudquery39EED116",
+              "GroupId",
+            ],
+          },
+        ],
       },
-      "Type": "AWS::EC2::SecurityGroup",
+      "Type": "AWS::RDS::DBInstance",
+      "UpdateReplacePolicy": "Snapshot",
     },
-    "PostgresAccessSecurityGroupParam38DFE001": {
+    "PostgresInstance1CloudqueryAccessSecurityGroupParam9F461088": {
       "Properties": {
         "DataType": "text",
-        "Name": "/TEST/deploy/cloudquery/postgres-access-security-group",
+        "Name": "/TEST/deploy/cloudquery/database/access-security-group",
         "Tags": {
+          "App": "cloudquery",
           "Stack": "deploy",
           "Stage": "TEST",
           "gu:cdk:version": "TEST",
@@ -452,83 +551,36 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
         "Type": "String",
         "Value": {
           "Fn::GetAtt": [
-            "PostgresAccessSecurityGroupCloudqueryE959A23F",
+            "DefaultSecurityGroupCloudquery39EED116",
             "GroupId",
           ],
         },
       },
       "Type": "AWS::SSM::Parameter",
     },
-    "PostgresInstance16DE4286E": {
-      "DeletionPolicy": "Snapshot",
+    "PostgresInstance1CloudqueryEndpointAddressParamB17A3B97": {
       "Properties": {
-        "AllocatedStorage": "100",
-        "CopyTagsToSnapshot": true,
-        "DBInstanceClass": "db.t4g.small",
-        "DBSubnetGroupName": {
-          "Ref": "PostgresInstance1SubnetGroupCAC045A5",
+        "DataType": "text",
+        "Name": "/TEST/deploy/cloudquery/database/endpoint-address",
+        "Tags": {
+          "App": "cloudquery",
+          "Stack": "deploy",
+          "Stage": "TEST",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/service-catalogue",
         },
-        "EnableIAMDatabaseAuthentication": true,
-        "Engine": "postgres",
-        "MasterUserPassword": {
-          "Fn::Join": [
-            "",
-            [
-              "{{resolve:secretsmanager:",
-              {
-                "Ref": "PostgresInstance1Secret7FA1A24B",
-              },
-              ":SecretString:password::}}",
-            ],
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": {
+          "Fn::GetAtt": [
+            "PostgresInstance1Cloudquery223DB538",
+            "Endpoint.Address",
           ],
         },
-        "MasterUsername": {
-          "Fn::Join": [
-            "",
-            [
-              "{{resolve:secretsmanager:",
-              {
-                "Ref": "PostgresInstance1Secret7FA1A24B",
-              },
-              ":SecretString:username::}}",
-            ],
-          ],
-        },
-        "Port": "5432",
-        "PubliclyAccessible": false,
-        "StorageEncrypted": true,
-        "StorageType": "gp2",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "VPCSecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "PostgresInstance1SecurityGroupFA28C3C0",
-              "GroupId",
-            ],
-          },
-        ],
       },
-      "Type": "AWS::RDS::DBInstance",
-      "UpdateReplacePolicy": "Snapshot",
+      "Type": "AWS::SSM::Parameter",
     },
-    "PostgresInstance1Secret7FA1A24B": {
+    "PostgresInstance1CloudquerySecret896B33F7": {
       "DeletionPolicy": "Delete",
       "Properties": {
         "Description": {
@@ -550,6 +602,10 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
         },
         "Tags": [
           {
+            "Key": "App",
+            "Value": "cloudquery",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -570,80 +626,29 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
     },
-    "PostgresInstance1SecretAttachmentBA0D257D": {
+    "PostgresInstance1CloudquerySecretAttachmentADDCFC44": {
       "Properties": {
         "SecretId": {
-          "Ref": "PostgresInstance1Secret7FA1A24B",
+          "Ref": "PostgresInstance1CloudquerySecret896B33F7",
         },
         "TargetId": {
-          "Ref": "PostgresInstance16DE4286E",
+          "Ref": "PostgresInstance1Cloudquery223DB538",
         },
         "TargetType": "AWS::RDS::DBInstance",
       },
       "Type": "AWS::SecretsManager::SecretTargetAttachment",
     },
-    "PostgresInstance1SecurityGroupFA28C3C0": {
+    "PostgresInstance1CloudquerySubnetGroup1E0841E2": {
       "Properties": {
-        "GroupDescription": "Security group for PostgresInstance1 database",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "PostgresInstance1SecurityGroupfromCloudQueryPostgresAccessSecurityGroupCloudqueryAE627D465432AE3168F5": {
-      "Properties": {
-        "Description": "from CloudQueryPostgresAccessSecurityGroupCloudqueryAE627D46:5432",
-        "FromPort": 5432,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "PostgresInstance1SecurityGroupFA28C3C0",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "PostgresAccessSecurityGroupCloudqueryE959A23F",
-            "GroupId",
-          ],
-        },
-        "ToPort": 5432,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
-    },
-    "PostgresInstance1SubnetGroupCAC045A5": {
-      "Properties": {
-        "DBSubnetGroupDescription": "Subnet group for PostgresInstance1 database",
+        "DBSubnetGroupDescription": "Subnet group for PostgresInstance1Cloudquery database",
         "SubnetIds": {
           "Ref": "cloudqueryPrivateSubnets",
         },
         "Tags": [
+          {
+            "Key": "App",
+            "Value": "cloudquery",
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",
@@ -663,27 +668,6 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::RDS::DBSubnetGroup",
-    },
-    "PostgresInstanceEndpointAddress6E14162C": {
-      "Properties": {
-        "DataType": "text",
-        "Name": "/TEST/deploy/cloudquery/postgres-instance-endpoint-address",
-        "Tags": {
-          "Stack": "deploy",
-          "Stage": "TEST",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/service-catalogue",
-        },
-        "Tier": "Standard",
-        "Type": "String",
-        "Value": {
-          "Fn::GetAtt": [
-            "PostgresInstance16DE4286E",
-            "Endpoint.Address",
-          ],
-        },
-      },
-      "Type": "AWS::SSM::Parameter",
     },
     "WazuhSecurityGroup": {
       "Properties": {
@@ -821,7 +805,7 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
             },
             {
               "Fn::GetAtt": [
-                "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                "DefaultSecurityGroupCloudquery39EED116",
                 "GroupId",
               ],
             },

--- a/packages/cdk/lib/constructs/database.test.ts
+++ b/packages/cdk/lib/constructs/database.test.ts
@@ -1,0 +1,172 @@
+import { simpleGuStackForTesting } from '@guardian/cdk/lib/utils/test';
+import { Template } from 'aws-cdk-lib/assertions';
+import { User } from 'aws-cdk-lib/aws-iam';
+import { GuDatabase } from './database';
+
+describe('The GuDatabase construct', () => {
+	it('The simplest implementation', () => {
+		const stack = simpleGuStackForTesting();
+
+		new GuDatabase(stack, 'test', {
+			app: 'cloudquery',
+		});
+
+		const template = Template.fromStack(stack);
+		template.resourceCountIs('AWS::RDS::DBInstance', 1);
+
+		const [database] = Object.values(
+			template.findResources('AWS::RDS::DBInstance'),
+		);
+
+		expect(database).toMatchInlineSnapshot(`
+		{
+		  "DeletionPolicy": "Snapshot",
+		  "Properties": {
+		    "AllocatedStorage": "100",
+		    "CACertificateIdentifier": "rds-ca-rsa2048-g1",
+		    "CopyTagsToSnapshot": true,
+		    "DBInstanceClass": "db.m5.large",
+		    "DBSubnetGroupName": {
+		      "Ref": "testCloudquerySubnetGroupAE76545B",
+		    },
+		    "DeletionProtection": true,
+		    "EnableIAMDatabaseAuthentication": true,
+		    "Engine": "postgres",
+		    "MasterUserPassword": {
+		      "Fn::Join": [
+		        "",
+		        [
+		          "{{resolve:secretsmanager:",
+		          {
+		            "Ref": "testCloudquerySecret1B41F53F",
+		          },
+		          ":SecretString:password::}}",
+		        ],
+		      ],
+		    },
+		    "MasterUsername": {
+		      "Fn::Join": [
+		        "",
+		        [
+		          "{{resolve:secretsmanager:",
+		          {
+		            "Ref": "testCloudquerySecret1B41F53F",
+		          },
+		          ":SecretString:username::}}",
+		        ],
+		      ],
+		    },
+		    "MultiAZ": true,
+		    "Port": "5432",
+		    "PubliclyAccessible": false,
+		    "StorageEncrypted": true,
+		    "StorageType": "gp2",
+		    "Tags": [
+		      {
+		        "Key": "App",
+		        "Value": "cloudquery",
+		      },
+		      {
+		        "Key": "gu:cdk:version",
+		        "Value": "TEST",
+		      },
+		      {
+		        "Key": "gu:repo",
+		        "Value": "guardian/service-catalogue",
+		      },
+		      {
+		        "Key": "Stack",
+		        "Value": "test-stack",
+		      },
+		      {
+		        "Key": "Stage",
+		        "Value": "TEST",
+		      },
+		    ],
+		    "VPCSecurityGroups": [
+		      {
+		        "Fn::GetAtt": [
+		          "DefaultSecurityGroupCloudquery39EED116",
+		          "GroupId",
+		        ],
+		      },
+		    ],
+		  },
+		  "Type": "AWS::RDS::DBInstance",
+		  "UpdateReplacePolicy": "Snapshot",
+		}
+	`);
+	});
+
+	it('Creates an IAM Policy for IAM authentication', () => {
+		const stack = simpleGuStackForTesting();
+
+		const database = new GuDatabase(stack, 'test', {
+			app: 'cloudquery',
+		});
+
+		const user = new User(stack, 'MyUser');
+		database.grantConnect(user);
+
+		const template = Template.fromStack(stack);
+		template.resourceCountIs('AWS::IAM::Policy', 1);
+
+		const [firstPolicy] = Object.values(
+			template.findResources('AWS::IAM::Policy'),
+		);
+
+		expect(firstPolicy).toMatchInlineSnapshot(`
+		{
+		  "Properties": {
+		    "PolicyDocument": {
+		      "Statement": [
+		        {
+		          "Action": "rds-db:connect",
+		          "Effect": "Allow",
+		          "Resource": {
+		            "Fn::Join": [
+		              "",
+		              [
+		                "arn:",
+		                {
+		                  "Ref": "AWS::Partition",
+		                },
+		                ":rds-db:",
+		                {
+		                  "Ref": "AWS::Region",
+		                },
+		                ":",
+		                {
+		                  "Ref": "AWS::AccountId",
+		                },
+		                ":dbuser:",
+		                {
+		                  "Fn::GetAtt": [
+		                    "testCloudqueryC806EA2D",
+		                    "DbiResourceId",
+		                  ],
+		                },
+		                "/{{resolve:secretsmanager:",
+		                {
+		                  "Ref": "testCloudquerySecretAttachmentA5056ECE",
+		                },
+		                ":SecretString:username::}}",
+		              ],
+		            ],
+		          },
+		        },
+		      ],
+		      "Version": "2012-10-17",
+		    },
+		    "PolicyName": "MyUserDefaultPolicy7B897426",
+		    "Users": [
+		      {
+		        "Ref": "MyUserDC45028B",
+		      },
+		    ],
+		  },
+		  "Type": "AWS::IAM::Policy",
+		}
+	`);
+	});
+});

--- a/packages/cdk/lib/constructs/database.ts
+++ b/packages/cdk/lib/constructs/database.ts
@@ -1,0 +1,171 @@
+import type { AppIdentity, GuStack } from '@guardian/cdk/lib/constructs/core';
+import {
+	GuSecurityGroup,
+	GuVpc,
+	SubnetType,
+} from '@guardian/cdk/lib/constructs/ec2';
+import { GuAppAwareConstruct } from '@guardian/cdk/lib/utils/mixin/app-aware-construct';
+import { RemovalPolicy } from 'aws-cdk-lib';
+import type { IVpc } from 'aws-cdk-lib/aws-ec2';
+import { Port } from 'aws-cdk-lib/aws-ec2';
+import type { CfnDBInstance, DatabaseInstanceProps } from 'aws-cdk-lib/aws-rds';
+import { DatabaseInstance, DatabaseInstanceEngine } from 'aws-cdk-lib/aws-rds';
+import type { IInstanceEngine } from 'aws-cdk-lib/aws-rds/lib/instance-engine';
+import {
+	ParameterDataType,
+	ParameterTier,
+	StringParameter,
+} from 'aws-cdk-lib/aws-ssm';
+
+interface GuDatabaseProps
+	extends AppIdentity,
+		Omit<
+			DatabaseInstanceProps,
+			// The following are required props on `DatabaseInstanceProps`.
+			// Make them optional, with sensible defaults.
+			// They're still settable though.
+			| 'engine' // Defaults to Postgres.
+			| 'vpc' // `vpc` is a required property in `DatabaseInstanceProps`. It's optional here, and defaults to the primary VPC.
+
+			// The following are optional props on `DatabaseInstanceProps`.
+			// Remove them to offer better defaults.
+			| 'storageEncrypted' // Always encrypted.
+			| 'securityGroups' // We create our own explicit security group, and optionally wire it into an SSM Parameter.
+		> {
+	/**
+	 * The database engine;
+	 *
+	 * @default DatabaseInstanceEngine.POSTGRES
+	 */
+	engine?: IInstanceEngine;
+
+	/**
+	 * The VPC network where the DB subnet group should be created.
+	 *
+	 * @default The account's Primary VPC
+	 */
+	vpc?: IVpc;
+
+	/**
+	 * The identifier of the CA certificate for this DB instance.
+	 * Ensure to add the certificate to the environment's trust store.
+	 *
+	 * @default rds-ca-rsa2048-g1
+	 *
+	 * @see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.RegionCertificateAuthorities
+	 * @see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions
+	 */
+	caCertificateIdentifier?:
+		| 'rds-ca-2019'
+		| 'rds-ca-rsa2048-g1'
+		| 'rds-ca-rsa4096-g1'
+		| 'rds-ca-ecc384-g1';
+
+	/**
+	 * Create SSM Parameters holding the security group, and endpoint address for easy use by downstream systems.
+	 *
+	 * The SSM Parameters created are:
+	 *  - /STAGE/STACK/APP/database/access-security-group
+	 *  - /STAGE/STACK/APP/database/endpoint-address
+	 *
+	 * @default false
+	 */
+	allowExternalConnection?: boolean;
+}
+
+/**
+ * A Postgres database instance with the following defaults:
+ *  - Storage encryption
+ *  - Placement in the Primary VPC, and in the private subnets
+ *  - A Certificate Authority of rds-ca-rsa2048-g1, which supports auto-rotation
+ *
+ * TODO:
+ *  - Move to the GuCDK library (https://github.com/guardian/cdk/issues/1786)
+ *  - Contribute grantConnect patch upstream to AWS CDK (https://github.com/aws/aws-cdk/issues/11851)
+ */
+export class GuDatabase extends GuAppAwareConstruct(DatabaseInstance) {
+	/**
+	 * The AWS Region-unique, immutable identifier for the DB instance.
+	 * This identifier is found in AWS CloudTrail log entries whenever the AWS KMS key for the DB instance is accessed.
+	 *
+	 * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbinstance.html#aws-resource-rds-dbinstance-return-values
+	 */
+	public readonly instanceResourceId: string;
+
+	/**
+	 * The security group that applications should use to gain access to the database.
+	 */
+	public readonly accessSecurityGroup: GuSecurityGroup;
+
+	private get cfnResource(): CfnDBInstance {
+		return this.node.defaultChild as CfnDBInstance;
+	}
+
+	constructor(scope: GuStack, id: string, props: GuDatabaseProps) {
+		const {
+			app,
+			allowExternalConnection = false,
+			caCertificateIdentifier = 'rds-ca-rsa2048-g1',
+			vpc = GuVpc.fromIdParameter(scope, 'primary-vpc'),
+			vpcSubnets = {
+				subnets: GuVpc.subnetsFromParameter(scope, {
+					type: SubnetType.PRIVATE,
+					app,
+				}),
+			},
+			port = 5432,
+			engine = DatabaseInstanceEngine.POSTGRES,
+		} = props;
+
+		const defaultSecurityGroup = new GuSecurityGroup(
+			scope,
+			'DefaultSecurityGroup',
+			{
+				vpc,
+				app,
+			},
+		);
+
+		const defaults: DatabaseInstanceProps = {
+			vpc,
+			vpcSubnets,
+			engine,
+			port,
+			storageEncrypted: true,
+			deletionProtection: true,
+			removalPolicy: RemovalPolicy.SNAPSHOT,
+			publiclyAccessible: false,
+			iamAuthentication: true,
+			multiAz: true,
+			securityGroups: [defaultSecurityGroup],
+		};
+
+		super(scope, id, { ...defaults, ...props });
+
+		this.instanceResourceId = this.cfnResource.attrDbiResourceId;
+		this.accessSecurityGroup = defaultSecurityGroup;
+
+		this.cfnResource.caCertificateIdentifier = caCertificateIdentifier;
+
+		this.connections.allowFrom(defaultSecurityGroup, Port.tcp(port));
+
+		if (allowExternalConnection) {
+			const { stack, stage } = scope;
+
+			new StringParameter(this, 'AccessSecurityGroupParam', {
+				parameterName: `/${stage}/${stack}/${app}/database/access-security-group`,
+				simpleName: false,
+				stringValue: defaultSecurityGroup.securityGroupId,
+				tier: ParameterTier.STANDARD,
+				dataType: ParameterDataType.TEXT,
+			});
+			new StringParameter(this, 'EndpointAddressParam', {
+				parameterName: `/${stage}/${stack}/${app}/database/endpoint-address`,
+				simpleName: false,
+				stringValue: this.dbInstanceEndpointAddress,
+				tier: ParameterTier.STANDARD,
+				dataType: ParameterDataType.TEXT,
+			});
+		}
+	}
+}

--- a/packages/cloudquery/prod-config/cloudquery.sh
+++ b/packages/cloudquery/prod-config/cloudquery.sh
@@ -3,7 +3,7 @@
 set -e
 # This is created in the Cloudformation
 # TODO: At the moment this is hard-coded, but if we want multiple stages in the future we would need to change this
-SSM_PATH=/INFRA/deploy/cloudquery/postgres-instance-endpoint-address
+SSM_PATH=/INFRA/deploy/cloudquery/database/endpoint-address
 
 # This function will generate a connection string to the RDS database, with a temporary password that expires after 15 minutes.
 issueRdsAuthToken() {


### PR DESCRIPTION
> **Warning**
> This change causes database replacement.

## What does this change?
In https://github.com/guardian/cdk/issues/1786 we describe ambition to offer an opinionated RDS construct as there are some defaults in AWS CDK that, when changed, causes replacement.

In this change, we create a `GuDatabase` construct with sensible defaults of:
  - Storage encryption
  - Use of the AWS Account's Primary VPC, and private subnets
  - Use of a [new certificate authority (CA)](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.RegionCertificateAuthorities) that offers an improved updating process to the `rds-ca-2019` CA
  - Deletion protection
  - IAM authentication
  - Multi AZ

## Why?
This is a start to address https://github.com/guardian/cdk/issues/1786 in a real-world service. Once proven to work, we can move the construct into the GuCDK library.

## How has it been verified?
It hasn't been verified in production, however, this is because the changes are quite destructive.

Using [`cdk diff`](https://docs.aws.amazon.com/cdk/v2/guide/cli.html#cli-commands) (see below) shows these changes will cause replacement. Even following the [guidance around stateful resources](https://github.com/guardian/cdk/blob/main/docs/stateful-resources.md) does not change this as we're changing properties of the RDS DB instance in addition to the logical ID.

Therefore, to deploy this change we need to:
1. Snapshot the current database
2. Deploy, and replace the database instance
3. Restore the snapshot to the new database

### Output of `cdk diff`
```
[~] AWS::RDS::DBInstance PostgresInstance1Cloudquery PostgresInstance16DE4286E replace
 ├─ [+] CACertificateIdentifier
 │   └─ rds-ca-2019
 ├─ [~] DBSubnetGroupName (requires replacement)
 │   └─ [~] .Ref:
 │       ├─ [-] PostgresInstance1SubnetGroupCAC045A5
 │       └─ [+] PostgresInstance1CloudquerySubnetGroup1E0841E2
 ├─ [+] DeletionProtection
 │   └─ true
 ├─ [~] MasterUserPassword
 │   └─ [~] .Fn::Join:
 │       └─ @@ -3,7 +3,7 @@
 │          [ ] [
 │          [ ]   "{{resolve:secretsmanager:",
 │          [ ]   {
 │          [-]     "Ref": "PostgresInstance1Secret7FA1A24B"
 │          [+]     "Ref": "PostgresInstance1CloudquerySecret896B33F7"
 │          [ ]   },
 │          [ ]   ":SecretString:password::}}"
 │          [ ] ]
 ├─ [~] MasterUsername (requires replacement)
 │   └─ [~] .Fn::Join:
 │       └─ @@ -3,7 +3,7 @@
 │          [ ] [
 │          [ ]   "{{resolve:secretsmanager:",
 │          [ ]   {
 │          [-]     "Ref": "PostgresInstance1Secret7FA1A24B"
 │          [+]     "Ref": "PostgresInstance1CloudquerySecret896B33F7"
 │          [ ]   },
 │          [ ]   ":SecretString:username::}}"
 │          [ ] ]
 ├─ [+] MultiAZ
 │   └─ true
 ├─ [~] Tags
 │   └─ @@ -1,5 +1,9 @@
 │      [ ] [
 │      [ ]   {
 │      [+]     "Key": "App",
 │      [+]     "Value": "cloudquery"
 │      [+]   },
 │      [+]   {
 │      [ ]     "Key": "gu:cdk:version",
 │      [ ]     "Value": "48.5.2"
 │      [ ]   },
 └─ [~] VPCSecurityGroups
     └─ @@ -1,7 +1,7 @@
        [ ] [
        [ ]   {
        [ ]     "Fn::GetAtt": [
        [-]       "PostgresInstance1SecurityGroupFA28C3C0",
        [+]       "DefaultSecurityGroupCloudquery39EED116",
        [ ]       "GroupId"
        [ ]     ]
        [ ]   }
```