### PR TITLE
chore(deps): Update CloudQuery to v2.5.3

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -892,8 +892,8 @@ aws s3 cp 's3://",
                 },
                 "/deploy/TEST/cloudquery/cloudquery.sh' '/opt/cloudquery/cloudquery.sh'
 set -xe
-curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.1/cloudquery_linux_arm64 -o /opt/cloudquery/cloudquery
-echo "8f06db6e35b907dae754a2b16435cbc25206f3d978b6015336b2a4e880bbf836  /opt/cloudquery/cloudquery" | shasum -c -a 256
+curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.3/cloudquery_linux_arm64 -o /opt/cloudquery/cloudquery
+echo "286cff19c54098328c0b85dbbfa94e87234b5a53be421c3b6ca406803122a7ee  /opt/cloudquery/cloudquery" | shasum -c -a 256
 chmod a+x /opt/cloudquery/cloudquery
 chmod a+x /opt/cloudquery/cloudquery.sh
 sed -i "s/£DEPLOY_TOOLS_ACCOUNT_ID/",

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -38,14 +38,14 @@ const CloudQueryManifest = {
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=cli
 	 */
-	version: '2.5.1',
+	version: '2.5.3',
 
 	/**
 	 * The checksum of the CloudQuery CLI. Found in the `checksums.txt` asset.
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=cli
 	 */
-	checksum: '8f06db6e35b907dae754a2b16435cbc25206f3d978b6015336b2a4e880bbf836',
+	checksum: '286cff19c54098328c0b85dbbfa94e87234b5a53be421c3b6ca406803122a7ee',
 };
 
 export class CloudQuery extends GuStack {


### PR DESCRIPTION
## What does this change?
This is the [latest version](https://github.com/cloudquery/cloudquery/releases?q=cli) of the CloudQuery CLI.

## Why?
Keeping up to date is good!

## How has it been verified?
The checksum was obtained from https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.3/checksums.txt and also confirmed via:

```sh
curl -sL https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.3/cloudquery_linux_arm64 | shasum -a 256
```