### PR TITLE
chore(deps): Update cloudquery/aws to v16.1.0

### DIFF
--- a/packages/cloudquery/prod-config/aws.yaml
+++ b/packages/cloudquery/prod-config/aws.yaml
@@ -2,8 +2,9 @@ kind: source
 spec:
   name: 'aws'
   path: 'cloudquery/aws'
-  version: 'v15.7.0'
-  # tables: ["*"]
+
+  # Track releases on https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
+  version: 'v16.1.0'
   destinations: ['postgresql']
   skip_tables:
     - aws_ec2_vpc_endpoint_services # this resource includes services that are available from AWS as well as other AWS Accounts


### PR DESCRIPTION
## What does this change?
This is a major bump, with [breaking changes](https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws). Reading https://www.cloudquery.io/docs/advanced-topics/migrations and following #162, CloudQuery should automatically perform the necessary steps to migrate.

## Why?
Keeping up to date.

## How has it been verified?
I've tested locally via #171.