### PR TITLE
Run Cloudquery in all of our AWS accounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
           go-version: '1.20'
           cache-dependency-path: packages/cloudformation-lens/go.sum
 
+      - uses: guardian/actions-read-private-repos@v0.1.0
+        with:
+          private-ssh-keys: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
+
       - name: Run script/ci
         run: ./scripts/ci.sh
 

--- a/config/cloudquery/aws.yaml
+++ b/config/cloudquery/aws.yaml
@@ -25,7 +25,7 @@ spec:
     regions:
       - eu-west-1
       - us-east-1
-  org:
-    member_role_name: cloudquery-access # See: https://github.com/guardian/aws-account-setup/pull/58.
-    organization_units:
-      - £TARGET_ORG_UNIT
+    org:
+      member_role_name: cloudquery-access # See: https://github.com/guardian/aws-account-setup/pull/58.
+      organization_units:
+        - £TARGET_ORG_UNIT

--- a/config/cloudquery/aws.yaml
+++ b/config/cloudquery/aws.yaml
@@ -21,6 +21,7 @@ spec:
     - aws_rds_db_parameter_groups
     - aws_rds_engine_versions
     - aws_servicequotas_services
+  concurrency: 100000 # this is known to work with a t4g.medium and our current sources but not optimised.
   spec:
     regions:
       - eu-west-1

--- a/config/cloudquery/aws.yaml
+++ b/config/cloudquery/aws.yaml
@@ -25,8 +25,7 @@ spec:
     regions:
       - eu-west-1
       - us-east-1
-    accounts:
-      - id: deployTools
-        role_arn: arn:aws:iam::£DEPLOY_TOOLS_ACCOUNT_ID:role/cloudquery-access
-      - id: developerPlayground
-        role_arn: arn:aws:iam::£DEV_PLAYGROUND_ACCOUNT_ID:role/cloudquery-access
+  org:
+    member_role_name: cloudquery-access # See: https://github.com/guardian/aws-account-setup/pull/58.
+    organization_units:
+      - £TARGET_ORG_UNIT

--- a/config/cloudquery/aws.yaml
+++ b/config/cloudquery/aws.yaml
@@ -21,7 +21,7 @@ spec:
     - aws_rds_db_parameter_groups
     - aws_rds_engine_versions
     - aws_servicequotas_services
-  concurrency: 100000 # this is known to work with a t4g.medium and our current sources but not optimised.
+  concurrency: 100000 # this is expected to work with a t4g.medium and our current sources but not optimised. Will adjust once live.
   spec:
     regions:
       - eu-west-1

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,9 @@ const generateProject = (name) => {
 		transform: {
 			'^.+\\.tsx?$': 'ts-jest',
 		},
+		transformIgnorePatterns: [
+			'node_modules/(?!@guardian/private-infrastructure-config)',
+		],
 		testMatch: [`<rootDir>/packages/${name}/**/*.test.ts`],
 		setupFilesAfterEnv: [`./packages/${name}/jest.setup.js`],
 		moduleNameMapper: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2186,6 +2186,11 @@
         "prettier": "^2.4.0"
       }
     },
+    "node_modules/@guardian/private-infrastructure-config": {
+      "version": "2.2.0",
+      "resolved": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#232c773a3c4af0fcf831f82a9093e67c0e1b7c51",
+      "dev": true
+    },
     "node_modules/@guardian/tsconfig": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@guardian/tsconfig/-/tsconfig-0.2.0.tgz",
@@ -10392,6 +10397,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "@guardian/cdk": "48.5.2",
+        "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
         "aws-cdk": "2.51.1",
         "aws-cdk-lib": "2.51.1",
         "constructs": "10.1.167",
@@ -12228,6 +12234,11 @@
       "dev": true,
       "requires": {}
     },
+    "@guardian/private-infrastructure-config": {
+      "version": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#232c773a3c4af0fcf831f82a9093e67c0e1b7c51",
+      "dev": true,
+      "from": "@guardian/private-infrastructure-config@github:guardian/private-infrastructure-config#v2.3.0"
+    },
     "@guardian/tsconfig": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@guardian/tsconfig/-/tsconfig-0.2.0.tgz",
@@ -13944,6 +13955,7 @@
       "version": "file:packages/cdk",
       "requires": {
         "@guardian/cdk": "48.5.2",
+        "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
         "aws-cdk": "2.51.1",
         "aws-cdk-lib": "2.51.1",
         "constructs": "10.1.167",

--- a/packages/cdk/jest.setup.js
+++ b/packages/cdk/jest.setup.js
@@ -1,1 +1,2 @@
-jest.mock("@guardian/cdk/lib/constants/tracking-tag");
+jest.mock('@guardian/cdk/lib/constants/tracking-tag');
+jest.mock('@guardian/private-infrastructure-config');

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -47,14 +47,6 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       "Description": "A list of private subnets",
       "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
-    "deployToolsAccountIDParam": {
-      "Description": "Account ID for deployTools",
-      "Type": "String",
-    },
-    "devPlaygroundAccountIDParam": {
-      "Description": "Account ID for developerPlayground",
-      "Type": "String",
-    },
   },
   "Resources": {
     "DescribeEC2PolicyFF5F9295": {
@@ -316,6 +308,15 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
                   ],
                 ],
               },
+            },
+            {
+              "Action": [
+                "organizations:ListAccounts",
+                "organizations:ListAccountsForParent",
+                "organizations:ListChildren",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
             },
           ],
           "Version": "2012-10-17",
@@ -896,16 +897,7 @@ curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.3/cl
 echo "286cff19c54098328c0b85dbbfa94e87234b5a53be421c3b6ca406803122a7ee  /opt/cloudquery/cloudquery" | shasum -c -a 256
 chmod a+x /opt/cloudquery/cloudquery
 chmod a+x /opt/cloudquery/cloudquery.sh
-sed -i "s/£DEPLOY_TOOLS_ACCOUNT_ID/",
-                {
-                  "Ref": "deployToolsAccountIDParam",
-                },
-                "/g" /opt/cloudquery/aws.yaml
-sed -i "s/£DEV_PLAYGROUND_ACCOUNT_ID/",
-                {
-                  "Ref": "devPlaygroundAccountIDParam",
-                },
-                "/g" /opt/cloudquery/aws.yaml
+sed -i "s/£TARGET_ORG_UNIT/ou-123/g" /opt/cloudquery/aws.yaml
 curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/ca-certificates/rds-ca-2019-root.crt
 update-ca-certificates
 systemctl enable cloudquery.timer

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -832,7 +832,7 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
         "ImageId": {
           "Ref": "AMICloudquery",
         },
-        "InstanceType": "t4g.small",
+        "InstanceType": "t4g.medium",
         "MetadataOptions": {
           "HttpTokens": "required",
         },

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -179,7 +179,7 @@ export class CloudQuery extends GuStack {
 			vpcSubnets: { subnets: privateSubnets },
 			minimumInstances: 1,
 			userData: userData,
-			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.MEDIUM),
 			imageRecipe: 'arm64-jammy-java11-deploy-infrastructure',
 			additionalSecurityGroups: [applicationToPostgresSecurityGroup],
 		};

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -13,8 +13,9 @@ import {
 	GuVpc,
 	SubnetType,
 } from '@guardian/cdk/lib/constructs/ec2';
+import { GuardianOrganisationalUnits } from '@guardian/private-infrastructure-config';
 import type { App } from 'aws-cdk-lib';
-import { CfnParameter, Tags } from 'aws-cdk-lib';
+import { Tags } from 'aws-cdk-lib';
 import {
 	InstanceClass,
 	InstanceSize,
@@ -109,24 +110,6 @@ export class CloudQuery extends GuStack {
 
 		const userData = UserData.forLinux();
 
-		const deployToolsAccountID = new CfnParameter(
-			this,
-			'deployToolsAccountIDParam',
-			{
-				type: 'String',
-				description: 'Account ID for deployTools',
-			},
-		);
-
-		const devPlaygroundAccountID = new CfnParameter(
-			this,
-			'devPlaygroundAccountIDParam',
-			{
-				type: 'String',
-				description: 'Account ID for developerPlayground',
-			},
-		);
-
 		const bucket = Bucket.fromBucketName(
 			this,
 			'distributionBucket',
@@ -179,9 +162,8 @@ export class CloudQuery extends GuStack {
 			// Set permission to execute cloudquery.sh
 			`chmod a+x ${cloudqueryScript}`,
 
-			// Set target accounts - temp until we use OUs
-			`sed -i "s/£DEPLOY_TOOLS_ACCOUNT_ID/${deployToolsAccountID.valueAsString}/g" ${awsYamlFile}`,
-			`sed -i "s/£DEV_PLAYGROUND_ACCOUNT_ID/${devPlaygroundAccountID.valueAsString}/g" ${awsYamlFile}`,
+			// Set target Org Unit
+			`sed -i "s/£TARGET_ORG_UNIT/${GuardianOrganisationalUnits.Root}/g" ${awsYamlFile}`,
 
 			// Install RDS certificate
 			'curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/ca-certificates/rds-ca-2019-root.crt',
@@ -277,6 +259,18 @@ export class CloudQuery extends GuStack {
 					`arn:aws:rds-db:${this.region}:${this.account}:dbuser:${attrDbiResourceId}/cloudquery`,
 				],
 				actions: ['rds-db:connect'],
+			}),
+		);
+
+		asg.addToRolePolicy(
+			new PolicyStatement({
+				effect: Effect.ALLOW,
+				resources: ['*'],
+				actions: [
+					'organizations:ListAccounts',
+					'organizations:ListAccountsForParent',
+					'organizations:ListChildren',
+				],
 			}),
 		);
 	}

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@guardian/cdk": "48.5.2",
+    "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
     "aws-cdk": "2.51.1",
     "aws-cdk-lib": "2.51.1",
     "constructs": "10.1.167",


### PR DESCRIPTION
## What does this change?

Run Cloudquery in all of our AWS accounts.

## Why

So that we can inspect all of our AWS accounts to understand how we are using them.

## How

This uses the OU support that Cloudquery provides to query all of our AWS accounts without having to manually specify them. The docs on how this works are here:

https://www.cloudquery.io/docs/plugins/sources/aws/multi-account#aws-organizations

Cloudquery discovers accounts by querying AWS for the OU members, and then assumes a role in each target accounts to query it.

Note, the process isn't entirely automatic; the cloudquery-access role must be present in target accounts, and this is only present in accounts the aws-account-setup manages. See:

https://github.com/guardian/aws-account-setup/pull/58

## How has it been verified?

TODO - suggestion is that we deploy this branch for a day and see how it goes.