### PR TITLE
feat(cloudquery): Collect data across all supported regions

### DIFF
--- a/packages/cloudquery/prod-config/aws.yaml
+++ b/packages/cloudquery/prod-config/aws.yaml
@@ -25,8 +25,15 @@ spec:
   concurrency: 100000 # this is expected to work with a t4g.medium and our current sources but not optimised. Will adjust once live.
   spec:
     regions:
-      - eu-west-1
-      - us-east-1
+      # All regions we support.
+      # See https://github.com/guardian/infosec-platform/blob/main/policies/DenyAccessToNonApprovedRegions.json
+      - "eu-west-1"
+      - "eu-west-2"
+      - "us-east-1"
+      - "us-east-2"
+      - "us-west-1"
+      - "ap-southeast-2"
+      - "ca-central-1"
     org:
       member_role_name: cloudquery-access # See: https://github.com/guardian/aws-account-setup/pull/58.
       organization_units:


### PR DESCRIPTION
## What does this change?
Collect data from all regions as defined by the service control policy - https://github.com/guardian/infosec-platform/blob/main/policies/DenyAccessToNonApprovedRegions.json.

I suspect we'll see the performance issues highlighted in https://github.com/guardian/service-catalogue/pull/170 a lot faster with these changes...

## Why?
I've spotted a number of EC2 instances outside of eu-west-1 and us-east-1. Being able to see complete usage of all AWS services, across all regions, will be useful.

## How has it been verified?
N/A