### PR TITLE
chore(deps): Update CloudQuery Postgres destination to v4.0.2

### DIFF
--- a/packages/cloudquery/dev-config/cloudquery.yaml
+++ b/packages/cloudquery/dev-config/cloudquery.yaml
@@ -37,7 +37,9 @@ spec:
   name: 'postgresql'
   registry: 'github'
   path: 'cloudquery/postgresql'
-  version: 'v3.0.0'
+
+  # Track releases on https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql-&expanded=true
+  version: 'v4.0.2'
 
   # Automatically apply migrations whenever plugins are updated.
   # Note: This is not encouraged if risk averse, so we should consider removing this once fully in production.

--- a/packages/cloudquery/prod-config/postgresql.yaml
+++ b/packages/cloudquery/prod-config/postgresql.yaml
@@ -3,7 +3,9 @@ spec:
   name: 'postgresql'
   registry: 'github'
   path: 'cloudquery/postgresql'
-  version: 'v3.0.0'
+
+  # Track releases on https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql-&expanded=true
+  version: 'v4.0.2'
 
   # Automatically apply migrations whenever plugins are updated.
   # Note: This is not encouraged if risk averse, so we should consider removing this once fully in production.


### PR DESCRIPTION
## What does this change?
Updates to a later version of the Postgres destination plugin. Although this is a new major version, it shouldn't contain breaking changes:

From https://github.com/cloudquery/cloudquery/releases/tag/plugins-destination-postgresql-v4.0.0:

> This should not have any visible breaking changes, however due to the size of the change we are introducing it under a major version bump to communicate that it might have some bugs that we weren't able to catch during our internal tests.

## Why?
It looks like CloudQuery is not removing stale data. This is evidenced in the [dashboard for instances with port 22 open](https://metrics.gutools.co.uk/d/3n6tttEVz/best-practice-violations?orgId=1). If you filter by the deployTools account, we can see a large number of TeamCity agent instances, however these never live for more than 24 hours, so the majority of them are actually now terminated.

CloudQuery's default `write_mode` is `overwrite-delete-stale`, which:

> overwrite existing rows with the same primary key, and delete rows that are no longer present in the cloud.

On the assumption that this stale data is a bug in v3.0.0, upgrade to the latest version.

## How has it been verified?
Ran locally. No errors witnessed.