### PR TITLE
fix(cloudquery): Skip erroring tables

### DIFF
--- a/packages/cloudquery/dev-config/cloudquery.yaml
+++ b/packages/cloudquery/dev-config/cloudquery.yaml
@@ -23,13 +23,36 @@ spec:
     - aws_rds_db_parameter_groups
     - aws_rds_engine_versions
     - aws_servicequotas_services
+    - aws_organizations_delegated_services
+    - aws_organizations_roots
+    - aws_organizations_delegated_administrators
+    - aws_organizations_policies
+    - aws_organizations_organizational_units
+    - aws_organization_resource_policies
+    - aws_identitystore_users
+    - aws_identitystore_groups
+    - aws_quicksight_data_sets
+    - aws_quicksight_dashboards
+    - aws_quicksight_analyses
+    - aws_quicksight_users
+    - aws_quicksight_templates
+    - aws_quicksight_groups
+    - aws_quicksight_folders
+    - aws_quicksight_data_sources
+    - aws_amp_workspaces
+    - aws_ssoadmin_instances
+    - aws_glue_connections
+    - aws_computeoptimizer_ecs_service_recommendations
+    - aws_xray_sampling_rules
+    - aws_xray_resource_policies
+    - aws_xray_groups
   spec:
     regions:
       - eu-west-1
       - us-east-1
     accounts:
-      - id: "developerPlayground"
-        local_profile: "developerPlayground"
+      - id: 'developerPlayground'
+        local_profile: 'developerPlayground'
 
 ---
 kind: destination

--- a/packages/cloudquery/prod-config/aws.yaml
+++ b/packages/cloudquery/prod-config/aws.yaml
@@ -22,6 +22,21 @@ spec:
     - aws_rds_db_parameter_groups
     - aws_rds_engine_versions
     - aws_servicequotas_services
+    - aws_organizations_delegated_services
+    - aws_organizations_roots
+    - aws_organizations_delegated_administrators
+    - aws_organizations_policies
+    - aws_organizations_organizational_units
+    - aws_organization_resource_policies
+    - aws_identitystore_users
+    - aws_identitystore_groups
+    - aws_quicksight_data_sets
+    - aws_quicksight_dashboards
+    - aws_quicksight_analyses
+    - aws_amp_workspaces
+    - aws_ssoadmin_instances
+    - aws_glue_connections
+    - aws_computeoptimizer_ecs_service_recommendations
   concurrency: 100000 # this is expected to work with a t4g.medium and our current sources but not optimised. Will adjust once live.
   spec:
     regions:

--- a/packages/cloudquery/prod-config/aws.yaml
+++ b/packages/cloudquery/prod-config/aws.yaml
@@ -33,6 +33,11 @@ spec:
     - aws_quicksight_data_sets
     - aws_quicksight_dashboards
     - aws_quicksight_analyses
+    - aws_quicksight_users
+    - aws_quicksight_templates
+    - aws_quicksight_groups
+    - aws_quicksight_folders
+    - aws_quicksight_data_sources
     - aws_amp_workspaces
     - aws_ssoadmin_instances
     - aws_glue_connections
@@ -42,13 +47,13 @@ spec:
     regions:
       # All regions we support.
       # See https://github.com/guardian/infosec-platform/blob/main/policies/DenyAccessToNonApprovedRegions.json
-      - "eu-west-1"
-      - "eu-west-2"
-      - "us-east-1"
-      - "us-east-2"
-      - "us-west-1"
-      - "ap-southeast-2"
-      - "ca-central-1"
+      - eu-west-1
+      - eu-west-2
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - ap-southeast-2
+      - ca-central-1
     org:
       member_role_name: cloudquery-access # See: https://github.com/guardian/aws-account-setup/pull/58.
       organization_units:

--- a/packages/cloudquery/prod-config/aws.yaml
+++ b/packages/cloudquery/prod-config/aws.yaml
@@ -42,6 +42,9 @@ spec:
     - aws_ssoadmin_instances
     - aws_glue_connections
     - aws_computeoptimizer_ecs_service_recommendations
+    - aws_xray_sampling_rules
+    - aws_xray_resource_policies
+    - aws_xray_groups
   concurrency: 100000 # this is expected to work with a t4g.medium and our current sources but not optimised. Will adjust once live.
   spec:
     regions:


### PR DESCRIPTION
## What does this change?

This adds 23 additional tables to the list of those that are ignored (skipped) by Cloudquery.

## Why?

We are seeing permissions errors on 28 tables ([see logs](https://logs.gutools.co.uk/s/devx/app/discover#/view/461d0f40-d87b-11ed-9ed7-4d35b765d6ad?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2023-04-18T05:00:00.000Z',to:'2023-04-18T07:00:00.000Z'))&_a=(columns:!(table,message,error),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'626e7830-dd3a-11ea-88b6-37713dba5739',key:app.keyword,negate:!f,params:(query:cloudquery),type:phrase),query:(match_phrase:(app.keyword:cloudquery))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'626e7830-dd3a-11ea-88b6-37713dba5739',key:level.keyword,negate:!f,params:(query:error),type:phrase),query:(match_phrase:(level.keyword:error)))),grid:(),hideChart:!f,index:'626e7830-dd3a-11ea-88b6-37713dba5739',interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc))))). After triaging the tables, we have prioritised 5 tables to fix permissions for (in a separate PR), and the rest have been prioritised for fixing later or ignoring.

### Priority 1 (to fix)
- [aws_organizations_accounts](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_organizations_accounts)
- [aws_ecs_task_definitions](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_ecs_task_definitions)
- [aws_ecs_clusters](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_ecs_clusters)
- [aws_ecs_cluster_tasks](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_ecs_cluster_tasks)
- [aws_securityhub_findings](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_securityhub_findings)

### Priority 2 (to fix later)
- [aws_ssoadmin_instances](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_ssoadmin_instances)
- [aws_glue_connections](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_glue_connections)
- [aws_computeoptimizer_ecs_service_recommendations](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_computeoptimizer_ecs_service_recommendations)
- [aws_xray_sampling_rules](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_xray_sampling_rules)
- [aws_xray_resource_policies](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_xray_resource_policies)
- [aws_xray_groups](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_xray_groups)

### Priority 3 (to fix much later or we currently don't use the services)
- [aws_organizations_delegated_services](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_organizations_delegated_services)
- [aws_organizations_roots](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_organizations_roots)
- [aws_organizations_delegated_administrators](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_organizations_delegated_administrators)
- [aws_organizations_policies](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_organizations_policies)
- [aws_organizations_organizational_units](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_organizations_organizational_units)
- [aws_organization_resource_policies](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_organization_resource_policies)
- [aws_identitystore_users](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_identitystore_users)
- [aws_identitystore_groups](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_identitystore_groups)
- [aws_quicksight_data_sets](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_quicksight_data_sets)
- [aws_quicksight_dashboards](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_quicksight_dashboards)
- [aws_quicksight_analyses](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_quicksight_analyses)
- [aws_quicksight_users](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_quicksight_users)
- [aws_quicksight_templates](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_quicksight_templates)
- [aws_quicksight_groups](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_quicksight_groups)
- [aws_quicksight_folders](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_quicksight_folders)
- [aws_quicksight_data_sources](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_quicksight_data_sources)
- [aws_amp_workspaces](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_amp_workspaces)


## How has it been verified?

Run cloudquery on branch and observe errors between main and this branch.

### Before (main)

![image](https://user-images.githubusercontent.com/15648334/233989883-ae6e4220-e26b-4713-a1a2-ee2cbe1868bf.png)

### After

![image](https://user-images.githubusercontent.com/15648334/233990281-9348b19c-a1ad-4fc4-ae6a-1f7c93b2fffb.png)
