### PR TITLE
fix(cloudquery): Update actions on role policy

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -310,11 +310,7 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
               },
             },
             {
-              "Action": [
-                "organizations:ListAccounts",
-                "organizations:ListAccountsForParent",
-                "organizations:ListChildren",
-              ],
+              "Action": "organizations:List*",
               "Effect": "Allow",
               "Resource": "*",
             },

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -266,11 +266,7 @@ export class CloudQuery extends GuStack {
 			new PolicyStatement({
 				effect: Effect.ALLOW,
 				resources: ['*'],
-				actions: [
-					'organizations:ListAccounts',
-					'organizations:ListAccountsForParent',
-					'organizations:ListChildren',
-				],
+				actions: ['organizations:List*'],
 			}),
 		);
 	}


### PR DESCRIPTION
## What does this change?

Changes the role policy to allow all `List` actions rather than 3 specific ones.

## Why?

We are seeing permissions errors on the CloudQuery `aws_organizations_accounts` table such as `ListTagsForResource, https response error StatusCode: 400, RequestID: 2e5cd926-af8e-432e-b9b0-b67dd1ed1627, AccessDeniedException: You don't have permissions to access this resource`. 

It appears that the [CloudQuery documentation we followed](https://github.com/cloudquery/cloudquery/blob/main/website/pages/docs/plugins/sources/aws/multi-account.mdx) conflicts with [their template](https://github.com/cloudquery/iam-for-aws-orgs/blame/d44ffe5509ba8a6c84c31dcc1dac7f475a5099e3/template.yml#L35). 

## How has it been verified?

Ran Cloudquery on the branch and the `aws_organizations_accounts` permission errors are nil: 
![image](https://user-images.githubusercontent.com/15648334/234521174-60acc6f6-93ef-4374-b281-04110705a7f1.png)
