### PR TITLE
chore(deps): Update GuCDK to v50.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.30",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.30.tgz",
-      "integrity": "sha512-mFRF5n1jxjKpX8ZZSCRhJc6Hj8BkeZFUPwK0j6jRcouQQZHsZyydbf4UuzMYQ4SZU6cCLM7DKmWO0Kx156ZSnw==",
+      "version": "2.2.153",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.153.tgz",
+      "integrity": "sha512-t66eh2VexLotjGnWZbI3fh24Ohw6nR1k0PawSnfvHEmxXlKO5hmr/+7eIr3oXRPT3tPBTbsgp1Al+AlR3cWd1A==",
       "dev": true
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
@@ -53,9 +53,9 @@
       "dev": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.36.tgz",
-      "integrity": "sha512-acG7qHXrLXGVsOnkHNrNfzGaMtONZ+2nsjhUXhCRf9zQZMzs7lzkv9dTUaHJywAABR9DaRRUFMpUytJDqvN8Ew==",
+      "version": "2.0.128",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.128.tgz",
+      "integrity": "sha512-d3lTtX/19N9vwyh8Y1NVwmsmwro4YmyE3AoMO+XKFrtndCHc68N890yUGGvNE6R3zM+95yrQ6YPHCWZjR79S9Q==",
       "dev": true
     },
     "node_modules/@aws-crypto/crc32": {
@@ -2117,6 +2117,35 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@guardian/cdk": {
+      "version": "49.0.2",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.0.2.tgz",
+      "integrity": "sha512-81uvX7E29+ynn/9mWaYoH0swL55gLBPnH+Z3nW9dO6Jg0RFd1qarHKbJjq+lPUJ/SPce5KqAuLekMmIlEo9R4Q==",
+      "dev": true,
+      "dependencies": {
+        "@oclif/core": "1.24.2",
+        "aws-cdk-lib": "2.59.0",
+        "aws-sdk": "^2.1296.0",
+        "chalk": "^4.1.2",
+        "codemaker": "^1.73.0",
+        "constructs": "10.1.215",
+        "git-url-parse": "^13.1.0",
+        "js-yaml": "^4.1.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.upperfirst": "^4.3.1",
+        "read-pkg-up": "7.0.1",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "gu-cdk": "bin/gu-cdk"
+      },
+      "peerDependencies": {
+        "aws-cdk": "2.59.0",
+        "aws-cdk-lib": "2.59.0",
+        "constructs": "10.1.215"
+      }
+    },
     "node_modules/@guardian/eslint-config": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-2.0.3.tgz",
@@ -2644,6 +2673,82 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oclif/core": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.24.2.tgz",
+      "integrity": "sha512-0wfAa6HG4sJ4j5c4/GV4BWZwALtJyw2ZO6titnrWKcowxU1BWd8mBM45ilTPnDhClMowz7+8EtK4kqUGc1rNwA==",
+      "dev": true,
+      "dependencies": {
+        "@oclif/linewrap": "^1.0.0",
+        "@oclif/screen": "^3.0.4",
+        "ansi-escapes": "^4.3.2",
+        "ansi-styles": "^4.3.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.2",
+        "clean-stack": "^3.0.1",
+        "cli-progress": "^3.10.0",
+        "debug": "^4.3.4",
+        "ejs": "^3.1.6",
+        "fs-extra": "^9.1.0",
+        "get-package-type": "^0.1.0",
+        "globby": "^11.1.0",
+        "hyperlinker": "^1.0.0",
+        "indent-string": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "js-yaml": "^3.14.1",
+        "natural-orderby": "^2.0.3",
+        "object-treeify": "^1.1.33",
+        "password-prompt": "^1.1.2",
+        "semver": "^7.3.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "supports-color": "^8.1.1",
+        "supports-hyperlinks": "^2.2.0",
+        "tslib": "^2.4.1",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@oclif/core/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/@oclif/linewrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
@@ -2651,9 +2756,10 @@
       "dev": true
     },
     "node_modules/@oclif/screen": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.3.tgz",
-      "integrity": "sha512-KX8gMYA9ujBPOd1HFsV9e0iEx7Uoj8AG/3YsW4TtWQTg4lJvr82qNm7o/cFQfYRIt+jw7Ew/4oL4A22zOT+IRA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.4.tgz",
+      "integrity": "sha512-IMsTN1dXEXaOSre27j/ywGbBjrzx0FNd1XmuhCWCB9NTPrhWI1Ifbz+YLSEcstfQfocYsrbrIessxXb2oon4lA==",
+      "deprecated": "Deprecated in favor of @oclif/core",
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
@@ -3690,10 +3796,231 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-cdk": {
+      "version": "2.59.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.59.0.tgz",
+      "integrity": "sha512-5xKh+nC6wLsjYGwA+YYbX9ZonJLYmthxSZy8pK/Bm9rL2mFpnMKvQZJz67L6ghOt1XumoB1vZbIhptln68jTuw==",
+      "dev": true,
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.59.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.59.0.tgz",
+      "integrity": "sha512-FT6QRsou8TibQcz/TqI3rEkB9EBVF5Om5lv9MXz/5qiKehWRbKZVX0I0l/SSAvGSmdTU5Pfr+WRBTk51oNMAdw==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "yaml"
+      ],
+      "dev": true,
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.30",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.38",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^9.1.0",
+        "ignore": "^5.2.1",
+        "jsonschema": "^1.4.1",
+        "minimatch": "^3.1.2",
+        "punycode": "^2.1.1",
+        "semver": "^7.3.8",
+        "yaml": "1.10.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/at-least-node": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.3.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/aws-sdk": {
-      "version": "2.1273.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1273.0.tgz",
-      "integrity": "sha512-QF37fm1DfUxjw+IJtDMTDBckVwAOf8EHQjs4NxJp5TtRkeqtWkxNzq/ViI8kAS+0n8JZaom8Oenmy8ufGfLMAQ==",
+      "version": "2.1366.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1366.0.tgz",
+      "integrity": "sha512-tS7y18KHH0eq43I8WJsxVBpwOMY45FSsu6a+A/6k0bMrE4zhd1fzhPN+5coNIODaGxnqVvgw9guLg3AOe4SpaA==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -3705,7 +4032,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.4.19"
+        "xml2js": "0.5.0"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -4137,9 +4464,9 @@
       }
     },
     "node_modules/cli-progress": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.2.tgz",
-      "integrity": "sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
       "dev": true,
       "dependencies": {
         "string-width": "^4.2.3"
@@ -4179,9 +4506,9 @@
       }
     },
     "node_modules/codemaker": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.72.0.tgz",
-      "integrity": "sha512-U4TM++FGA+vnWHTSMA8juU+C9iXn1TDauMFmn44gz9pKrbLtjGUiMjfC4vX5HachkNQgitRj6bc/g7PA4j0C3Q==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.80.0.tgz",
+      "integrity": "sha512-8d9TWXA+eLDFLkYiFKmyXDmXFBmASVxly2PyOK/kLryuhielDZEahSoltF+ES2Dm/F4IzZ4uL7ZjTgkjy69s0w==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -4309,6 +4636,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/constructs": {
+      "version": "10.1.215",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.215.tgz",
+      "integrity": "sha512-X9gJAHsb9D4etv70JQxUmqhHkhMSiUFNCnfBvOMHRYvIaFCgc91gcWyrb5UMBGPnzZBlcX8LTTHPOLik3waPmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.17.0"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -4579,9 +4915,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
       "dev": true,
       "dependencies": {
         "jake": "^10.8.5"
@@ -5790,9 +6126,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-      "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -8586,6 +8922,7 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -9986,19 +10323,22 @@
       }
     },
     "node_modules/xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
       "dependencies": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -10064,332 +10404,12 @@
     "packages/cdk": {
       "version": "1.0.0",
       "devDependencies": {
-        "@guardian/cdk": "49.0.0",
+        "@guardian/cdk": "49.0.2",
         "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-        "aws-cdk": "2.54.0",
-        "aws-cdk-lib": "2.54.0",
-        "constructs": "10.1.187",
+        "aws-cdk": "2.59.0",
+        "aws-cdk-lib": "2.59.0",
+        "constructs": "10.1.215",
         "source-map-support": "^0.5.21"
-      }
-    },
-    "packages/cdk/node_modules/@guardian/cdk": {
-      "version": "49.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.0.0.tgz",
-      "integrity": "sha512-VDuyHyHxiYU5WKQAG+IO0rwiPiWFaM6wKYgAaMkefAwKaYxswzEoSqKyJevhYxHbnWNWht0n3w1L6aTqdWpxGA==",
-      "dev": true,
-      "dependencies": {
-        "@oclif/core": "1.21.0",
-        "aws-cdk-lib": "2.54.0",
-        "aws-sdk": "^2.1272.0",
-        "chalk": "^4.1.2",
-        "codemaker": "^1.72.0",
-        "constructs": "10.1.187",
-        "git-url-parse": "^13.1.0",
-        "js-yaml": "^4.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.upperfirst": "^4.3.1",
-        "read-pkg-up": "7.0.1",
-        "yargs": "^17.6.2"
-      },
-      "bin": {
-        "gu-cdk": "bin/gu-cdk"
-      },
-      "peerDependencies": {
-        "aws-cdk": "2.54.0",
-        "aws-cdk-lib": "2.54.0",
-        "constructs": "10.1.187"
-      }
-    },
-    "packages/cdk/node_modules/@oclif/core": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.21.0.tgz",
-      "integrity": "sha512-B/AKYfHcNRAbb6Xz2kj0FlH9gWEi8aFS4iEr7EzguP3E2DpDk4wcf7eOMOfJYEmhuVd9sOpVWSnI2yP+FL/3Sg==",
-      "dev": true,
-      "dependencies": {
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^3.0.3",
-        "ansi-escapes": "^4.3.2",
-        "ansi-styles": "^4.3.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.2",
-        "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
-        "debug": "^4.3.4",
-        "ejs": "^3.1.6",
-        "fs-extra": "^9.1.0",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.14.1",
-        "natural-orderby": "^2.0.3",
-        "object-treeify": "^1.1.33",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "supports-color": "^8.1.1",
-        "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "packages/cdk/node_modules/@oclif/core/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "packages/cdk/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk": {
-      "version": "2.54.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.54.0.tgz",
-      "integrity": "sha512-Muk4/cS5SrwPmj4wCoXEXubknIMaIBGteb8dohWFFyAr3I6QrvZ+41EkVvhPnEQEeJpzZQ2Qa65HxgoRC6WMhw==",
-      "dev": true,
-      "bin": {
-        "cdk": "bin/cdk"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib": {
-      "version": "2.54.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.54.0.tgz",
-      "integrity": "sha512-DooUehpsNnFY2WjIxtXNBF37PTCvFSNK6E5c9cYpgQiofF3ayT7h7ppFhoWrc53trV3hw544kZDWL6aJszXCaA==",
-      "bundleDependencies": [
-        "@balena/dockerignore",
-        "case",
-        "fs-extra",
-        "ignore",
-        "jsonschema",
-        "minimatch",
-        "punycode",
-        "semver",
-        "yaml"
-      ],
-      "dev": true,
-      "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.16",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.21",
-        "@balena/dockerignore": "^1.0.2",
-        "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
-        "jsonschema": "^1.4.1",
-        "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.8",
-        "yaml": "1.10.2"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "constructs": "^10.0.0"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/at-least-node": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/case": {
-      "version": "1.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "packages/cdk/node_modules/constructs": {
-      "version": "10.1.187",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.187.tgz",
-      "integrity": "sha512-1Nam2kyu7RJfVVA3ECN6gAtF5ln+7nwkl0VNu4co2Jh7jfPc6Mh5T5O5Od1IniW1Z/sms08/blQxOEUclPV2cg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.17.0"
       }
     },
     "packages/cdk/node_modules/source-map-support": {
@@ -10399,21 +10419,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "packages/cdk/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "packages/cloudformation-lens": {
@@ -10497,9 +10502,9 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.30",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.30.tgz",
-      "integrity": "sha512-mFRF5n1jxjKpX8ZZSCRhJc6Hj8BkeZFUPwK0j6jRcouQQZHsZyydbf4UuzMYQ4SZU6cCLM7DKmWO0Kx156ZSnw==",
+      "version": "2.2.153",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.153.tgz",
+      "integrity": "sha512-t66eh2VexLotjGnWZbI3fh24Ohw6nR1k0PawSnfvHEmxXlKO5hmr/+7eIr3oXRPT3tPBTbsgp1Al+AlR3cWd1A==",
       "dev": true
     },
     "@aws-cdk/asset-kubectl-v20": {
@@ -10509,9 +10514,9 @@
       "dev": true
     },
     "@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.36.tgz",
-      "integrity": "sha512-acG7qHXrLXGVsOnkHNrNfzGaMtONZ+2nsjhUXhCRf9zQZMzs7lzkv9dTUaHJywAABR9DaRRUFMpUytJDqvN8Ew==",
+      "version": "2.0.128",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.128.tgz",
+      "integrity": "sha512-d3lTtX/19N9vwyh8Y1NVwmsmwro4YmyE3AoMO+XKFrtndCHc68N890yUGGvNE6R3zM+95yrQ6YPHCWZjR79S9Q==",
       "dev": true
     },
     "@aws-crypto/crc32": {
@@ -12188,6 +12193,27 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@guardian/cdk": {
+      "version": "49.0.2",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.0.2.tgz",
+      "integrity": "sha512-81uvX7E29+ynn/9mWaYoH0swL55gLBPnH+Z3nW9dO6Jg0RFd1qarHKbJjq+lPUJ/SPce5KqAuLekMmIlEo9R4Q==",
+      "dev": true,
+      "requires": {
+        "@oclif/core": "1.24.2",
+        "aws-cdk-lib": "2.59.0",
+        "aws-sdk": "^2.1296.0",
+        "chalk": "^4.1.2",
+        "codemaker": "^1.73.0",
+        "constructs": "10.1.215",
+        "git-url-parse": "^13.1.0",
+        "js-yaml": "^4.1.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.upperfirst": "^4.3.1",
+        "read-pkg-up": "7.0.1",
+        "yargs": "^17.6.2"
+      }
+    },
     "@guardian/eslint-config": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-2.0.3.tgz",
@@ -12595,6 +12621,72 @@
         "fastq": "^1.6.0"
       }
     },
+    "@oclif/core": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.24.2.tgz",
+      "integrity": "sha512-0wfAa6HG4sJ4j5c4/GV4BWZwALtJyw2ZO6titnrWKcowxU1BWd8mBM45ilTPnDhClMowz7+8EtK4kqUGc1rNwA==",
+      "dev": true,
+      "requires": {
+        "@oclif/linewrap": "^1.0.0",
+        "@oclif/screen": "^3.0.4",
+        "ansi-escapes": "^4.3.2",
+        "ansi-styles": "^4.3.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.2",
+        "clean-stack": "^3.0.1",
+        "cli-progress": "^3.10.0",
+        "debug": "^4.3.4",
+        "ejs": "^3.1.6",
+        "fs-extra": "^9.1.0",
+        "get-package-type": "^0.1.0",
+        "globby": "^11.1.0",
+        "hyperlinker": "^1.0.0",
+        "indent-string": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "js-yaml": "^3.14.1",
+        "natural-orderby": "^2.0.3",
+        "object-treeify": "^1.1.33",
+        "password-prompt": "^1.1.2",
+        "semver": "^7.3.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "supports-color": "^8.1.1",
+        "supports-hyperlinks": "^2.2.0",
+        "tslib": "^2.4.1",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@oclif/linewrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
@@ -12602,9 +12694,9 @@
       "dev": true
     },
     "@oclif/screen": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.3.tgz",
-      "integrity": "sha512-KX8gMYA9ujBPOd1HFsV9e0iEx7Uoj8AG/3YsW4TtWQTg4lJvr82qNm7o/cFQfYRIt+jw7Ew/4oL4A22zOT+IRA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.4.tgz",
+      "integrity": "sha512-IMsTN1dXEXaOSre27j/ywGbBjrzx0FNd1XmuhCWCB9NTPrhWI1Ifbz+YLSEcstfQfocYsrbrIessxXb2oon4lA==",
       "dev": true
     },
     "@octokit/auth-app": {
@@ -13422,10 +13514,154 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
+    "aws-cdk": {
+      "version": "2.59.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.59.0.tgz",
+      "integrity": "sha512-5xKh+nC6wLsjYGwA+YYbX9ZonJLYmthxSZy8pK/Bm9rL2mFpnMKvQZJz67L6ghOt1XumoB1vZbIhptln68jTuw==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "aws-cdk-lib": {
+      "version": "2.59.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.59.0.tgz",
+      "integrity": "sha512-FT6QRsou8TibQcz/TqI3rEkB9EBVF5Om5lv9MXz/5qiKehWRbKZVX0I0l/SSAvGSmdTU5Pfr+WRBTk51oNMAdw==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.30",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.38",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^9.1.0",
+        "ignore": "^5.2.1",
+        "jsonschema": "^1.4.1",
+        "minimatch": "^3.1.2",
+        "punycode": "^2.1.1",
+        "semver": "^7.3.8",
+        "yaml": "1.10.2"
+      },
+      "dependencies": {
+        "@balena/dockerignore": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "at-least-node": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "case": {
+          "version": "1.6.3",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.10",
+          "bundled": true,
+          "dev": true
+        },
+        "ignore": {
+          "version": "5.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonschema": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "yaml": {
+          "version": "1.10.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
     "aws-sdk": {
-      "version": "2.1273.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1273.0.tgz",
-      "integrity": "sha512-QF37fm1DfUxjw+IJtDMTDBckVwAOf8EHQjs4NxJp5TtRkeqtWkxNzq/ViI8kAS+0n8JZaom8Oenmy8ufGfLMAQ==",
+      "version": "2.1366.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1366.0.tgz",
+      "integrity": "sha512-tS7y18KHH0eq43I8WJsxVBpwOMY45FSsu6a+A/6k0bMrE4zhd1fzhPN+5coNIODaGxnqVvgw9guLg3AOe4SpaA==",
       "dev": true,
       "requires": {
         "buffer": "4.9.2",
@@ -13437,7 +13673,7 @@
         "url": "0.10.3",
         "util": "^0.12.4",
         "uuid": "8.0.0",
-        "xml2js": "0.4.19"
+        "xml2js": "0.5.0"
       },
       "dependencies": {
         "uuid": {
@@ -13729,257 +13965,20 @@
     "cdk": {
       "version": "file:packages/cdk",
       "requires": {
-        "@guardian/cdk": "49.0.0",
+        "@guardian/cdk": "49.0.2",
         "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-        "aws-cdk": "2.54.0",
-        "aws-cdk-lib": "2.54.0",
-        "constructs": "10.1.187",
+        "aws-cdk": "2.59.0",
+        "aws-cdk-lib": "2.59.0",
+        "constructs": "10.1.215",
         "source-map-support": "^0.5.21"
       },
       "dependencies": {
-        "@guardian/cdk": {
-          "version": "49.0.0",
-          "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.0.0.tgz",
-          "integrity": "sha512-VDuyHyHxiYU5WKQAG+IO0rwiPiWFaM6wKYgAaMkefAwKaYxswzEoSqKyJevhYxHbnWNWht0n3w1L6aTqdWpxGA==",
-          "dev": true,
-          "requires": {
-            "@oclif/core": "1.21.0",
-            "aws-cdk-lib": "2.54.0",
-            "aws-sdk": "^2.1272.0",
-            "chalk": "^4.1.2",
-            "codemaker": "^1.72.0",
-            "constructs": "10.1.187",
-            "git-url-parse": "^13.1.0",
-            "js-yaml": "^4.1.0",
-            "lodash.camelcase": "^4.3.0",
-            "lodash.kebabcase": "^4.1.1",
-            "lodash.upperfirst": "^4.3.1",
-            "read-pkg-up": "7.0.1",
-            "yargs": "^17.6.2"
-          }
-        },
-        "@oclif/core": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.21.0.tgz",
-          "integrity": "sha512-B/AKYfHcNRAbb6Xz2kj0FlH9gWEi8aFS4iEr7EzguP3E2DpDk4wcf7eOMOfJYEmhuVd9sOpVWSnI2yP+FL/3Sg==",
-          "dev": true,
-          "requires": {
-            "@oclif/linewrap": "^1.0.0",
-            "@oclif/screen": "^3.0.3",
-            "ansi-escapes": "^4.3.2",
-            "ansi-styles": "^4.3.0",
-            "cardinal": "^2.1.1",
-            "chalk": "^4.1.2",
-            "clean-stack": "^3.0.1",
-            "cli-progress": "^3.10.0",
-            "debug": "^4.3.4",
-            "ejs": "^3.1.6",
-            "fs-extra": "^9.1.0",
-            "get-package-type": "^0.1.0",
-            "globby": "^11.1.0",
-            "hyperlinker": "^1.0.0",
-            "indent-string": "^4.0.0",
-            "is-wsl": "^2.2.0",
-            "js-yaml": "^3.14.1",
-            "natural-orderby": "^2.0.3",
-            "object-treeify": "^1.1.33",
-            "password-prompt": "^1.1.2",
-            "semver": "^7.3.7",
-            "string-width": "^4.2.3",
-            "strip-ansi": "^6.0.1",
-            "supports-color": "^8.1.1",
-            "supports-hyperlinks": "^2.2.0",
-            "tslib": "^2.4.1",
-            "widest-line": "^3.1.0",
-            "wrap-ansi": "^7.0.0"
-          },
-          "dependencies": {
-            "js-yaml": {
-              "version": "3.14.1",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-              "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-              "dev": true,
-              "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-              }
-            }
-          }
-        },
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "aws-cdk": {
-          "version": "2.54.0",
-          "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.54.0.tgz",
-          "integrity": "sha512-Muk4/cS5SrwPmj4wCoXEXubknIMaIBGteb8dohWFFyAr3I6QrvZ+41EkVvhPnEQEeJpzZQ2Qa65HxgoRC6WMhw==",
-          "dev": true,
-          "requires": {
-            "fsevents": "2.3.2"
-          }
-        },
-        "aws-cdk-lib": {
-          "version": "2.54.0",
-          "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.54.0.tgz",
-          "integrity": "sha512-DooUehpsNnFY2WjIxtXNBF37PTCvFSNK6E5c9cYpgQiofF3ayT7h7ppFhoWrc53trV3hw544kZDWL6aJszXCaA==",
-          "dev": true,
-          "requires": {
-            "@aws-cdk/asset-awscli-v1": "^2.2.16",
-            "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-            "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.21",
-            "@balena/dockerignore": "^1.0.2",
-            "case": "1.6.3",
-            "fs-extra": "^9.1.0",
-            "ignore": "^5.2.0",
-            "jsonschema": "^1.4.1",
-            "minimatch": "^3.1.2",
-            "punycode": "^2.1.1",
-            "semver": "^7.3.8",
-            "yaml": "1.10.2"
-          },
-          "dependencies": {
-            "@balena/dockerignore": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "at-least-node": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "balanced-match": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "brace-expansion": {
-              "version": "1.1.11",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "case": {
-              "version": "1.6.3",
-              "bundled": true,
-              "dev": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "fs-extra": {
-              "version": "9.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-              }
-            },
-            "graceful-fs": {
-              "version": "4.2.10",
-              "bundled": true,
-              "dev": true
-            },
-            "ignore": {
-              "version": "5.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "jsonfile": {
-              "version": "6.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.6",
-                "universalify": "^2.0.0"
-              }
-            },
-            "jsonschema": {
-              "version": "1.4.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lru-cache": {
-              "version": "6.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "minimatch": {
-              "version": "3.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            },
-            "punycode": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "semver": {
-              "version": "7.3.8",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "^6.0.0"
-              }
-            },
-            "universalify": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "yaml": {
-              "version": "1.10.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "constructs": {
-          "version": "10.1.187",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.187.tgz",
-          "integrity": "sha512-1Nam2kyu7RJfVVA3ECN6gAtF5ln+7nwkl0VNu4co2Jh7jfPc6Mh5T5O5Od1IniW1Z/sms08/blQxOEUclPV2cg==",
-          "dev": true
-        },
         "source-map-support": {
           "version": "0.5.21",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         }
       }
@@ -14018,9 +14017,9 @@
       }
     },
     "cli-progress": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.11.2.tgz",
-      "integrity": "sha512-lCPoS6ncgX4+rJu5bS3F/iCz17kZ9MPZ6dpuTtI0KXKABkhyXIdYB3Inby1OpaGti3YlI3EeEkM9AuWpelJrVA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
       "dev": true,
       "requires": {
         "string-width": "^4.2.3"
@@ -14048,9 +14047,9 @@
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ=="
     },
     "codemaker": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.72.0.tgz",
-      "integrity": "sha512-U4TM++FGA+vnWHTSMA8juU+C9iXn1TDauMFmn44gz9pKrbLtjGUiMjfC4vX5HachkNQgitRj6bc/g7PA4j0C3Q==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.80.0.tgz",
+      "integrity": "sha512-8d9TWXA+eLDFLkYiFKmyXDmXFBmASVxly2PyOK/kLryuhielDZEahSoltF+ES2Dm/F4IzZ4uL7ZjTgkjy69s0w==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",
@@ -14171,6 +14170,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "constructs": {
+      "version": "10.1.215",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.215.tgz",
+      "integrity": "sha512-X9gJAHsb9D4etv70JQxUmqhHkhMSiUFNCnfBvOMHRYvIaFCgc91gcWyrb5UMBGPnzZBlcX8LTTHPOLik3waPmQ==",
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -14372,9 +14377,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
       "dev": true,
       "requires": {
         "jake": "^10.8.5"
@@ -15210,9 +15215,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-          "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -17312,7 +17317,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "qs": {
       "version": "6.11.0",
@@ -18350,19 +18356,19 @@
       }
     },
     "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dev": true,
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true
     },
     "y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2117,35 +2117,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@guardian/cdk": {
-      "version": "50.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-50.0.0.tgz",
-      "integrity": "sha512-dIp8xHRNfzsDxZkzYvChgCvfTpuPhEQqY9xpItDGfDV6mrt7CxvScVpN/RleH3gHUNcaRHn0ydEYp2oERGpzKg==",
-      "dev": true,
-      "dependencies": {
-        "@oclif/core": "2.7.1",
-        "aws-cdk-lib": "2.68.0",
-        "aws-sdk": "^2.1339.0",
-        "chalk": "^4.1.2",
-        "codemaker": "^1.78.1",
-        "constructs": "10.1.273",
-        "git-url-parse": "^13.1.0",
-        "js-yaml": "^4.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.upperfirst": "^4.3.1",
-        "read-pkg-up": "7.0.1",
-        "yargs": "^17.6.2"
-      },
-      "bin": {
-        "gu-cdk": "bin/gu-cdk"
-      },
-      "peerDependencies": {
-        "aws-cdk": "2.68.0",
-        "aws-cdk-lib": "2.68.0",
-        "constructs": "10.1.273"
-      }
-    },
     "node_modules/@guardian/eslint-config": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-2.0.3.tgz",
@@ -2671,83 +2642,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@oclif/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-HnaZ0ezNJUGok4uACOmVl05aSrCblmuq5Sqyg3Qa8aLFnTBuvHn3d67fTJKSttyAnJ5LI3zw8e5vzLD7WZuP0A==",
-      "dev": true,
-      "dependencies": {
-        "@types/cli-progress": "^3.11.0",
-        "ansi-escapes": "^4.3.2",
-        "ansi-styles": "^4.3.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.2",
-        "clean-stack": "^3.0.1",
-        "cli-progress": "^3.12.0",
-        "debug": "^4.3.4",
-        "ejs": "^3.1.8",
-        "fs-extra": "^9.1.0",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.14.1",
-        "natural-orderby": "^2.0.3",
-        "object-treeify": "^1.1.33",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "supports-color": "^8.1.1",
-        "supports-hyperlinks": "^2.2.0",
-        "ts-node": "^10.9.1",
-        "tslib": "^2.5.0",
-        "widest-line": "^3.1.0",
-        "wordwrap": "^1.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/@octokit/auth-app": {
@@ -3790,227 +3684,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/aws-cdk": {
-      "version": "2.68.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.68.0.tgz",
-      "integrity": "sha512-r+C5M4J3C7RLiixhxsO/W9Kpb5iB0mFshyn5PXT1cGPkDbx23bnWLOab03jG7uHWIWI01DCipHQyTaeXXqvT3A==",
-      "dev": true,
-      "bin": {
-        "cdk": "bin/cdk"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/aws-cdk-lib": {
-      "version": "2.68.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.68.0.tgz",
-      "integrity": "sha512-roN3xwzv/GleGG3CaJrf+thdzr9WBzJU4LotumEOs+0cGfeXSta8Pm/cGAeY4kplr5r10QWUovH0fv/bi6Vrbw==",
-      "bundleDependencies": [
-        "@balena/dockerignore",
-        "case",
-        "fs-extra",
-        "ignore",
-        "jsonschema",
-        "minimatch",
-        "punycode",
-        "semver",
-        "yaml"
-      ],
-      "dev": true,
-      "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.97",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
-        "@balena/dockerignore": "^1.0.2",
-        "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.4",
-        "jsonschema": "^1.4.1",
-        "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
-        "semver": "^7.3.8",
-        "yaml": "1.10.2"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/aws-cdk-lib/node_modules/at-least-node": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/case": {
-      "version": "1.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/aws-sdk": {
       "version": "2.1366.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1366.0.tgz",
@@ -4630,15 +4303,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "node_modules/constructs": {
-      "version": "10.1.273",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.273.tgz",
-      "integrity": "sha512-JRaydmKm58aQm7crUcai3qGXtqhsh9e/dXyjQoZV6RiiEamf1V9A3yLLJIjit66Kl0Sub9quXgPmtqRfPYYlIg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -10403,12 +10067,512 @@
     "packages/cdk": {
       "version": "1.0.0",
       "devDependencies": {
-        "@guardian/cdk": "50.0.0",
+        "@guardian/cdk": "50.3.3",
         "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-        "aws-cdk": "2.68.0",
-        "aws-cdk-lib": "2.68.0",
-        "constructs": "10.1.273",
+        "aws-cdk": "2.77.0",
+        "aws-cdk-lib": "2.77.0",
+        "constructs": "10.2.8",
         "source-map-support": "^0.5.21"
+      }
+    },
+    "packages/cdk/node_modules/@guardian/cdk": {
+      "version": "50.3.3",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-50.3.3.tgz",
+      "integrity": "sha512-SO1slq9msSD1VA3mwQclo45SGSGGya3fxofw/g5K0K9CBxmlt+B6Xw7P/QjZj5+iVRPVzwJX7auqhYIla2e62w==",
+      "dev": true,
+      "dependencies": {
+        "@oclif/core": "2.8.2",
+        "aws-cdk-lib": "2.77.0",
+        "aws-sdk": "^2.1365.0",
+        "chalk": "^4.1.2",
+        "codemaker": "^1.80.0",
+        "constructs": "10.2.8",
+        "git-url-parse": "^13.1.0",
+        "js-yaml": "^4.1.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.upperfirst": "^4.3.1",
+        "read-pkg-up": "7.0.1",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "gu-cdk": "bin/gu-cdk"
+      },
+      "peerDependencies": {
+        "aws-cdk": "2.77.0",
+        "aws-cdk-lib": "2.77.0",
+        "constructs": "10.2.8"
+      }
+    },
+    "packages/cdk/node_modules/@oclif/core": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.8.2.tgz",
+      "integrity": "sha512-g50NrCdEcFlBfuwZb9RxLmxPNQ9wIaBPOiwbxlGYRkHMnsC6LNHcvVtyDnmndU8qoXrmCOZ6ocSZenOMlG+G1w==",
+      "dev": true,
+      "dependencies": {
+        "@types/cli-progress": "^3.11.0",
+        "ansi-escapes": "^4.3.2",
+        "ansi-styles": "^4.3.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.2",
+        "clean-stack": "^3.0.1",
+        "cli-progress": "^3.12.0",
+        "debug": "^4.3.4",
+        "ejs": "^3.1.8",
+        "fs-extra": "^9.1.0",
+        "get-package-type": "^0.1.0",
+        "globby": "^11.1.0",
+        "hyperlinker": "^1.0.0",
+        "indent-string": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "js-yaml": "^3.14.1",
+        "natural-orderby": "^2.0.3",
+        "object-treeify": "^1.1.33",
+        "password-prompt": "^1.1.2",
+        "semver": "^7.3.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "supports-color": "^8.1.1",
+        "supports-hyperlinks": "^2.2.0",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
+        "widest-line": "^3.1.0",
+        "wordwrap": "^1.0.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/cdk/node_modules/@oclif/core/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "packages/cdk/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk": {
+      "version": "2.77.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.77.0.tgz",
+      "integrity": "sha512-f0UpWjBxrFkINqlwL50OpIIC03V39hTzg4+NEBlfUc/ftFX8WQQYyT6h29IfxT9Tgo+YoEMlM1nnH/s1c+VKSw==",
+      "dev": true,
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib": {
+      "version": "2.77.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.77.0.tgz",
+      "integrity": "sha512-T0GUFHBY1B+LkyGk1Df5E1PXwHa7BqvafD4pGvpwWqu8Mu9s/i0kp8YJu6xY//hEC5R8O7V6bfyQJ0S9pUqwQg==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "table",
+        "yaml"
+      ],
+      "dev": true,
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.97",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^9.1.0",
+        "ignore": "^5.2.4",
+        "jsonschema": "^1.4.1",
+        "minimatch": "^3.1.2",
+        "punycode": "^2.3.0",
+        "semver": "^7.3.8",
+        "table": "^6.8.1",
+        "yaml": "1.10.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.12.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/at-least-node": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.3.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/uri-js": {
+      "version": "4.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "packages/cdk/node_modules/constructs": {
+      "version": "10.2.8",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.2.8.tgz",
+      "integrity": "sha512-3Dr4htAd64LRn6+ts5cDm1ZijE/2rDJnaPRD9FQi3CGTfZIm0nA9ZzJDOEwBRFfU8A6wmQvZ3B56p4XLM6B4hg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.17.0"
       }
     },
     "packages/cdk/node_modules/source-map-support": {
@@ -10418,6 +10582,21 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "packages/cdk/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "packages/cloudformation-lens": {
@@ -12192,27 +12371,6 @@
         "strip-json-comments": "^3.1.1"
       }
     },
-    "@guardian/cdk": {
-      "version": "50.0.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-50.0.0.tgz",
-      "integrity": "sha512-dIp8xHRNfzsDxZkzYvChgCvfTpuPhEQqY9xpItDGfDV6mrt7CxvScVpN/RleH3gHUNcaRHn0ydEYp2oERGpzKg==",
-      "dev": true,
-      "requires": {
-        "@oclif/core": "2.7.1",
-        "aws-cdk-lib": "2.68.0",
-        "aws-sdk": "^2.1339.0",
-        "chalk": "^4.1.2",
-        "codemaker": "^1.78.1",
-        "constructs": "10.1.273",
-        "git-url-parse": "^13.1.0",
-        "js-yaml": "^4.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.upperfirst": "^4.3.1",
-        "read-pkg-up": "7.0.1",
-        "yargs": "^17.6.2"
-      }
-    },
     "@guardian/eslint-config": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-2.0.3.tgz",
@@ -12618,73 +12776,6 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
-      }
-    },
-    "@oclif/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-HnaZ0ezNJUGok4uACOmVl05aSrCblmuq5Sqyg3Qa8aLFnTBuvHn3d67fTJKSttyAnJ5LI3zw8e5vzLD7WZuP0A==",
-      "dev": true,
-      "requires": {
-        "@types/cli-progress": "^3.11.0",
-        "ansi-escapes": "^4.3.2",
-        "ansi-styles": "^4.3.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.2",
-        "clean-stack": "^3.0.1",
-        "cli-progress": "^3.12.0",
-        "debug": "^4.3.4",
-        "ejs": "^3.1.8",
-        "fs-extra": "^9.1.0",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.14.1",
-        "natural-orderby": "^2.0.3",
-        "object-treeify": "^1.1.33",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "supports-color": "^8.1.1",
-        "supports-hyperlinks": "^2.2.0",
-        "ts-node": "^10.9.1",
-        "tslib": "^2.5.0",
-        "widest-line": "^3.1.0",
-        "wordwrap": "^1.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "@octokit/auth-app": {
@@ -13511,150 +13602,6 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
-    "aws-cdk": {
-      "version": "2.68.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.68.0.tgz",
-      "integrity": "sha512-r+C5M4J3C7RLiixhxsO/W9Kpb5iB0mFshyn5PXT1cGPkDbx23bnWLOab03jG7uHWIWI01DCipHQyTaeXXqvT3A==",
-      "dev": true,
-      "requires": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "aws-cdk-lib": {
-      "version": "2.68.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.68.0.tgz",
-      "integrity": "sha512-roN3xwzv/GleGG3CaJrf+thdzr9WBzJU4LotumEOs+0cGfeXSta8Pm/cGAeY4kplr5r10QWUovH0fv/bi6Vrbw==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.97",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
-        "@balena/dockerignore": "^1.0.2",
-        "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.4",
-        "jsonschema": "^1.4.1",
-        "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
-        "semver": "^7.3.8",
-        "yaml": "1.10.2"
-      },
-      "dependencies": {
-        "@balena/dockerignore": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "at-least-node": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "case": {
-          "version": "1.6.3",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.10",
-          "bundled": true,
-          "dev": true
-        },
-        "ignore": {
-          "version": "5.2.4",
-          "bundled": true,
-          "dev": true
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "jsonschema": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "punycode": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "yaml": {
-          "version": "1.10.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
-    },
     "aws-sdk": {
       "version": "2.1366.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1366.0.tgz",
@@ -13962,20 +13909,379 @@
     "cdk": {
       "version": "file:packages/cdk",
       "requires": {
-        "@guardian/cdk": "50.0.0",
+        "@guardian/cdk": "50.3.3",
         "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-        "aws-cdk": "2.68.0",
-        "aws-cdk-lib": "2.68.0",
-        "constructs": "10.1.273",
+        "aws-cdk": "2.77.0",
+        "aws-cdk-lib": "2.77.0",
+        "constructs": "10.2.8",
         "source-map-support": "^0.5.21"
       },
       "dependencies": {
+        "@guardian/cdk": {
+          "version": "50.3.3",
+          "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-50.3.3.tgz",
+          "integrity": "sha512-SO1slq9msSD1VA3mwQclo45SGSGGya3fxofw/g5K0K9CBxmlt+B6Xw7P/QjZj5+iVRPVzwJX7auqhYIla2e62w==",
+          "dev": true,
+          "requires": {
+            "@oclif/core": "2.8.2",
+            "aws-cdk-lib": "2.77.0",
+            "aws-sdk": "^2.1365.0",
+            "chalk": "^4.1.2",
+            "codemaker": "^1.80.0",
+            "constructs": "10.2.8",
+            "git-url-parse": "^13.1.0",
+            "js-yaml": "^4.1.0",
+            "lodash.camelcase": "^4.3.0",
+            "lodash.kebabcase": "^4.1.1",
+            "lodash.upperfirst": "^4.3.1",
+            "read-pkg-up": "7.0.1",
+            "yargs": "^17.6.2"
+          }
+        },
+        "@oclif/core": {
+          "version": "2.8.2",
+          "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.8.2.tgz",
+          "integrity": "sha512-g50NrCdEcFlBfuwZb9RxLmxPNQ9wIaBPOiwbxlGYRkHMnsC6LNHcvVtyDnmndU8qoXrmCOZ6ocSZenOMlG+G1w==",
+          "dev": true,
+          "requires": {
+            "@types/cli-progress": "^3.11.0",
+            "ansi-escapes": "^4.3.2",
+            "ansi-styles": "^4.3.0",
+            "cardinal": "^2.1.1",
+            "chalk": "^4.1.2",
+            "clean-stack": "^3.0.1",
+            "cli-progress": "^3.12.0",
+            "debug": "^4.3.4",
+            "ejs": "^3.1.8",
+            "fs-extra": "^9.1.0",
+            "get-package-type": "^0.1.0",
+            "globby": "^11.1.0",
+            "hyperlinker": "^1.0.0",
+            "indent-string": "^4.0.0",
+            "is-wsl": "^2.2.0",
+            "js-yaml": "^3.14.1",
+            "natural-orderby": "^2.0.3",
+            "object-treeify": "^1.1.33",
+            "password-prompt": "^1.1.2",
+            "semver": "^7.3.7",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
+            "supports-color": "^8.1.1",
+            "supports-hyperlinks": "^2.2.0",
+            "ts-node": "^10.9.1",
+            "tslib": "^2.5.0",
+            "widest-line": "^3.1.0",
+            "wordwrap": "^1.0.0",
+            "wrap-ansi": "^7.0.0"
+          },
+          "dependencies": {
+            "js-yaml": {
+              "version": "3.14.1",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+              "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+              "dev": true,
+              "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+              }
+            }
+          }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "aws-cdk": {
+          "version": "2.77.0",
+          "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.77.0.tgz",
+          "integrity": "sha512-f0UpWjBxrFkINqlwL50OpIIC03V39hTzg4+NEBlfUc/ftFX8WQQYyT6h29IfxT9Tgo+YoEMlM1nnH/s1c+VKSw==",
+          "dev": true,
+          "requires": {
+            "fsevents": "2.3.2"
+          }
+        },
+        "aws-cdk-lib": {
+          "version": "2.77.0",
+          "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.77.0.tgz",
+          "integrity": "sha512-T0GUFHBY1B+LkyGk1Df5E1PXwHa7BqvafD4pGvpwWqu8Mu9s/i0kp8YJu6xY//hEC5R8O7V6bfyQJ0S9pUqwQg==",
+          "dev": true,
+          "requires": {
+            "@aws-cdk/asset-awscli-v1": "^2.2.97",
+            "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+            "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
+            "@balena/dockerignore": "^1.0.2",
+            "case": "1.6.3",
+            "fs-extra": "^9.1.0",
+            "ignore": "^5.2.4",
+            "jsonschema": "^1.4.1",
+            "minimatch": "^3.1.2",
+            "punycode": "^2.3.0",
+            "semver": "^7.3.8",
+            "table": "^6.8.1",
+            "yaml": "1.10.2"
+          },
+          "dependencies": {
+            "@balena/dockerignore": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "ajv": {
+              "version": "8.12.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
+              }
+            },
+            "ansi-regex": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "4.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "astral-regex": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "at-least-node": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "balanced-match": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "case": {
+              "version": "1.6.3",
+              "bundled": true,
+              "dev": true
+            },
+            "color-convert": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "color-name": "~1.1.4"
+              }
+            },
+            "color-name": {
+              "version": "1.1.4",
+              "bundled": true,
+              "dev": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "emoji-regex": {
+              "version": "8.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "fast-deep-equal": {
+              "version": "3.1.3",
+              "bundled": true,
+              "dev": true
+            },
+            "fs-extra": {
+              "version": "9.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.2.10",
+              "bundled": true,
+              "dev": true
+            },
+            "ignore": {
+              "version": "5.2.4",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "json-schema-traverse": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "jsonfile": {
+              "version": "6.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+              }
+            },
+            "jsonschema": {
+              "version": "1.4.1",
+              "bundled": true,
+              "dev": true
+            },
+            "lodash.truncate": {
+              "version": "4.4.2",
+              "bundled": true,
+              "dev": true
+            },
+            "lru-cache": {
+              "version": "6.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "punycode": {
+              "version": "2.3.0",
+              "bundled": true,
+              "dev": true
+            },
+            "require-from-string": {
+              "version": "2.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "semver": {
+              "version": "7.3.8",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            },
+            "slice-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+              }
+            },
+            "string-width": {
+              "version": "4.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.1"
+              }
+            },
+            "table": {
+              "version": "6.8.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ajv": "^8.0.1",
+                "lodash.truncate": "^4.4.2",
+                "slice-ansi": "^4.0.0",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1"
+              }
+            },
+            "universalify": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "uri-js": {
+              "version": "4.4.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "punycode": "^2.1.0"
+              }
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "yaml": {
+              "version": "1.10.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "constructs": {
+          "version": "10.2.8",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.2.8.tgz",
+          "integrity": "sha512-3Dr4htAd64LRn6+ts5cDm1ZijE/2rDJnaPRD9FQi3CGTfZIm0nA9ZzJDOEwBRFfU8A6wmQvZ3B56p4XLM6B4hg==",
+          "dev": true
+        },
         "source-map-support": {
           "version": "0.5.21",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -14167,12 +14473,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "constructs": {
-      "version": "10.1.273",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.273.tgz",
-      "integrity": "sha512-JRaydmKm58aQm7crUcai3qGXtqhsh9e/dXyjQoZV6RiiEamf1V9A3yLLJIjit66Kl0Sub9quXgPmtqRfPYYlIg==",
-      "dev": true
     },
     "content-disposition": {
       "version": "0.5.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2117,35 +2117,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@guardian/cdk": {
-      "version": "49.0.2",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.0.2.tgz",
-      "integrity": "sha512-81uvX7E29+ynn/9mWaYoH0swL55gLBPnH+Z3nW9dO6Jg0RFd1qarHKbJjq+lPUJ/SPce5KqAuLekMmIlEo9R4Q==",
-      "dev": true,
-      "dependencies": {
-        "@oclif/core": "1.24.2",
-        "aws-cdk-lib": "2.59.0",
-        "aws-sdk": "^2.1296.0",
-        "chalk": "^4.1.2",
-        "codemaker": "^1.73.0",
-        "constructs": "10.1.215",
-        "git-url-parse": "^13.1.0",
-        "js-yaml": "^4.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.upperfirst": "^4.3.1",
-        "read-pkg-up": "7.0.1",
-        "yargs": "^17.6.2"
-      },
-      "bin": {
-        "gu-cdk": "bin/gu-cdk"
-      },
-      "peerDependencies": {
-        "aws-cdk": "2.59.0",
-        "aws-cdk-lib": "2.59.0",
-        "constructs": "10.1.215"
-      }
-    },
     "node_modules/@guardian/eslint-config": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-2.0.3.tgz",
@@ -3796,227 +3767,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/aws-cdk": {
-      "version": "2.59.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.59.0.tgz",
-      "integrity": "sha512-5xKh+nC6wLsjYGwA+YYbX9ZonJLYmthxSZy8pK/Bm9rL2mFpnMKvQZJz67L6ghOt1XumoB1vZbIhptln68jTuw==",
-      "dev": true,
-      "bin": {
-        "cdk": "bin/cdk"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/aws-cdk-lib": {
-      "version": "2.59.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.59.0.tgz",
-      "integrity": "sha512-FT6QRsou8TibQcz/TqI3rEkB9EBVF5Om5lv9MXz/5qiKehWRbKZVX0I0l/SSAvGSmdTU5Pfr+WRBTk51oNMAdw==",
-      "bundleDependencies": [
-        "@balena/dockerignore",
-        "case",
-        "fs-extra",
-        "ignore",
-        "jsonschema",
-        "minimatch",
-        "punycode",
-        "semver",
-        "yaml"
-      ],
-      "dev": true,
-      "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.30",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.38",
-        "@balena/dockerignore": "^1.0.2",
-        "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.1",
-        "jsonschema": "^1.4.1",
-        "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.8",
-        "yaml": "1.10.2"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/aws-cdk-lib/node_modules/at-least-node": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/case": {
-      "version": "1.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/aws-sdk": {
       "version": "2.1366.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1366.0.tgz",
@@ -4636,15 +4386,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "node_modules/constructs": {
-      "version": "10.1.215",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.215.tgz",
-      "integrity": "sha512-X9gJAHsb9D4etv70JQxUmqhHkhMSiUFNCnfBvOMHRYvIaFCgc91gcWyrb5UMBGPnzZBlcX8LTTHPOLik3waPmQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -8922,7 +8663,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10404,12 +10144,271 @@
     "packages/cdk": {
       "version": "1.0.0",
       "devDependencies": {
-        "@guardian/cdk": "49.0.2",
+        "@guardian/cdk": "49.4.0",
         "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-        "aws-cdk": "2.59.0",
-        "aws-cdk-lib": "2.59.0",
-        "constructs": "10.1.215",
+        "aws-cdk": "2.64.0",
+        "aws-cdk-lib": "2.64.0",
+        "constructs": "10.1.246",
         "source-map-support": "^0.5.21"
+      }
+    },
+    "packages/cdk/node_modules/@guardian/cdk": {
+      "version": "49.4.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.4.0.tgz",
+      "integrity": "sha512-p6S/Eilw+oPcy8PylsFLX8y38PJLPF38SLD+i0zmwIBYWh0SYi/Z8m4q6kr24W6J1bmnE6Q15XsNW7GEVFa9zg==",
+      "dev": true,
+      "dependencies": {
+        "@oclif/core": "1.24.2",
+        "aws-cdk-lib": "2.64.0",
+        "aws-sdk": "^2.1315.0",
+        "chalk": "^4.1.2",
+        "codemaker": "^1.75.0",
+        "constructs": "10.1.246",
+        "git-url-parse": "^13.1.0",
+        "js-yaml": "^4.1.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.upperfirst": "^4.3.1",
+        "read-pkg-up": "7.0.1",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "gu-cdk": "bin/gu-cdk"
+      },
+      "peerDependencies": {
+        "aws-cdk": "2.64.0",
+        "aws-cdk-lib": "2.64.0",
+        "constructs": "10.1.246"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk": {
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.64.0.tgz",
+      "integrity": "sha512-iXkvVeYKt6Glboeicrb3QxC6K6o25+zitM/UTfgVzDlKEvC4hwQp1KqXy/caN7SfA6X2N0LJmXfC99T4cvIH0A==",
+      "dev": true,
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib": {
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.64.0.tgz",
+      "integrity": "sha512-IrgL7thb6TeOyHgyR/qKWTdA9FBb9lv7Z9QPDzCNJlkKI+0ANjYHy3RYV8Gd+1+kc6l8DG9Z1elij40YCr/Ptg==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "yaml"
+      ],
+      "dev": true,
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.52",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.42",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^9.1.0",
+        "ignore": "^5.2.4",
+        "jsonschema": "^1.4.1",
+        "minimatch": "^3.1.2",
+        "punycode": "^2.3.0",
+        "semver": "^7.3.8",
+        "yaml": "1.10.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/at-least-node": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.3.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "packages/cdk/node_modules/constructs": {
+      "version": "10.1.246",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.246.tgz",
+      "integrity": "sha512-2U2hnAuA4tCGGjHk/TulZfSlPobTyokEh+Azuch9nivv2yGI7/5nXDHC14i2MU/K7HFnnkQOHRSrwKSmOZkT/w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.17.0"
       }
     },
     "packages/cdk/node_modules/source-map-support": {
@@ -12193,27 +12192,6 @@
         "strip-json-comments": "^3.1.1"
       }
     },
-    "@guardian/cdk": {
-      "version": "49.0.2",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.0.2.tgz",
-      "integrity": "sha512-81uvX7E29+ynn/9mWaYoH0swL55gLBPnH+Z3nW9dO6Jg0RFd1qarHKbJjq+lPUJ/SPce5KqAuLekMmIlEo9R4Q==",
-      "dev": true,
-      "requires": {
-        "@oclif/core": "1.24.2",
-        "aws-cdk-lib": "2.59.0",
-        "aws-sdk": "^2.1296.0",
-        "chalk": "^4.1.2",
-        "codemaker": "^1.73.0",
-        "constructs": "10.1.215",
-        "git-url-parse": "^13.1.0",
-        "js-yaml": "^4.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.upperfirst": "^4.3.1",
-        "read-pkg-up": "7.0.1",
-        "yargs": "^17.6.2"
-      }
-    },
     "@guardian/eslint-config": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-2.0.3.tgz",
@@ -13514,150 +13492,6 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
-    "aws-cdk": {
-      "version": "2.59.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.59.0.tgz",
-      "integrity": "sha512-5xKh+nC6wLsjYGwA+YYbX9ZonJLYmthxSZy8pK/Bm9rL2mFpnMKvQZJz67L6ghOt1XumoB1vZbIhptln68jTuw==",
-      "dev": true,
-      "requires": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "aws-cdk-lib": {
-      "version": "2.59.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.59.0.tgz",
-      "integrity": "sha512-FT6QRsou8TibQcz/TqI3rEkB9EBVF5Om5lv9MXz/5qiKehWRbKZVX0I0l/SSAvGSmdTU5Pfr+WRBTk51oNMAdw==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.30",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.38",
-        "@balena/dockerignore": "^1.0.2",
-        "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.1",
-        "jsonschema": "^1.4.1",
-        "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.8",
-        "yaml": "1.10.2"
-      },
-      "dependencies": {
-        "@balena/dockerignore": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "at-least-node": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "case": {
-          "version": "1.6.3",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.10",
-          "bundled": true,
-          "dev": true
-        },
-        "ignore": {
-          "version": "5.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "jsonschema": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "punycode": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "yaml": {
-          "version": "1.10.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
-    },
     "aws-sdk": {
       "version": "2.1366.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1366.0.tgz",
@@ -13965,14 +13799,185 @@
     "cdk": {
       "version": "file:packages/cdk",
       "requires": {
-        "@guardian/cdk": "49.0.2",
+        "@guardian/cdk": "49.4.0",
         "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-        "aws-cdk": "2.59.0",
-        "aws-cdk-lib": "2.59.0",
-        "constructs": "10.1.215",
+        "aws-cdk": "2.64.0",
+        "aws-cdk-lib": "2.64.0",
+        "constructs": "10.1.246",
         "source-map-support": "^0.5.21"
       },
       "dependencies": {
+        "@guardian/cdk": {
+          "version": "49.4.0",
+          "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.4.0.tgz",
+          "integrity": "sha512-p6S/Eilw+oPcy8PylsFLX8y38PJLPF38SLD+i0zmwIBYWh0SYi/Z8m4q6kr24W6J1bmnE6Q15XsNW7GEVFa9zg==",
+          "dev": true,
+          "requires": {
+            "@oclif/core": "1.24.2",
+            "aws-cdk-lib": "2.64.0",
+            "aws-sdk": "^2.1315.0",
+            "chalk": "^4.1.2",
+            "codemaker": "^1.75.0",
+            "constructs": "10.1.246",
+            "git-url-parse": "^13.1.0",
+            "js-yaml": "^4.1.0",
+            "lodash.camelcase": "^4.3.0",
+            "lodash.kebabcase": "^4.1.1",
+            "lodash.upperfirst": "^4.3.1",
+            "read-pkg-up": "7.0.1",
+            "yargs": "^17.6.2"
+          }
+        },
+        "aws-cdk": {
+          "version": "2.64.0",
+          "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.64.0.tgz",
+          "integrity": "sha512-iXkvVeYKt6Glboeicrb3QxC6K6o25+zitM/UTfgVzDlKEvC4hwQp1KqXy/caN7SfA6X2N0LJmXfC99T4cvIH0A==",
+          "dev": true,
+          "requires": {
+            "fsevents": "2.3.2"
+          }
+        },
+        "aws-cdk-lib": {
+          "version": "2.64.0",
+          "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.64.0.tgz",
+          "integrity": "sha512-IrgL7thb6TeOyHgyR/qKWTdA9FBb9lv7Z9QPDzCNJlkKI+0ANjYHy3RYV8Gd+1+kc6l8DG9Z1elij40YCr/Ptg==",
+          "dev": true,
+          "requires": {
+            "@aws-cdk/asset-awscli-v1": "^2.2.52",
+            "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+            "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.42",
+            "@balena/dockerignore": "^1.0.2",
+            "case": "1.6.3",
+            "fs-extra": "^9.1.0",
+            "ignore": "^5.2.4",
+            "jsonschema": "^1.4.1",
+            "minimatch": "^3.1.2",
+            "punycode": "^2.3.0",
+            "semver": "^7.3.8",
+            "yaml": "1.10.2"
+          },
+          "dependencies": {
+            "@balena/dockerignore": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "at-least-node": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "balanced-match": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "case": {
+              "version": "1.6.3",
+              "bundled": true,
+              "dev": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "fs-extra": {
+              "version": "9.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.2.10",
+              "bundled": true,
+              "dev": true
+            },
+            "ignore": {
+              "version": "5.2.4",
+              "bundled": true,
+              "dev": true
+            },
+            "jsonfile": {
+              "version": "6.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+              }
+            },
+            "jsonschema": {
+              "version": "1.4.1",
+              "bundled": true,
+              "dev": true
+            },
+            "lru-cache": {
+              "version": "6.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "punycode": {
+              "version": "2.3.0",
+              "bundled": true,
+              "dev": true
+            },
+            "semver": {
+              "version": "7.3.8",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            },
+            "universalify": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "yaml": {
+              "version": "1.10.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "constructs": {
+          "version": "10.1.246",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.246.tgz",
+          "integrity": "sha512-2U2hnAuA4tCGGjHk/TulZfSlPobTyokEh+Azuch9nivv2yGI7/5nXDHC14i2MU/K7HFnnkQOHRSrwKSmOZkT/w==",
+          "dev": true
+        },
         "source-map-support": {
           "version": "0.5.21",
           "dev": true,
@@ -14170,12 +14175,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "constructs": {
-      "version": "10.1.215",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.215.tgz",
-      "integrity": "sha512-X9gJAHsb9D4etv70JQxUmqhHkhMSiUFNCnfBvOMHRYvIaFCgc91gcWyrb5UMBGPnzZBlcX8LTTHPOLik3waPmQ==",
-      "dev": true
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -17317,8 +17316,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "qs": {
       "version": "6.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2117,6 +2117,35 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@guardian/cdk": {
+      "version": "50.0.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-50.0.0.tgz",
+      "integrity": "sha512-dIp8xHRNfzsDxZkzYvChgCvfTpuPhEQqY9xpItDGfDV6mrt7CxvScVpN/RleH3gHUNcaRHn0ydEYp2oERGpzKg==",
+      "dev": true,
+      "dependencies": {
+        "@oclif/core": "2.7.1",
+        "aws-cdk-lib": "2.68.0",
+        "aws-sdk": "^2.1339.0",
+        "chalk": "^4.1.2",
+        "codemaker": "^1.78.1",
+        "constructs": "10.1.273",
+        "git-url-parse": "^13.1.0",
+        "js-yaml": "^4.1.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.upperfirst": "^4.3.1",
+        "read-pkg-up": "7.0.1",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "gu-cdk": "bin/gu-cdk"
+      },
+      "peerDependencies": {
+        "aws-cdk": "2.68.0",
+        "aws-cdk-lib": "2.68.0",
+        "constructs": "10.1.273"
+      }
+    },
     "node_modules/@guardian/eslint-config": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-2.0.3.tgz",
@@ -2645,21 +2674,20 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.24.2.tgz",
-      "integrity": "sha512-0wfAa6HG4sJ4j5c4/GV4BWZwALtJyw2ZO6titnrWKcowxU1BWd8mBM45ilTPnDhClMowz7+8EtK4kqUGc1rNwA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-HnaZ0ezNJUGok4uACOmVl05aSrCblmuq5Sqyg3Qa8aLFnTBuvHn3d67fTJKSttyAnJ5LI3zw8e5vzLD7WZuP0A==",
       "dev": true,
       "dependencies": {
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^3.0.4",
+        "@types/cli-progress": "^3.11.0",
         "ansi-escapes": "^4.3.2",
         "ansi-styles": "^4.3.0",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
+        "cli-progress": "^3.12.0",
         "debug": "^4.3.4",
-        "ejs": "^3.1.6",
+        "ejs": "^3.1.8",
         "fs-extra": "^9.1.0",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
@@ -2675,8 +2703,10 @@
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
         "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
         "widest-line": "^3.1.0",
+        "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
       },
       "engines": {
@@ -2718,22 +2748,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/@oclif/linewrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
-      "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==",
-      "dev": true
-    },
-    "node_modules/@oclif/screen": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.4.tgz",
-      "integrity": "sha512-IMsTN1dXEXaOSre27j/ywGbBjrzx0FNd1XmuhCWCB9NTPrhWI1Ifbz+YLSEcstfQfocYsrbrIessxXb2oon4lA==",
-      "deprecated": "Deprecated in favor of @oclif/core",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@octokit/auth-app": {
@@ -3126,6 +3140,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha512-wJsiX1tosQ+J5+bY5LrSahHxr2wT+uME5UDwdN1kg4frt40euqA+wzECkmq4t5QbveHiJepfdThgQrPw6KiSlg=="
+    },
+    "node_modules/@types/cli-progress": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.0.tgz",
+      "integrity": "sha512-XhXhBv1R/q2ahF3BM7qT5HLzJNlIL0wbcGyZVjqOTqAybAnsLisd7gy1UCyIqpL+5Iv6XhlSyzjLCnI2sIdbCg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/connect": {
       "version": "3.4.35",
@@ -3767,6 +3790,227 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-cdk": {
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.68.0.tgz",
+      "integrity": "sha512-r+C5M4J3C7RLiixhxsO/W9Kpb5iB0mFshyn5PXT1cGPkDbx23bnWLOab03jG7uHWIWI01DCipHQyTaeXXqvT3A==",
+      "dev": true,
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.68.0.tgz",
+      "integrity": "sha512-roN3xwzv/GleGG3CaJrf+thdzr9WBzJU4LotumEOs+0cGfeXSta8Pm/cGAeY4kplr5r10QWUovH0fv/bi6Vrbw==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "yaml"
+      ],
+      "dev": true,
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.97",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^9.1.0",
+        "ignore": "^5.2.4",
+        "jsonschema": "^1.4.1",
+        "minimatch": "^3.1.2",
+        "punycode": "^2.3.0",
+        "semver": "^7.3.8",
+        "yaml": "1.10.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/at-least-node": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.3.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/aws-sdk": {
       "version": "2.1366.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1366.0.tgz",
@@ -4386,6 +4630,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/constructs": {
+      "version": "10.1.273",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.273.tgz",
+      "integrity": "sha512-JRaydmKm58aQm7crUcai3qGXtqhsh9e/dXyjQoZV6RiiEamf1V9A3yLLJIjit66Kl0Sub9quXgPmtqRfPYYlIg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.17.0"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -9685,9 +9938,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -10029,6 +10282,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -10144,271 +10403,12 @@
     "packages/cdk": {
       "version": "1.0.0",
       "devDependencies": {
-        "@guardian/cdk": "49.4.0",
+        "@guardian/cdk": "50.0.0",
         "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-        "aws-cdk": "2.64.0",
-        "aws-cdk-lib": "2.64.0",
-        "constructs": "10.1.246",
+        "aws-cdk": "2.68.0",
+        "aws-cdk-lib": "2.68.0",
+        "constructs": "10.1.273",
         "source-map-support": "^0.5.21"
-      }
-    },
-    "packages/cdk/node_modules/@guardian/cdk": {
-      "version": "49.4.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.4.0.tgz",
-      "integrity": "sha512-p6S/Eilw+oPcy8PylsFLX8y38PJLPF38SLD+i0zmwIBYWh0SYi/Z8m4q6kr24W6J1bmnE6Q15XsNW7GEVFa9zg==",
-      "dev": true,
-      "dependencies": {
-        "@oclif/core": "1.24.2",
-        "aws-cdk-lib": "2.64.0",
-        "aws-sdk": "^2.1315.0",
-        "chalk": "^4.1.2",
-        "codemaker": "^1.75.0",
-        "constructs": "10.1.246",
-        "git-url-parse": "^13.1.0",
-        "js-yaml": "^4.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.upperfirst": "^4.3.1",
-        "read-pkg-up": "7.0.1",
-        "yargs": "^17.6.2"
-      },
-      "bin": {
-        "gu-cdk": "bin/gu-cdk"
-      },
-      "peerDependencies": {
-        "aws-cdk": "2.64.0",
-        "aws-cdk-lib": "2.64.0",
-        "constructs": "10.1.246"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.64.0.tgz",
-      "integrity": "sha512-iXkvVeYKt6Glboeicrb3QxC6K6o25+zitM/UTfgVzDlKEvC4hwQp1KqXy/caN7SfA6X2N0LJmXfC99T4cvIH0A==",
-      "dev": true,
-      "bin": {
-        "cdk": "bin/cdk"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.64.0.tgz",
-      "integrity": "sha512-IrgL7thb6TeOyHgyR/qKWTdA9FBb9lv7Z9QPDzCNJlkKI+0ANjYHy3RYV8Gd+1+kc6l8DG9Z1elij40YCr/Ptg==",
-      "bundleDependencies": [
-        "@balena/dockerignore",
-        "case",
-        "fs-extra",
-        "ignore",
-        "jsonschema",
-        "minimatch",
-        "punycode",
-        "semver",
-        "yaml"
-      ],
-      "dev": true,
-      "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.52",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.42",
-        "@balena/dockerignore": "^1.0.2",
-        "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.4",
-        "jsonschema": "^1.4.1",
-        "minimatch": "^3.1.2",
-        "punycode": "^2.3.0",
-        "semver": "^7.3.8",
-        "yaml": "1.10.2"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "constructs": "^10.0.0"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/at-least-node": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/case": {
-      "version": "1.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "packages/cdk/node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "packages/cdk/node_modules/constructs": {
-      "version": "10.1.246",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.246.tgz",
-      "integrity": "sha512-2U2hnAuA4tCGGjHk/TulZfSlPobTyokEh+Azuch9nivv2yGI7/5nXDHC14i2MU/K7HFnnkQOHRSrwKSmOZkT/w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.17.0"
       }
     },
     "packages/cdk/node_modules/source-map-support": {
@@ -12192,6 +12192,27 @@
         "strip-json-comments": "^3.1.1"
       }
     },
+    "@guardian/cdk": {
+      "version": "50.0.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-50.0.0.tgz",
+      "integrity": "sha512-dIp8xHRNfzsDxZkzYvChgCvfTpuPhEQqY9xpItDGfDV6mrt7CxvScVpN/RleH3gHUNcaRHn0ydEYp2oERGpzKg==",
+      "dev": true,
+      "requires": {
+        "@oclif/core": "2.7.1",
+        "aws-cdk-lib": "2.68.0",
+        "aws-sdk": "^2.1339.0",
+        "chalk": "^4.1.2",
+        "codemaker": "^1.78.1",
+        "constructs": "10.1.273",
+        "git-url-parse": "^13.1.0",
+        "js-yaml": "^4.1.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.upperfirst": "^4.3.1",
+        "read-pkg-up": "7.0.1",
+        "yargs": "^17.6.2"
+      }
+    },
     "@guardian/eslint-config": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-2.0.3.tgz",
@@ -12600,21 +12621,20 @@
       }
     },
     "@oclif/core": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.24.2.tgz",
-      "integrity": "sha512-0wfAa6HG4sJ4j5c4/GV4BWZwALtJyw2ZO6titnrWKcowxU1BWd8mBM45ilTPnDhClMowz7+8EtK4kqUGc1rNwA==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-HnaZ0ezNJUGok4uACOmVl05aSrCblmuq5Sqyg3Qa8aLFnTBuvHn3d67fTJKSttyAnJ5LI3zw8e5vzLD7WZuP0A==",
       "dev": true,
       "requires": {
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^3.0.4",
+        "@types/cli-progress": "^3.11.0",
         "ansi-escapes": "^4.3.2",
         "ansi-styles": "^4.3.0",
         "cardinal": "^2.1.1",
         "chalk": "^4.1.2",
         "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
+        "cli-progress": "^3.12.0",
         "debug": "^4.3.4",
-        "ejs": "^3.1.6",
+        "ejs": "^3.1.8",
         "fs-extra": "^9.1.0",
         "get-package-type": "^0.1.0",
         "globby": "^11.1.0",
@@ -12630,8 +12650,10 @@
         "strip-ansi": "^6.0.1",
         "supports-color": "^8.1.1",
         "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.5.0",
         "widest-line": "^3.1.0",
+        "wordwrap": "^1.0.0",
         "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
@@ -12664,18 +12686,6 @@
           }
         }
       }
-    },
-    "@oclif/linewrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@oclif/linewrap/-/linewrap-1.0.0.tgz",
-      "integrity": "sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==",
-      "dev": true
-    },
-    "@oclif/screen": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@oclif/screen/-/screen-3.0.4.tgz",
-      "integrity": "sha512-IMsTN1dXEXaOSre27j/ywGbBjrzx0FNd1XmuhCWCB9NTPrhWI1Ifbz+YLSEcstfQfocYsrbrIessxXb2oon4lA==",
-      "dev": true
     },
     "@octokit/auth-app": {
       "version": "4.0.7",
@@ -13004,6 +13014,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha512-wJsiX1tosQ+J5+bY5LrSahHxr2wT+uME5UDwdN1kg4frt40euqA+wzECkmq4t5QbveHiJepfdThgQrPw6KiSlg=="
+    },
+    "@types/cli-progress": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.0.tgz",
+      "integrity": "sha512-XhXhBv1R/q2ahF3BM7qT5HLzJNlIL0wbcGyZVjqOTqAybAnsLisd7gy1UCyIqpL+5Iv6XhlSyzjLCnI2sIdbCg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/connect": {
       "version": "3.4.35",
@@ -13492,6 +13511,150 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
+    "aws-cdk": {
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.68.0.tgz",
+      "integrity": "sha512-r+C5M4J3C7RLiixhxsO/W9Kpb5iB0mFshyn5PXT1cGPkDbx23bnWLOab03jG7uHWIWI01DCipHQyTaeXXqvT3A==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "aws-cdk-lib": {
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.68.0.tgz",
+      "integrity": "sha512-roN3xwzv/GleGG3CaJrf+thdzr9WBzJU4LotumEOs+0cGfeXSta8Pm/cGAeY4kplr5r10QWUovH0fv/bi6Vrbw==",
+      "dev": true,
+      "requires": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.97",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^9.1.0",
+        "ignore": "^5.2.4",
+        "jsonschema": "^1.4.1",
+        "minimatch": "^3.1.2",
+        "punycode": "^2.3.0",
+        "semver": "^7.3.8",
+        "yaml": "1.10.2"
+      },
+      "dependencies": {
+        "@balena/dockerignore": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "at-least-node": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "case": {
+          "version": "1.6.3",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.10",
+          "bundled": true,
+          "dev": true
+        },
+        "ignore": {
+          "version": "5.2.4",
+          "bundled": true,
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonschema": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "punycode": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.8",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "yaml": {
+          "version": "1.10.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
     "aws-sdk": {
       "version": "2.1366.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1366.0.tgz",
@@ -13799,185 +13962,14 @@
     "cdk": {
       "version": "file:packages/cdk",
       "requires": {
-        "@guardian/cdk": "49.4.0",
+        "@guardian/cdk": "50.0.0",
         "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-        "aws-cdk": "2.64.0",
-        "aws-cdk-lib": "2.64.0",
-        "constructs": "10.1.246",
+        "aws-cdk": "2.68.0",
+        "aws-cdk-lib": "2.68.0",
+        "constructs": "10.1.273",
         "source-map-support": "^0.5.21"
       },
       "dependencies": {
-        "@guardian/cdk": {
-          "version": "49.4.0",
-          "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.4.0.tgz",
-          "integrity": "sha512-p6S/Eilw+oPcy8PylsFLX8y38PJLPF38SLD+i0zmwIBYWh0SYi/Z8m4q6kr24W6J1bmnE6Q15XsNW7GEVFa9zg==",
-          "dev": true,
-          "requires": {
-            "@oclif/core": "1.24.2",
-            "aws-cdk-lib": "2.64.0",
-            "aws-sdk": "^2.1315.0",
-            "chalk": "^4.1.2",
-            "codemaker": "^1.75.0",
-            "constructs": "10.1.246",
-            "git-url-parse": "^13.1.0",
-            "js-yaml": "^4.1.0",
-            "lodash.camelcase": "^4.3.0",
-            "lodash.kebabcase": "^4.1.1",
-            "lodash.upperfirst": "^4.3.1",
-            "read-pkg-up": "7.0.1",
-            "yargs": "^17.6.2"
-          }
-        },
-        "aws-cdk": {
-          "version": "2.64.0",
-          "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.64.0.tgz",
-          "integrity": "sha512-iXkvVeYKt6Glboeicrb3QxC6K6o25+zitM/UTfgVzDlKEvC4hwQp1KqXy/caN7SfA6X2N0LJmXfC99T4cvIH0A==",
-          "dev": true,
-          "requires": {
-            "fsevents": "2.3.2"
-          }
-        },
-        "aws-cdk-lib": {
-          "version": "2.64.0",
-          "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.64.0.tgz",
-          "integrity": "sha512-IrgL7thb6TeOyHgyR/qKWTdA9FBb9lv7Z9QPDzCNJlkKI+0ANjYHy3RYV8Gd+1+kc6l8DG9Z1elij40YCr/Ptg==",
-          "dev": true,
-          "requires": {
-            "@aws-cdk/asset-awscli-v1": "^2.2.52",
-            "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-            "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.42",
-            "@balena/dockerignore": "^1.0.2",
-            "case": "1.6.3",
-            "fs-extra": "^9.1.0",
-            "ignore": "^5.2.4",
-            "jsonschema": "^1.4.1",
-            "minimatch": "^3.1.2",
-            "punycode": "^2.3.0",
-            "semver": "^7.3.8",
-            "yaml": "1.10.2"
-          },
-          "dependencies": {
-            "@balena/dockerignore": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "at-least-node": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "balanced-match": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true
-            },
-            "brace-expansion": {
-              "version": "1.1.11",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-              }
-            },
-            "case": {
-              "version": "1.6.3",
-              "bundled": true,
-              "dev": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "fs-extra": {
-              "version": "9.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-              }
-            },
-            "graceful-fs": {
-              "version": "4.2.10",
-              "bundled": true,
-              "dev": true
-            },
-            "ignore": {
-              "version": "5.2.4",
-              "bundled": true,
-              "dev": true
-            },
-            "jsonfile": {
-              "version": "6.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.1.6",
-                "universalify": "^2.0.0"
-              }
-            },
-            "jsonschema": {
-              "version": "1.4.1",
-              "bundled": true,
-              "dev": true
-            },
-            "lru-cache": {
-              "version": "6.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "minimatch": {
-              "version": "3.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            },
-            "punycode": {
-              "version": "2.3.0",
-              "bundled": true,
-              "dev": true
-            },
-            "semver": {
-              "version": "7.3.8",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "^6.0.0"
-              }
-            },
-            "universalify": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "yaml": {
-              "version": "1.10.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "constructs": {
-          "version": "10.1.246",
-          "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.246.tgz",
-          "integrity": "sha512-2U2hnAuA4tCGGjHk/TulZfSlPobTyokEh+Azuch9nivv2yGI7/5nXDHC14i2MU/K7HFnnkQOHRSrwKSmOZkT/w==",
-          "dev": true
-        },
         "source-map-support": {
           "version": "0.5.21",
           "dev": true,
@@ -14175,6 +14167,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "constructs": {
+      "version": "10.1.273",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.273.tgz",
+      "integrity": "sha512-JRaydmKm58aQm7crUcai3qGXtqhsh9e/dXyjQoZV6RiiEamf1V9A3yLLJIjit66Kl0Sub9quXgPmtqRfPYYlIg==",
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -18065,9 +18063,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -18328,6 +18326,12 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true,
       "peer": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2117,35 +2117,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@guardian/cdk": {
-      "version": "48.5.2",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-48.5.2.tgz",
-      "integrity": "sha512-kh8gxYGXt4sHjokAPw0GLsfqB6tzufoeayd9kcgwZaP/CQjMePBn9y9lL58OKAqv1j2TQVRzk/pZ3VOYN6SoAw==",
-      "dev": true,
-      "dependencies": {
-        "@oclif/core": "1.20.4",
-        "aws-cdk-lib": "2.51.1",
-        "aws-sdk": "^2.1260.0",
-        "chalk": "^4.1.2",
-        "codemaker": "^1.71.0",
-        "constructs": "10.1.167",
-        "git-url-parse": "^13.1.0",
-        "js-yaml": "^4.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.upperfirst": "^4.3.1",
-        "read-pkg-up": "7.0.1",
-        "yargs": "^17.6.2"
-      },
-      "bin": {
-        "gu-cdk": "bin/gu-cdk"
-      },
-      "peerDependencies": {
-        "aws-cdk": "2.51.1",
-        "aws-cdk-lib": "2.51.1",
-        "constructs": "10.1.167"
-      }
-    },
     "node_modules/@guardian/eslint-config": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-2.0.3.tgz",
@@ -2671,82 +2642,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@oclif/core": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.20.4.tgz",
-      "integrity": "sha512-giug32M4YhSYNYKQwE1L57/+k5gp1+Bq3/0vKNQmzAY1tizFGhvBJc6GIRZasHjU+xtZLutQvrVrJo7chX3hxg==",
-      "dev": true,
-      "dependencies": {
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^3.0.3",
-        "ansi-escapes": "^4.3.2",
-        "ansi-styles": "^4.3.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.2",
-        "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
-        "debug": "^4.3.4",
-        "ejs": "^3.1.6",
-        "fs-extra": "^9.1.0",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.14.1",
-        "natural-orderby": "^2.0.3",
-        "object-treeify": "^1.1.33",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "supports-color": "^8.1.1",
-        "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@oclif/core/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/@oclif/linewrap": {
@@ -3795,227 +3690,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/aws-cdk": {
-      "version": "2.51.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.51.1.tgz",
-      "integrity": "sha512-c60bIcMfe/gn4qkw/TZvqw+DxVGFn25D624RcciLxIAI/t9v2taaPfIdlCVXDSr3qfy0Oc7GpEh3jL9I/RpVFw==",
-      "dev": true,
-      "bin": {
-        "cdk": "bin/cdk"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/aws-cdk-lib": {
-      "version": "2.51.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.51.1.tgz",
-      "integrity": "sha512-88HC6giHaShsP1z7z1+7gdY3bmHUrp77hWefutE1JcH3O2nzCpFnd6exDQLjFyzauJa+uEFo1u5ToXynfQi2zg==",
-      "bundleDependencies": [
-        "@balena/dockerignore",
-        "case",
-        "fs-extra",
-        "ignore",
-        "jsonschema",
-        "minimatch",
-        "punycode",
-        "semver",
-        "yaml"
-      ],
-      "dev": true,
-      "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.9",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.15",
-        "@balena/dockerignore": "^1.0.2",
-        "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
-        "jsonschema": "^1.4.1",
-        "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.8",
-        "yaml": "1.10.2"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "peerDependencies": {
-        "constructs": "^10.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/aws-cdk-lib/node_modules/at-least-node": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/case": {
-      "version": "1.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "(MIT OR GPL-3.0-or-later)",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "3.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/universalify": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/aws-sdk": {
       "version": "2.1273.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1273.0.tgz",
@@ -4635,15 +4309,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "node_modules/constructs": {
-      "version": "10.1.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.167.tgz",
-      "integrity": "sha512-zGt88EmcJUtWbd/sTM9GKcHRjYWzEx5jzMYuK69vl25Dj01sJAc7uF6AEJgZBtlLAc3VnRUvzgitHwmJkS9BFw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.17.0"
-      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -8921,7 +8586,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10400,12 +10064,332 @@
     "packages/cdk": {
       "version": "1.0.0",
       "devDependencies": {
-        "@guardian/cdk": "48.5.2",
+        "@guardian/cdk": "49.0.0",
         "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-        "aws-cdk": "2.51.1",
-        "aws-cdk-lib": "2.51.1",
-        "constructs": "10.1.167",
+        "aws-cdk": "2.54.0",
+        "aws-cdk-lib": "2.54.0",
+        "constructs": "10.1.187",
         "source-map-support": "^0.5.21"
+      }
+    },
+    "packages/cdk/node_modules/@guardian/cdk": {
+      "version": "49.0.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.0.0.tgz",
+      "integrity": "sha512-VDuyHyHxiYU5WKQAG+IO0rwiPiWFaM6wKYgAaMkefAwKaYxswzEoSqKyJevhYxHbnWNWht0n3w1L6aTqdWpxGA==",
+      "dev": true,
+      "dependencies": {
+        "@oclif/core": "1.21.0",
+        "aws-cdk-lib": "2.54.0",
+        "aws-sdk": "^2.1272.0",
+        "chalk": "^4.1.2",
+        "codemaker": "^1.72.0",
+        "constructs": "10.1.187",
+        "git-url-parse": "^13.1.0",
+        "js-yaml": "^4.1.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.upperfirst": "^4.3.1",
+        "read-pkg-up": "7.0.1",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "gu-cdk": "bin/gu-cdk"
+      },
+      "peerDependencies": {
+        "aws-cdk": "2.54.0",
+        "aws-cdk-lib": "2.54.0",
+        "constructs": "10.1.187"
+      }
+    },
+    "packages/cdk/node_modules/@oclif/core": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.21.0.tgz",
+      "integrity": "sha512-B/AKYfHcNRAbb6Xz2kj0FlH9gWEi8aFS4iEr7EzguP3E2DpDk4wcf7eOMOfJYEmhuVd9sOpVWSnI2yP+FL/3Sg==",
+      "dev": true,
+      "dependencies": {
+        "@oclif/linewrap": "^1.0.0",
+        "@oclif/screen": "^3.0.3",
+        "ansi-escapes": "^4.3.2",
+        "ansi-styles": "^4.3.0",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.2",
+        "clean-stack": "^3.0.1",
+        "cli-progress": "^3.10.0",
+        "debug": "^4.3.4",
+        "ejs": "^3.1.6",
+        "fs-extra": "^9.1.0",
+        "get-package-type": "^0.1.0",
+        "globby": "^11.1.0",
+        "hyperlinker": "^1.0.0",
+        "indent-string": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "js-yaml": "^3.14.1",
+        "natural-orderby": "^2.0.3",
+        "object-treeify": "^1.1.33",
+        "password-prompt": "^1.1.2",
+        "semver": "^7.3.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "supports-color": "^8.1.1",
+        "supports-hyperlinks": "^2.2.0",
+        "tslib": "^2.4.1",
+        "widest-line": "^3.1.0",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/cdk/node_modules/@oclif/core/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "packages/cdk/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk": {
+      "version": "2.54.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.54.0.tgz",
+      "integrity": "sha512-Muk4/cS5SrwPmj4wCoXEXubknIMaIBGteb8dohWFFyAr3I6QrvZ+41EkVvhPnEQEeJpzZQ2Qa65HxgoRC6WMhw==",
+      "dev": true,
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib": {
+      "version": "2.54.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.54.0.tgz",
+      "integrity": "sha512-DooUehpsNnFY2WjIxtXNBF37PTCvFSNK6E5c9cYpgQiofF3ayT7h7ppFhoWrc53trV3hw544kZDWL6aJszXCaA==",
+      "bundleDependencies": [
+        "@balena/dockerignore",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "yaml"
+      ],
+      "dev": true,
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.16",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.21",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^9.1.0",
+        "ignore": "^5.2.0",
+        "jsonschema": "^1.4.1",
+        "minimatch": "^3.1.2",
+        "punycode": "^2.1.1",
+        "semver": "^7.3.8",
+        "yaml": "1.10.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/at-least-node": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.3.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "packages/cdk/node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "packages/cdk/node_modules/constructs": {
+      "version": "10.1.187",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.187.tgz",
+      "integrity": "sha512-1Nam2kyu7RJfVVA3ECN6gAtF5ln+7nwkl0VNu4co2Jh7jfPc6Mh5T5O5Od1IniW1Z/sms08/blQxOEUclPV2cg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.17.0"
       }
     },
     "packages/cdk/node_modules/source-map-support": {
@@ -10415,6 +10399,21 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "packages/cdk/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "packages/cloudformation-lens": {
@@ -12189,27 +12188,6 @@
         "strip-json-comments": "^3.1.1"
       }
     },
-    "@guardian/cdk": {
-      "version": "48.5.2",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-48.5.2.tgz",
-      "integrity": "sha512-kh8gxYGXt4sHjokAPw0GLsfqB6tzufoeayd9kcgwZaP/CQjMePBn9y9lL58OKAqv1j2TQVRzk/pZ3VOYN6SoAw==",
-      "dev": true,
-      "requires": {
-        "@oclif/core": "1.20.4",
-        "aws-cdk-lib": "2.51.1",
-        "aws-sdk": "^2.1260.0",
-        "chalk": "^4.1.2",
-        "codemaker": "^1.71.0",
-        "constructs": "10.1.167",
-        "git-url-parse": "^13.1.0",
-        "js-yaml": "^4.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.upperfirst": "^4.3.1",
-        "read-pkg-up": "7.0.1",
-        "yargs": "^17.6.2"
-      }
-    },
     "@guardian/eslint-config": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@guardian/eslint-config/-/eslint-config-2.0.3.tgz",
@@ -12615,72 +12593,6 @@
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
-      }
-    },
-    "@oclif/core": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.20.4.tgz",
-      "integrity": "sha512-giug32M4YhSYNYKQwE1L57/+k5gp1+Bq3/0vKNQmzAY1tizFGhvBJc6GIRZasHjU+xtZLutQvrVrJo7chX3hxg==",
-      "dev": true,
-      "requires": {
-        "@oclif/linewrap": "^1.0.0",
-        "@oclif/screen": "^3.0.3",
-        "ansi-escapes": "^4.3.2",
-        "ansi-styles": "^4.3.0",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.2",
-        "clean-stack": "^3.0.1",
-        "cli-progress": "^3.10.0",
-        "debug": "^4.3.4",
-        "ejs": "^3.1.6",
-        "fs-extra": "^9.1.0",
-        "get-package-type": "^0.1.0",
-        "globby": "^11.1.0",
-        "hyperlinker": "^1.0.0",
-        "indent-string": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "js-yaml": "^3.14.1",
-        "natural-orderby": "^2.0.3",
-        "object-treeify": "^1.1.33",
-        "password-prompt": "^1.1.2",
-        "semver": "^7.3.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "supports-color": "^8.1.1",
-        "supports-hyperlinks": "^2.2.0",
-        "tslib": "^2.4.1",
-        "widest-line": "^3.1.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "@oclif/linewrap": {
@@ -13510,150 +13422,6 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
       "dev": true
     },
-    "aws-cdk": {
-      "version": "2.51.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.51.1.tgz",
-      "integrity": "sha512-c60bIcMfe/gn4qkw/TZvqw+DxVGFn25D624RcciLxIAI/t9v2taaPfIdlCVXDSr3qfy0Oc7GpEh3jL9I/RpVFw==",
-      "dev": true,
-      "requires": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "aws-cdk-lib": {
-      "version": "2.51.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.51.1.tgz",
-      "integrity": "sha512-88HC6giHaShsP1z7z1+7gdY3bmHUrp77hWefutE1JcH3O2nzCpFnd6exDQLjFyzauJa+uEFo1u5ToXynfQi2zg==",
-      "dev": true,
-      "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.9",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.15",
-        "@balena/dockerignore": "^1.0.2",
-        "case": "1.6.3",
-        "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
-        "jsonschema": "^1.4.1",
-        "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.8",
-        "yaml": "1.10.2"
-      },
-      "dependencies": {
-        "@balena/dockerignore": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "at-least-node": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "case": {
-          "version": "1.6.3",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "9.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.10",
-          "bundled": true,
-          "dev": true
-        },
-        "ignore": {
-          "version": "5.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "jsonschema": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "punycode": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "7.3.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "yaml": {
-          "version": "1.10.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
-    },
     "aws-sdk": {
       "version": "2.1273.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1273.0.tgz",
@@ -13961,20 +13729,257 @@
     "cdk": {
       "version": "file:packages/cdk",
       "requires": {
-        "@guardian/cdk": "48.5.2",
+        "@guardian/cdk": "49.0.0",
         "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-        "aws-cdk": "2.51.1",
-        "aws-cdk-lib": "2.51.1",
-        "constructs": "10.1.167",
+        "aws-cdk": "2.54.0",
+        "aws-cdk-lib": "2.54.0",
+        "constructs": "10.1.187",
         "source-map-support": "^0.5.21"
       },
       "dependencies": {
+        "@guardian/cdk": {
+          "version": "49.0.0",
+          "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-49.0.0.tgz",
+          "integrity": "sha512-VDuyHyHxiYU5WKQAG+IO0rwiPiWFaM6wKYgAaMkefAwKaYxswzEoSqKyJevhYxHbnWNWht0n3w1L6aTqdWpxGA==",
+          "dev": true,
+          "requires": {
+            "@oclif/core": "1.21.0",
+            "aws-cdk-lib": "2.54.0",
+            "aws-sdk": "^2.1272.0",
+            "chalk": "^4.1.2",
+            "codemaker": "^1.72.0",
+            "constructs": "10.1.187",
+            "git-url-parse": "^13.1.0",
+            "js-yaml": "^4.1.0",
+            "lodash.camelcase": "^4.3.0",
+            "lodash.kebabcase": "^4.1.1",
+            "lodash.upperfirst": "^4.3.1",
+            "read-pkg-up": "7.0.1",
+            "yargs": "^17.6.2"
+          }
+        },
+        "@oclif/core": {
+          "version": "1.21.0",
+          "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.21.0.tgz",
+          "integrity": "sha512-B/AKYfHcNRAbb6Xz2kj0FlH9gWEi8aFS4iEr7EzguP3E2DpDk4wcf7eOMOfJYEmhuVd9sOpVWSnI2yP+FL/3Sg==",
+          "dev": true,
+          "requires": {
+            "@oclif/linewrap": "^1.0.0",
+            "@oclif/screen": "^3.0.3",
+            "ansi-escapes": "^4.3.2",
+            "ansi-styles": "^4.3.0",
+            "cardinal": "^2.1.1",
+            "chalk": "^4.1.2",
+            "clean-stack": "^3.0.1",
+            "cli-progress": "^3.10.0",
+            "debug": "^4.3.4",
+            "ejs": "^3.1.6",
+            "fs-extra": "^9.1.0",
+            "get-package-type": "^0.1.0",
+            "globby": "^11.1.0",
+            "hyperlinker": "^1.0.0",
+            "indent-string": "^4.0.0",
+            "is-wsl": "^2.2.0",
+            "js-yaml": "^3.14.1",
+            "natural-orderby": "^2.0.3",
+            "object-treeify": "^1.1.33",
+            "password-prompt": "^1.1.2",
+            "semver": "^7.3.7",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
+            "supports-color": "^8.1.1",
+            "supports-hyperlinks": "^2.2.0",
+            "tslib": "^2.4.1",
+            "widest-line": "^3.1.0",
+            "wrap-ansi": "^7.0.0"
+          },
+          "dependencies": {
+            "js-yaml": {
+              "version": "3.14.1",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+              "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+              "dev": true,
+              "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+              }
+            }
+          }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "aws-cdk": {
+          "version": "2.54.0",
+          "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.54.0.tgz",
+          "integrity": "sha512-Muk4/cS5SrwPmj4wCoXEXubknIMaIBGteb8dohWFFyAr3I6QrvZ+41EkVvhPnEQEeJpzZQ2Qa65HxgoRC6WMhw==",
+          "dev": true,
+          "requires": {
+            "fsevents": "2.3.2"
+          }
+        },
+        "aws-cdk-lib": {
+          "version": "2.54.0",
+          "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.54.0.tgz",
+          "integrity": "sha512-DooUehpsNnFY2WjIxtXNBF37PTCvFSNK6E5c9cYpgQiofF3ayT7h7ppFhoWrc53trV3hw544kZDWL6aJszXCaA==",
+          "dev": true,
+          "requires": {
+            "@aws-cdk/asset-awscli-v1": "^2.2.16",
+            "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+            "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.21",
+            "@balena/dockerignore": "^1.0.2",
+            "case": "1.6.3",
+            "fs-extra": "^9.1.0",
+            "ignore": "^5.2.0",
+            "jsonschema": "^1.4.1",
+            "minimatch": "^3.1.2",
+            "punycode": "^2.1.1",
+            "semver": "^7.3.8",
+            "yaml": "1.10.2"
+          },
+          "dependencies": {
+            "@balena/dockerignore": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "at-least-node": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "balanced-match": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "case": {
+              "version": "1.6.3",
+              "bundled": true,
+              "dev": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "fs-extra": {
+              "version": "9.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.2.10",
+              "bundled": true,
+              "dev": true
+            },
+            "ignore": {
+              "version": "5.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "jsonfile": {
+              "version": "6.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+              }
+            },
+            "jsonschema": {
+              "version": "1.4.1",
+              "bundled": true,
+              "dev": true
+            },
+            "lru-cache": {
+              "version": "6.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "yallist": "^4.0.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "punycode": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "semver": {
+              "version": "7.3.8",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "^6.0.0"
+              }
+            },
+            "universalify": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "yallist": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "yaml": {
+              "version": "1.10.2",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "constructs": {
+          "version": "10.1.187",
+          "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.187.tgz",
+          "integrity": "sha512-1Nam2kyu7RJfVVA3ECN6gAtF5ln+7nwkl0VNu4co2Jh7jfPc6Mh5T5O5Od1IniW1Z/sms08/blQxOEUclPV2cg==",
+          "dev": true
+        },
         "source-map-support": {
           "version": "0.5.21",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -14166,12 +14171,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
-    },
-    "constructs": {
-      "version": "10.1.167",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.167.tgz",
-      "integrity": "sha512-zGt88EmcJUtWbd/sTM9GKcHRjYWzEx5jzMYuK69vl25Dj01sJAc7uF6AEJgZBtlLAc3VnRUvzgitHwmJkS9BFw==",
-      "dev": true
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -17313,8 +17312,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "qs": {
       "version": "6.11.0",

--- a/packages/cdk/lib/__snapshots__/cloudformation-lens.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudformation-lens.test.ts.snap
@@ -19,8 +19,8 @@ exports[`The CloudFormation Lens stack matches the snapshot 1`] = `
       "GuParameterStoreReadPolicy",
       "GuAmiParameter",
       "GuHttpsEgressSecurityGroup",
-      "GuAutoScalingGroup",
       "GuWazuhAccess",
+      "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
@@ -83,8 +83,16 @@ exports[`The CloudFormation Lens stack matches the snapshot 1`] = `
       "Properties": {
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
-        "LaunchConfigurationName": {
-          "Ref": "AutoScalingGroupCloudformationlensLaunchConfig82219E2C",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "deployTESTcloudformationlens282DC7E0",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "deployTESTcloudformationlens282DC7E0",
+              "LatestVersionNumber",
+            ],
+          },
         },
         "MaxSize": "2",
         "MinSize": "1",
@@ -112,11 +120,6 @@ exports[`The CloudFormation Lens stack matches the snapshot 1`] = `
             },
           },
           {
-            "Key": "Name",
-            "PropagateAtLaunch": true,
-            "Value": "CloudFormationLens/AutoScalingGroupCloudformationlens",
-          },
-          {
             "Key": "Stack",
             "PropagateAtLaunch": true,
             "Value": "deploy",
@@ -142,83 +145,6 @@ exports[`The CloudFormation Lens stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
-    },
-    "AutoScalingGroupCloudformationlensInstanceProfile4261FC07": {
-      "Properties": {
-        "Roles": [
-          {
-            "Ref": "InstanceRoleCloudformationlensBF921D31",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
-    },
-    "AutoScalingGroupCloudformationlensLaunchConfig82219E2C": {
-      "DependsOn": [
-        "InstanceRoleCloudformationlensDefaultPolicy5FCE5D0D",
-        "InstanceRoleCloudformationlensBF921D31",
-      ],
-      "Properties": {
-        "IamInstanceProfile": {
-          "Ref": "AutoScalingGroupCloudformationlensInstanceProfile4261FC07",
-        },
-        "ImageId": {
-          "Ref": "AMICloudformationlens",
-        },
-        "InstanceType": "t4g.nano",
-        "MetadataOptions": {
-          "HttpTokens": "required",
-        },
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "GuHttpsEgressSecurityGroupCloudformationlens7F9B14D7",
-              "GroupId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
-              "WazuhSecurityGroup",
-              "GroupId",
-            ],
-          },
-        ],
-        "UserData": {
-          "Fn::Base64": {
-            "Fn::Join": [
-              "",
-              [
-                "#!/bin/bash -ev
-cat << EOF > /etc/systemd/system/cloudformation-lens.service
-[Unit]
-Description=CDK Metadata
-
-[Service]
-Environment="BUCKET=",
-                {
-                  "Ref": "databucketA7E4F76C",
-                },
-                ""
-ExecStart=/cloudformation-lens
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-aws s3 cp s3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/deploy/TEST/cloudformation-lens/cloudformation-lens /cloudformation-lens
-chmod +x /cloudformation-lens
-systemctl start cloudformation-lens
-",
-              ],
-            ],
-          },
-        },
-      },
-      "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
     "CertificateCloudformationlens470553BA": {
       "DeletionPolicy": "Retain",
@@ -712,6 +638,27 @@ systemctl start cloudformation-lens
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "InternalIngressSecurityGroupCloudformationlenstoCloudFormationLensWazuhSecurityGroup7663AD3989006D2B44A7": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 8900,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "InternalIngressSecurityGroupCloudformationlens0AC9589A",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 8900,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "ListenerCloudformationlens664D2766": {
       "Properties": {
         "Certificates": [
@@ -826,6 +773,27 @@ systemctl start cloudformation-lens
         "DestinationSecurityGroupId": {
           "Fn::GetAtt": [
             "GuHttpsEgressSecurityGroupCloudformationlens7F9B14D7",
+            "GroupId",
+          ],
+        },
+        "FromPort": 8900,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerCloudformationlensSecurityGroup43E2BD8C",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 8900,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "LoadBalancerCloudformationlensSecurityGrouptoCloudFormationLensWazuhSecurityGroup7663AD398900E92E9724": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
             "GroupId",
           ],
         },
@@ -1096,6 +1064,48 @@ systemctl start cloudformation-lens
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
+    "WazuhSecurityGroupfromCloudFormationLensInternalIngressSecurityGroupCloudformationlensA274C0878900CA0BDDEF": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 8900,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "InternalIngressSecurityGroupCloudformationlens0AC9589A",
+            "GroupId",
+          ],
+        },
+        "ToPort": 8900,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "WazuhSecurityGroupfromCloudFormationLensLoadBalancerCloudformationlensSecurityGroup432308D38900722D57BD": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 8900,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerCloudformationlensSecurityGroup43E2BD8C",
+            "GroupId",
+          ],
+        },
+        "ToPort": 8900,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
     "cname": {
       "Properties": {
         "Name": "cloudformation-lens.gutools.co.uk",
@@ -1145,6 +1155,165 @@ systemctl start cloudformation-lens
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
+    },
+    "deployTESTcloudformationlens282DC7E0": {
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "deployTESTcloudformationlensProfile688D83E7",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMICloudformationlens",
+          },
+          "InstanceType": "t4g.nano",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupCloudformationlens7F9B14D7",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "WazuhSecurityGroup",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/service-catalogue",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "CloudFormationLens/deploy-TEST-cloudformation-lens",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/service-catalogue",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "CloudFormationLens/deploy-TEST-cloudformation-lens",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": {
+              "Fn::Join": [
+                "",
+                [
+                  "#!/bin/bash -ev
+cat << EOF > /etc/systemd/system/cloudformation-lens.service
+[Unit]
+Description=CDK Metadata
+
+[Service]
+Environment="BUCKET=",
+                  {
+                    "Ref": "databucketA7E4F76C",
+                  },
+                  ""
+ExecStart=/cloudformation-lens
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+aws s3 cp s3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/TEST/cloudformation-lens/cloudformation-lens /cloudformation-lens
+chmod +x /cloudformation-lens
+systemctl start cloudformation-lens
+",
+                ],
+              ],
+            },
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/service-catalogue",
+              },
+              {
+                "Key": "Name",
+                "Value": "CloudFormationLens/deploy-TEST-cloudformation-lens",
+              },
+              {
+                "Key": "Stack",
+                "Value": "deploy",
+              },
+              {
+                "Key": "Stage",
+                "Value": "TEST",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "deployTESTcloudformationlensProfile688D83E7": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCloudformationlensBF921D31",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
     },
   },
 }

--- a/packages/cdk/lib/__snapshots__/cloudformation-lens.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudformation-lens.test.ts.snap
@@ -12,7 +12,6 @@ exports[`The CloudFormation Lens stack matches the snapshot 1`] = `
       "GuEc2App",
       "GuCertificate",
       "GuInstanceRole",
-      "GuSSMRunCommandPolicy",
       "GuDescribeEC2Policy",
       "GuLoggingStreamNameParameter",
       "GuLogShippingPolicy",
@@ -561,6 +560,20 @@ systemctl start cloudformation-lens
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
+              ],
+            ],
+          },
+        ],
         "Path": "/",
         "Tags": [
           {
@@ -879,42 +892,6 @@ systemctl start cloudformation-lens
           "Version": "2012-10-17",
         },
         "PolicyName": "parameter-store-read-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleCloudformationlensBF921D31",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "SSMRunCommandPolicy244E1613": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "ec2messages:AcknowledgeMessage",
-                "ec2messages:DeleteMessage",
-                "ec2messages:FailMessage",
-                "ec2messages:GetEndpoint",
-                "ec2messages:GetMessages",
-                "ec2messages:SendReply",
-                "ssm:UpdateInstanceInformation",
-                "ssm:ListInstanceAssociations",
-                "ssm:DescribeInstanceProperties",
-                "ssm:DescribeDocumentParameters",
-                "ssmmessages:CreateControlChannel",
-                "ssmmessages:CreateDataChannel",
-                "ssmmessages:OpenControlChannel",
-                "ssmmessages:OpenDataChannel",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "ssm-run-command-policy",
         "Roles": [
           {
             "Ref": "InstanceRoleCloudformationlensBF921D31",

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -10,7 +10,6 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       "GuDistributionBucketParameter",
       "GuAmiParameter",
       "GuInstanceRole",
-      "GuSSMRunCommandPolicy",
       "GuDescribeEC2Policy",
       "GuLoggingStreamNameParameter",
       "GuLogShippingPolicy",
@@ -204,6 +203,18 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
           "Version": "2012-10-17",
         },
         "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
+              ],
+            ],
+          },
           "arn:aws:iam::aws:policy/ReadOnlyAccess",
         ],
         "Path": "/",
@@ -669,42 +680,6 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::SSM::Parameter",
-    },
-    "SSMRunCommandPolicy244E1613": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "ec2messages:AcknowledgeMessage",
-                "ec2messages:DeleteMessage",
-                "ec2messages:FailMessage",
-                "ec2messages:GetEndpoint",
-                "ec2messages:GetMessages",
-                "ec2messages:SendReply",
-                "ssm:UpdateInstanceInformation",
-                "ssm:ListInstanceAssociations",
-                "ssm:DescribeInstanceProperties",
-                "ssm:DescribeDocumentParameters",
-                "ssmmessages:CreateControlChannel",
-                "ssmmessages:CreateDataChannel",
-                "ssmmessages:OpenControlChannel",
-                "ssmmessages:OpenDataChannel",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "ssm-run-command-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleCloudquery54F86B54",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "WazuhSecurityGroup": {
       "Properties": {

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -16,8 +16,8 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       "GuGetDistributablePolicy",
       "GuParameterStoreReadPolicy",
       "GuHttpsEgressSecurityGroup",
-      "GuAutoScalingGroup",
       "GuWazuhAccess",
+      "GuAutoScalingGroup",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -726,8 +726,16 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
     },
     "asgCloudqueryASG40AB7667": {
       "Properties": {
-        "LaunchConfigurationName": {
-          "Ref": "asgCloudqueryLaunchConfigEECD8C1E",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "deployTESTcloudquery13DE7BFF",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "deployTESTcloudquery13DE7BFF",
+              "LatestVersionNumber",
+            ],
+          },
         },
         "MaxSize": "2",
         "MinSize": "1",
@@ -755,11 +763,6 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
             },
           },
           {
-            "Key": "Name",
-            "PropagateAtLaunch": true,
-            "Value": "CloudQuery/asgCloudquery",
-          },
-          {
             "Key": "Stack",
             "PropagateAtLaunch": true,
             "Value": "deploy",
@@ -781,88 +784,132 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
     },
-    "asgCloudqueryInstanceProfileD6927F3E": {
+    "deployTESTcloudquery13DE7BFF": {
       "Properties": {
-        "Roles": [
-          {
-            "Ref": "InstanceRoleCloudquery54F86B54",
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "deployTESTcloudqueryProfile4BE5D073",
+                "Arn",
+              ],
+            },
           },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
-    },
-    "asgCloudqueryLaunchConfigEECD8C1E": {
-      "DependsOn": [
-        "InstanceRoleCloudqueryDefaultPolicyBCEDADAD",
-        "InstanceRoleCloudquery54F86B54",
-      ],
-      "Properties": {
-        "IamInstanceProfile": {
-          "Ref": "asgCloudqueryInstanceProfileD6927F3E",
-        },
-        "ImageId": {
-          "Ref": "AMICloudquery",
-        },
-        "InstanceType": "t4g.medium",
-        "MetadataOptions": {
-          "HttpTokens": "required",
-        },
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "GuHttpsEgressSecurityGroupCloudquery3AE9FC4C",
-              "GroupId",
-            ],
+          "ImageId": {
+            "Ref": "AMICloudquery",
           },
-          {
-            "Fn::GetAtt": [
-              "WazuhSecurityGroup",
-              "GroupId",
-            ],
+          "InstanceType": "t4g.medium",
+          "MetadataOptions": {
+            "HttpTokens": "required",
           },
-          {
-            "Fn::GetAtt": [
-              "PostgresAccessSecurityGroupCloudqueryE959A23F",
-              "GroupId",
-            ],
-          },
-        ],
-        "UserData": {
-          "Fn::Base64": {
-            "Fn::Join": [
-              "",
-              [
-                "#!/bin/bash
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupCloudquery3AE9FC4C",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "WazuhSecurityGroup",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/service-catalogue",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "CloudQuery/deploy-TEST-cloudquery",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/service-catalogue",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "CloudQuery/deploy-TEST-cloudquery",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "TEST",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": {
+              "Fn::Join": [
+                "",
+                [
+                  "#!/bin/bash
 mkdir -p $(dirname '/opt/cloudquery/aws.yaml')
 aws s3 cp 's3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/deploy/TEST/cloudquery/aws.yaml' '/opt/cloudquery/aws.yaml'
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/TEST/cloudquery/aws.yaml' '/opt/cloudquery/aws.yaml'
 mkdir -p $(dirname '/opt/cloudquery/postgresql.yaml')
 aws s3 cp 's3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/deploy/TEST/cloudquery/postgresql.yaml' '/opt/cloudquery/postgresql.yaml'
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/TEST/cloudquery/postgresql.yaml' '/opt/cloudquery/postgresql.yaml'
 mkdir -p $(dirname '/etc/systemd/system/cloudquery.service')
 aws s3 cp 's3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/deploy/TEST/cloudquery/cloudquery.service' '/etc/systemd/system/cloudquery.service'
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/TEST/cloudquery/cloudquery.service' '/etc/systemd/system/cloudquery.service'
 mkdir -p $(dirname '/etc/systemd/system/cloudquery.timer')
 aws s3 cp 's3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/deploy/TEST/cloudquery/cloudquery.timer' '/etc/systemd/system/cloudquery.timer'
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/TEST/cloudquery/cloudquery.timer' '/etc/systemd/system/cloudquery.timer'
 mkdir -p $(dirname '/opt/cloudquery/cloudquery.sh')
 aws s3 cp 's3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/deploy/TEST/cloudquery/cloudquery.sh' '/opt/cloudquery/cloudquery.sh'
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/TEST/cloudquery/cloudquery.sh' '/opt/cloudquery/cloudquery.sh'
 set -xe
 curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.3/cloudquery_linux_arm64 -o /opt/cloudquery/cloudquery
 echo "286cff19c54098328c0b85dbbfa94e87234b5a53be421c3b6ca406803122a7ee  /opt/cloudquery/cloudquery" | shasum -c -a 256
@@ -873,12 +920,50 @@ curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/s
 update-ca-certificates
 systemctl enable cloudquery.timer
 systemctl start cloudquery.timer",
+                ],
               ],
-            ],
+            },
           },
         },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/service-catalogue",
+              },
+              {
+                "Key": "Name",
+                "Value": "CloudQuery/deploy-TEST-cloudquery",
+              },
+              {
+                "Key": "Stack",
+                "Value": "deploy",
+              },
+              {
+                "Key": "Stage",
+                "Value": "TEST",
+              },
+            ],
+          },
+        ],
       },
-      "Type": "AWS::AutoScaling::LaunchConfiguration",
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "deployTESTcloudqueryProfile4BE5D073": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleCloudquery54F86B54",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
     },
   },
 }

--- a/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
@@ -16,7 +16,6 @@ exports[`The GithubLens stack matches the snapshot 1`] = `
       "GuEc2App",
       "GuCertificate",
       "GuInstanceRole",
-      "GuSSMRunCommandPolicy",
       "GuDescribeEC2Policy",
       "GuLoggingStreamNameParameter",
       "GuLogShippingPolicy",
@@ -657,6 +656,20 @@ systemctl start github-lens-api
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
+              ],
+            ],
+          },
+        ],
         "Path": "/",
         "Tags": [
           {
@@ -970,42 +983,6 @@ systemctl start github-lens-api
           "Version": "2012-10-17",
         },
         "PolicyName": "parameter-store-read-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleGithublensapi15815617",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "SSMRunCommandPolicy244E1613": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "ec2messages:AcknowledgeMessage",
-                "ec2messages:DeleteMessage",
-                "ec2messages:FailMessage",
-                "ec2messages:GetEndpoint",
-                "ec2messages:GetMessages",
-                "ec2messages:SendReply",
-                "ssm:UpdateInstanceInformation",
-                "ssm:ListInstanceAssociations",
-                "ssm:DescribeInstanceProperties",
-                "ssm:DescribeDocumentParameters",
-                "ssmmessages:CreateControlChannel",
-                "ssmmessages:CreateDataChannel",
-                "ssmmessages:OpenControlChannel",
-                "ssmmessages:OpenDataChannel",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "ssm-run-command-policy",
         "Roles": [
           {
             "Ref": "InstanceRoleGithublensapi15815617",

--- a/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/github-lens.test.ts.snap
@@ -23,8 +23,8 @@ exports[`The GithubLens stack matches the snapshot 1`] = `
       "GuParameterStoreReadPolicy",
       "GuAmiParameter",
       "GuHttpsEgressSecurityGroup",
-      "GuAutoScalingGroup",
       "GuWazuhAccess",
+      "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
@@ -105,8 +105,16 @@ exports[`The GithubLens stack matches the snapshot 1`] = `
       "Properties": {
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
-        "LaunchConfigurationName": {
-          "Ref": "AutoScalingGroupGithublensapiLaunchConfigED794D0D",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "deployINFRAgithublensapi5D5BAC5D",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "deployINFRAgithublensapi5D5BAC5D",
+              "LatestVersionNumber",
+            ],
+          },
         },
         "MaxSize": "2",
         "MinSize": "1",
@@ -134,11 +142,6 @@ exports[`The GithubLens stack matches the snapshot 1`] = `
             },
           },
           {
-            "Key": "Name",
-            "PropagateAtLaunch": true,
-            "Value": "GithubLens/AutoScalingGroupGithublensapi",
-          },
-          {
             "Key": "Stack",
             "PropagateAtLaunch": true,
             "Value": "deploy",
@@ -164,86 +167,6 @@ exports[`The GithubLens stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
-    },
-    "AutoScalingGroupGithublensapiInstanceProfile02115151": {
-      "Properties": {
-        "Roles": [
-          {
-            "Ref": "InstanceRoleGithublensapi15815617",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
-    },
-    "AutoScalingGroupGithublensapiLaunchConfigED794D0D": {
-      "DependsOn": [
-        "InstanceRoleGithublensapiDefaultPolicy0C5E588B",
-        "InstanceRoleGithublensapi15815617",
-      ],
-      "Properties": {
-        "IamInstanceProfile": {
-          "Ref": "AutoScalingGroupGithublensapiInstanceProfile02115151",
-        },
-        "ImageId": {
-          "Ref": "AMIGithublensapi",
-        },
-        "InstanceType": "t4g.nano",
-        "MetadataOptions": {
-          "HttpTokens": "required",
-        },
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "GuHttpsEgressSecurityGroupGithublensapi4002F148",
-              "GroupId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
-              "WazuhSecurityGroup",
-              "GroupId",
-            ],
-          },
-        ],
-        "UserData": {
-          "Fn::Base64": {
-            "Fn::Join": [
-              "",
-              [
-                "#!/bin/bash -ev
-cat << EOF > /etc/systemd/system/github-lens-api.service
-[Unit]
-Description=Github Lens API
-
-[Service]
-Environment="DATA_BUCKET_NAME=",
-                {
-                  "Ref": "githublensdatabucketGithublens7C07FDE7",
-                },
-                ""
-Environment="PORT=8900"
-Environment="STAGE=INFRA"
-ExecStart=/usr/bin/node /handler.js
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-aws s3 cp s3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/deploy/INFRA/github-lens-api/github-lens-api.zip github-lens-api.zip
-unzip github-lens-api.zip
-chmod +x /handler.js
-systemctl start github-lens-api
-",
-              ],
-            ],
-          },
-        },
-      },
-      "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
     "CertificateGithublensapi4318D111": {
       "DeletionPolicy": "Retain",
@@ -803,6 +726,27 @@ systemctl start github-lens-api
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "InternalIngressSecurityGroupGithublensapitoGithubLensWazuhSecurityGroup44449F2B8900D45DACE8": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 8900,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "InternalIngressSecurityGroupGithublensapi2BEE9DF4",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 8900,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "ListenerGithublensapiCF255DF8": {
       "Properties": {
         "Certificates": [
@@ -917,6 +861,27 @@ systemctl start github-lens-api
         "DestinationSecurityGroupId": {
           "Fn::GetAtt": [
             "GuHttpsEgressSecurityGroupGithublensapi4002F148",
+            "GroupId",
+          ],
+        },
+        "FromPort": 8900,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerGithublensapiSecurityGroup3BAB53B9",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 8900,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "LoadBalancerGithublensapiSecurityGrouptoGithubLensWazuhSecurityGroup44449F2B8900F68D66F0": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
             "GroupId",
           ],
         },
@@ -1186,6 +1151,210 @@ systemctl start github-lens-api
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "WazuhSecurityGroupfromGithubLensInternalIngressSecurityGroupGithublensapiD4073FAD8900154E9DF1": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 8900,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "InternalIngressSecurityGroupGithublensapi2BEE9DF4",
+            "GroupId",
+          ],
+        },
+        "ToPort": 8900,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "WazuhSecurityGroupfromGithubLensLoadBalancerGithublensapiSecurityGroup2BC6E5BA8900658C78D5": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 8900,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerGithublensapiSecurityGroup3BAB53B9",
+            "GroupId",
+          ],
+        },
+        "ToPort": 8900,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "deployINFRAgithublensapi5D5BAC5D": {
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "deployINFRAgithublensapiProfileA453D57A",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMIGithublensapi",
+          },
+          "InstanceType": "t4g.nano",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupGithublensapi4002F148",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "WazuhSecurityGroup",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/service-catalogue",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "GithubLens/deploy-INFRA-github-lens-api",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "INFRA",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/service-catalogue",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "GithubLens/deploy-INFRA-github-lens-api",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "INFRA",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": {
+              "Fn::Join": [
+                "",
+                [
+                  "#!/bin/bash -ev
+cat << EOF > /etc/systemd/system/github-lens-api.service
+[Unit]
+Description=Github Lens API
+
+[Service]
+Environment="DATA_BUCKET_NAME=",
+                  {
+                    "Ref": "githublensdatabucketGithublens7C07FDE7",
+                  },
+                  ""
+Environment="PORT=8900"
+Environment="STAGE=INFRA"
+ExecStart=/usr/bin/node /handler.js
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+aws s3 cp s3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/INFRA/github-lens-api/github-lens-api.zip github-lens-api.zip
+unzip github-lens-api.zip
+chmod +x /handler.js
+systemctl start github-lens-api
+",
+                ],
+              ],
+            },
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/service-catalogue",
+              },
+              {
+                "Key": "Name",
+                "Value": "GithubLens/deploy-INFRA-github-lens-api",
+              },
+              {
+                "Key": "Stack",
+                "Value": "deploy",
+              },
+              {
+                "Key": "Stage",
+                "Value": "INFRA",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "deployINFRAgithublensapiProfileA453D57A": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleGithublensapi15815617",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
     },
     "githubdatafetcherlambda94945EFA": {
       "DependsOn": [

--- a/packages/cdk/lib/__snapshots__/services-api.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/services-api.test.ts.snap
@@ -19,8 +19,8 @@ exports[`The ServicesAPI stack matches the snapshot 1`] = `
       "GuParameterStoreReadPolicy",
       "GuAmiParameter",
       "GuHttpsEgressSecurityGroup",
-      "GuAutoScalingGroup",
       "GuWazuhAccess",
+      "GuAutoScalingGroup",
       "GuApplicationLoadBalancer",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
@@ -88,8 +88,16 @@ exports[`The ServicesAPI stack matches the snapshot 1`] = `
       "Properties": {
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
-        "LaunchConfigurationName": {
-          "Ref": "AutoScalingGroupServicesapiLaunchConfigCE2ECB8E",
+        "LaunchTemplate": {
+          "LaunchTemplateId": {
+            "Ref": "deployINFRAservicesapi1571C7B5",
+          },
+          "Version": {
+            "Fn::GetAtt": [
+              "deployINFRAservicesapi1571C7B5",
+              "LatestVersionNumber",
+            ],
+          },
         },
         "MaxSize": "2",
         "MinSize": "1",
@@ -117,11 +125,6 @@ exports[`The ServicesAPI stack matches the snapshot 1`] = `
             },
           },
           {
-            "Key": "Name",
-            "PropagateAtLaunch": true,
-            "Value": "ServicesApi/AutoScalingGroupServicesapi",
-          },
-          {
             "Key": "Stack",
             "PropagateAtLaunch": true,
             "Value": "deploy",
@@ -147,86 +150,6 @@ exports[`The ServicesAPI stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
-    },
-    "AutoScalingGroupServicesapiInstanceProfile24D91637": {
-      "Properties": {
-        "Roles": [
-          {
-            "Ref": "InstanceRoleServicesapi62D8A4C9",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
-    },
-    "AutoScalingGroupServicesapiLaunchConfigCE2ECB8E": {
-      "DependsOn": [
-        "InstanceRoleServicesapiDefaultPolicyCC9CBC9F",
-        "InstanceRoleServicesapi62D8A4C9",
-      ],
-      "Properties": {
-        "IamInstanceProfile": {
-          "Ref": "AutoScalingGroupServicesapiInstanceProfile24D91637",
-        },
-        "ImageId": {
-          "Ref": "AMIServicesapi",
-        },
-        "InstanceType": "t4g.nano",
-        "MetadataOptions": {
-          "HttpTokens": "required",
-        },
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "GuHttpsEgressSecurityGroupServicesapi97019AE9",
-              "GroupId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
-              "WazuhSecurityGroup",
-              "GroupId",
-            ],
-          },
-        ],
-        "UserData": {
-          "Fn::Base64": {
-            "Fn::Join": [
-              "",
-              [
-                "#!/bin/bash -ev
-cat << EOF > /etc/systemd/system/services-api.service
-[Unit]
-Description=Github Lens API
-
-[Service]
-Environment="PORT=8900"
-Environment="STAGE=INFRA"
-Environment="GALAXIES_BUCKET_NAME=",
-                {
-                  "Ref": "galaxiesbucketname",
-                },
-                ""
-ExecStart=/usr/bin/node /handler.js
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-aws s3 cp s3://",
-                {
-                  "Ref": "DistributionBucketName",
-                },
-                "/deploy/INFRA/services-api/services-api.zip services-api.zip
-unzip services-api.zip
-chmod +x /handler.js
-systemctl start services-api
-",
-              ],
-            ],
-          },
-        },
-      },
-      "Type": "AWS::AutoScaling::LaunchConfiguration",
     },
     "CertificateServicesapi12F9DD3E": {
       "DeletionPolicy": "Retain",
@@ -743,6 +666,27 @@ systemctl start services-api
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "InternalIngressSecurityGroupServicesapitoServicesApiWazuhSecurityGroupD11932B68900004C3881": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "FromPort": 8900,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "InternalIngressSecurityGroupServicesapi63B228EB",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 8900,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "ListenerServicesapiED329399": {
       "Properties": {
         "Certificates": [
@@ -857,6 +801,27 @@ systemctl start services-api
         "DestinationSecurityGroupId": {
           "Fn::GetAtt": [
             "GuHttpsEgressSecurityGroupServicesapi97019AE9",
+            "GroupId",
+          ],
+        },
+        "FromPort": 8900,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerServicesapiSecurityGroup382D3D00",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 8900,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "LoadBalancerServicesapiSecurityGrouptoServicesApiWazuhSecurityGroupD11932B68900990A1552": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
             "GroupId",
           ],
         },
@@ -1126,6 +1091,210 @@ systemctl start services-api
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
+    },
+    "WazuhSecurityGroupfromServicesApiInternalIngressSecurityGroupServicesapiAED8783A8900F38783EF": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 8900,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "InternalIngressSecurityGroupServicesapi63B228EB",
+            "GroupId",
+          ],
+        },
+        "ToPort": 8900,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "WazuhSecurityGroupfromServicesApiLoadBalancerServicesapiSecurityGroup2FB0855D89005F47080D": {
+      "Properties": {
+        "Description": "Load balancer to target",
+        "FromPort": 8900,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "WazuhSecurityGroup",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "LoadBalancerServicesapiSecurityGroup382D3D00",
+            "GroupId",
+          ],
+        },
+        "ToPort": 8900,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "deployINFRAservicesapi1571C7B5": {
+      "Properties": {
+        "LaunchTemplateData": {
+          "IamInstanceProfile": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "deployINFRAservicesapiProfile0E81820A",
+                "Arn",
+              ],
+            },
+          },
+          "ImageId": {
+            "Ref": "AMIServicesapi",
+          },
+          "InstanceType": "t4g.nano",
+          "MetadataOptions": {
+            "HttpTokens": "required",
+          },
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "GuHttpsEgressSecurityGroupServicesapi97019AE9",
+                "GroupId",
+              ],
+            },
+            {
+              "Fn::GetAtt": [
+                "WazuhSecurityGroup",
+                "GroupId",
+              ],
+            },
+          ],
+          "TagSpecifications": [
+            {
+              "ResourceType": "instance",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/service-catalogue",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "ServicesApi/deploy-INFRA-services-api",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "INFRA",
+                },
+              ],
+            },
+            {
+              "ResourceType": "volume",
+              "Tags": [
+                {
+                  "Key": "gu:cdk:version",
+                  "Value": "TEST",
+                },
+                {
+                  "Key": "gu:repo",
+                  "Value": "guardian/service-catalogue",
+                },
+                {
+                  "Key": "Name",
+                  "Value": "ServicesApi/deploy-INFRA-services-api",
+                },
+                {
+                  "Key": "Stack",
+                  "Value": "deploy",
+                },
+                {
+                  "Key": "Stage",
+                  "Value": "INFRA",
+                },
+              ],
+            },
+          ],
+          "UserData": {
+            "Fn::Base64": {
+              "Fn::Join": [
+                "",
+                [
+                  "#!/bin/bash -ev
+cat << EOF > /etc/systemd/system/services-api.service
+[Unit]
+Description=Github Lens API
+
+[Service]
+Environment="PORT=8900"
+Environment="STAGE=INFRA"
+Environment="GALAXIES_BUCKET_NAME=",
+                  {
+                    "Ref": "galaxiesbucketname",
+                  },
+                  ""
+ExecStart=/usr/bin/node /handler.js
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+aws s3 cp s3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/INFRA/services-api/services-api.zip services-api.zip
+unzip services-api.zip
+chmod +x /handler.js
+systemctl start services-api
+",
+                ],
+              ],
+            },
+          },
+        },
+        "TagSpecifications": [
+          {
+            "ResourceType": "launch-template",
+            "Tags": [
+              {
+                "Key": "gu:cdk:version",
+                "Value": "TEST",
+              },
+              {
+                "Key": "gu:repo",
+                "Value": "guardian/service-catalogue",
+              },
+              {
+                "Key": "Name",
+                "Value": "ServicesApi/deploy-INFRA-services-api",
+              },
+              {
+                "Key": "Stack",
+                "Value": "deploy",
+              },
+              {
+                "Key": "Stage",
+                "Value": "INFRA",
+              },
+            ],
+          },
+        ],
+      },
+      "Type": "AWS::EC2::LaunchTemplate",
+    },
+    "deployINFRAservicesapiProfile0E81820A": {
+      "Properties": {
+        "Roles": [
+          {
+            "Ref": "InstanceRoleServicesapi62D8A4C9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
     },
   },
 }

--- a/packages/cdk/lib/__snapshots__/services-api.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/services-api.test.ts.snap
@@ -12,7 +12,6 @@ exports[`The ServicesAPI stack matches the snapshot 1`] = `
       "GuEc2App",
       "GuCertificate",
       "GuInstanceRole",
-      "GuSSMRunCommandPolicy",
       "GuDescribeEC2Policy",
       "GuLoggingStreamNameParameter",
       "GuLogShippingPolicy",
@@ -586,6 +585,20 @@ systemctl start services-api
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AmazonSSMManagedInstanceCore",
+              ],
+            ],
+          },
+        ],
         "Path": "/",
         "Tags": [
           {
@@ -910,42 +923,6 @@ systemctl start services-api
           "Version": "2012-10-17",
         },
         "PolicyName": "parameter-store-read-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleServicesapi62D8A4C9",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "SSMRunCommandPolicy244E1613": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "ec2messages:AcknowledgeMessage",
-                "ec2messages:DeleteMessage",
-                "ec2messages:FailMessage",
-                "ec2messages:GetEndpoint",
-                "ec2messages:GetMessages",
-                "ec2messages:SendReply",
-                "ssm:UpdateInstanceInformation",
-                "ssm:ListInstanceAssociations",
-                "ssm:DescribeInstanceProperties",
-                "ssm:DescribeDocumentParameters",
-                "ssmmessages:CreateControlChannel",
-                "ssmmessages:CreateDataChannel",
-                "ssmmessages:OpenControlChannel",
-                "ssmmessages:OpenDataChannel",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "ssm-run-command-policy",
         "Roles": [
           {
             "Ref": "InstanceRoleServicesapi62D8A4C9",

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -8,11 +8,11 @@
     "synth": "cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "49.0.2",
+    "@guardian/cdk": "49.4.0",
     "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-    "aws-cdk": "2.59.0",
-    "aws-cdk-lib": "2.59.0",
-    "constructs": "10.1.215",
+    "aws-cdk": "2.64.0",
+    "aws-cdk-lib": "2.64.0",
+    "constructs": "10.1.246",
     "source-map-support": "^0.5.21"
   }
 }

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -8,11 +8,11 @@
     "synth": "cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "48.5.2",
+    "@guardian/cdk": "49.0.0",
     "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-    "aws-cdk": "2.51.1",
-    "aws-cdk-lib": "2.51.1",
-    "constructs": "10.1.167",
+    "aws-cdk": "2.54.0",
+    "aws-cdk-lib": "2.54.0",
+    "constructs": "10.1.187",
     "source-map-support": "^0.5.21"
   }
 }

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -8,11 +8,11 @@
     "synth": "cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "49.4.0",
+    "@guardian/cdk": "50.0.0",
     "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-    "aws-cdk": "2.64.0",
-    "aws-cdk-lib": "2.64.0",
-    "constructs": "10.1.246",
+    "aws-cdk": "2.68.0",
+    "aws-cdk-lib": "2.68.0",
+    "constructs": "10.1.273",
     "source-map-support": "^0.5.21"
   }
 }

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -8,11 +8,11 @@
     "synth": "cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "49.0.0",
+    "@guardian/cdk": "49.0.2",
     "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-    "aws-cdk": "2.54.0",
-    "aws-cdk-lib": "2.54.0",
-    "constructs": "10.1.187",
+    "aws-cdk": "2.59.0",
+    "aws-cdk-lib": "2.59.0",
+    "constructs": "10.1.215",
     "source-map-support": "^0.5.21"
   }
 }

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -8,11 +8,11 @@
     "synth": "cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "50.0.0",
+    "@guardian/cdk": "50.3.3",
     "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
-    "aws-cdk": "2.68.0",
-    "aws-cdk-lib": "2.68.0",
-    "constructs": "10.1.273",
+    "aws-cdk": "2.77.0",
+    "aws-cdk-lib": "2.77.0",
+    "constructs": "10.2.8",
     "source-map-support": "^0.5.21"
   }
 }


### PR DESCRIPTION
## What does this change?
Updates the version of GuCDK being used, to the latest version.

This update includes a couple of key changes that are reflected in the snapshot diff:
  - A change to the IAM Policy that enables SSM access ([v49.0.2](https://github.com/guardian/cdk/releases/tag/v49.0.2))
  - Moving to launch templates over launch configurations ([v49.4.0](https://github.com/guardian/cdk/releases/tag/v49.4.0))
 
These are best illustrated in [the commit view](https://github.com/guardian/service-catalogue/pull/178/commits).

## Why?
Keeping up to date.

## How has it been verified?
See CI - the snapshot tests should pass.