### PR TITLE
chore(deps): Bump CloudQuery AWS source and Postgres destination

### DIFF
--- a/packages/cloudquery/dev-config/cloudquery.yaml
+++ b/packages/cloudquery/dev-config/cloudquery.yaml
@@ -5,7 +5,7 @@ spec:
   path: 'cloudquery/aws'
 
   # Track releases on https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
-  version: 'v16.1.0'
+  version: 'v17.0.0'
   destinations: ['postgresql']
   skip_tables:
     - aws_ec2_vpc_endpoint_services
@@ -62,7 +62,7 @@ spec:
   path: 'cloudquery/postgresql'
 
   # Track releases on https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql-&expanded=true
-  version: 'v4.0.2'
+  version: 'v4.0.4'
 
   # Automatically apply migrations whenever plugins are updated.
   # Note: This is not encouraged if risk averse, so we should consider removing this once fully in production.

--- a/packages/cloudquery/prod-config/aws.yaml
+++ b/packages/cloudquery/prod-config/aws.yaml
@@ -4,7 +4,7 @@ spec:
   path: 'cloudquery/aws'
 
   # Track releases on https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
-  version: 'v16.1.0'
+  version: 'v17.0.0'
   destinations: ['postgresql']
   skip_tables:
     - aws_ec2_vpc_endpoint_services # this resource includes services that are available from AWS as well as other AWS Accounts

--- a/packages/cloudquery/prod-config/postgresql.yaml
+++ b/packages/cloudquery/prod-config/postgresql.yaml
@@ -5,7 +5,7 @@ spec:
   path: 'cloudquery/postgresql'
 
   # Track releases on https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql-&expanded=true
-  version: 'v4.0.2'
+  version: 'v4.0.4'
 
   # Automatically apply migrations whenever plugins are updated.
   # Note: This is not encouraged if risk averse, so we should consider removing this once fully in production.


### PR DESCRIPTION
## What does this change?
Upgrades CloudQuery versions for:
  - AWS source
  - Postgres destination

There is nothing too significant in the Postgres version.

The AWS version is a new major which includes breaking changes. The [release notes](https://github.com/cloudquery/cloudquery/releases/tag/plugins-source-aws-v17.0.0) do not suggest anything concerning though.

## Why?
Keeping up to date is good practice. There might potentially be some performance improvements in these versions too.

## How has it been verified?
Ran locally.