### PR TITLE
Add guardian/cloudformation-template-summary plugin

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -890,6 +890,12 @@ aws s3 cp 's3://",
                     "Ref": "DistributionBucketName",
                   },
                   "/deploy/TEST/cloudquery/aws.yaml' '/opt/cloudquery/aws.yaml'
+mkdir -p $(dirname '/opt/cloudquery/template-summary.yaml')
+aws s3 cp 's3://",
+                  {
+                    "Ref": "DistributionBucketName",
+                  },
+                  "/deploy/TEST/cloudquery/template-summary.yaml' '/opt/cloudquery/template-summary.yaml'
 mkdir -p $(dirname '/opt/cloudquery/postgresql.yaml')
 aws s3 cp 's3://",
                   {
@@ -920,6 +926,7 @@ echo "286cff19c54098328c0b85dbbfa94e87234b5a53be421c3b6ca406803122a7ee  /opt/clo
 chmod a+x /opt/cloudquery/cloudquery
 chmod a+x /opt/cloudquery/cloudquery.sh
 sed -i "s/£TARGET_ORG_UNIT/ou-123/g" /opt/cloudquery/aws.yaml
+sed -i "s/£TARGET_ORG_UNIT/ou-123/g" /opt/cloudquery/template-summary.yaml
 curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/ca-certificates/rds-ca-2019-root.crt
 update-ca-certificates
 systemctl enable cloudquery.timer

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -125,6 +125,12 @@ export class CloudQuery extends GuStack {
 			localFile: path.join(baseDirectory, 'aws.yaml'),
 		});
 
+		const templateSummaryYamlFile = userData.addS3DownloadCommand({
+			bucket: bucket,
+			bucketKey: `${stack}/${stage}/${app}/template-summary.yaml`,
+			localFile: path.join(baseDirectory, 'template-summary.yaml'),
+		});
+
 		userData.addS3DownloadCommand({
 			bucket: bucket,
 			bucketKey: `${stack}/${stage}/${app}/postgresql.yaml`,
@@ -164,6 +170,7 @@ export class CloudQuery extends GuStack {
 
 			// Set target Org Unit
 			`sed -i "s/£TARGET_ORG_UNIT/${GuardianOrganisationalUnits.Root}/g" ${awsYamlFile}`,
+			`sed -i "s/£TARGET_ORG_UNIT/${GuardianOrganisationalUnits.Root}/g" ${templateSummaryYamlFile}`,
 
 			// Install RDS certificate
 			'curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/ca-certificates/rds-ca-2019-root.crt',

--- a/packages/cloudquery/dev-config/cloudquery.yaml
+++ b/packages/cloudquery/dev-config/cloudquery.yaml
@@ -53,6 +53,21 @@ spec:
     accounts:
       - id: 'developerPlayground'
         local_profile: 'developerPlayground'
+---
+kind: source
+spec:
+  name: 'template-summary'
+  path: 'guardian/cloudformation-template-summary'
+  version: 'v0.1.0'
+  tables: ['*']
+  destinations: ['postgresql']
+  spec:
+    regions:
+      - eu-west-1
+      - us-east-1
+    accounts:
+      - id: 'developerPlayground'
+        local_profile: 'developerPlayground'
 
 ---
 kind: source

--- a/packages/cloudquery/dev-config/cloudquery.yaml
+++ b/packages/cloudquery/dev-config/cloudquery.yaml
@@ -58,7 +58,7 @@ kind: source
 spec:
   name: 'template-summary'
   path: 'guardian/cloudformation-template-summary'
-  version: 'v0.1.0'
+  version: 'v0.3.0'
   tables: ['*']
   destinations: ['postgresql']
   spec:

--- a/packages/cloudquery/prod-config/cloudquery.sh
+++ b/packages/cloudquery/prod-config/cloudquery.sh
@@ -17,12 +17,17 @@ PG_PASSWORD="$(aws rds generate-db-auth-token --hostname $RDS_HOST --port 5432 -
 # See https://www.cloudquery.io/docs/advanced-topics/environment-variable-substitution
 echo "user=cloudquery password=$PG_PASSWORD host=$RDS_HOST port=5432 dbname=postgres sslmode=verify-full" > /opt/cloudquery/connection_string
 
-
 # Run cloudquery
 /opt/cloudquery/cloudquery \
   --log-format json \
   --log-console \
   sync \
-  /opt/cloudquery/template-summary.yaml \
   /opt/cloudquery/aws.yaml \
+  /opt/cloudquery/postgresql.yaml
+
+/opt/cloudquery/cloudquery \
+  --log-format json \
+  --log-console \
+  sync \
+  /opt/cloudquery/template-summary.yaml \
   /opt/cloudquery/postgresql.yaml

--- a/packages/cloudquery/prod-config/cloudquery.sh
+++ b/packages/cloudquery/prod-config/cloudquery.sh
@@ -23,5 +23,6 @@ echo "user=cloudquery password=$PG_PASSWORD host=$RDS_HOST port=5432 dbname=post
   --log-format json \
   --log-console \
   sync \
+  /opt/cloudquery/template-summary.yaml \
   /opt/cloudquery/aws.yaml \
   /opt/cloudquery/postgresql.yaml

--- a/packages/cloudquery/prod-config/template-summary.yaml
+++ b/packages/cloudquery/prod-config/template-summary.yaml
@@ -1,0 +1,22 @@
+kind: source
+spec:
+  name: 'template-summary'
+  path: 'guardian/cloudformation-template-summary'
+  version: 'v0.1.3'
+  tables: ['*']
+  destinations: ['postgresql']
+  spec:
+    regions:
+      # All regions we support.
+      # See https://github.com/guardian/infosec-platform/blob/main/policies/DenyAccessToNonApprovedRegions.json
+      - eu-west-1
+      - eu-west-2
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - ap-southeast-2
+      - ca-central-1
+    org:
+      member_role_name: cloudquery-access # See: https://github.com/guardian/aws-account-setup/pull/58.
+      organization_units:
+        - £TARGET_ORG_UNIT


### PR DESCRIPTION
The plugin lives here:

https://github.com/guardian/cq-source-cloudformation-template-summary

We have published a v0.1.0 tag version for now, which will become a v1.0.0 once we are happy it is stable.

Note: the plan is to migrate this plugin into the official AWS plugin but that is not wholly within our control.

## What does this change?

Introduces our cloudformation-template-summary plugin, to add Cloudformation template metadata as a source.

For now, we use a v0.1.0 tag, which is based off [this PR](https://github.com/guardian/cq-source-cloudformation-template-summary/pull/1).

## Why?

To track GuCDK usage (see [here](https://github.com/guardian/cdk/pull/1394)).

## How has it been verified?

It has been run locally with the dev config successfully. But testing on PROD is also required as the auth mechanism (assumed roles) is different. We may also test this locally following some Janus changes (regular dev roles deny assuming other roles).

UPDATE: have successfully tested in INFRA! Search Grafana for the `cloudformation_template_summaries` table to see the data.