### PR TITLE
refactor(cloudquery): Use AWS CDK method to get DB access

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -300,7 +300,11 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:rds-db:",
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
                     {
                       "Ref": "AWS::Region",
                     },

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -24,7 +24,7 @@ import {
 	UserData,
 } from 'aws-cdk-lib/aws-ec2';
 import { Effect, ManagedPolicy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import type { CfnDBInstance, DatabaseInstanceProps } from 'aws-cdk-lib/aws-rds';
+import type { DatabaseInstanceProps } from 'aws-cdk-lib/aws-rds';
 import { DatabaseInstance, DatabaseInstanceEngine } from 'aws-cdk-lib/aws-rds';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import {
@@ -250,17 +250,7 @@ export class CloudQuery extends GuStack {
 			}),
 		);
 
-		const { attrDbiResourceId } = db.node.defaultChild as CfnDBInstance;
-
-		asg.addToRolePolicy(
-			new PolicyStatement({
-				effect: Effect.ALLOW,
-				resources: [
-					`arn:aws:rds-db:${this.region}:${this.account}:dbuser:${attrDbiResourceId}/cloudquery`,
-				],
-				actions: ['rds-db:connect'],
-			}),
-		);
+		db.grantConnect(asg, 'cloudquery');
 
 		asg.addToRolePolicy(
 			new PolicyStatement({


### PR DESCRIPTION
## What does this change?
The `grantConnect` function was patched in [AWS CDK v2.77.0](https://github.com/aws/aws-cdk/releases/tag/v2.77.0), which we updated to in #178.

## Why?
Less code for us to maintain.

## How has it been verified?
N/A - this is a no-op.