### PR TITLE
refactor(cloudquery): Obtain AWS root org at launch time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,6 @@ jobs:
           go-version: '1.20'
           cache-dependency-path: packages/cloudformation-lens/go.sum
 
-      - uses: guardian/actions-read-private-repos@v0.1.0
-        with:
-          private-ssh-keys: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
-
       - name: Run script/ci
         run: ./scripts/ci.sh
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2157,11 +2157,6 @@
         "prettier": "^2.4.0"
       }
     },
-    "node_modules/@guardian/private-infrastructure-config": {
-      "version": "2.2.0",
-      "resolved": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#232c773a3c4af0fcf831f82a9093e67c0e1b7c51",
-      "dev": true
-    },
     "node_modules/@guardian/tsconfig": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@guardian/tsconfig/-/tsconfig-0.2.0.tgz",
@@ -10069,7 +10064,6 @@
       "version": "1.0.0",
       "devDependencies": {
         "@guardian/cdk": "50.3.3",
-        "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
         "aws-cdk": "2.77.0",
         "aws-cdk-lib": "2.77.0",
         "constructs": "10.2.8",
@@ -12403,11 +12397,6 @@
       "dev": true,
       "requires": {}
     },
-    "@guardian/private-infrastructure-config": {
-      "version": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#232c773a3c4af0fcf831f82a9093e67c0e1b7c51",
-      "dev": true,
-      "from": "@guardian/private-infrastructure-config@github:guardian/private-infrastructure-config#v2.3.0"
-    },
     "@guardian/tsconfig": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@guardian/tsconfig/-/tsconfig-0.2.0.tgz",
@@ -13911,7 +13900,6 @@
       "version": "file:packages/cdk",
       "requires": {
         "@guardian/cdk": "50.3.3",
-        "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
         "aws-cdk": "2.77.0",
         "aws-cdk-lib": "2.77.0",
         "constructs": "10.2.8",

--- a/packages/cdk/jest.setup.js
+++ b/packages/cdk/jest.setup.js
@@ -1,2 +1,1 @@
 jest.mock('@guardian/cdk/lib/constants/tracking-tag');
-jest.mock('@guardian/private-infrastructure-config');

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -925,8 +925,7 @@ curl -L https://github.com/cloudquery/cloudquery/releases/download/cli-v2.5.3/cl
 echo "286cff19c54098328c0b85dbbfa94e87234b5a53be421c3b6ca406803122a7ee  /opt/cloudquery/cloudquery" | shasum -c -a 256
 chmod a+x /opt/cloudquery/cloudquery
 chmod a+x /opt/cloudquery/cloudquery.sh
-sed -i "s/£TARGET_ORG_UNIT/ou-123/g" /opt/cloudquery/aws.yaml
-sed -i "s/£TARGET_ORG_UNIT/ou-123/g" /opt/cloudquery/template-summary.yaml
+aws organizations list-roots | jq '.Roots[0].Id' > /opt/cloudquery/aws-organisation-root
 curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/ca-certificates/rds-ca-2019-root.crt
 update-ca-certificates
 systemctl enable cloudquery.timer

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -13,7 +13,6 @@ import {
 	GuVpc,
 	SubnetType,
 } from '@guardian/cdk/lib/constructs/ec2';
-import { GuardianOrganisationalUnits } from '@guardian/private-infrastructure-config';
 import type { App } from 'aws-cdk-lib';
 import { Tags } from 'aws-cdk-lib';
 import {
@@ -119,13 +118,13 @@ export class CloudQuery extends GuStack {
 		const baseDirectory = '/opt/cloudquery';
 		const cloudqueryBinary = path.join(baseDirectory, 'cloudquery');
 
-		const awsYamlFile = userData.addS3DownloadCommand({
+		userData.addS3DownloadCommand({
 			bucket: bucket,
 			bucketKey: `${stack}/${stage}/${app}/aws.yaml`,
 			localFile: path.join(baseDirectory, 'aws.yaml'),
 		});
 
-		const templateSummaryYamlFile = userData.addS3DownloadCommand({
+		userData.addS3DownloadCommand({
 			bucket: bucket,
 			bucketKey: `${stack}/${stage}/${app}/template-summary.yaml`,
 			localFile: path.join(baseDirectory, 'template-summary.yaml'),
@@ -169,8 +168,7 @@ export class CloudQuery extends GuStack {
 			`chmod a+x ${cloudqueryScript}`,
 
 			// Set target Org Unit
-			`sed -i "s/£TARGET_ORG_UNIT/${GuardianOrganisationalUnits.Root}/g" ${awsYamlFile}`,
-			`sed -i "s/£TARGET_ORG_UNIT/${GuardianOrganisationalUnits.Root}/g" ${templateSummaryYamlFile}`,
+			`aws organizations list-roots | jq '.Roots[0].Id' > ${baseDirectory}/aws-organisation-root`,
 
 			// Install RDS certificate
 			'curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem -o /usr/local/share/ca-certificates/rds-ca-2019-root.crt',

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -9,7 +9,6 @@
   },
   "devDependencies": {
     "@guardian/cdk": "50.3.3",
-    "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
     "aws-cdk": "2.77.0",
     "aws-cdk-lib": "2.77.0",
     "constructs": "10.2.8",

--- a/packages/cloudquery/prod-config/aws.yaml
+++ b/packages/cloudquery/prod-config/aws.yaml
@@ -48,7 +48,7 @@ spec:
   concurrency: 100000 # this is expected to work with a t4g.medium and our current sources but not optimised. Will adjust once live.
   spec:
     regions:
-      # All regions we support.
+      # All regions we support.
       # See https://github.com/guardian/infosec-platform/blob/main/policies/DenyAccessToNonApprovedRegions.json
       - eu-west-1
       - eu-west-2
@@ -60,4 +60,4 @@ spec:
     org:
       member_role_name: cloudquery-access # See: https://github.com/guardian/aws-account-setup/pull/58.
       organization_units:
-        - £TARGET_ORG_UNIT
+        - ${file:/opt/cloudquery/aws-organisation-root}

--- a/packages/cloudquery/prod-config/template-summary.yaml
+++ b/packages/cloudquery/prod-config/template-summary.yaml
@@ -7,7 +7,7 @@ spec:
   destinations: ['postgresql']
   spec:
     regions:
-      # All regions we support.
+      # All regions we support.
       # See https://github.com/guardian/infosec-platform/blob/main/policies/DenyAccessToNonApprovedRegions.json
       - eu-west-1
       - eu-west-2
@@ -19,4 +19,4 @@ spec:
     org:
       member_role_name: cloudquery-access # See: https://github.com/guardian/aws-account-setup/pull/58.
       organization_units:
-        - £TARGET_ORG_UNIT
+        - ${file:/opt/cloudquery/aws-organisation-root}


### PR DESCRIPTION
## What does this change?
Replace the `@guardian/private-infrastructure-config` library with an AWS CLI call to obtain the AWS Organisation.

## Why?
This removes a dependency.

More widely, I wonder if all the CloudQuery configuration should be set like this. That is, any private values should be obtained in the launch configuration, written to a file, and [CloudQuery reads that value](https://www.cloudquery.io/docs/advanced-topics/environment-variable-substitution).

The downside of this change is a "shift right", as the value only becomes known at launch time, rather than build time.

## How has it been verified?
- [Deployed](https://riffraff.gutools.co.uk/deployment/view/33c188fd-f1c5-4bc4-b2cb-edaa4bea186d)
- Verified the file via `cat /opt/cloudquery/aws-organisation-root`
- Verified CloudQuery still runs via `sudo systemctl start cloudquery && sudo journalctl -fu cloudquery`