### PR TITLE
fix(cloudquery): Provide cross account access only when needed

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -555,11 +555,6 @@ spec:
               },
             },
             {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Resource": "arn:aws:iam::*:role/cloudquery-access",
-            },
-            {
               "Action": [
                 "cloudformation:GetTemplate",
                 "dynamodb:GetItem",
@@ -579,6 +574,11 @@ spec:
               ],
               "Effect": "Deny",
               "Resource": "*",
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": "arn:aws:iam::*:role/cloudquery-access",
             },
             {
               "Action": "rds-db:connect",
@@ -1121,11 +1121,6 @@ spec:
               },
             },
             {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Resource": "arn:aws:iam::*:role/cloudquery-access",
-            },
-            {
               "Action": "organizations:List*",
               "Effect": "Allow",
               "Resource": "*",
@@ -1150,6 +1145,11 @@ spec:
               ],
               "Effect": "Deny",
               "Resource": "*",
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": "arn:aws:iam::000000000018:role/cloudquery-access",
             },
             {
               "Action": "rds-db:connect",
@@ -1688,11 +1688,6 @@ spec:
               },
             },
             {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Resource": "arn:aws:iam::*:role/cloudquery-access",
-            },
-            {
               "Action": [
                 "cloudformation:GetTemplate",
                 "dynamodb:GetItem",
@@ -1712,6 +1707,11 @@ spec:
               ],
               "Effect": "Deny",
               "Resource": "*",
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": "arn:aws:iam::000000000015:role/cloudquery-access",
             },
             {
               "Action": "rds-db:connect",

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -29,6 +29,7 @@ import {
 	skipTables,
 } from './ecs/config';
 import {
+	cloudqueryAccess,
 	listOrgsPolicy,
 	readonlyAccessManagedPolicy,
 	standardDenyPolicy,
@@ -115,7 +116,7 @@ export class CloudQuery extends GuStack {
 					managedPolicies: [
 						readonlyAccessManagedPolicy(this, 'fetch-all-managed-policy'),
 					],
-					policies: [standardDenyPolicy],
+					policies: [standardDenyPolicy, cloudqueryAccess('*')],
 				},
 				{
 					name: 'DeployToolsListOrgs',
@@ -136,7 +137,11 @@ export class CloudQuery extends GuStack {
 					managedPolicies: [
 						readonlyAccessManagedPolicy(this, 'list-orgs-managed-policy'),
 					],
-					policies: [listOrgsPolicy, standardDenyPolicy],
+					policies: [
+						listOrgsPolicy,
+						standardDenyPolicy,
+						cloudqueryAccess(GuardianAwsAccounts.DeployTools),
+					],
 				},
 				{
 					name: 'SecurityAccessAnalyser',
@@ -153,7 +158,10 @@ export class CloudQuery extends GuStack {
 					managedPolicies: [
 						readonlyAccessManagedPolicy(this, 'access-analyser-managed-policy'),
 					],
-					policies: [standardDenyPolicy],
+					policies: [
+						standardDenyPolicy,
+						cloudqueryAccess(GuardianAwsAccounts.Security),
+					],
 				},
 			],
 		});

--- a/packages/cdk/lib/ecs/cluster.ts
+++ b/packages/cdk/lib/ecs/cluster.ts
@@ -87,20 +87,11 @@ export class CloudqueryCluster extends Cluster {
 			resourceName: loggingStreamName,
 		});
 
-		const essentialPolicies = [
-			// Log shipping
-			new PolicyStatement({
-				actions: ['kinesis:Describe*', 'kinesis:Put*'],
-				effect: Effect.ALLOW,
-				resources: [loggingStreamArn],
-			}),
-
-			new PolicyStatement({
-				effect: Effect.ALLOW,
-				resources: ['arn:aws:iam::*:role/cloudquery-access'],
-				actions: ['sts:AssumeRole'],
-			}),
-		];
+		const logShippingPolicy = new PolicyStatement({
+			actions: ['kinesis:Describe*', 'kinesis:Put*'],
+			effect: Effect.ALLOW,
+			resources: [loggingStreamArn],
+		});
 
 		const taskProps = {
 			app,
@@ -115,7 +106,7 @@ export class CloudqueryCluster extends Cluster {
 				new ScheduledCloudqueryTask(scope, `CloudquerySource-${name}`, {
 					...taskProps,
 					managedPolicies,
-					policies: essentialPolicies.concat(policies),
+					policies: [logShippingPolicy, ...policies],
 					schedule,
 					sourceConfig: config,
 				});

--- a/packages/cdk/lib/ecs/policies.ts
+++ b/packages/cdk/lib/ecs/policies.ts
@@ -42,3 +42,11 @@ export const listOrgsPolicy = new PolicyStatement({
 	resources: ['*'],
 	actions: ['organizations:List*'],
 });
+
+export function cloudqueryAccess(accountId: string) {
+	return new PolicyStatement({
+		effect: Effect.ALLOW,
+		resources: [`arn:aws:iam::${accountId}:role/cloudquery-access`],
+		actions: ['sts:AssumeRole'],
+	});
+}


### PR DESCRIPTION
## What does this change?
Further tightens the IAM policies that the CloudQuery tasks get by ensuring we can only assume the necessary cross account roles. Those tasks that run in only one account can now only assume the `cloudquery-access` role in that account, rather than `*` previously.