### PR TITLE
feat(cloudquery): Collect GitHub repository data 

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -27,18 +27,6 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
-    "githubappidParameter": {
-      "Default": "/TEST/deploy/cloudquery/github-app-id",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "githubinstallationidParameter": {
-      "Default": "/TEST/deploy/cloudquery/github-installation-id",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "githubprivatekeyParameter": {
-      "Default": "/TEST/deploy/cloudquery/github-private-key",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
   },
   "Resources": {
     "CloudquerySourceAllScheduledEventRuleAE930F8B": {
@@ -1409,10 +1397,8 @@ spec:
           "Statement": [
             {
               "Action": [
-                "ssm:DescribeParameters",
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-                "ssm:GetParameterHistory",
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
               ],
               "Effect": "Allow",
               "Resource": {
@@ -1423,7 +1409,7 @@ spec:
                     {
                       "Ref": "AWS::Partition",
                     },
-                    ":ssm:",
+                    ":secretsmanager:",
                     {
                       "Ref": "AWS::Region",
                     },
@@ -1431,65 +1417,7 @@ spec:
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/deploy/cloudquery/github-private-key",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:DescribeParameters",
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-                "ssm:GetParameterHistory",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/TEST/deploy/cloudquery/github-app-id",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:DescribeParameters",
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-                "ssm:GetParameterHistory",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/TEST/deploy/cloudquery/github-installation-id",
+                    ":secret:/TEST/deploy/cloudquery/github-credentials-??????",
                   ],
                 ],
               },
@@ -1557,7 +1485,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "echo $GITHUB_PRIVATE_KEY > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+              "echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
 spec:
   name: github
   path: cloudquery/github
@@ -1629,7 +1557,7 @@ spec:
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":ssm:",
+                      ":secretsmanager:",
                       {
                         "Ref": "AWS::Region",
                       },
@@ -1637,7 +1565,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":parameter/TEST/deploy/cloudquery/github-private-key",
+                      ":secret:/TEST/deploy/cloudquery/github-credentials:private-key::",
                     ],
                   ],
                 },
@@ -1652,7 +1580,7 @@ spec:
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":ssm:",
+                      ":secretsmanager:",
                       {
                         "Ref": "AWS::Region",
                       },
@@ -1660,7 +1588,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":parameter/TEST/deploy/cloudquery/github-app-id",
+                      ":secret:/TEST/deploy/cloudquery/github-credentials:app-id::",
                     ],
                   ],
                 },
@@ -1675,7 +1603,7 @@ spec:
                       {
                         "Ref": "AWS::Partition",
                       },
-                      ":ssm:",
+                      ":secretsmanager:",
                       {
                         "Ref": "AWS::Region",
                       },
@@ -1683,7 +1611,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":parameter/TEST/deploy/cloudquery/github-installation-id",
+                      ":secret:/TEST/deploy/cloudquery/github-credentials:installation-id::",
                     ],
                   ],
                 },

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -27,6 +27,18 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
+    "githubappidParameter": {
+      "Default": "/TEST/deploy/cloudquery/github-app-id",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "githubinstallationidParameter": {
+      "Default": "/TEST/deploy/cloudquery/github-installation-id",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "githubprivatekeyParameter": {
+      "Default": "/TEST/deploy/cloudquery/github-private-key",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
   },
   "Resources": {
     "CloudquerySourceAllScheduledEventRuleAE930F8B": {
@@ -1189,6 +1201,692 @@ spec:
         "Roles": [
           {
             "Ref": "CloudquerySourceDeployToolsListOrgsTaskDefinitionTaskRole1340B0DE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGitHubRepositoriesScheduledEventRule92EB197A": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 day)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "cloudqueryCluster5370C11B",
+                "Arn",
+              ],
+            },
+            "EcsParameters": {
+              "LaunchType": "FARGATE",
+              "NetworkConfiguration": {
+                "AwsVpcConfiguration": {
+                  "AssignPublicIp": "DISABLED",
+                  "SecurityGroups": [
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "GroupId",
+                      ],
+                    },
+                  ],
+                  "Subnets": {
+                    "Ref": "PrivateSubnets",
+                  },
+                },
+              },
+              "TaskCount": 1,
+              "TaskDefinitionArn": {
+                "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionF922DBC7",
+              },
+            },
+            "Id": "Target0",
+            "Input": "{}",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRoleB1DAD5D1",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionCloudquerySourceGitHubRepositoriesFirelensLogGroup79D2F011": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRoleB1DAD5D1": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRoleDefaultPolicy6C5373E1": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ecs:RunTask",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": {
+                    "Fn::GetAtt": [
+                      "cloudqueryCluster5370C11B",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionF922DBC7",
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRole4915D08F",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRole6D516435",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRoleDefaultPolicy6C5373E1",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRoleB1DAD5D1",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRole4915D08F": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRoleDefaultPolicy0A64529F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "ssm:DescribeParameters",
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+                "ssm:GetParameterHistory",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/cloudquery/github-private-key",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:DescribeParameters",
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+                "ssm:GetParameterHistory",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/cloudquery/github-app-id",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:DescribeParameters",
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+                "ssm:GetParameterHistory",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/cloudquery/github-installation-id",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGitHubRepositoriesTaskDefinitionCloudquerySourceGitHubRepositoriesFirelensLogGroup79D2F011",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRoleDefaultPolicy0A64529F",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRole4915D08F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionF922DBC7": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/bash",
+              "-c",
+              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Environment": [
+              {
+                "Name": "DB_HOST",
+                "Value": {
+                  "Fn::GetAtt": [
+                    "PostgresInstance16DE4286E",
+                    "Endpoint.Address",
+                  ],
+                },
+              },
+            ],
+            "Essential": false,
+            "Image": "public.ecr.aws/aws-cli/aws-cli",
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": false,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-GitHub RepositoriesAwsCli",
+          },
+          {
+            "Command": [
+              "/bin/sh",
+              "-c",
+              "echo $GITHUB_PRIVATE_KEY > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+spec:
+  name: github
+  path: cloudquery/github
+  version: v5.2.0
+  tables:
+    - github_repositories
+  destinations:
+    - postgresql
+  concurrency: 1000
+  spec:
+    orgs:
+      - guardian
+    app_auth:
+      - org: guardian
+        private_key_path: /github-private-key
+        app_id: \${file:/github-app-id}
+        installation_id: \${file:/github-installation-id}
+' > /source.yaml;printf 'kind: destination
+spec:
+  name: postgresql
+  registry: github
+  path: cloudquery/postgresql
+  version: v4.1.0
+  migrate_mode: forced
+  spec:
+    connection_string: \${file:/var/scratch/connection_string}
+' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "SUCCESS",
+                "ContainerName": "CloudquerySource-GitHub RepositoriesAwsCli",
+              },
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Essential": true,
+            "Image": "ghcr.io/cloudquery/cloudquery:3.3.1",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": true,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-GitHub RepositoriesContainer",
+            "Secrets": [
+              {
+                "Name": "GITHUB_PRIVATE_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/TEST/deploy/cloudquery/github-private-key",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "GITHUB_APP_ID",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/TEST/deploy/cloudquery/github-app-id",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "GITHUB_INSTALLATION_ID",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":ssm:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":parameter/TEST/deploy/cloudquery/github-installation-id",
+                    ],
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            "Environment": [
+              {
+                "Name": "STACK",
+                "Value": "deploy",
+              },
+              {
+                "Name": "STAGE",
+                "Value": "TEST",
+              },
+              {
+                "Name": "APP",
+                "Value": "cloudquery",
+              },
+              {
+                "Name": "GU_REPO",
+                "Value": "guardian/service-catalogue",
+              },
+            ],
+            "Essential": true,
+            "FirelensConfiguration": {
+              "Options": {
+                "config-file-type": "file",
+                "config-file-value": "/custom.conf",
+                "enable-ecs-log-metadata": "true",
+              },
+              "Type": "fluentbit",
+            },
+            "Image": "ghcr.io/guardian/hackday-firelens:main",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionCloudquerySourceGitHubRepositoriesFirelensLogGroup79D2F011",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+              },
+            },
+            "Name": "CloudquerySource-GitHub RepositoriesFirelens",
+          },
+        ],
+        "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRole4915D08F",
+            "Arn",
+          ],
+        },
+        "Family": "CloudQueryCloudquerySourceGitHubRepositoriesTaskDefinition3B546046",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRole6D516435",
+            "Arn",
+          ],
+        },
+        "Volumes": [
+          {
+            "Host": {},
+            "Name": "scratch",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRole6D516435": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRoleDefaultPolicy2521BC73": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":kinesis:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/cloudquery",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRoleDefaultPolicy2521BC73",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRole6D516435",
           },
         ],
       },

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -1194,7 +1194,7 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
-    "CloudquerySourceGitHubRepositoriesScheduledEventRule92EB197A": {
+    "CloudquerySourceGitHubRepositoriesScheduledEventRuleC7F5836E": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",
         "State": "ENABLED",
@@ -1226,14 +1226,14 @@ spec:
               },
               "TaskCount": 1,
               "TaskDefinitionArn": {
-                "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionF922DBC7",
+                "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinition921DC1BC",
               },
             },
             "Id": "Target0",
             "Input": "{}",
             "RoleArn": {
               "Fn::GetAtt": [
-                "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRoleB1DAD5D1",
+                "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRole93DB1A26",
                 "Arn",
               ],
             },
@@ -1242,212 +1242,7 @@ spec:
       },
       "Type": "AWS::Events::Rule",
     },
-    "CloudquerySourceGitHubRepositoriesTaskDefinitionCloudquerySourceGitHubRepositoriesFirelensLogGroup79D2F011": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "RetentionInDays": 1,
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRoleB1DAD5D1": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "events.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRoleDefaultPolicy6C5373E1": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "ecs:RunTask",
-              "Condition": {
-                "ArnEquals": {
-                  "ecs:cluster": {
-                    "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
-                      "Arn",
-                    ],
-                  },
-                },
-              },
-              "Effect": "Allow",
-              "Resource": {
-                "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionF922DBC7",
-              },
-            },
-            {
-              "Action": "iam:PassRole",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRole4915D08F",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": "iam:PassRole",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRole6D516435",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRoleDefaultPolicy6C5373E1",
-        "Roles": [
-          {
-            "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRoleB1DAD5D1",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRole4915D08F": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "ecs-tasks.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRoleDefaultPolicy0A64529F": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "secretsmanager:GetSecretValue",
-                "secretsmanager:DescribeSecret",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":secretsmanager:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":secret:/TEST/deploy/cloudquery/github-credentials-??????",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "CloudquerySourceGitHubRepositoriesTaskDefinitionCloudquerySourceGitHubRepositoriesFirelensLogGroup79D2F011",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRoleDefaultPolicy0A64529F",
-        "Roles": [
-          {
-            "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRole4915D08F",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CloudquerySourceGitHubRepositoriesTaskDefinitionF922DBC7": {
+    "CloudquerySourceGitHubRepositoriesTaskDefinition921DC1BC": {
       "Properties": {
         "ContainerDefinitions": [
           {
@@ -1479,7 +1274,7 @@ spec:
                 "SourceVolume": "scratch",
               },
             ],
-            "Name": "CloudquerySource-GitHub RepositoriesAwsCli",
+            "Name": "CloudquerySource-GitHubRepositoriesAwsCli",
           },
           {
             "Command": [
@@ -1517,7 +1312,7 @@ spec:
             "DependsOn": [
               {
                 "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-GitHub RepositoriesAwsCli",
+                "ContainerName": "CloudquerySource-GitHubRepositoriesAwsCli",
               },
             ],
             "EntryPoint": [
@@ -1545,7 +1340,7 @@ spec:
                 "SourceVolume": "scratch",
               },
             ],
-            "Name": "CloudquerySource-GitHub RepositoriesContainer",
+            "Name": "CloudquerySource-GitHubRepositoriesContainer",
             "Secrets": [
               {
                 "Name": "GITHUB_PRIVATE_KEY",
@@ -1651,7 +1446,7 @@ spec:
               "LogDriver": "awslogs",
               "Options": {
                 "awslogs-group": {
-                  "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionCloudquerySourceGitHubRepositoriesFirelensLogGroup79D2F011",
+                  "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionCloudquerySourceGitHubRepositoriesFirelensLogGroup42A4D85D",
                 },
                 "awslogs-region": {
                   "Ref": "AWS::Region",
@@ -1659,17 +1454,17 @@ spec:
                 "awslogs-stream-prefix": "deploy/TEST/cloudquery",
               },
             },
-            "Name": "CloudquerySource-GitHub RepositoriesFirelens",
+            "Name": "CloudquerySource-GitHubRepositoriesFirelens",
           },
         ],
         "Cpu": "256",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
-            "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRole4915D08F",
+            "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRole03A80EA4",
             "Arn",
           ],
         },
-        "Family": "CloudQueryCloudquerySourceGitHubRepositoriesTaskDefinition3B546046",
+        "Family": "CloudQueryCloudquerySourceGitHubRepositoriesTaskDefinition885F5347",
         "Memory": "512",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
@@ -1695,7 +1490,7 @@ spec:
         ],
         "TaskRoleArn": {
           "Fn::GetAtt": [
-            "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRole6D516435",
+            "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRoleCEEE8FE4",
             "Arn",
           ],
         },
@@ -1708,7 +1503,121 @@ spec:
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
-    "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRole6D516435": {
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionCloudquerySourceGitHubRepositoriesFirelensLogGroup42A4D85D": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRole93DB1A26": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRoleDefaultPolicy1ECEEEB2": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ecs:RunTask",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": {
+                    "Fn::GetAtt": [
+                      "cloudqueryCluster5370C11B",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinition921DC1BC",
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRole03A80EA4",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRoleCEEE8FE4",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRoleDefaultPolicy1ECEEEB2",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionEventsRole93DB1A26",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRole03A80EA4": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -1743,7 +1652,98 @@ spec:
       },
       "Type": "AWS::IAM::Role",
     },
-    "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRoleDefaultPolicy2521BC73": {
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRoleDefaultPolicy04F69199": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:/TEST/deploy/cloudquery/github-credentials-??????",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGitHubRepositoriesTaskDefinitionCloudquerySourceGitHubRepositoriesFirelensLogGroup42A4D85D",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRoleDefaultPolicy04F69199",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionExecutionRole03A80EA4",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRoleCEEE8FE4": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRoleDefaultPolicy77BC36C4": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -1811,10 +1811,10 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRoleDefaultPolicy2521BC73",
+        "PolicyName": "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRoleDefaultPolicy77BC36C4",
         "Roles": [
           {
-            "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRole6D516435",
+            "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinitionTaskRoleCEEE8FE4",
           },
         ],
       },

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -177,7 +177,7 @@ export class CloudQuery extends GuStack {
 
 		const githubSources: CloudquerySource[] = [
 			{
-				name: 'GitHub Repositories',
+				name: 'GitHubRepositories',
 				description: 'Collect GitHub repository data',
 				schedule: Schedule.rate(Duration.days(1)),
 				config: githubSourceConfig({ tables: ['github_repositories'] }),

--- a/packages/cdk/lib/ecs/cluster.ts
+++ b/packages/cdk/lib/ecs/cluster.ts
@@ -3,6 +3,7 @@ import type { AppIdentity, GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
 import type { IVpc } from 'aws-cdk-lib/aws-ec2';
 import { Cluster } from 'aws-cdk-lib/aws-ecs';
+import type { Secret } from 'aws-cdk-lib/aws-ecs/lib/container-definition';
 import type { Schedule } from 'aws-cdk-lib/aws-events';
 import type { IManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
@@ -42,6 +43,19 @@ interface CloudquerySource {
 	 * Managed policies required by this source.
 	 */
 	managedPolicies?: IManagedPolicy[];
+
+	/**
+	 * Any secrets to pass to the CloudQuery container.
+	 *
+	 * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.ContainerDefinitionOptions.html#secrets
+	 * @see https://repost.aws/knowledge-center/ecs-data-security-container-task
+	 */
+	secrets?: Record<string, Secret>;
+
+	/**
+	 * Additional commands to run within the CloudQuery container, executed first.
+	 */
+	additionalCommands?: string[];
 }
 
 interface CloudqueryClusterProps extends AppIdentity {
@@ -102,13 +116,23 @@ export class CloudqueryCluster extends Cluster {
 		};
 
 		sources.forEach(
-			({ name, schedule, config, managedPolicies = [], policies = [] }) => {
+			({
+				name,
+				schedule,
+				config,
+				managedPolicies = [],
+				policies = [],
+				secrets,
+				additionalCommands,
+			}) => {
 				new ScheduledCloudqueryTask(scope, `CloudquerySource-${name}`, {
 					...taskProps,
 					managedPolicies,
 					policies: [logShippingPolicy, ...policies],
 					schedule,
 					sourceConfig: config,
+					secrets,
+					additionalCommands,
 				});
 			},
 		);

--- a/packages/cdk/lib/ecs/cluster.ts
+++ b/packages/cdk/lib/ecs/cluster.ts
@@ -11,7 +11,7 @@ import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
 import type { CloudqueryConfig } from './config';
 import { ScheduledCloudqueryTask } from './task';
 
-interface CloudquerySource {
+export interface CloudquerySource {
 	/**
 	 * The name of the source.
 	 */

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -3,6 +3,7 @@ import { dump } from 'js-yaml';
 import {
 	awsSourceConfigForAccount,
 	awsSourceConfigForOrganisation,
+	githubSourceConfig,
 	postgresDestinationConfig,
 } from './config';
 
@@ -120,6 +121,31 @@ describe('Config generation, and converting to YAML', () => {
 		    accounts:
 		      - id: cq-for-000000000015
 		        role_arn: arn:aws:iam::000000000015:role/cloudquery-access
+		"
+	`);
+	});
+
+	it('Should create a GitHub source configuration', () => {
+		const config = githubSourceConfig({ tables: ['github_repositories'] });
+		expect(dump(config)).toMatchInlineSnapshot(`
+		"kind: source
+		spec:
+		  name: github
+		  path: cloudquery/github
+		  version: v5.2.0
+		  tables:
+		    - github_repositories
+		  destinations:
+		    - postgresql
+		  concurrency: 1000
+		  spec:
+		    orgs:
+		      - guardian
+		    app_auth:
+		      - org: guardian
+		        private_key_path: /github-private-key
+		        app_id: \${file:/github-app-id}
+		        installation_id: \${file:/github-installation-id}
 		"
 	`);
 	});

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -106,6 +106,42 @@ export function awsSourceConfigForAccount(
 	});
 }
 
+export function githubSourceConfig(
+	tableConfig: CloudqueryTableConfig,
+): CloudqueryConfig {
+	const { tables, skipTables } = tableConfig;
+
+	if (!tables && !skipTables) {
+		throw new Error('Must specify either tables or skipTables');
+	}
+
+	return {
+		kind: 'source',
+		spec: {
+			name: 'github',
+			path: 'cloudquery/github',
+			version: `v${Versions.CloudqueryGithub}`,
+			tables,
+			skip_tables: skipTables,
+			destinations: ['postgresql'],
+			concurrency: 1000, // TODO what's the ideal value here?!
+			spec: {
+				orgs: ['guardian'],
+				app_auth: [
+					{
+						org: 'guardian',
+
+						// For simplicity, read all configuration from disk.
+						private_key_path: '/github-private-key',
+						app_id: '${file:/github-app-id}',
+						installation_id: '${file:/github-installation-id}',
+					},
+				],
+			},
+		},
+	};
+}
+
 // Tables we are skipping because they are slow and or uninteresting to us.
 export const skipTables = [
 	'aws_ec2_vpc_endpoint_services', // this resource includes services that are available from AWS as well as other AWS Accounts

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -19,4 +19,11 @@ export const Versions = {
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
 	 */
 	CloudqueryAws: '17.0.0',
+
+	/**
+	 * The version of the CloudQuery GitHub source plugin to install.
+	 *
+	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
+	 */
+	CloudqueryGithub: '5.2.0',
 };


### PR DESCRIPTION
This replaces #184 following the recent adoption of ECS in #189.

## What does this change?
In this change we add the [GitHub source](https://www.cloudquery.io/docs/plugins/sources/github/overview) to CloudQuery, initially collecting data only for repositories, once a day.

We authenticate with GitHub using a [GitHub App](https://docs.github.com/en/apps/creating-github-apps/setting-up-a-github-app/creating-a-github-app) that we manually created earlier with read-only access to the org.

CloudQuery requires three bits of GitHub config: private key, app ID, installation ID. These live in a manually created Secrets Manager resource on path `/INFRA/deploy/cloudquery/github-credentials`. The ARN of this resource has a random GUID at the end of it. The only way I could read this secret without passing in the ARN (which is [private information](https://github.com/guardian/recommendations/blob/main/github.md#repository-contents)) was to use [`Secret.fromSecretPartialArn`](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_secretsmanager.Secret.html#static-fromwbrsecretwbrpartialwbrarnscope-id-secretpartialarn). Interestingly, this creates an IAM policy with a resource of:

```
"Fn::Join": [
  "",
  [
    "arn:",
    {
      "Ref": "AWS::Partition",
    },
    ":secretsmanager:",
    {
      "Ref": "AWS::Region",
    },
    ":",
    {
      "Ref": "AWS::AccountId",
    },
    ":secret:/TEST/deploy/cloudquery/github-credentials-??????",
  ],
],
```

I don't know _how_ the `--??????` works, but it does!

## Why?
Having GitHub data is integral to Service Catalogue; collecting it via CloudQuery means we can retire the [github-data-fetcher](https://github.com/guardian/service-catalogue/tree/main/packages/github-data-fetcher) and [github-lens-api](https://github.com/guardian/service-catalogue/tree/main/packages/github-lens-api) projects.

## How has it been verified?
I've manually [deployed](https://riffraff.gutools.co.uk/deployment/view/2c16c108-ec12-4ba8-a0ca-d7bc8d304826) this, and manually triggered the task. To confirm all is working as expected, the screenshot below shows when data was last collected (i.e. when the task was manually triggered):

<img width="496" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/e97685eb-2120-4373-83d2-49937c3e8f52">
