### PR TITLE
feat(cloudquery): Add Fastly data source

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -1194,6 +1194,584 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
+    "CloudquerySourceFastlyServicesScheduledEventRule1F83E593": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 day)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "cloudqueryCluster5370C11B",
+                "Arn",
+              ],
+            },
+            "EcsParameters": {
+              "LaunchType": "FARGATE",
+              "NetworkConfiguration": {
+                "AwsVpcConfiguration": {
+                  "AssignPublicIp": "DISABLED",
+                  "SecurityGroups": [
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "GroupId",
+                      ],
+                    },
+                  ],
+                  "Subnets": {
+                    "Ref": "PrivateSubnets",
+                  },
+                },
+              },
+              "TaskCount": 1,
+              "TaskDefinitionArn": {
+                "Ref": "CloudquerySourceFastlyServicesTaskDefinitionDCCD3FD4",
+              },
+            },
+            "Id": "Target0",
+            "Input": "{}",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CloudquerySourceFastlyServicesTaskDefinitionEventsRoleE821B76C",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CloudquerySourceFastlyServicesTaskDefinitionCloudquerySourceFastlyServicesFirelensLogGroupF5954401": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudquerySourceFastlyServicesTaskDefinitionDCCD3FD4": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/bash",
+              "-c",
+              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Environment": [
+              {
+                "Name": "DB_HOST",
+                "Value": {
+                  "Fn::GetAtt": [
+                    "PostgresInstance16DE4286E",
+                    "Endpoint.Address",
+                  ],
+                },
+              },
+            ],
+            "Essential": false,
+            "Image": "public.ecr.aws/aws-cli/aws-cli",
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": false,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-FastlyServicesAwsCli",
+          },
+          {
+            "Command": [
+              "/bin/sh",
+              "-c",
+              "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+spec:
+  name: fastly
+  path: cloudquery/fastly
+  version: v1.3.1
+  tables:
+    - fastly_services
+    - fastly_service_versions
+    - fastly_service_backends
+    - fastly_service_domains
+    - fastly_service_health_checks
+  destinations:
+    - postgresql
+  concurrency: 1000
+  spec:
+    fastly_api_key: \${FASTLY_API_KEY}
+' > /source.yaml;printf 'kind: destination
+spec:
+  name: postgresql
+  registry: github
+  path: cloudquery/postgresql
+  version: v4.1.0
+  migrate_mode: forced
+  spec:
+    connection_string: \${file:/var/scratch/connection_string}
+' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "SUCCESS",
+                "ContainerName": "CloudquerySource-FastlyServicesAwsCli",
+              },
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Essential": true,
+            "Image": "ghcr.io/cloudquery/cloudquery:3.3.1",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": true,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-FastlyServicesContainer",
+            "Secrets": [
+              {
+                "Name": "FASTLY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":secretsmanager:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":secret:/TEST/deploy/cloudquery/fastly-credentials:api-key::",
+                    ],
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            "Environment": [
+              {
+                "Name": "STACK",
+                "Value": "deploy",
+              },
+              {
+                "Name": "STAGE",
+                "Value": "TEST",
+              },
+              {
+                "Name": "APP",
+                "Value": "cloudquery",
+              },
+              {
+                "Name": "GU_REPO",
+                "Value": "guardian/service-catalogue",
+              },
+            ],
+            "Essential": true,
+            "FirelensConfiguration": {
+              "Options": {
+                "config-file-type": "file",
+                "config-file-value": "/custom.conf",
+                "enable-ecs-log-metadata": "true",
+              },
+              "Type": "fluentbit",
+            },
+            "Image": "ghcr.io/guardian/hackday-firelens:main",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudquerySourceFastlyServicesTaskDefinitionCloudquerySourceFastlyServicesFirelensLogGroupF5954401",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+              },
+            },
+            "Name": "CloudquerySource-FastlyServicesFirelens",
+          },
+        ],
+        "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceFastlyServicesTaskDefinitionExecutionRoleEF21A3A9",
+            "Arn",
+          ],
+        },
+        "Family": "CloudQueryCloudquerySourceFastlyServicesTaskDefinitionB7E1552F",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceFastlyServicesTaskDefinitionTaskRole83C775A7",
+            "Arn",
+          ],
+        },
+        "Volumes": [
+          {
+            "Host": {},
+            "Name": "scratch",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "CloudquerySourceFastlyServicesTaskDefinitionEventsRoleDefaultPolicy4E34F504": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ecs:RunTask",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": {
+                    "Fn::GetAtt": [
+                      "cloudqueryCluster5370C11B",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CloudquerySourceFastlyServicesTaskDefinitionDCCD3FD4",
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceFastlyServicesTaskDefinitionExecutionRoleEF21A3A9",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceFastlyServicesTaskDefinitionTaskRole83C775A7",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceFastlyServicesTaskDefinitionEventsRoleDefaultPolicy4E34F504",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceFastlyServicesTaskDefinitionEventsRoleE821B76C",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceFastlyServicesTaskDefinitionEventsRoleE821B76C": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceFastlyServicesTaskDefinitionExecutionRoleDefaultPolicy1B888D16": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:/TEST/deploy/cloudquery/fastly-credentials-??????",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceFastlyServicesTaskDefinitionCloudquerySourceFastlyServicesFirelensLogGroupF5954401",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceFastlyServicesTaskDefinitionExecutionRoleDefaultPolicy1B888D16",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceFastlyServicesTaskDefinitionExecutionRoleEF21A3A9",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceFastlyServicesTaskDefinitionExecutionRoleEF21A3A9": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceFastlyServicesTaskDefinitionTaskRole83C775A7": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceFastlyServicesTaskDefinitionTaskRoleDefaultPolicy81E15098": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":kinesis:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/cloudquery",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceFastlyServicesTaskDefinitionTaskRoleDefaultPolicy81E15098",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceFastlyServicesTaskDefinitionTaskRole83C775A7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "CloudquerySourceGitHubRepositoriesScheduledEventRuleC7F5836E": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -3,6 +3,7 @@ import { dump } from 'js-yaml';
 import {
 	awsSourceConfigForAccount,
 	awsSourceConfigForOrganisation,
+	fastlySourceConfig,
 	githubSourceConfig,
 	postgresDestinationConfig,
 } from './config';
@@ -146,6 +147,25 @@ describe('Config generation, and converting to YAML', () => {
 		        private_key_path: /github-private-key
 		        app_id: \${file:/github-app-id}
 		        installation_id: \${file:/github-installation-id}
+		"
+	`);
+	});
+
+	it('Should create a Fastly source configuration', () => {
+		const config = fastlySourceConfig({ tables: ['*'] });
+		expect(dump(config)).toMatchInlineSnapshot(`
+		"kind: source
+		spec:
+		  name: fastly
+		  path: cloudquery/fastly
+		  version: v1.3.1
+		  tables:
+		    - '*'
+		  destinations:
+		    - postgresql
+		  concurrency: 1000
+		  spec:
+		    fastly_api_key: \${FASTLY_API_KEY}
 		"
 	`);
 	});

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -142,6 +142,40 @@ export function githubSourceConfig(
 	};
 }
 
+/**
+ * Configuration for the Fastly source plugin.
+ * @see https://www.cloudquery.io/docs/plugins/sources/fastly/overview#configuration
+ */
+export function fastlySourceConfig(
+	tableConfig: CloudqueryTableConfig,
+): CloudqueryConfig {
+	const { tables, skipTables } = tableConfig;
+
+	if (!tables && !skipTables) {
+		throw new Error('Must specify either tables or skipTables');
+	}
+
+	return {
+		kind: 'source',
+		spec: {
+			name: 'fastly',
+			path: 'cloudquery/fastly',
+			version: `v${Versions.CloudqueryFastly}`,
+			tables,
+			skip_tables: skipTables,
+			destinations: ['postgresql'],
+
+			// The Fastly API is rate limited to 1000 requests per hour.
+			// See https://docs.fastly.com/en/guides/resource-limits#rate-and-time-limits.
+			// TODO what's the ideal value here?!
+			concurrency: 1000,
+			spec: {
+				fastly_api_key: '${FASTLY_API_KEY}',
+			},
+		},
+	};
+}
+
 // Tables we are skipping because they are slow and or uninteresting to us.
 export const skipTables = [
 	'aws_ec2_vpc_endpoint_services', // this resource includes services that are available from AWS as well as other AWS Accounts

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -26,4 +26,11 @@ export const Versions = {
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
 	 */
 	CloudqueryGithub: '5.2.0',
+
+	/**
+	 * The version of the CloudQuery Fastly source plugin to install.
+	 *
+	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-fastly
+	 */
+	CloudqueryFastly: '1.3.1',
 };


### PR DESCRIPTION
## What does this change?
Collecting data for Fastly services once a day, this change adds [Fastly](https://www.cloudquery.io/docs/plugins/sources/fastly/overview) to the data collected using CloudQuery.

To enable this, I've manually created a Secrets Manager resource on path `/INFRA/deploy/cloudquery/fastly-credentials` with a [read-only automation token](https://docs.fastly.com/en/guides/using-api-tokens) provided by @davidfurey. The token has been set to expire on 22-Sep-2023, so we'd need to rotate it before then, should we deem this data useful.

## Why?
This might allow us to remove some of the Fastly crawling from https://github.com/guardian/aws-budgets.

## How has it been verified?
This has been [deployed](https://riffraff.gutools.co.uk/deployment/view/21fe8d9a-ef9a-461f-9655-0b52353e9f40). The ECS task has been manually run, and we can now see Fastly data in [Grafana](https://metrics.gutools.co.uk/goto/tPAO6cw4z?orgId=1).