### PR TITLE
chore(deps): Bump CloudQuery versions

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -119,7 +119,7 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
 spec:
   name: aws
   path: cloudquery/aws
-  version: v17.0.0
+  version: v17.4.0
   tables:
     - '*'
   skip_tables:
@@ -175,7 +175,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.1.0
+  version: v4.2.0
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -191,7 +191,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.3.1",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -739,7 +739,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v17.0.0
+  version: v17.4.0
   tables:
     - aws_organizations
     - aws_organizations_accounts
@@ -767,7 +767,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.1.0
+  version: v4.2.0
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -783,7 +783,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.3.1",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -1327,7 +1327,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.1.0
+  version: v4.2.0
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -1343,7 +1343,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.3.1",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -1881,7 +1881,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.1.0
+  version: v4.2.0
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -1897,7 +1897,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.3.1",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -2514,7 +2514,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v17.0.0
+  version: v17.4.0
   tables:
     - aws_accessanalyzer_analyzers
     - aws_accessanalyzer_analyzer_archive_rules
@@ -2538,7 +2538,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.1.0
+  version: v4.2.0
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -2554,7 +2554,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.3.1",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -17,7 +17,7 @@ describe('Config generation, and converting to YAML', () => {
 		  name: postgresql
 		  registry: github
 		  path: cloudquery/postgresql
-		  version: v4.1.0
+		  version: v4.2.0
 		  migrate_mode: forced
 		  spec:
 		    connection_string: \${file:/var/scratch/connection_string}
@@ -34,7 +34,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v17.0.0
+		  version: v17.4.0
 		  tables:
 		    - aws_s3_buckets
 		  destinations:
@@ -66,7 +66,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v17.0.0
+		  version: v17.4.0
 		  tables:
 		    - '*'
 		  skip_tables:
@@ -103,7 +103,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v17.0.0
+		  version: v17.4.0
 		  tables:
 		    - aws_accessanalyzer_analyzers
 		    - aws_accessanalyzer_analyzer_archive_rules

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -4,21 +4,21 @@ export const Versions = {
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=cli
 	 */
-	CloudqueryCli: '3.3.1',
+	CloudqueryCli: '3.5.0',
 
 	/**
 	 * The version of the CloudQuery Postgres destination plugin to install.
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql
 	 */
-	CloudqueryPostgres: '4.1.0',
+	CloudqueryPostgres: '4.2.0',
 
 	/**
 	 * The version of the CloudQuery AWS source plugin to install.
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
 	 */
-	CloudqueryAws: '17.0.0',
+	CloudqueryAws: '17.4.0',
 
 	/**
 	 * The version of the CloudQuery GitHub source plugin to install.


### PR DESCRIPTION
## What does this change?
- CLI goes from 3.3.1 to 3.5.0
- Postgres goes from 4.1.0 to 4.2.0
- AWS goes from 17.0.0 to 17.4.0