### PR TITLE
Introduce Galaxies as Cloudquery source

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -7,11 +7,16 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       "GuSubnetListParameter",
       "GuVpcParameter",
       "GuSecurityGroup",
+      "GuStringParameter",
       "GuLoggingStreamNameParameter",
     ],
     "gu:cdk:version": "TEST",
   },
   "Parameters": {
+    "ActionsStaticSiteBucketArnParam": {
+      "Default": "/INFRA/deploy/cloudquery/actions-static-site-bucket-arn",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "LoggingStreamName": {
       "Default": "/account/services/logging.stream.name",
       "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
@@ -1767,6 +1772,575 @@ spec:
         "Roles": [
           {
             "Ref": "CloudquerySourceFastlyServicesTaskDefinitionTaskRole83C775A7",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGalaxiesScheduledEventRuleCC774CB8": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 day)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "cloudqueryCluster5370C11B",
+                "Arn",
+              ],
+            },
+            "EcsParameters": {
+              "LaunchType": "FARGATE",
+              "NetworkConfiguration": {
+                "AwsVpcConfiguration": {
+                  "AssignPublicIp": "DISABLED",
+                  "SecurityGroups": [
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "GroupId",
+                      ],
+                    },
+                  ],
+                  "Subnets": {
+                    "Ref": "PrivateSubnets",
+                  },
+                },
+              },
+              "TaskCount": 1,
+              "TaskDefinitionArn": {
+                "Ref": "CloudquerySourceGalaxiesTaskDefinition0777FEFC",
+              },
+            },
+            "Id": "Target0",
+            "Input": "{}",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CloudquerySourceGalaxiesTaskDefinitionEventsRoleD1AF9A82",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CloudquerySourceGalaxiesTaskDefinition0777FEFC": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/bash",
+              "-c",
+              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Environment": [
+              {
+                "Name": "DB_HOST",
+                "Value": {
+                  "Fn::GetAtt": [
+                    "PostgresInstance16DE4286E",
+                    "Endpoint.Address",
+                  ],
+                },
+              },
+            ],
+            "Essential": false,
+            "Image": "public.ecr.aws/aws-cli/aws-cli",
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": false,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-GalaxiesAwsCli",
+          },
+          {
+            "Command": [
+              "/bin/sh",
+              "-c",
+              {
+                "Fn::Join": [
+                  "",
+                  [
+                    "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+spec:
+  name: galaxies
+  path: guardian/galaxies
+  version: v1.1.0
+  destinations:
+    - postgresql
+  tables:
+    - galaxies_people_table
+    - galaxies_teams_table
+    - galaxies_streams_table
+  spec:
+    bucket: ",
+                    {
+                      "Fn::Select": [
+                        0,
+                        {
+                          "Fn::Split": [
+                            "/",
+                            {
+                              "Fn::Select": [
+                                5,
+                                {
+                                  "Fn::Split": [
+                                    ":",
+                                    {
+                                      "Ref": "ActionsStaticSiteBucketArnParam",
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    "
+' > /source.yaml;printf 'kind: destination
+spec:
+  name: postgresql
+  registry: github
+  path: cloudquery/postgresql
+  version: v4.2.0
+  migrate_mode: forced
+  spec:
+    connection_string: \${file:/var/scratch/connection_string}
+' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+                  ],
+                ],
+              },
+            ],
+            "DependsOn": [
+              {
+                "Condition": "SUCCESS",
+                "ContainerName": "CloudquerySource-GalaxiesAwsCli",
+              },
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Essential": true,
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": true,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-GalaxiesContainer",
+          },
+          {
+            "Environment": [
+              {
+                "Name": "STACK",
+                "Value": "deploy",
+              },
+              {
+                "Name": "STAGE",
+                "Value": "TEST",
+              },
+              {
+                "Name": "APP",
+                "Value": "cloudquery",
+              },
+              {
+                "Name": "GU_REPO",
+                "Value": "guardian/service-catalogue",
+              },
+            ],
+            "Essential": true,
+            "FirelensConfiguration": {
+              "Options": {
+                "config-file-type": "file",
+                "config-file-value": "/custom.conf",
+                "enable-ecs-log-metadata": "true",
+              },
+              "Type": "fluentbit",
+            },
+            "Image": "ghcr.io/guardian/hackday-firelens:main",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudquerySourceGalaxiesTaskDefinitionCloudquerySourceGalaxiesFirelensLogGroupB5272E0D",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+              },
+            },
+            "Name": "CloudquerySource-GalaxiesFirelens",
+          },
+        ],
+        "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceGalaxiesTaskDefinitionExecutionRoleDDB0DD4B",
+            "Arn",
+          ],
+        },
+        "Family": "CloudQueryCloudquerySourceGalaxiesTaskDefinition4D5FC019",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceGalaxiesTaskDefinitionTaskRole0FC08F83",
+            "Arn",
+          ],
+        },
+        "Volumes": [
+          {
+            "Host": {},
+            "Name": "scratch",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "CloudquerySourceGalaxiesTaskDefinitionCloudquerySourceGalaxiesFirelensLogGroupB5272E0D": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudquerySourceGalaxiesTaskDefinitionEventsRoleD1AF9A82": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceGalaxiesTaskDefinitionEventsRoleDefaultPolicy022DA6EA": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ecs:RunTask",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": {
+                    "Fn::GetAtt": [
+                      "cloudqueryCluster5370C11B",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CloudquerySourceGalaxiesTaskDefinition0777FEFC",
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGalaxiesTaskDefinitionExecutionRoleDDB0DD4B",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGalaxiesTaskDefinitionTaskRole0FC08F83",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceGalaxiesTaskDefinitionEventsRoleDefaultPolicy022DA6EA",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceGalaxiesTaskDefinitionEventsRoleD1AF9A82",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGalaxiesTaskDefinitionExecutionRoleDDB0DD4B": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceGalaxiesTaskDefinitionExecutionRoleDefaultPolicyB6D2CB7A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGalaxiesTaskDefinitionCloudquerySourceGalaxiesFirelensLogGroupB5272E0D",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceGalaxiesTaskDefinitionExecutionRoleDefaultPolicyB6D2CB7A",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceGalaxiesTaskDefinitionExecutionRoleDDB0DD4B",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGalaxiesTaskDefinitionTaskRole0FC08F83": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceGalaxiesTaskDefinitionTaskRoleDefaultPolicy58C64BC8": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":kinesis:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Ref": "ActionsStaticSiteBucketArnParam",
+                    },
+                    "/galaxies.gutools.co.uk/data/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/cloudquery",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceGalaxiesTaskDefinitionTaskRoleDefaultPolicy58C64BC8",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceGalaxiesTaskDefinitionTaskRole0FC08F83",
           },
         ],
       },

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -4,6 +4,7 @@ import {
 	awsSourceConfigForAccount,
 	awsSourceConfigForOrganisation,
 	fastlySourceConfig,
+	galaxiesSourceConfig,
 	githubSourceConfig,
 	postgresDestinationConfig,
 } from './config';
@@ -166,6 +167,26 @@ describe('Config generation, and converting to YAML', () => {
 		  concurrency: 1000
 		  spec:
 		    fastly_api_key: \${FASTLY_API_KEY}
+		"
+	`);
+	});
+
+	it('Should create a Galaxies source configuration', () => {
+		const config = galaxiesSourceConfig('my-galaxies-bucket');
+		expect(dump(config)).toMatchInlineSnapshot(`
+		"kind: source
+		spec:
+		  name: galaxies
+		  path: guardian/galaxies
+		  version: v1.1.0
+		  destinations:
+		    - postgresql
+		  tables:
+		    - galaxies_people_table
+		    - galaxies_teams_table
+		    - galaxies_streams_table
+		  spec:
+		    bucket: my-galaxies-bucket
 		"
 	`);
 	});

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -176,6 +176,26 @@ export function fastlySourceConfig(
 	};
 }
 
+export function galaxiesSourceConfig(bucketName: string): CloudqueryConfig {
+	return {
+		kind: 'source',
+		spec: {
+			name: 'galaxies',
+			path: 'guardian/galaxies',
+			version: Versions.CloudqueryGalaxies,
+			destinations: ['postgresql'],
+			tables: [
+				'galaxies_people_table',
+				'galaxies_teams_table',
+				'galaxies_streams_table',
+			],
+			spec: {
+				bucket: bucketName,
+			},
+		},
+	};
+}
+
 // Tables we are skipping because they are slow and or uninteresting to us.
 export const skipTables = [
 	'aws_ec2_vpc_endpoint_services', // this resource includes services that are available from AWS as well as other AWS Accounts

--- a/packages/cdk/lib/ecs/policies.ts
+++ b/packages/cdk/lib/ecs/policies.ts
@@ -50,3 +50,19 @@ export function cloudqueryAccess(accountId: string) {
 		actions: ['sts:AssumeRole'],
 	});
 }
+
+/**
+ * Create a policy statement allowing read access to the given S3 bucket.
+ *
+ * @param resources a list of S3 bucket ARN resources. E.g.
+ * `arn:aws:s3:::my-bucket/foo/*` to allow read access to everything under
+ * `/foo`.
+ * @returns a policy statement allowing read access to the given S3 bucket
+ */
+export const readBucketPolicy = (...resources: string[]): PolicyStatement => {
+	return new PolicyStatement({
+		effect: Effect.ALLOW,
+		resources: resources,
+		actions: ['s3:GetObject'],
+	});
+};

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -33,4 +33,11 @@ export const Versions = {
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-fastly
 	 */
 	CloudqueryFastly: '1.3.1',
+
+	/**
+	 * The version of the our custom Galaxies source plugin to install.
+	 *
+	 * @see https://github.com/guardian/cq-source-galaxies
+	 */
+	CloudqueryGalaxies: 'v1.1.0',
 };


### PR DESCRIPTION
## What does this change?

Introduces Galaxies as a *source* for Cloudquery using an in-house plugin that lives here:

https://github.com/guardian/cq-source-galaxies

Galaxies does not (atm) support machine access to the API. Reading directly from the bucket is a 'pragmatic' solution here - it is easy to implement but vulnerable to changes in the model. The team do not expect these in the medium term though.

An initial rate of once per day is used as this data doesn't change very often.

## Why?

Galaxies is the Guardian's source of truth for people, teams, and streams. We want this data to be able to link services to teams and answer questions around **ownership**.

## How has it been verified?

TODO - test in INFRA and see how it goes. (The plugin has already been verified separately through local testing.)
