### PR TITLE
Update DX of running CloudQuery locally

### DIFF
--- a/packages/cloudquery/.env.example
+++ b/packages/cloudquery/.env.example
@@ -1,0 +1,14 @@
+# See https://github.com/cloudquery/cloudquery/releases?q=cli
+CQ_CLI=3.5.0
+
+# See https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql
+CQ_POSTGRES=4.2.0
+
+# See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
+CQ_AWS=17.4.0
+
+# See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
+CQ_GITHUB=5.2.0
+
+# See https://github.com/settings/tokens?type=beta
+GITHUB_ACCESS_TOKEN=

--- a/packages/cloudquery/dev-config/cloudquery.yaml
+++ b/packages/cloudquery/dev-config/cloudquery.yaml
@@ -3,10 +3,10 @@ kind: source
 spec:
   name: 'aws'
   path: 'cloudquery/aws'
-
-  # Track releases on https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
-  version: 'v17.4.0'
+  version: v${CQ_AWS}
   destinations: ['postgresql']
+  tables:
+    - '*'
   skip_tables:
     - aws_ec2_vpc_endpoint_services
     - aws_cloudtrail_events
@@ -53,17 +53,11 @@ spec:
   # Source spec section
   name: 'github'
   path: 'cloudquery/github'
-  version: 'v5.2.0'
+  version: v${CQ_GITHUB}
   tables: ['*']
   destinations: ['postgresql']
   spec:
-    ## App Authentication (one per org):
-    app_auth:
-      - org: 'guardian'
-        private_key_path: '/github-key' # Path to private key file
-        app_id: '${GITHUB_APP_ID}' # App ID, required for App Authentication.
-        installation_id: '${GITHUB_INSTALLATION_ID}' # Installation ID for this org
-    #orgs: [] # Optional. List of organizations to extract from
+    access_token: ${GITHUB_ACCESS_TOKEN}
     repos: [
         # example devX owned repos
         'guardian/cdk',
@@ -74,7 +68,7 @@ spec:
 
         # example private repo
         'guardian/tracker',
-      ] # Optional. List of repositories to extract from
+      ]
 
 ---
 kind: destination
@@ -82,9 +76,7 @@ spec:
   name: 'postgresql'
   registry: 'github'
   path: 'cloudquery/postgresql'
-
-  # Track releases on https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql-&expanded=true
-  version: 'v4.2.0'
+  version: v${CQ_POSTGRES}
 
   # Automatically apply migrations whenever plugins are updated.
   # Note: This is not encouraged if risk averse, so we should consider removing this once fully in production.

--- a/packages/cloudquery/dev-config/cloudquery.yaml
+++ b/packages/cloudquery/dev-config/cloudquery.yaml
@@ -5,7 +5,7 @@ spec:
   path: 'cloudquery/aws'
 
   # Track releases on https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
-  version: 'v17.0.0'
+  version: 'v17.4.0'
   destinations: ['postgresql']
   skip_tables:
     - aws_ec2_vpc_endpoint_services
@@ -69,7 +69,7 @@ spec:
   # Source spec section
   name: 'github'
   path: 'cloudquery/github'
-  version: 'v5.1.0'
+  version: 'v5.2.0'
   tables: ['*']
   destinations: ['postgresql']
   spec:
@@ -100,7 +100,7 @@ spec:
   path: 'cloudquery/postgresql'
 
   # Track releases on https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql-&expanded=true
-  version: 'v4.0.4'
+  version: 'v4.2.0'
 
   # Automatically apply migrations whenever plugins are updated.
   # Note: This is not encouraged if risk averse, so we should consider removing this once fully in production.

--- a/packages/cloudquery/dev-config/cloudquery.yaml
+++ b/packages/cloudquery/dev-config/cloudquery.yaml
@@ -50,22 +50,6 @@ spec:
 ---
 kind: source
 spec:
-  name: 'template-summary'
-  path: 'guardian/cloudformation-template-summary'
-  version: 'v0.3.0'
-  tables: ['*']
-  destinations: ['postgresql']
-  spec:
-    regions:
-      - eu-west-1
-      - us-east-1
-    accounts:
-      - id: 'developerPlayground'
-        local_profile: 'developerPlayground'
-
----
-kind: source
-spec:
   # Source spec section
   name: 'github'
   path: 'cloudquery/github'

--- a/packages/cloudquery/docker-compose.yaml
+++ b/packages/cloudquery/docker-compose.yaml
@@ -9,18 +9,19 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: not_at_all_secret
   cloudquery:
-    image: ghcr.io/cloudquery/cloudquery:3.5.0
+    image: ghcr.io/cloudquery/cloudquery:${CQ_CLI}
     platform: linux/amd64
     depends_on:
       - postgres
     volumes:
       - ~/.aws/credentials:/.aws/credentials
       - ./dev-config/cloudquery.yaml:/dev-config.yaml
-      - ~/.gu/cloudquery-github-key:/github-key
     environment:
       AWS_SHARED_CREDENTIALS_FILE: "/.aws/credentials"
-      GITHUB_APP_ID: ${GITHUB_APP_ID}
-      GITHUB_INSTALLATION_ID: ${GITHUB_INSTALLATION_ID}
+      CQ_POSTGRES: ${CQ_POSTGRES}
+      CQ_AWS: ${CQ_AWS}
+      CQ_GITHUB: ${CQ_GITHUB}
+      GITHUB_ACCESS_TOKEN: ${GITHUB_ACCESS_TOKEN}
     command: sync /dev-config.yaml --log-console --log-level warn
   grafana:
     image: grafana/grafana-oss:9.4.7

--- a/packages/cloudquery/docker-compose.yaml
+++ b/packages/cloudquery/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: not_at_all_secret
   cloudquery:
-    image: ghcr.io/cloudquery/cloudquery:2.5.3
+    image: ghcr.io/cloudquery/cloudquery:3.5.0
     platform: linux/amd64
     depends_on:
       - postgres

--- a/packages/cloudquery/script/setup
+++ b/packages/cloudquery/script/setup
@@ -4,16 +4,7 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-COMMON_PARAMS="--profile deployTools --region eu-west-1"
-BUCKET=$(aws ssm get-parameter --name /account/services/artifact.bucket ${COMMON_PARAMS} | jq -r .Parameter.Value)
+echo "Creating .env file from .env.example"
+cp $DIR/../.env.example $DIR/../.env
 
-mkdir -p ~/.gu
-
-if [ "$BUCKET" ]; then
-    aws s3 cp s3://"$BUCKET"/deploy/DEV/cloudquery/cloudquery-github-key ~/.gu/cloudquery-github-key ${COMMON_PARAMS}
-    aws s3 cp s3://"$BUCKET"/deploy/DEV/cloudquery/.env $DIR/../.env ${COMMON_PARAMS}
-
-else
-    echo "Could not get artifact bucket parameter value from SSM, make sure you have deployTools credentials configured."
-    exit 1
-fi
+echo "Visit https://github.com/settings/tokens?type=beta to create a GitHub token, and add it to the .env file"

--- a/packages/cloudquery/script/setup
+++ b/packages/cloudquery/script/setup
@@ -8,3 +8,15 @@ echo "Creating .env file from .env.example"
 cp $DIR/../.env.example $DIR/../.env
 
 echo "Visit https://github.com/settings/tokens?type=beta to create a GitHub token, and add it to the .env file"
+
+echo "Checking AWS credentials"
+STATUS=$(aws sts get-caller-identity --profile developerPlayground 2>&1 || true)
+if [[ ${STATUS} =~ (ExpiredToken) ]]; then
+  echo "Credentials for the developerPlayground profile have expired. Please fetch new credentials."
+  exit 1
+elif [[ ${STATUS} =~ ("could not be found") ]]; then
+  echo "Credentials for the developerPlayground profile are missing. Please fetch some."
+  exit 1
+else
+  echo "AWS credentials are valid"
+fi

--- a/packages/cloudquery/script/start
+++ b/packages/cloudquery/script/start
@@ -4,6 +4,18 @@ set -e
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
+echo "Checking AWS credentials"
+STATUS=$(aws sts get-caller-identity --profile developerPlayground 2>&1 || true)
+if [[ ${STATUS} =~ (ExpiredToken) ]]; then
+  echo "Credentials for the developerPlayground profile have expired. Please fetch new credentials, and run this script again."
+  exit 1
+elif [[ ${STATUS} =~ ("could not be found") ]]; then
+  echo "Credentials for the developerPlayground profile are missing. Please fetch some, and run this script again."
+  exit 1
+else
+  echo "AWS credentials are valid"
+fi
+
 if curl -s --unix-socket /var/run/docker.sock http/_ping 2>&1 >/dev/null; then
   docker compose -f "${DIR}/../docker-compose.yaml" up -d
 else


### PR DESCRIPTION
## What does this change?
Updates the DX of running CloudQuery locally in two:
1. Reduced number of AWS credentials needed
2. Aligning versions to those used in INFRA

### Reduced number of AWS credentials needed
Currently, to run CloudQuery locally we require two sets of AWS credentials:
- deployTools - used to download the GitHub credentials from S3
- developerPlayground - used by CloudQuery to crawl AWS

The first time setup and running process is:
- Get credentials for deployTools
- Run setup
- Get credentials for developerPlayground
- Run start

Whilst this works, it reduces the ability for non-DevX contributions[^1]. Using shared GitHub credentials also increases the chance or hitting the GitHub API rate limits.

In this change we switch to using [Personal Access Tokens](https://github.com/settings/tokens?type=beta) for [CloudQuery](https://www.cloudquery.io/docs/plugins/sources/github/overview) locally. This means each developer uses their own API quota, and the need for deployTools AWS credentials is removed.

Additionally, we now check if the developerPlayground credentials are valid.

### Aligning versions to those used in INFRA
The versions of the CloudQuery CLI, source, and destinations plugins now match those used in INFRA. This means we can test and reproduce things more reliably.

To simplify things, the versions are now tracked in a `.env` file. Ideally we'd use [versions.ts](https://github.com/guardian/service-catalogue/blob/25f1b7fe9eb9ff94001755312d1fa743aeb00b18/packages/cdk/lib/ecs/versions.ts) as the single source of truth, but that's an optimisation for later.

## Why?
Simpler DX is better.

## How has it been verified?
- Checkout this branch
- Run the setup script, and follow the resulting instructions
- Run the start script
- Visit localhost:3000 and observe data being collected

[^1]: We've not had such contributions to-date, but it's good to enable it.