### PR TITLE
fix(cloudquery): Attempt to get the all AWS task to complete

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -4854,6 +4854,7 @@ spec:
     - aws_ec2_instance_types
   destinations:
     - postgresql
+  concurrency: 10000
   spec:
     regions:
       - eu-west-1
@@ -5416,6 +5417,7 @@ spec:
     - aws_stepfunctions_*
   destinations:
     - postgresql
+  concurrency: 5000
   spec:
     regions:
       - eu-west-1
@@ -6544,6 +6546,7 @@ spec:
     - aws_s3_*
   destinations:
     - postgresql
+  concurrency: 10000
   spec:
     regions:
       - eu-west-1

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -160,6 +160,20 @@ spec:
     - aws_xray_sampling_rules
     - aws_xray_resource_policies
     - aws_xray_groups
+    - aws_organizations
+    - aws_organizations_accounts
+    - aws_organizations_delegated_services
+    - aws_organizations_delegated_administrators
+    - aws_organizations_organizational_units
+    - aws_organizations_policies
+    - aws_organizations_roots
+    - aws_accessanalyzer_analyzers
+    - aws_accessanalyzer_analyzer_archive_rules
+    - aws_accessanalyzer_analyzer_findings
+    - aws_cloudformation_stacks
+    - aws_cloudformation_stack_resources
+    - aws_cloudformation_stack_templates
+    - aws_cloudformation_template_summaries
   destinations:
     - postgresql
   spec:

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -271,7 +271,7 @@ spec:
           ],
         },
         "Family": "CloudQueryCloudquerySourceAllTaskDefinitionC1F1D919",
-        "Memory": "512",
+        "Memory": "2048",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -285,7 +285,7 @@ spec:
             "Name": "CloudquerySource-AllFirelens",
           },
         ],
-        "Cpu": "256",
+        "Cpu": "1024",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "CloudquerySourceAllTaskDefinitionExecutionRole57AE7309",
@@ -5519,7 +5519,7 @@ spec:
             "Name": "CloudquerySource-OrgWideLambdaFirelens",
           },
         ],
-        "Cpu": "256",
+        "Cpu": "1024",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "CloudquerySourceOrgWideLambdaTaskDefinitionExecutionRole855AB313",
@@ -5527,7 +5527,7 @@ spec:
           ],
         },
         "Family": "CloudQueryCloudquerySourceOrgWideLambdaTaskDefinition26B11C87",
-        "Memory": "2048",
+        "Memory": "3072",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -176,6 +176,7 @@ spec:
     - aws_cloudformation_template_summaries
   destinations:
     - postgresql
+  concurrency: 10000
   spec:
     regions:
       - eu-west-1

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -126,7 +126,7 @@ spec:
   path: cloudquery/aws
   version: v17.4.0
   tables:
-    - '*'
+    - aws_*
   skip_tables:
     - aws_ec2_vpc_endpoint_services
     - aws_cloudtrail_events
@@ -5956,16 +5956,7 @@ spec:
   path: cloudquery/snyk
   version: v3.0.0
   tables:
-    - snyk_dependencies
-    - snyk_groups
-    - snyk_group_members
-    - snyk_integrations
-    - snyk_organizations
-    - snyk_organization_members
-    - snyk_organization_provisions
-    - snyk_projects
-    - snyk_reporting_issues
-    - snyk_reporting_latest_issues
+    - snyk_*
   destinations:
     - postgresql
   spec:

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -5417,7 +5417,7 @@ spec:
     - aws_stepfunctions_*
   destinations:
     - postgresql
-  concurrency: 5000
+  concurrency: 10000
   spec:
     regions:
       - eu-west-1
@@ -5527,7 +5527,7 @@ spec:
           ],
         },
         "Family": "CloudQueryCloudquerySourceOrgWideLambdaTaskDefinition26B11C87",
-        "Memory": "512",
+        "Memory": "2048",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -174,6 +174,10 @@ spec:
     - aws_cloudformation_stack_resources
     - aws_cloudformation_stack_templates
     - aws_cloudformation_template_summaries
+    - aws_elbv1_*
+    - aws_elbv2_*
+    - aws_cloudwatch_alarms
+    - aws_ec2_*
   destinations:
     - postgresql
   concurrency: 10000
@@ -4749,6 +4753,569 @@ spec:
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceOrgWideEc2ScheduledEventRule3D54BEFB": {
+      "Properties": {
+        "ScheduleExpression": "rate(3 hours)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "cloudqueryCluster5370C11B",
+                "Arn",
+              ],
+            },
+            "EcsParameters": {
+              "LaunchType": "FARGATE",
+              "NetworkConfiguration": {
+                "AwsVpcConfiguration": {
+                  "AssignPublicIp": "DISABLED",
+                  "SecurityGroups": [
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "GroupId",
+                      ],
+                    },
+                  ],
+                  "Subnets": {
+                    "Ref": "PrivateSubnets",
+                  },
+                },
+              },
+              "TaskCount": 1,
+              "TaskDefinitionArn": {
+                "Ref": "CloudquerySourceOrgWideEc2TaskDefinition7E4B2AE4",
+              },
+            },
+            "Id": "Target0",
+            "Input": "{}",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CloudquerySourceOrgWideEc2TaskDefinitionEventsRole34519DB3",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CloudquerySourceOrgWideEc2TaskDefinition7E4B2AE4": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/bash",
+              "-c",
+              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Environment": [
+              {
+                "Name": "DB_HOST",
+                "Value": {
+                  "Fn::GetAtt": [
+                    "PostgresInstance16DE4286E",
+                    "Endpoint.Address",
+                  ],
+                },
+              },
+            ],
+            "Essential": false,
+            "Image": "public.ecr.aws/aws-cli/aws-cli",
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": false,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-OrgWideEc2AwsCli",
+          },
+          {
+            "Command": [
+              "/bin/sh",
+              "-c",
+              "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+spec:
+  name: aws
+  path: cloudquery/aws
+  version: v17.4.0
+  tables:
+    - aws_ec2_*
+  skip_tables:
+    - aws_ec2_instance_types
+  destinations:
+    - postgresql
+  spec:
+    regions:
+      - eu-west-1
+      - eu-west-2
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - ap-southeast-2
+      - ca-central-1
+    org:
+      member_role_name: cloudquery-access
+      organization_units:
+        - ou-123
+' > /source.yaml;printf 'kind: destination
+spec:
+  name: postgresql
+  registry: github
+  path: cloudquery/postgresql
+  version: v4.2.0
+  migrate_mode: forced
+  spec:
+    connection_string: \${file:/var/scratch/connection_string}
+' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "SUCCESS",
+                "ContainerName": "CloudquerySource-OrgWideEc2AwsCli",
+              },
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Essential": true,
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": true,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-OrgWideEc2Container",
+          },
+          {
+            "Environment": [
+              {
+                "Name": "STACK",
+                "Value": "deploy",
+              },
+              {
+                "Name": "STAGE",
+                "Value": "TEST",
+              },
+              {
+                "Name": "APP",
+                "Value": "cloudquery",
+              },
+              {
+                "Name": "GU_REPO",
+                "Value": "guardian/service-catalogue",
+              },
+            ],
+            "Essential": true,
+            "FirelensConfiguration": {
+              "Options": {
+                "config-file-type": "file",
+                "config-file-value": "/custom.conf",
+                "enable-ecs-log-metadata": "true",
+              },
+              "Type": "fluentbit",
+            },
+            "Image": "ghcr.io/guardian/hackday-firelens:main",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudquerySourceOrgWideEc2TaskDefinitionCloudquerySourceOrgWideEc2FirelensLogGroup5214B9E0",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+              },
+            },
+            "Name": "CloudquerySource-OrgWideEc2Firelens",
+          },
+        ],
+        "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceOrgWideEc2TaskDefinitionExecutionRole806432F0",
+            "Arn",
+          ],
+        },
+        "Family": "CloudQueryCloudquerySourceOrgWideEc2TaskDefinition907CA169",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceOrgWideEc2TaskDefinitionTaskRole6C3A882C",
+            "Arn",
+          ],
+        },
+        "Volumes": [
+          {
+            "Host": {},
+            "Name": "scratch",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "CloudquerySourceOrgWideEc2TaskDefinitionCloudquerySourceOrgWideEc2FirelensLogGroup5214B9E0": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudquerySourceOrgWideEc2TaskDefinitionEventsRole34519DB3": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceOrgWideEc2TaskDefinitionEventsRoleDefaultPolicyA48042A3": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ecs:RunTask",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": {
+                    "Fn::GetAtt": [
+                      "cloudqueryCluster5370C11B",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CloudquerySourceOrgWideEc2TaskDefinition7E4B2AE4",
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceOrgWideEc2TaskDefinitionExecutionRole806432F0",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceOrgWideEc2TaskDefinitionTaskRole6C3A882C",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceOrgWideEc2TaskDefinitionEventsRoleDefaultPolicyA48042A3",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceOrgWideEc2TaskDefinitionEventsRole34519DB3",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceOrgWideEc2TaskDefinitionExecutionRole806432F0": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceOrgWideEc2TaskDefinitionExecutionRoleDefaultPolicy1BF4301F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceOrgWideEc2TaskDefinitionCloudquerySourceOrgWideEc2FirelensLogGroup5214B9E0",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceOrgWideEc2TaskDefinitionExecutionRoleDefaultPolicy1BF4301F",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceOrgWideEc2TaskDefinitionExecutionRole806432F0",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceOrgWideEc2TaskDefinitionTaskRole6C3A882C": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceOrgWideEc2TaskDefinitionTaskRoleDefaultPolicy908F983F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":kinesis:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "cloudformation:GetTemplate",
+                "dynamodb:GetItem",
+                "dynamodb:BatchGetItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "ec2:GetConsoleOutput",
+                "ec2:GetConsoleScreenshot",
+                "ecr:BatchGetImage",
+                "ecr:GetAuthorizationToken",
+                "ecr:GetDownloadUrlForLayer",
+                "kinesis:Get*",
+                "lambda:GetFunction",
+                "logs:GetLogEvents",
+                "sdb:Select*",
+                "sqs:ReceiveMessage",
+              ],
+              "Effect": "Deny",
+              "Resource": "*",
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": "arn:aws:iam::*:role/cloudquery-access",
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/cloudquery",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceOrgWideEc2TaskDefinitionTaskRoleDefaultPolicy908F983F",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceOrgWideEc2TaskDefinitionTaskRole6C3A882C",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "CloudquerySourceOrgWideLoadBalancersScheduledEventRule1B13EFF3": {
       "Properties": {

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -180,6 +180,7 @@ spec:
     - aws_ec2_*
     - aws_lambda_*
     - aws_stepfunctions_*
+    - aws_s3_*
   destinations:
     - postgresql
   concurrency: 10000
@@ -6443,6 +6444,567 @@ spec:
         "Roles": [
           {
             "Ref": "CloudquerySourceOrgWideLoadBalancersTaskDefinitionTaskRoleABB2ABAD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceOrgWideS3ScheduledEventRuleB310F050": {
+      "Properties": {
+        "ScheduleExpression": "rate(3 hours)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "cloudqueryCluster5370C11B",
+                "Arn",
+              ],
+            },
+            "EcsParameters": {
+              "LaunchType": "FARGATE",
+              "NetworkConfiguration": {
+                "AwsVpcConfiguration": {
+                  "AssignPublicIp": "DISABLED",
+                  "SecurityGroups": [
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "GroupId",
+                      ],
+                    },
+                  ],
+                  "Subnets": {
+                    "Ref": "PrivateSubnets",
+                  },
+                },
+              },
+              "TaskCount": 1,
+              "TaskDefinitionArn": {
+                "Ref": "CloudquerySourceOrgWideS3TaskDefinition8B6BA52D",
+              },
+            },
+            "Id": "Target0",
+            "Input": "{}",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CloudquerySourceOrgWideS3TaskDefinitionEventsRole9E60BBDE",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CloudquerySourceOrgWideS3TaskDefinition8B6BA52D": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/bash",
+              "-c",
+              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Environment": [
+              {
+                "Name": "DB_HOST",
+                "Value": {
+                  "Fn::GetAtt": [
+                    "PostgresInstance16DE4286E",
+                    "Endpoint.Address",
+                  ],
+                },
+              },
+            ],
+            "Essential": false,
+            "Image": "public.ecr.aws/aws-cli/aws-cli",
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": false,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-OrgWideS3AwsCli",
+          },
+          {
+            "Command": [
+              "/bin/sh",
+              "-c",
+              "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+spec:
+  name: aws
+  path: cloudquery/aws
+  version: v17.4.0
+  tables:
+    - aws_s3_*
+  destinations:
+    - postgresql
+  spec:
+    regions:
+      - eu-west-1
+      - eu-west-2
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - ap-southeast-2
+      - ca-central-1
+    org:
+      member_role_name: cloudquery-access
+      organization_units:
+        - ou-123
+' > /source.yaml;printf 'kind: destination
+spec:
+  name: postgresql
+  registry: github
+  path: cloudquery/postgresql
+  version: v4.2.0
+  migrate_mode: forced
+  spec:
+    connection_string: \${file:/var/scratch/connection_string}
+' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "SUCCESS",
+                "ContainerName": "CloudquerySource-OrgWideS3AwsCli",
+              },
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Essential": true,
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": true,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-OrgWideS3Container",
+          },
+          {
+            "Environment": [
+              {
+                "Name": "STACK",
+                "Value": "deploy",
+              },
+              {
+                "Name": "STAGE",
+                "Value": "TEST",
+              },
+              {
+                "Name": "APP",
+                "Value": "cloudquery",
+              },
+              {
+                "Name": "GU_REPO",
+                "Value": "guardian/service-catalogue",
+              },
+            ],
+            "Essential": true,
+            "FirelensConfiguration": {
+              "Options": {
+                "config-file-type": "file",
+                "config-file-value": "/custom.conf",
+                "enable-ecs-log-metadata": "true",
+              },
+              "Type": "fluentbit",
+            },
+            "Image": "ghcr.io/guardian/hackday-firelens:main",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudquerySourceOrgWideS3TaskDefinitionCloudquerySourceOrgWideS3FirelensLogGroupF8BCB6DF",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+              },
+            },
+            "Name": "CloudquerySource-OrgWideS3Firelens",
+          },
+        ],
+        "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceOrgWideS3TaskDefinitionExecutionRole4F6DD2B0",
+            "Arn",
+          ],
+        },
+        "Family": "CloudQueryCloudquerySourceOrgWideS3TaskDefinitionCD4F6884",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceOrgWideS3TaskDefinitionTaskRole32E46B16",
+            "Arn",
+          ],
+        },
+        "Volumes": [
+          {
+            "Host": {},
+            "Name": "scratch",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "CloudquerySourceOrgWideS3TaskDefinitionCloudquerySourceOrgWideS3FirelensLogGroupF8BCB6DF": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudquerySourceOrgWideS3TaskDefinitionEventsRole9E60BBDE": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceOrgWideS3TaskDefinitionEventsRoleDefaultPolicy214D9C1E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ecs:RunTask",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": {
+                    "Fn::GetAtt": [
+                      "cloudqueryCluster5370C11B",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CloudquerySourceOrgWideS3TaskDefinition8B6BA52D",
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceOrgWideS3TaskDefinitionExecutionRole4F6DD2B0",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceOrgWideS3TaskDefinitionTaskRole32E46B16",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceOrgWideS3TaskDefinitionEventsRoleDefaultPolicy214D9C1E",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceOrgWideS3TaskDefinitionEventsRole9E60BBDE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceOrgWideS3TaskDefinitionExecutionRole4F6DD2B0": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceOrgWideS3TaskDefinitionExecutionRoleDefaultPolicy6874A226": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceOrgWideS3TaskDefinitionCloudquerySourceOrgWideS3FirelensLogGroupF8BCB6DF",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceOrgWideS3TaskDefinitionExecutionRoleDefaultPolicy6874A226",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceOrgWideS3TaskDefinitionExecutionRole4F6DD2B0",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceOrgWideS3TaskDefinitionTaskRole32E46B16": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceOrgWideS3TaskDefinitionTaskRoleDefaultPolicyAF6A0EA5": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":kinesis:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "cloudformation:GetTemplate",
+                "dynamodb:GetItem",
+                "dynamodb:BatchGetItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "ec2:GetConsoleOutput",
+                "ec2:GetConsoleScreenshot",
+                "ecr:BatchGetImage",
+                "ecr:GetAuthorizationToken",
+                "ecr:GetDownloadUrlForLayer",
+                "kinesis:Get*",
+                "lambda:GetFunction",
+                "logs:GetLogEvents",
+                "sdb:Select*",
+                "sqs:ReceiveMessage",
+              ],
+              "Effect": "Deny",
+              "Resource": "*",
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": "arn:aws:iam::*:role/cloudquery-access",
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/cloudquery",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceOrgWideS3TaskDefinitionTaskRoleDefaultPolicyAF6A0EA5",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceOrgWideS3TaskDefinitionTaskRole32E46B16",
           },
         ],
       },

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -178,6 +178,8 @@ spec:
     - aws_elbv2_*
     - aws_cloudwatch_alarms
     - aws_ec2_*
+    - aws_lambda_*
+    - aws_stepfunctions_*
   destinations:
     - postgresql
   concurrency: 10000
@@ -5312,6 +5314,568 @@ spec:
         "Roles": [
           {
             "Ref": "CloudquerySourceOrgWideEc2TaskDefinitionTaskRole6C3A882C",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceOrgWideLambdaScheduledEventRule489C491A": {
+      "Properties": {
+        "ScheduleExpression": "rate(3 hours)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "cloudqueryCluster5370C11B",
+                "Arn",
+              ],
+            },
+            "EcsParameters": {
+              "LaunchType": "FARGATE",
+              "NetworkConfiguration": {
+                "AwsVpcConfiguration": {
+                  "AssignPublicIp": "DISABLED",
+                  "SecurityGroups": [
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "GroupId",
+                      ],
+                    },
+                  ],
+                  "Subnets": {
+                    "Ref": "PrivateSubnets",
+                  },
+                },
+              },
+              "TaskCount": 1,
+              "TaskDefinitionArn": {
+                "Ref": "CloudquerySourceOrgWideLambdaTaskDefinition841CAE64",
+              },
+            },
+            "Id": "Target0",
+            "Input": "{}",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CloudquerySourceOrgWideLambdaTaskDefinitionEventsRoleC3640247",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CloudquerySourceOrgWideLambdaTaskDefinition841CAE64": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/bash",
+              "-c",
+              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Environment": [
+              {
+                "Name": "DB_HOST",
+                "Value": {
+                  "Fn::GetAtt": [
+                    "PostgresInstance16DE4286E",
+                    "Endpoint.Address",
+                  ],
+                },
+              },
+            ],
+            "Essential": false,
+            "Image": "public.ecr.aws/aws-cli/aws-cli",
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": false,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-OrgWideLambdaAwsCli",
+          },
+          {
+            "Command": [
+              "/bin/sh",
+              "-c",
+              "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+spec:
+  name: aws
+  path: cloudquery/aws
+  version: v17.4.0
+  tables:
+    - aws_lambda_*
+    - aws_stepfunctions_*
+  destinations:
+    - postgresql
+  spec:
+    regions:
+      - eu-west-1
+      - eu-west-2
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - ap-southeast-2
+      - ca-central-1
+    org:
+      member_role_name: cloudquery-access
+      organization_units:
+        - ou-123
+' > /source.yaml;printf 'kind: destination
+spec:
+  name: postgresql
+  registry: github
+  path: cloudquery/postgresql
+  version: v4.2.0
+  migrate_mode: forced
+  spec:
+    connection_string: \${file:/var/scratch/connection_string}
+' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "SUCCESS",
+                "ContainerName": "CloudquerySource-OrgWideLambdaAwsCli",
+              },
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Essential": true,
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": true,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-OrgWideLambdaContainer",
+          },
+          {
+            "Environment": [
+              {
+                "Name": "STACK",
+                "Value": "deploy",
+              },
+              {
+                "Name": "STAGE",
+                "Value": "TEST",
+              },
+              {
+                "Name": "APP",
+                "Value": "cloudquery",
+              },
+              {
+                "Name": "GU_REPO",
+                "Value": "guardian/service-catalogue",
+              },
+            ],
+            "Essential": true,
+            "FirelensConfiguration": {
+              "Options": {
+                "config-file-type": "file",
+                "config-file-value": "/custom.conf",
+                "enable-ecs-log-metadata": "true",
+              },
+              "Type": "fluentbit",
+            },
+            "Image": "ghcr.io/guardian/hackday-firelens:main",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudquerySourceOrgWideLambdaTaskDefinitionCloudquerySourceOrgWideLambdaFirelensLogGroupE242AC17",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+              },
+            },
+            "Name": "CloudquerySource-OrgWideLambdaFirelens",
+          },
+        ],
+        "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceOrgWideLambdaTaskDefinitionExecutionRole855AB313",
+            "Arn",
+          ],
+        },
+        "Family": "CloudQueryCloudquerySourceOrgWideLambdaTaskDefinition26B11C87",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceOrgWideLambdaTaskDefinitionTaskRole74D7A7B0",
+            "Arn",
+          ],
+        },
+        "Volumes": [
+          {
+            "Host": {},
+            "Name": "scratch",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "CloudquerySourceOrgWideLambdaTaskDefinitionCloudquerySourceOrgWideLambdaFirelensLogGroupE242AC17": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudquerySourceOrgWideLambdaTaskDefinitionEventsRoleC3640247": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceOrgWideLambdaTaskDefinitionEventsRoleDefaultPolicy4BA4A632": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ecs:RunTask",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": {
+                    "Fn::GetAtt": [
+                      "cloudqueryCluster5370C11B",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CloudquerySourceOrgWideLambdaTaskDefinition841CAE64",
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceOrgWideLambdaTaskDefinitionExecutionRole855AB313",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceOrgWideLambdaTaskDefinitionTaskRole74D7A7B0",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceOrgWideLambdaTaskDefinitionEventsRoleDefaultPolicy4BA4A632",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceOrgWideLambdaTaskDefinitionEventsRoleC3640247",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceOrgWideLambdaTaskDefinitionExecutionRole855AB313": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceOrgWideLambdaTaskDefinitionExecutionRoleDefaultPolicy38DD112B": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceOrgWideLambdaTaskDefinitionCloudquerySourceOrgWideLambdaFirelensLogGroupE242AC17",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceOrgWideLambdaTaskDefinitionExecutionRoleDefaultPolicy38DD112B",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceOrgWideLambdaTaskDefinitionExecutionRole855AB313",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceOrgWideLambdaTaskDefinitionTaskRole74D7A7B0": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceOrgWideLambdaTaskDefinitionTaskRoleDefaultPolicyE77C1814": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":kinesis:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "cloudformation:GetTemplate",
+                "dynamodb:GetItem",
+                "dynamodb:BatchGetItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "ec2:GetConsoleOutput",
+                "ec2:GetConsoleScreenshot",
+                "ecr:BatchGetImage",
+                "ecr:GetAuthorizationToken",
+                "ecr:GetDownloadUrlForLayer",
+                "kinesis:Get*",
+                "lambda:GetFunction",
+                "logs:GetLogEvents",
+                "sdb:Select*",
+                "sqs:ReceiveMessage",
+              ],
+              "Effect": "Deny",
+              "Resource": "*",
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": "arn:aws:iam::*:role/cloudquery-access",
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/cloudquery",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceOrgWideLambdaTaskDefinitionTaskRoleDefaultPolicyE77C1814",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceOrgWideLambdaTaskDefinitionTaskRole74D7A7B0",
           },
         ],
       },

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -203,6 +203,17 @@ export class CloudQuery extends GuStack {
 				managedPolicies: [readonlyPolicy],
 				policies: [standardDenyPolicy, cloudqueryAccess('*')],
 			},
+			{
+				name: 'OrgWideLambda',
+				description:
+					'Collecting lambda and step function data across the organisation',
+				schedule: Schedule.rate(Duration.hours(3)),
+				config: awsSourceConfigForOrganisation({
+					tables: ['aws_lambda_*', 'aws_stepfunctions_*'],
+				}),
+				managedPolicies: [readonlyPolicy],
+				policies: [standardDenyPolicy, cloudqueryAccess('*')],
+			},
 		];
 
 		const selectedAwsTables = awsSources.flatMap(

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -214,6 +214,16 @@ export class CloudQuery extends GuStack {
 				managedPolicies: [readonlyPolicy],
 				policies: [standardDenyPolicy, cloudqueryAccess('*')],
 			},
+			{
+				name: 'OrgWideS3',
+				description: 'Collecting Se data across the organisation',
+				schedule: Schedule.rate(Duration.hours(3)),
+				config: awsSourceConfigForOrganisation({
+					tables: ['aws_s3_*'],
+				}),
+				managedPolicies: [readonlyPolicy],
+				policies: [standardDenyPolicy, cloudqueryAccess('*')],
+			},
 		];
 
 		const selectedAwsTables = awsSources.flatMap(

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -205,6 +205,7 @@ export class CloudQuery extends GuStack {
 			config: awsSourceConfigForOrganisation({
 				tables: ['aws_*'],
 				skipTables: [...skipTables, ...selectedAwsTables],
+				concurrency: 10000,
 			}),
 			managedPolicies: [readonlyPolicy],
 			policies: [standardDenyPolicy, cloudqueryAccess('*')],

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -192,6 +192,17 @@ export class CloudQuery extends GuStack {
 				managedPolicies: [readonlyPolicy],
 				policies: [listOrgsPolicy, standardDenyPolicy, cloudqueryAccess('*')],
 			},
+			{
+				name: 'OrgWideEc2',
+				description: 'Collecting EC2 data across the organisation',
+				schedule: Schedule.rate(Duration.hours(3)),
+				config: awsSourceConfigForOrganisation({
+					tables: ['aws_ec2_*'],
+					skipTables: ['aws_ec2_instance_types'],
+				}),
+				managedPolicies: [readonlyPolicy],
+				policies: [standardDenyPolicy, cloudqueryAccess('*')],
+			},
 		];
 
 		const selectedAwsTables = awsSources.flatMap(

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -124,6 +124,7 @@ export class CloudQuery extends GuStack {
 				}),
 				managedPolicies: [readonlyPolicy],
 				policies: [standardDenyPolicy, cloudqueryAccess('*')],
+				memoryLimitMiB: 2048,
 			},
 			{
 				name: 'DeployToolsListOrgs',

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -211,10 +211,11 @@ export class CloudQuery extends GuStack {
 				schedule: Schedule.rate(Duration.hours(3)),
 				config: awsSourceConfigForOrganisation({
 					tables: ['aws_lambda_*', 'aws_stepfunctions_*'],
-					concurrency: 5000,
+					concurrency: 10000,
 				}),
 				managedPolicies: [readonlyPolicy],
 				policies: [standardDenyPolicy, cloudqueryAccess('*')],
+				memoryLimitMiB: 2048,
 			},
 			{
 				name: 'OrgWideS3',

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -215,7 +215,8 @@ export class CloudQuery extends GuStack {
 				}),
 				managedPolicies: [readonlyPolicy],
 				policies: [standardDenyPolicy, cloudqueryAccess('*')],
-				memoryLimitMiB: 2048,
+				memoryLimitMiB: 3072,
+				cpu: 1024,
 			},
 			{
 				name: 'OrgWideS3',
@@ -246,6 +247,7 @@ export class CloudQuery extends GuStack {
 			managedPolicies: [readonlyPolicy],
 			policies: [standardDenyPolicy, cloudqueryAccess('*')],
 			memoryLimitMiB: 2048,
+			cpu: 1024,
 		};
 
 		const githubCredentials = SecretsManager.fromSecretPartialArn(

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -199,6 +199,7 @@ export class CloudQuery extends GuStack {
 				config: awsSourceConfigForOrganisation({
 					tables: ['aws_ec2_*'],
 					skipTables: ['aws_ec2_instance_types'],
+					concurrency: 10000,
 				}),
 				managedPolicies: [readonlyPolicy],
 				policies: [standardDenyPolicy, cloudqueryAccess('*')],
@@ -210,6 +211,7 @@ export class CloudQuery extends GuStack {
 				schedule: Schedule.rate(Duration.hours(3)),
 				config: awsSourceConfigForOrganisation({
 					tables: ['aws_lambda_*', 'aws_stepfunctions_*'],
+					concurrency: 5000,
 				}),
 				managedPolicies: [readonlyPolicy],
 				policies: [standardDenyPolicy, cloudqueryAccess('*')],
@@ -220,6 +222,7 @@ export class CloudQuery extends GuStack {
 				schedule: Schedule.rate(Duration.hours(3)),
 				config: awsSourceConfigForOrganisation({
 					tables: ['aws_s3_*'],
+					concurrency: 10000,
 				}),
 				managedPolicies: [readonlyPolicy],
 				policies: [standardDenyPolicy, cloudqueryAccess('*')],

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -119,7 +119,7 @@ export class CloudQuery extends GuStack {
 				description: 'Data fetched across all accounts in the organisation.',
 				schedule: Schedule.rate(Duration.days(1)),
 				config: awsSourceConfigForOrganisation({
-					tables: ['*'],
+					tables: ['aws_*'],
 					skipTables: skipTables,
 				}),
 				managedPolicies: [readonlyPolicy],
@@ -340,18 +340,7 @@ export class CloudQuery extends GuStack {
 				description: 'Collecting all Snyk data',
 				schedule: Schedule.rate(Duration.days(1)),
 				config: snykSourceConfig({
-					tables: [
-						'snyk_dependencies',
-						'snyk_groups',
-						'snyk_group_members',
-						'snyk_integrations',
-						'snyk_organizations',
-						'snyk_organization_members',
-						'snyk_organization_provisions',
-						'snyk_projects',
-						'snyk_reporting_issues',
-						'snyk_reporting_latest_issues',
-					],
+					tables: ['snyk_*'],
 				}),
 				secrets: {
 					SNYK_API_KEY: Secret.fromSecretsManager(snykCredentials, 'api-key'),

--- a/packages/cdk/lib/ecs/cluster.ts
+++ b/packages/cdk/lib/ecs/cluster.ts
@@ -56,6 +56,11 @@ export interface CloudquerySource {
 	 * Additional commands to run within the CloudQuery container, executed first.
 	 */
 	additionalCommands?: string[];
+
+	/**
+	 * The amount (in MiB) of memory used by the task.
+	 */
+	memoryLimitMiB?: number;
 }
 
 interface CloudqueryClusterProps extends AppIdentity {
@@ -124,6 +129,7 @@ export class CloudqueryCluster extends Cluster {
 				policies = [],
 				secrets,
 				additionalCommands,
+				memoryLimitMiB,
 			}) => {
 				new ScheduledCloudqueryTask(scope, `CloudquerySource-${name}`, {
 					...taskProps,
@@ -133,6 +139,7 @@ export class CloudqueryCluster extends Cluster {
 					sourceConfig: config,
 					secrets,
 					additionalCommands,
+					memoryLimitMiB,
 				});
 			},
 		);

--- a/packages/cdk/lib/ecs/cluster.ts
+++ b/packages/cdk/lib/ecs/cluster.ts
@@ -60,7 +60,12 @@ export interface CloudquerySource {
 	/**
 	 * The amount (in MiB) of memory used by the task.
 	 */
-	memoryLimitMiB?: number;
+	memoryLimitMiB?: 512 | 1024 | 2048 | 3072 | 4096 | 8192 | 16384 | 32768;
+
+	/**
+	 * The number of cpu units used by the task.
+	 */
+	cpu?: 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384;
 }
 
 interface CloudqueryClusterProps extends AppIdentity {
@@ -130,6 +135,7 @@ export class CloudqueryCluster extends Cluster {
 				secrets,
 				additionalCommands,
 				memoryLimitMiB,
+				cpu,
 			}) => {
 				new ScheduledCloudqueryTask(scope, `CloudquerySource-${name}`, {
 					...taskProps,
@@ -140,6 +146,7 @@ export class CloudqueryCluster extends Cluster {
 					secrets,
 					additionalCommands,
 					memoryLimitMiB,
+					cpu,
 				});
 			},
 		);

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -12,6 +12,7 @@ export type CloudqueryConfig = {
 interface CloudqueryTableConfig {
 	tables?: string[];
 	skipTables?: string[];
+	concurrency?: number;
 }
 
 /**
@@ -37,7 +38,7 @@ export function awsSourceConfig(
 	tableConfig: CloudqueryTableConfig,
 	extraConfig: Record<string, unknown> = {},
 ): CloudqueryConfig {
-	const { tables, skipTables } = tableConfig;
+	const { tables, skipTables, concurrency } = tableConfig;
 
 	if (!tables && !skipTables) {
 		throw new Error('Must specify either tables or skipTables');
@@ -52,6 +53,7 @@ export function awsSourceConfig(
 			tables,
 			skip_tables: skipTables,
 			destinations: ['postgresql'],
+			concurrency,
 			spec: {
 				regions: [
 					// All regions we support.

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -1,7 +1,13 @@
 import { GuardianOrganisationalUnits } from '@guardian/private-infrastructure-config';
 import { Versions } from './versions';
 
-export type CloudqueryConfig = Record<string, unknown>;
+export type CloudqueryConfig = {
+	spec: {
+		tables?: string[];
+		[k: string]: unknown;
+	};
+	[k: string]: unknown;
+};
 
 interface CloudqueryTableConfig {
 	tables?: string[];

--- a/packages/cdk/lib/ecs/task.ts
+++ b/packages/cdk/lib/ecs/task.ts
@@ -102,12 +102,14 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			secrets,
 			additionalCommands = [],
 			memoryLimitMiB,
+			cpu,
 		} = props;
 		const { region, stack, stage } = scope;
 		const thisRepo = 'guardian/service-catalogue'; // TODO get this from GuStack
 
 		const task = new FargateTaskDefinition(scope, `${id}TaskDefinition`, {
 			memoryLimitMiB,
+			cpu,
 		});
 
 		const dbUser = 'cloudquery';

--- a/packages/cdk/lib/ecs/task.ts
+++ b/packages/cdk/lib/ecs/task.ts
@@ -101,11 +101,14 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			enabled,
 			secrets,
 			additionalCommands = [],
+			memoryLimitMiB,
 		} = props;
 		const { region, stack, stage } = scope;
 		const thisRepo = 'guardian/service-catalogue'; // TODO get this from GuStack
 
-		const task = new FargateTaskDefinition(scope, `${id}TaskDefinition`);
+		const task = new FargateTaskDefinition(scope, `${id}TaskDefinition`, {
+			memoryLimitMiB,
+		});
 
 		const dbUser = 'cloudquery';
 		const destinationConfig = postgresDestinationConfig();

--- a/packages/cloudquery/dev-config/cloudquery.yaml
+++ b/packages/cloudquery/dev-config/cloudquery.yaml
@@ -6,7 +6,7 @@ spec:
   version: v${CQ_AWS}
   destinations: ['postgresql']
   tables:
-    - '*'
+    - 'aws_*'
   skip_tables:
     - aws_ec2_vpc_endpoint_services
     - aws_cloudtrail_events
@@ -54,7 +54,7 @@ spec:
   name: 'github'
   path: 'cloudquery/github'
   version: v${CQ_GITHUB}
-  tables: ['*']
+  tables: ['github_*']
   destinations: ['postgresql']
   spec:
     access_token: ${GITHUB_ACCESS_TOKEN}
@@ -77,7 +77,7 @@ spec:
   version: v${CQ_SNYK}
   destinations: ['postgresql']
   tables:
-    - '*'
+    - 'snyk_*'
   spec:
     api_key: ${SNYK_TOKEN}
     table_options:


### PR DESCRIPTION
## What does this change?
The [release notes for the CloudQuery CLI v3.0.0](https://github.com/cloudquery/cloudquery/releases/tag/cli-v3.0.0) states:

> We're making it required as the previous default of ["*"] (all tables) is not suitable for production usage

This might hint to the error seen in #201:

```
failed to load spec(s) from /source.yaml, /destination.yaml. Error: failed to strip yaml comments in file /source.yaml (section 1): yaml: line 7: did not find expected alphabetic or numeric character
```

It looks like the catch-all AWS task is not working, presumably for the same reasons.

Listing all the [individual tables for AWS](https://www.cloudquery.io/docs/plugins/sources/aws/tables) is not maintainable, so use [wildcard matching](https://www.cloudquery.io/docs/advanced-topics/performance-tuning#use-wildcard-matching) instead.

Whilst this did resolve this issue, the task to collect all AWS data was getting terminated by AWS:

```log
Exit code: 1
OutOfMemoryError: Container killed due to memory usage
```

In an attempt to combat this, this change also collects EC2, Lambda, and S3 data in a different task.

We can use the same wildcard technique to simplify the Snyk source too.

## Why?
To ensure we collect all the data we're intending to.

## How has it been verified?
Each table has a `_cq_sync_time` column which we can use to determine when we last collected data for it. For S3 buckets, we can run:

```sql
SELECT max(_cq_sync_time) FROM aws_sqs_queues;
```

Prior to this change, this is `2023-05-22 14:02:42`, demonstrating that we've not collected data in a while (it should be updated daily).

After [deploying](https://riffraff.gutools.co.uk/deployment/view/a1365552-22e5-424a-8082-f33532c6d7f7) this branch, and manually running the all AWS task, this query returns `2023-06-01 22:09:05`, suggesting that we're collecting data again.

## Notes
In an attempt to summarise the state of the world on this branch, here's the configuration of the cluster:

| Tables | Frequency | Concurrency[^1] | Memory[^2] | Duration | Success |
|---|---|---|---|---|---|
| (AWS) Organisations | Daily | Default | Default | 2 | Yes |
| (AWS) Access Analyzer | Daily | Default | Default | 1 | Yes |
| (AWS) CloudFormation | Every 3 hours | Default | Default | 3 | Yes |
| (AWS) EC2 | Every 3 hours | 10000 | Default | 12 | Yes |
| (AWS) Lambda and Step Functions | Every 3 hours | 10000 | 2048 | 25 | No.[^3] |
| (AWS) S3 | Every 3 hours | 10000 | Default | 3 | Yes |
| (AWS) Everything else | Daily | 10000 | 2048 | 61 | No.[^4] |
| (GitHub) Repositories | Daily | Default | Default | 15 | Ish.[^5] |
| (GitHub) Teams (inc. members & repositories) | Weekly | Default | Default | 2 | Ish.[^5] |
| (Fastly) Services | Daily | Default | Default | 1 | Yes |
| (Galaxies) All | Daily | Default | Default | 1 | Yes |
| (Snyk) All | Daily | Default | Default | 9 | Yes |

[^1]: The default value is 500000. See https://www.cloudquery.io/docs/reference/source-spec#concurrency.
[^2]: The default value is 512MB.
[^3]: This is being terminated due to OOM issues.
[^4]: This isn't being terminated due to memory issues, I suspect there's a hard limit somewhere.
[^5]: We see GH API rate limiting.