### PR TITLE
ci: Bump guardian/actions-read-private-repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           distribution: 'corretto'
           cache: 'sbt'
 
-      - uses: guardian/actions-read-private-repos@v0.1.0
+      - uses: guardian/actions-read-private-repos@v0.1.1
         with:
           private-ssh-keys: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
 


### PR DESCRIPTION
## What does this change?
Update to remove some deprecation warnings on the version of Node being used. See https://github.com/guardian/actions-read-private-repos/pull/7.

## How has it been verified?
Observe CI. On `main` we see the following warning:

![image](https://github.com/guardian/service-catalogue/assets/836140/f858dd39-9fe3-45ca-9c1e-c538a73afcce)

On this branch, the warning is removed.