### PR TITLE
fix: Run GitHub team task once

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -2974,7 +2974,7 @@ spec:
     },
     "CloudquerySourceGitHubTeamsScheduledEventRule051F542B": {
       "Properties": {
-        "ScheduleExpression": "cron(* * ? * 1 *)",
+        "ScheduleExpression": "cron(0 10 ? * 1 *)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -246,7 +246,7 @@ export class CloudQuery extends GuStack {
 			{
 				name: 'GitHubTeams',
 				description: 'Collect GitHub team data',
-				schedule: Schedule.cron({ weekDay: '1' }),
+				schedule: Schedule.cron({ weekDay: '1', hour: '10', minute: '0' }),
 				config: githubSourceConfig({
 					tables: [
 						'github_teams',


### PR DESCRIPTION
## What does this change?
The cron expression `cron(* * ? * 1 *)` evaluates to "run every minute on the first day of the week"! That's a little too much. Indeed `cdk synth` on `main` produces this warning:

```
[Warning at /CloudQuery-INFRA/CloudquerySource-GitHubTeams/ScheduledEventRule] cron: If you don't pass 'minute', by default the event runs every minute. Pass 'minute: '*'' if that's what you intend, or 'minute: 0' to run once per hour instead.
```

Use `cron(0 10 ? * 1 *)` instead, which is "run at 10AM on the first day of the week".

## Why?
The GitHub API is rate limited. Let's not guarantee our violation of that rate limit!

## How has it been verified?
I've used https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html to understand the cron syntax.