### PR TITLE
fix: Skip GitHub tables that we do not (yet) need

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -2439,6 +2439,11 @@ spec:
   version: v5.2.0
   tables:
     - github_repositories
+  skip_tables:
+    - github_releases
+    - github_release_assets
+    - github_repository_branches
+    - github_repository_dependabot_secrets
   destinations:
     - postgresql
   concurrency: 1000

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -239,7 +239,18 @@ export class CloudQuery extends GuStack {
 				name: 'GitHubRepositories',
 				description: 'Collect GitHub repository data',
 				schedule: Schedule.rate(Duration.days(1)),
-				config: githubSourceConfig({ tables: ['github_repositories'] }),
+				config: githubSourceConfig({
+					tables: ['github_repositories'],
+
+					// We're not (yet) interested in the following tables, so do not collect them to reduce API quota usage.
+					// See https://www.cloudquery.io/docs/advanced-topics/performance-tuning#improve-performance-by-skipping-relations
+					skipTables: [
+						'github_releases',
+						'github_release_assets',
+						'github_repository_branches',
+						'github_repository_dependabot_secrets',
+					],
+				}),
 				secrets: githubSecrets,
 				additionalCommands: additionalGithubCommands,
 			},


### PR DESCRIPTION
## What does this change?
This is an attempt to reduce the number of requests made to the GitHub API as we're experiencing some rate limiting. [CloudQuery's docs](https://www.cloudquery.io/docs/advanced-topics/performance-tuning#improve-performance-by-skipping-relations) describe the default behaviour of CloudQuery is to collect data of dependant tables, and one needs to add them to `skip_tables` to change this.

The [`github_repositories` table](https://www.cloudquery.io/docs/plugins/sources/github/tables/github_repositories) has a few dependants that we're not (yet) interested in, so we can skip them.

Additionally, the credentials we're using are not scoped to some of these tables, which is resulting in the following errors in the logs:

```log
GET https://api.github.com/repos/guardian/interactive-atom-paygap-calendar/dependabot/secrets: 403 Resource not accessible by integration []
```

That is we're making redundant GitHub API calls that are eating into the quota. Skipping them should improve here.

## How has it been verified?
I've [deployed this](https://riffraff.gutools.co.uk/deployment/view/fa8cb9da-2f2b-4a18-b892-49d2d7a968f3), manually run the task, and observed the volume of errors in the logs fall, which suggests the requests being made is reduced.