### PR TITLE
fix: Collect Security Hub data once

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -629,6 +629,567 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
+    "CloudquerySourceDelegatedToSecurityAccountScheduledEventRuleC7320B4E": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 day)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "cloudqueryCluster5370C11B",
+                "Arn",
+              ],
+            },
+            "EcsParameters": {
+              "LaunchType": "FARGATE",
+              "NetworkConfiguration": {
+                "AwsVpcConfiguration": {
+                  "AssignPublicIp": "DISABLED",
+                  "SecurityGroups": [
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "GroupId",
+                      ],
+                    },
+                  ],
+                  "Subnets": {
+                    "Ref": "PrivateSubnets",
+                  },
+                },
+              },
+              "TaskCount": 1,
+              "TaskDefinitionArn": {
+                "Ref": "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionD407788D",
+              },
+            },
+            "Id": "Target0",
+            "Input": "{}",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionEventsRoleA78E8779",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionCloudquerySourceDelegatedToSecurityAccountFirelensLogGroupEC2CB8DA": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionD407788D": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/bash",
+              "-c",
+              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Environment": [
+              {
+                "Name": "DB_HOST",
+                "Value": {
+                  "Fn::GetAtt": [
+                    "PostgresInstance16DE4286E",
+                    "Endpoint.Address",
+                  ],
+                },
+              },
+            ],
+            "Essential": false,
+            "Image": "public.ecr.aws/aws-cli/aws-cli",
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": false,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-DelegatedToSecurityAccountAwsCli",
+          },
+          {
+            "Command": [
+              "/bin/sh",
+              "-c",
+              "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+spec:
+  name: aws
+  path: cloudquery/aws
+  version: v17.4.0
+  tables:
+    - aws_accessanalyzer_*
+    - aws_securityhub_*
+  destinations:
+    - postgresql
+  spec:
+    regions:
+      - eu-west-1
+      - eu-west-2
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - ap-southeast-2
+      - ca-central-1
+    accounts:
+      - id: cq-for-000000000015
+        role_arn: arn:aws:iam::000000000015:role/cloudquery-access
+' > /source.yaml;printf 'kind: destination
+spec:
+  name: postgresql
+  registry: github
+  path: cloudquery/postgresql
+  version: v4.2.0
+  migrate_mode: forced
+  spec:
+    connection_string: \${file:/var/scratch/connection_string}
+' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "SUCCESS",
+                "ContainerName": "CloudquerySource-DelegatedToSecurityAccountAwsCli",
+              },
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Essential": true,
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": true,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-DelegatedToSecurityAccountContainer",
+          },
+          {
+            "Environment": [
+              {
+                "Name": "STACK",
+                "Value": "deploy",
+              },
+              {
+                "Name": "STAGE",
+                "Value": "TEST",
+              },
+              {
+                "Name": "APP",
+                "Value": "cloudquery",
+              },
+              {
+                "Name": "GU_REPO",
+                "Value": "guardian/service-catalogue",
+              },
+            ],
+            "Essential": true,
+            "FirelensConfiguration": {
+              "Options": {
+                "config-file-type": "file",
+                "config-file-value": "/custom.conf",
+                "enable-ecs-log-metadata": "true",
+              },
+              "Type": "fluentbit",
+            },
+            "Image": "ghcr.io/guardian/hackday-firelens:main",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionCloudquerySourceDelegatedToSecurityAccountFirelensLogGroupEC2CB8DA",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+              },
+            },
+            "Name": "CloudquerySource-DelegatedToSecurityAccountFirelens",
+          },
+        ],
+        "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionExecutionRole40841493",
+            "Arn",
+          ],
+        },
+        "Family": "CloudQueryCloudquerySourceDelegatedToSecurityAccountTaskDefinitionD7565E6C",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionTaskRole95A21336",
+            "Arn",
+          ],
+        },
+        "Volumes": [
+          {
+            "Host": {},
+            "Name": "scratch",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionEventsRoleA78E8779": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionEventsRoleDefaultPolicy54F7B08B": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ecs:RunTask",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": {
+                    "Fn::GetAtt": [
+                      "cloudqueryCluster5370C11B",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionD407788D",
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionExecutionRole40841493",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionTaskRole95A21336",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionEventsRoleDefaultPolicy54F7B08B",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionEventsRoleA78E8779",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionExecutionRole40841493": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionExecutionRoleDefaultPolicy7CA81E4D": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionCloudquerySourceDelegatedToSecurityAccountFirelensLogGroupEC2CB8DA",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionExecutionRoleDefaultPolicy7CA81E4D",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionExecutionRole40841493",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionTaskRole95A21336": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionTaskRoleDefaultPolicy953F3BDF": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":kinesis:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "cloudformation:GetTemplate",
+                "dynamodb:GetItem",
+                "dynamodb:BatchGetItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "ec2:GetConsoleOutput",
+                "ec2:GetConsoleScreenshot",
+                "ecr:BatchGetImage",
+                "ecr:GetAuthorizationToken",
+                "ecr:GetDownloadUrlForLayer",
+                "kinesis:Get*",
+                "lambda:GetFunction",
+                "logs:GetLogEvents",
+                "sdb:Select*",
+                "sqs:ReceiveMessage",
+              ],
+              "Effect": "Deny",
+              "Resource": "*",
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": "arn:aws:iam::000000000015:role/cloudquery-access",
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/cloudquery",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionTaskRoleDefaultPolicy953F3BDF",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionTaskRole95A21336",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "CloudquerySourceDeployToolsListOrgsScheduledEventRuleDF9BD8AF": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",
@@ -7009,568 +7570,6 @@ spec:
         "Roles": [
           {
             "Ref": "CloudquerySourceOrgWideLoadBalancersTaskDefinitionTaskRoleABB2ABAD",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CloudquerySourceSecurityAccessAnalyserScheduledEventRuleF5D02F1B": {
-      "Properties": {
-        "ScheduleExpression": "rate(1 day)",
-        "State": "ENABLED",
-        "Targets": [
-          {
-            "Arn": {
-              "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
-                "Arn",
-              ],
-            },
-            "EcsParameters": {
-              "LaunchType": "FARGATE",
-              "NetworkConfiguration": {
-                "AwsVpcConfiguration": {
-                  "AssignPublicIp": "DISABLED",
-                  "SecurityGroups": [
-                    {
-                      "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
-                        "GroupId",
-                      ],
-                    },
-                  ],
-                  "Subnets": {
-                    "Ref": "PrivateSubnets",
-                  },
-                },
-              },
-              "TaskCount": 1,
-              "TaskDefinitionArn": {
-                "Ref": "CloudquerySourceSecurityAccessAnalyserTaskDefinitionEEA17FBA",
-              },
-            },
-            "Id": "Target0",
-            "Input": "{}",
-            "RoleArn": {
-              "Fn::GetAtt": [
-                "CloudquerySourceSecurityAccessAnalyserTaskDefinitionEventsRole9378F427",
-                "Arn",
-              ],
-            },
-          },
-        ],
-      },
-      "Type": "AWS::Events::Rule",
-    },
-    "CloudquerySourceSecurityAccessAnalyserTaskDefinitionCloudquerySourceSecurityAccessAnalyserFirelensLogGroup5B3FE9C1": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "RetentionInDays": 1,
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "CloudquerySourceSecurityAccessAnalyserTaskDefinitionEEA17FBA": {
-      "Properties": {
-        "ContainerDefinitions": [
-          {
-            "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-SecurityAccessAnalyserAwsCli",
-          },
-          {
-            "Command": [
-              "/bin/sh",
-              "-c",
-              "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
-spec:
-  name: aws
-  path: cloudquery/aws
-  version: v17.4.0
-  tables:
-    - aws_accessanalyzer_analyzers
-    - aws_accessanalyzer_analyzer_archive_rules
-    - aws_accessanalyzer_analyzer_findings
-  destinations:
-    - postgresql
-  spec:
-    regions:
-      - eu-west-1
-      - eu-west-2
-      - us-east-1
-      - us-east-2
-      - us-west-1
-      - ap-southeast-2
-      - ca-central-1
-    accounts:
-      - id: cq-for-000000000015
-        role_arn: arn:aws:iam::000000000015:role/cloudquery-access
-' > /source.yaml;printf 'kind: destination
-spec:
-  name: postgresql
-  registry: github
-  path: cloudquery/postgresql
-  version: v4.2.0
-  migrate_mode: forced
-  spec:
-    connection_string: \${file:/var/scratch/connection_string}
-' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-SecurityAccessAnalyserAwsCli",
-              },
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
-            "LogConfiguration": {
-              "LogDriver": "awsfirelens",
-              "Options": {
-                "Name": "kinesis_streams",
-                "region": {
-                  "Ref": "AWS::Region",
-                },
-                "retry_limit": "2",
-                "stream": {
-                  "Ref": "LoggingStreamName",
-                },
-              },
-            },
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-SecurityAccessAnalyserContainer",
-          },
-          {
-            "Environment": [
-              {
-                "Name": "STACK",
-                "Value": "deploy",
-              },
-              {
-                "Name": "STAGE",
-                "Value": "TEST",
-              },
-              {
-                "Name": "APP",
-                "Value": "cloudquery",
-              },
-              {
-                "Name": "GU_REPO",
-                "Value": "guardian/service-catalogue",
-              },
-            ],
-            "Essential": true,
-            "FirelensConfiguration": {
-              "Options": {
-                "config-file-type": "file",
-                "config-file-value": "/custom.conf",
-                "enable-ecs-log-metadata": "true",
-              },
-              "Type": "fluentbit",
-            },
-            "Image": "ghcr.io/guardian/hackday-firelens:main",
-            "LogConfiguration": {
-              "LogDriver": "awslogs",
-              "Options": {
-                "awslogs-group": {
-                  "Ref": "CloudquerySourceSecurityAccessAnalyserTaskDefinitionCloudquerySourceSecurityAccessAnalyserFirelensLogGroup5B3FE9C1",
-                },
-                "awslogs-region": {
-                  "Ref": "AWS::Region",
-                },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
-              },
-            },
-            "Name": "CloudquerySource-SecurityAccessAnalyserFirelens",
-          },
-        ],
-        "Cpu": "256",
-        "ExecutionRoleArn": {
-          "Fn::GetAtt": [
-            "CloudquerySourceSecurityAccessAnalyserTaskDefinitionExecutionRole3D443B15",
-            "Arn",
-          ],
-        },
-        "Family": "CloudQueryCloudquerySourceSecurityAccessAnalyserTaskDefinitionA7A5AECB",
-        "Memory": "512",
-        "NetworkMode": "awsvpc",
-        "RequiresCompatibilities": [
-          "FARGATE",
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "TaskRoleArn": {
-          "Fn::GetAtt": [
-            "CloudquerySourceSecurityAccessAnalyserTaskDefinitionTaskRole8B920EA4",
-            "Arn",
-          ],
-        },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
-      },
-      "Type": "AWS::ECS::TaskDefinition",
-    },
-    "CloudquerySourceSecurityAccessAnalyserTaskDefinitionEventsRole9378F427": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "events.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CloudquerySourceSecurityAccessAnalyserTaskDefinitionEventsRoleDefaultPolicy0FE84DC4": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "ecs:RunTask",
-              "Condition": {
-                "ArnEquals": {
-                  "ecs:cluster": {
-                    "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
-                      "Arn",
-                    ],
-                  },
-                },
-              },
-              "Effect": "Allow",
-              "Resource": {
-                "Ref": "CloudquerySourceSecurityAccessAnalyserTaskDefinitionEEA17FBA",
-              },
-            },
-            {
-              "Action": "iam:PassRole",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "CloudquerySourceSecurityAccessAnalyserTaskDefinitionExecutionRole3D443B15",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": "iam:PassRole",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "CloudquerySourceSecurityAccessAnalyserTaskDefinitionTaskRole8B920EA4",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CloudquerySourceSecurityAccessAnalyserTaskDefinitionEventsRoleDefaultPolicy0FE84DC4",
-        "Roles": [
-          {
-            "Ref": "CloudquerySourceSecurityAccessAnalyserTaskDefinitionEventsRole9378F427",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CloudquerySourceSecurityAccessAnalyserTaskDefinitionExecutionRole3D443B15": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "ecs-tasks.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CloudquerySourceSecurityAccessAnalyserTaskDefinitionExecutionRoleDefaultPolicy4CB6BB83": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "CloudquerySourceSecurityAccessAnalyserTaskDefinitionCloudquerySourceSecurityAccessAnalyserFirelensLogGroup5B3FE9C1",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CloudquerySourceSecurityAccessAnalyserTaskDefinitionExecutionRoleDefaultPolicy4CB6BB83",
-        "Roles": [
-          {
-            "Ref": "CloudquerySourceSecurityAccessAnalyserTaskDefinitionExecutionRole3D443B15",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CloudquerySourceSecurityAccessAnalyserTaskDefinitionTaskRole8B920EA4": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "ecs-tasks.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CloudquerySourceSecurityAccessAnalyserTaskDefinitionTaskRoleDefaultPolicyE507D9C0": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "kinesis:Describe*",
-                "kinesis:Put*",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":kinesis:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":stream/",
-                    {
-                      "Ref": "LoggingStreamName",
-                    },
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "cloudformation:GetTemplate",
-                "dynamodb:GetItem",
-                "dynamodb:BatchGetItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "ec2:GetConsoleOutput",
-                "ec2:GetConsoleScreenshot",
-                "ecr:BatchGetImage",
-                "ecr:GetAuthorizationToken",
-                "ecr:GetDownloadUrlForLayer",
-                "kinesis:Get*",
-                "lambda:GetFunction",
-                "logs:GetLogEvents",
-                "sdb:Select*",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Deny",
-              "Resource": "*",
-            },
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Resource": "arn:aws:iam::000000000015:role/cloudquery-access",
-            },
-            {
-              "Action": "rds-db:connect",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":rds-db:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":dbuser:",
-                    {
-                      "Fn::GetAtt": [
-                        "PostgresInstance16DE4286E",
-                        "DbiResourceId",
-                      ],
-                    },
-                    "/cloudquery",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CloudquerySourceSecurityAccessAnalyserTaskDefinitionTaskRoleDefaultPolicyE507D9C0",
-        "Roles": [
-          {
-            "Ref": "CloudquerySourceSecurityAccessAnalyserTaskDefinitionTaskRole8B920EA4",
           },
         ],
       },

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -167,16 +167,12 @@ export class CloudQuery extends GuStack {
 				],
 			},
 			{
-				name: 'SecurityAccessAnalyser',
+				name: 'DelegatedToSecurityAccount',
 				description:
-					'Data fetched from the Security account. Note, Access Analyzer collects data from our entire organisation so we only need to query it in one place.',
+					'Collecting data across the organisation from services delegated to the Security account.',
 				schedule: Schedule.rate(Duration.days(1)),
 				config: awsSourceConfigForAccount(GuardianAwsAccounts.Security, {
-					tables: [
-						'aws_accessanalyzer_analyzers',
-						'aws_accessanalyzer_analyzer_archive_rules',
-						'aws_accessanalyzer_analyzer_findings',
-					],
+					tables: ['aws_accessanalyzer_*', 'aws_securityhub_*'],
 				}),
 				managedPolicies: [readonlyPolicy],
 				policies: [


### PR DESCRIPTION
## What does this change?
We've setup Security Hub (SH) as a delegated service in the Security account. This means the Security account can see SH results for all accounts, and we do not need to collect the data again from each member account.

## Why?
Avoids duplicated data, which inflates numbers.

## How has it been verified?
I've manually deployed, and run this task. Using Grafana, we can observe the database is being updated, however the task is also being terminated by AWS after ~61 minutes. This behaviour is similar to that observed in #203. I cannot find anything to suggest this duration is configurable, will raise a support ticket with AWS.

The data we do have indicates there might be some optimisation we can do regarding `ARCHIVED` findings. If we remove these, would it take less time to collect the data?

```sql
select      ac.name
            , shf.record_state
            , count(shf.id)
from        aws_securityhub_findings shf
            left join   aws_accounts ac
            on          ac.id = shf.aws_account_id
group by    ac.name
            , shf.record_state
order by    count(shf.id) desc;
```

| name | record_state | count |
|---|---|---|
| Frontend | ARCHIVED | 134181 |
| Guardian Mobile Team | ARCHIVED | 43245 |
| Guardian Developer Playground | ARCHIVED | 43109 |
| Deploy Tools | ARCHIVED | 43099 |
| Aws-Investigations | ARCHIVED | 24380 |
| Composer | ARCHIVED | 23167 |
| Guardian AWS Membership | ARCHIVED | 20540 |
| Media-API-GNM | ARCHIVED | 19056 |
| Guardian Content API | ARCHIVED | 11405 |
| gnm-multimedia | ARCHIVED | 9912 |
| Guardian Identity | ARCHIVED | 7720 |
| Composer | ACTIVE | 6022 |
| CMS Workflow | ARCHIVED | 4260 |
| Guardian AWS Membership | ACTIVE | 3765 |
| guardian discussion team | ARCHIVED | 3485 |
| Guardian Content API | ACTIVE | 3465 |
| Frontend | ACTIVE | 3424 |
| Aws-Investigations | ACTIVE | 3303 |
| Media-API-GNM | ACTIVE | 2866 |
| Guardian Mobile Team | ACTIVE | 2809 |
| Deploy Tools | ACTIVE | 2804 |
| CMS Fronts | ARCHIVED | 2543 |
| Guardian Developer Playground | ACTIVE | 2475 |
| aws-baton | ARCHIVED | 1574 |
| guardian discussion team | ACTIVE | 1565 |
| gnm-multimedia | ACTIVE | 1538 |
| Guardian Identity | ACTIVE | 1530 |
| Guardian Security | ARCHIVED | 1412 |
| CMS Workflow | ACTIVE | 1139 |
| Infrastructure AWS Services | ACTIVE | 1095 |
| Guardian Security | ACTIVE | 985 |
| GNM InfoSec | ACTIVE | 888 |
| CMS Fronts | ACTIVE | 770 |
| Ophan | ACTIVE | 699 |
| aws-targeting | ACTIVE | 571 |
| GNM InfoSec | ARCHIVED | 497 |
| Guardian Websys General PROD | ACTIVE | 486 |
| aws-baton | ACTIVE | 444 |
| aws-data-tech | ACTIVE | 396 |
| aws-domains | ACTIVE | 360 |
| aws-domains | ARCHIVED | 347 |
| Guardian Websys General DEV | ACTIVE | 312 |
| Infrastructure AWS Services | ARCHIVED | 233 |
| aws-targeting | ARCHIVED | 94 |
| Guardian Websys General PROD | ARCHIVED | 60 |
| aws-data-tech | ARCHIVED | 56 |
| Guardian Websys General DEV | ARCHIVED | 53 |
| Guardian Digital Interactives PROD | ACTIVE | 42 |
| Ophan | ARCHIVED | 36 |
| Secure Collaboration | ACTIVE | 18 |
| editorial-feeds | ACTIVE | 17 |
| Personalisation | ACTIVE | 17 |
| Guardian US Interactives | ACTIVE | 2 |
| Editorial Systems Development | ACTIVE | 2 |
| Data Science Team | ACTIVE | 2 |
| Guardian ESD | ACTIVE | 1 |
| Guardian Network Team | ACTIVE | 1 |
| Guardian Print Sites | ACTIVE | 1 |
| Guardian GLABS | ACTIVE | 1 |