### PR TITLE
fix(cloudquery): Remove `aws_inspector_findings` table

### DIFF
--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -218,7 +218,7 @@ export class CloudQuery extends GuStack {
 				description: 'Collecting Inspector data across the organisation.',
 				schedule: Schedule.rate(Duration.days(1)),
 				config: awsSourceConfigForOrganisation({
-					tables: ['aws_inspector_findings', 'aws_inspector2_findings'],
+					tables: ['aws_inspector2_findings'],
 				}),
 				managedPolicies: [readonlyPolicy],
 				policies: [listOrgsPolicy, standardDenyPolicy, cloudqueryAccess('*')],


### PR DESCRIPTION
## What does this change?

Removes the `aws_inspector_findings` from the `OrgWideInspector` in Cloudquery. We found in testing that the `aws_inspector2_findings` were sufficient. This avoids duplication.


