### PR TITLE
Use custom plugin to fetch snyk projects

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -3721,7 +3721,7 @@ spec:
 spec:
   name: guardian-snyk
   path: guardian/snyk-full-project
-  version: v0.1.0
+  version: v0.1.1
   tables:
     - snyk_projects
   destinations:

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -3719,18 +3719,15 @@ spec:
               "-c",
               "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
 spec:
-  name: snyk
+  name: guardian-snyk
   path: guardian/snyk-full-project
-  version: v3.0.0
+  version: v0.1.0
   tables:
     - snyk_projects
   destinations:
     - postgresql
   spec:
     api_key: \${SNYK_API_KEY}
-    table_options:
-      snyk_reporting_issues:
-        period: 30d
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -3605,6 +3605,582 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
+    "CloudquerySourceGuardianCustomSnykProjectsScheduledEventRule92FBDA90": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 day)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "cloudqueryCluster5370C11B",
+                "Arn",
+              ],
+            },
+            "EcsParameters": {
+              "LaunchType": "FARGATE",
+              "NetworkConfiguration": {
+                "AwsVpcConfiguration": {
+                  "AssignPublicIp": "DISABLED",
+                  "SecurityGroups": [
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "GroupId",
+                      ],
+                    },
+                  ],
+                  "Subnets": {
+                    "Ref": "PrivateSubnets",
+                  },
+                },
+              },
+              "TaskCount": 1,
+              "TaskDefinitionArn": {
+                "Ref": "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionEB2B4EBC",
+              },
+            },
+            "Id": "Target0",
+            "Input": "{}",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionEventsRoleAA974CCE",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionCloudquerySourceGuardianCustomSnykProjectsFirelensLogGroup405A0620": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionEB2B4EBC": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/bash",
+              "-c",
+              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Environment": [
+              {
+                "Name": "DB_HOST",
+                "Value": {
+                  "Fn::GetAtt": [
+                    "PostgresInstance16DE4286E",
+                    "Endpoint.Address",
+                  ],
+                },
+              },
+            ],
+            "Essential": false,
+            "Image": "public.ecr.aws/aws-cli/aws-cli",
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": false,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-GuardianCustomSnykProjectsAwsCli",
+          },
+          {
+            "Command": [
+              "/bin/sh",
+              "-c",
+              "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+spec:
+  name: snyk
+  path: guardian/snyk-full-project
+  version: v3.0.0
+  tables:
+    - snyk_projects
+  destinations:
+    - postgresql
+  spec:
+    api_key: \${SNYK_API_KEY}
+    table_options:
+      snyk_reporting_issues:
+        period: 30d
+' > /source.yaml;printf 'kind: destination
+spec:
+  name: postgresql
+  registry: github
+  path: cloudquery/postgresql
+  version: v4.2.0
+  migrate_mode: forced
+  spec:
+    connection_string: \${file:/var/scratch/connection_string}
+' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "SUCCESS",
+                "ContainerName": "CloudquerySource-GuardianCustomSnykProjectsAwsCli",
+              },
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Essential": true,
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/var/scratch",
+                "ReadOnly": true,
+                "SourceVolume": "scratch",
+              },
+            ],
+            "Name": "CloudquerySource-GuardianCustomSnykProjectsContainer",
+            "Secrets": [
+              {
+                "Name": "SNYK_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":secretsmanager:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":secret:/TEST/deploy/cloudquery/snyk-credentials:api-key::",
+                    ],
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            "Environment": [
+              {
+                "Name": "STACK",
+                "Value": "deploy",
+              },
+              {
+                "Name": "STAGE",
+                "Value": "TEST",
+              },
+              {
+                "Name": "APP",
+                "Value": "cloudquery",
+              },
+              {
+                "Name": "GU_REPO",
+                "Value": "guardian/service-catalogue",
+              },
+            ],
+            "Essential": true,
+            "FirelensConfiguration": {
+              "Options": {
+                "config-file-type": "file",
+                "config-file-value": "/custom.conf",
+                "enable-ecs-log-metadata": "true",
+              },
+              "Type": "fluentbit",
+            },
+            "Image": "ghcr.io/guardian/hackday-firelens:main",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionCloudquerySourceGuardianCustomSnykProjectsFirelensLogGroup405A0620",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+              },
+            },
+            "Name": "CloudquerySource-GuardianCustomSnykProjectsFirelens",
+          },
+        ],
+        "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionExecutionRole4E86EDCB",
+            "Arn",
+          ],
+        },
+        "Family": "CloudQueryCloudquerySourceGuardianCustomSnykProjectsTaskDefinition0C269E5A",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionTaskRole4DF228BD",
+            "Arn",
+          ],
+        },
+        "Volumes": [
+          {
+            "Host": {},
+            "Name": "scratch",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionEventsRoleAA974CCE": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionEventsRoleDefaultPolicyDD853C3A": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ecs:RunTask",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": {
+                    "Fn::GetAtt": [
+                      "cloudqueryCluster5370C11B",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionEB2B4EBC",
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionExecutionRole4E86EDCB",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionTaskRole4DF228BD",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionEventsRoleDefaultPolicyDD853C3A",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionEventsRoleAA974CCE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionExecutionRole4E86EDCB": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionExecutionRoleDefaultPolicy3946861E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:/TEST/deploy/cloudquery/snyk-credentials-??????",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionCloudquerySourceGuardianCustomSnykProjectsFirelensLogGroup405A0620",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionExecutionRoleDefaultPolicy3946861E",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionExecutionRole4E86EDCB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionTaskRole4DF228BD": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionTaskRoleDefaultPolicy3CBF47E9": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":kinesis:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/cloudquery",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionTaskRoleDefaultPolicy3CBF47E9",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionTaskRole4DF228BD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "CloudquerySourceOrgWideCertificatesScheduledEventRule2D4505F4": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",
@@ -7101,7 +7677,6 @@ spec:
     - snyk_organizations
     - snyk_organization_members
     - snyk_organization_provisions
-    - snyk_projects
     - snyk_reporting_issues
     - snyk_reporting_latest_issues
   destinations:

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -33,6 +33,7 @@ import {
 	fastlySourceConfig,
 	galaxiesSourceConfig,
 	githubSourceConfig,
+	guardianSnykSourceConfig,
 	skipTables,
 	snykSourceConfig,
 } from './ecs/config';
@@ -43,7 +44,6 @@ import {
 	readonlyAccessManagedPolicy,
 	standardDenyPolicy,
 } from './ecs/policies';
-import { Versions } from './ecs/versions';
 
 export class CloudQuery extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
@@ -393,13 +393,9 @@ export class CloudQuery extends GuStack {
 				description:
 					'Collecting Snyk projects including grouped vulnerabilities and tags',
 				schedule: Schedule.rate(Duration.days(1)),
-				config: snykSourceConfig(
-					{
-						tables: ['snyk_projects'],
-					},
-					'guardian/snyk-full-project',
-					`v${Versions.CloudquerySnyk}`,
-				),
+				config: guardianSnykSourceConfig({
+					tables: ['snyk_projects'],
+				}),
 				secrets: {
 					SNYK_API_KEY: Secret.fromSecretsManager(snykCredentials, 'api-key'),
 				},

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -198,6 +198,8 @@ export function galaxiesSourceConfig(bucketName: string): CloudqueryConfig {
 
 export function snykSourceConfig(
 	tableConfig: CloudqueryTableConfig,
+	path = 'cloudquery/snyk',
+	version = `v${Versions.CloudquerySnyk}`,
 ): CloudqueryConfig {
 	const { tables, skipTables } = tableConfig;
 
@@ -209,8 +211,8 @@ export function snykSourceConfig(
 		kind: 'source',
 		spec: {
 			name: 'snyk',
-			path: 'cloudquery/snyk',
-			version: `v${Versions.CloudquerySnyk}`,
+			path,
+			version,
 			tables,
 			skip_tables: skipTables,
 			destinations: ['postgresql'],

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -198,8 +198,6 @@ export function galaxiesSourceConfig(bucketName: string): CloudqueryConfig {
 
 export function snykSourceConfig(
 	tableConfig: CloudqueryTableConfig,
-	path = 'cloudquery/snyk',
-	version = `v${Versions.CloudquerySnyk}`,
 ): CloudqueryConfig {
 	const { tables, skipTables } = tableConfig;
 
@@ -211,8 +209,8 @@ export function snykSourceConfig(
 		kind: 'source',
 		spec: {
 			name: 'snyk',
-			path,
-			version,
+			path: 'cloudquery/snyk',
+			version: `v${Versions.CloudquerySnyk}`,
 			tables,
 			skip_tables: skipTables,
 			destinations: ['postgresql'],

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -228,6 +228,31 @@ export function snykSourceConfig(
 	};
 }
 
+export function guardianSnykSourceConfig(
+	tableConfig: CloudqueryTableConfig,
+): CloudqueryConfig {
+	const { tables, skipTables } = tableConfig;
+
+	if (!tables && !skipTables) {
+		throw new Error('Must specify either tables or skipTables');
+	}
+
+	return {
+		kind: 'source',
+		spec: {
+			name: 'guardian-snyk',
+			path: 'guardian/snyk-full-project',
+			version: `v${Versions.CloudquerySnykGuardian}`,
+			tables,
+			skip_tables: skipTables,
+			destinations: ['postgresql'],
+			spec: {
+				api_key: '${SNYK_API_KEY}',
+			},
+		},
+	};
+}
+
 // Tables we are skipping because they are slow and or uninteresting to us.
 export const skipTables = [
 	'aws_ec2_vpc_endpoint_services', // this resource includes services that are available from AWS as well as other AWS Accounts

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -48,8 +48,8 @@ export const Versions = {
 	 */
 	CloudquerySnyk: '3.0.0',
 
-	/** 
-  	 * The version of the CloudQuery Snyk source plugin to install.
+	/**
+	 * The version of the CloudQuery Snyk source plugin to install.
 	 *
 	 * @see https://github.com/guardian/cq-source-snyk-full-project
 	 */

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -47,4 +47,6 @@ export const Versions = {
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-snyk
 	 */
 	CloudquerySnyk: '3.0.0',
+
+	CloudquerySnykGuardian: '0.1.0',
 };

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -48,5 +48,5 @@ export const Versions = {
 	 */
 	CloudquerySnyk: '3.0.0',
 
-	CloudquerySnykGuardian: '0.1.0',
+	CloudquerySnykGuardian: '0.1.1',
 };

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -48,5 +48,10 @@ export const Versions = {
 	 */
 	CloudquerySnyk: '3.0.0',
 
+	/** 
+  	 * The version of the CloudQuery Snyk source plugin to install.
+	 *
+	 * @see https://github.com/guardian/cq-source-snyk-full-project
+	 */
 	CloudquerySnykGuardian: '0.1.1',
 };

--- a/packages/cloudquery/dev-config/cloudquery.yaml
+++ b/packages/cloudquery/dev-config/cloudquery.yaml
@@ -77,12 +77,33 @@ spec:
   version: v${CQ_SNYK}
   destinations: ['postgresql']
   tables:
-    - '*'
+    - snyk_dependencies
+    - snyk_groups
+    - snyk_group_members
+    - snyk_integrations
+    - snyk_organizations
+    - snyk_organization_members
+    - snyk_organization_provisions
+    - snyk_reporting_issues
+    - snyk_reporting_latest_issues
   spec:
     api_key: ${SNYK_TOKEN}
     table_options:
       snyk_reporting_issues:
         period: 30d
+---
+kind: source
+spec:
+  name: 'guardian-snyk'
+  # https://github.com/guardian/cq-source-snyk-full-project
+  path: guardian/snyk-full-project
+  version: v0.1.1
+  tables:
+    - snyk_projects
+  destinations:
+    - postgresql
+  spec:
+    api_key: ${SNYK_TOKEN}
 ---
 kind: destination
 spec:


### PR DESCRIPTION
## What does this change?

Add [custom snyk plugin](https://github.com/guardian/cq-source-snyk-full-project) as a cloudquery source. This means we are now able to pull project tags and the aggregated issues, grouped by severity.

## Why?

This PR means we are more easily able to join Snyk data with other sources of information from GitHub or AWS. We are also able to see more about the state of a project at a glance, without needing to join with other tables.

## How has it been verified?

Running the changes locally using docker, we found that all the new information was collected. The change has been deployed and runs successfully
