### PR TITLE
feat: Allow access to Postgres from the office (and VPN)

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -7,6 +7,7 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       "GuSubnetListParameter",
       "GuVpcParameter",
       "GuSecurityGroup",
+      "GuSecurityGroup",
       "GuStringParameter",
       "GuLoggingStreamNameParameter",
     ],
@@ -7706,7 +7707,7 @@ spec:
         "VPCSecurityGroups": [
           {
             "Fn::GetAtt": [
-              "PostgresInstance1SecurityGroupFA28C3C0",
+              "PostgresSecurityGroupCloudquery65E31BB8",
               "GroupId",
             ],
           },
@@ -7769,61 +7770,6 @@ spec:
       },
       "Type": "AWS::SecretsManager::SecretTargetAttachment",
     },
-    "PostgresInstance1SecurityGroupFA28C3C0": {
-      "Properties": {
-        "GroupDescription": "Security group for PostgresInstance1 database",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound traffic by default",
-            "IpProtocol": "-1",
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "PostgresInstance1SecurityGroupfromCloudQueryPostgresAccessSecurityGroupCloudqueryAE627D465432AE3168F5": {
-      "Properties": {
-        "Description": "from CloudQueryPostgresAccessSecurityGroupCloudqueryAE627D46:5432",
-        "FromPort": 5432,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "PostgresInstance1SecurityGroupFA28C3C0",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "PostgresAccessSecurityGroupCloudqueryE959A23F",
-            "GroupId",
-          ],
-        },
-        "ToPort": 5432,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
-    },
     "PostgresInstance1SubnetGroupCAC045A5": {
       "Properties": {
         "DBSubnetGroupDescription": "Subnet group for PostgresInstance1 database",
@@ -7871,6 +7817,74 @@ spec:
         },
       },
       "Type": "AWS::SSM::Parameter",
+    },
+    "PostgresSecurityGroupCloudquery65E31BB8": {
+      "Properties": {
+        "GroupDescription": "CloudQuery/PostgresSecurityGroupCloudquery",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "10.0.0.4/22",
+            "Description": "Allow connection to Postgres from the office network.",
+            "FromPort": 5432,
+            "IpProtocol": "tcp",
+            "ToPort": 5432,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "cloudquery",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "PostgresSecurityGroupCloudqueryfromCloudQueryPostgresAccessSecurityGroupCloudqueryAE627D46543299D711F8": {
+      "Properties": {
+        "Description": "from CloudQueryPostgresAccessSecurityGroupCloudqueryAE627D46:5432",
+        "FromPort": 5432,
+        "GroupId": {
+          "Fn::GetAtt": [
+            "PostgresSecurityGroupCloudquery65E31BB8",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Fn::GetAtt": [
+            "PostgresAccessSecurityGroupCloudqueryE959A23F",
+            "GroupId",
+          ],
+        },
+        "ToPort": 5432,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
     },
     "cloudqueryCluster5370C11B": {
       "Properties": {

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -6,13 +6,17 @@ import {
 	SubnetType,
 } from '@guardian/cdk/lib/constructs/ec2';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
-import { GuardianAwsAccounts } from '@guardian/private-infrastructure-config';
+import {
+	GuardianAwsAccounts,
+	GuardianPrivateNetworks,
+} from '@guardian/private-infrastructure-config';
 import type { App } from 'aws-cdk-lib';
 import { ArnFormat, Duration } from 'aws-cdk-lib';
 import {
 	InstanceClass,
 	InstanceSize,
 	InstanceType,
+	Peer,
 	Port,
 } from 'aws-cdk-lib/aws-ec2';
 import { Secret } from 'aws-cdk-lib/aws-ecs';
@@ -69,6 +73,11 @@ export class CloudQuery extends GuStack {
 
 		const port = 5432;
 
+		const dbSecurityGroup = new GuSecurityGroup(this, 'PostgresSecurityGroup', {
+			app,
+			vpc,
+		});
+
 		const dbProps: DatabaseInstanceProps = {
 			engine: DatabaseInstanceEngine.POSTGRES,
 			port,
@@ -77,6 +86,7 @@ export class CloudQuery extends GuStack {
 			iamAuthentication: true,
 			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 			storageEncrypted: true,
+			securityGroups: [dbSecurityGroup],
 		};
 
 		const db = new DatabaseInstance(this, 'PostgresInstance1', dbProps);
@@ -85,6 +95,18 @@ export class CloudQuery extends GuStack {
 			this,
 			'PostgresAccessSecurityGroup',
 			{ app, vpc },
+		);
+
+		// TODO use a bastion host here instead? https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.BastionHostLinux.html
+		dbSecurityGroup.addIngressRule(
+			Peer.ipv4(GuardianPrivateNetworks.Engineering),
+			Port.tcp(port),
+			'Allow connection to Postgres from the office network.',
+		);
+
+		dbSecurityGroup.connections.allowFrom(
+			applicationToPostgresSecurityGroup,
+			Port.tcp(port),
 		);
 
 		// Used by downstream services that read CloudQuery data, namely Grafana.
@@ -102,11 +124,6 @@ export class CloudQuery extends GuStack {
 			tier: ParameterTier.STANDARD,
 			dataType: ParameterDataType.TEXT,
 		});
-
-		db.connections.allowFrom(
-			applicationToPostgresSecurityGroup,
-			Port.tcp(port),
-		);
 
 		const readonlyPolicy = readonlyAccessManagedPolicy(
 			this,


### PR DESCRIPTION
## What does this change?
Add an ingress rule to the Postgres security group, allowing connection from the Engineering subnet.

The CloudFormation diff is quite big, however that's largely due to one change - we're now explicitly creating a security group for the database, rather than letting AWS CDK create one. This change has a cascading effect across most other resources in the stack.

As noted, a [bastion host](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.BastionHostLinux.html) might be a better option here as it means we're not reliant on the network to limit access. Thoughts on whether this is blocking welcomed. See also https://github.com/guardian/cdk/issues/1786.

## Why?
This means we can connect to the database from the office network, as it is sometimes easier to run queries outside of Grafana.

We had previously added this ingress rule manually (i.e. introduced drift); this change encodes it.

_How_ one connects is down to preference. Personally, I'd be recommending using the [AWS Toolkit for JetBrains](https://docs.aws.amazon.com/toolkit-for-jetbrains/latest/userguide/welcome.html) as it allows one to authenticate via IAM credentials, i.e. credentials issued by Janus.

## How has it been verified?
I have performed the following steps:
- Confirmed I can access Postgres locally when connected to the VPN
- Removed drift
- Deployed `main`
- Confirmed I can no longer access Postgres locally
- Deployed this branch
- Confirmed I can access Postgres locally when connected to the VPN