### PR TITLE
docs: Add docs for CloudQuery adoption

### DIFF
--- a/ADR/02-cloudquery.md
+++ b/ADR/02-cloudquery.md
@@ -1,0 +1,71 @@
+# CloudQuery Adoption
+
+## Status
+Accepted, and implemented.
+
+## Context
+The Service Catalogue project aims to "allow easy exploration of Guardian services", allowing one to answer questions such as:
+- What services to I (and my team) own?
+- Which repository do services come from?
+- Which services follow DevX best practice/use tooling?
+
+Initially, the Service Catalogue was architected in two parts:
+1. Data collection
+   ```mermaid
+   flowchart LR
+   A["Source(s)"] --> B[Data collector]
+   B --> C[(DataStore)]
+   ```
+2. Data presentation
+   ```mermaid
+   flowchart LR
+   A[(DataStore)] --> B[Lens API]
+   B --> C[Service Catalogue API]
+   C --> D((User))
+   ```
+
+That is, for each data source, we'd build:
+- A data collector
+- A data aggregation API (informally known as a Lens API)
+- Public-facing APIs (informally known as the Service Catalogue API)
+
+To present a piece of data in the Service Catalogue API, we would:
+- Create a data collector, integrating with third-party APIs, and writing results to a data store
+- Create a Lens API that aggregates the data in the store
+- Service Catalogue API endpoints to expose the Lens API to the user
+
+Whilst this pattern works, it results in complex[^1] code that needs to be maintained over time.
+
+## Proposal
+[CloudQuery](https://www.cloudquery.io/) is an open-source project to:
+
+> Sync any source to any destination, transform and visualize.
+
+CloudQuery can collect data from AWS, GitHub, Snyk, and more. 
+It can also store the data in a variety of destinations, including Postgres.
+
+Using CloudQuery would allow us to replace the first diagram above, 
+with the data collection being handled by CloudQuery, and the data store being Postgres.
+Using Postgres would allow us to use Grafana to visualise the data.
+
+## Consequences
+At a high-level, CloudQuery is a data collection tool.
+It doesn't have any opinion on the data it collects,
+nor does it provide any APIs to expose the data.
+That is, we lose the second diagram above.
+
+If we wanted to provide an API, we'd have to write one ourselves.
+However, we should see how far we get with Grafana dashboards first.
+API access does still seem valuable, however we will wait to see if there is demand for this.
+Tools such as [Prisma](https://www.prisma.io/) could be explored here.
+
+## Out of scope
+### Decommissioning Prism
+[Prism](https://github.com/guardian/prism) is our home-grown tool that provides a real-time view of particular resources across our AWS estate. 
+We can consider the data collected by CloudQuery to be a superset of Prism.
+
+The Prism API is in use by services such as [Riff-Raff](https://github.com/guardian/riff-raff).
+
+Initially, there are no plans to rebuild the Prism API using data collected by CloudQuery.
+
+[^1]: Complexity comes in various forms, for example new programming languages, or handling of third-party API behaviours.

--- a/docs/cloudquery.md
+++ b/docs/cloudquery.md
@@ -1,0 +1,64 @@
+# CloudQuery
+Following the [ADR(/proposal)](../ADR/02-cloudquery.md), 
+and since PRs [#202](https://github.com/guardian/service-catalogue/pull/202) and [#212](https://github.com/guardian/service-catalogue/pull/212),
+this repository can be viewed as a set of CloudQuery configuration.
+
+## Implementation
+We are using CloudQuery to collect data from:
+- AWS
+- GitHub
+- Snyk
+- Fastly
+- Galaxies of the Guardian
+
+As it is relatively easy collect data with CloudQuery, we have, largely, opted to collect _all_ the data.
+By collecting this extra data, we enable others to answer their questions. For example:
+- Which of our EC2 apps still have port 22 open?
+- Which of our S3 buckets are publicly available?
+- I'm having trouble with a particular AWS service, who else is using it?
+- How many break-glass users do we have?
+
+We have implemented CloudQuery to run on AWS ECS, 
+writing data to [Postgres](https://www.cloudquery.io/docs/plugins/destinations/postgresql/overview).
+This is all [defined using GuCDK](../packages/cdk/lib/cloudquery.ts).
+
+We have more interest in some data sources than others.
+For example, we'd like to know more about AWS Lambdas across the estate than AWS Elastic Beanstalk deployments.
+For this reason, we have a number of ECS tasks, each running on their own schedule.
+
+### Postgres
+Each ECS task authenticates with Postgres using [IAM Authentication](https://repost.aws/knowledge-center/rds-postgresql-connect-using-iam).
+
+The root (sudo) user is not used. Instead, we manually created a user:
+
+```sql
+-- Create user for CloudQuery, and grant RDS IAM authentication.
+-- See https://repost.aws/knowledge-center/rds-postgresql-connect-using-iam
+CREATE USER cloudquery;
+GRANT rds_iam TO cloudquery;
+```
+
+### Grafana
+We're using [Grafana](https://metrics.gutools.co.uk/) to create dashboards, joining data across the above sources.
+We have connected Grafana with _read-only access_ to the Postgres database.
+
+Unfortunately, Grafana does not support IAM authentication.
+We have manually created a user for Grafana with static credentials:
+
+```sql
+-- Create users for Grafana CODE and PROD, with readonly access.
+-- See https://grafana.com/docs/grafana/latest/datasources/postgres/#database-user-permissions-important
+
+-- Unfortunately Grafana does not support RDS IAM authentication.
+-- See https://github.com/grafana/grafana/discussions/48170
+CREATE USER grafanareadercode WITH PASSWORD 'REDACTED';
+GRANT USAGE ON SCHEMA public TO grafanareadercode;
+
+CREATE USER grafanareaderprod WITH PASSWORD 'REDACTED';
+GRANT USAGE ON SCHEMA public TO grafanareaderprod;
+
+-- Provide Grafana with access to any new tables and views as soon as they're created.
+SET ROLE cloudquery;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO grafanareadercode;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO grafanareaderprod;
+```


### PR DESCRIPTION
## What does this change?
Adds an ADR to the repository to document the decision to adopt CloudQuery. This is largely an adaptation of the [original proposal document](https://docs.google.com/document/d/1AJGK4HjHf6znEXRGqbbF5gYaq2PmmcrJjsX0feKXd0I/edit).

Also adds an "implementation" document, primarily as a way to have the SQL we've manually executed tracked in VCS.

This is part 1 of a series of changes to document this repository. Other documentation should cover:
- How to manually invoke an ECS task
- How to debug configuration
- How to query the database locally
- Anything else...

## Why?
ADRs help provide context for our future selves.

## How has it been verified?
By reading the documents, and checking it's an accurate reflection of events.

---

Closes https://github.com/guardian/service-catalogue/pull/182.