### PR TITLE
chore(deps): Bump the version of CloudQuery CLI, sources, and destination

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -125,7 +125,7 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
 spec:
   name: aws
   path: cloudquery/aws
-  version: v17.4.0
+  version: v18.3.0
   tables:
     - '*'
   skip_tables:
@@ -181,7 +181,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.0
+  version: v4.2.2
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -197,7 +197,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -745,7 +745,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v17.4.0
+  version: v18.3.0
   tables:
     - aws_organizations
     - aws_organizations_accounts
@@ -773,7 +773,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.0
+  version: v4.2.2
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -789,7 +789,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -1316,7 +1316,7 @@ spec:
 spec:
   name: fastly
   path: cloudquery/fastly
-  version: v1.3.1
+  version: v2.0.2
   tables:
     - fastly_services
     - fastly_service_versions
@@ -1333,7 +1333,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.0
+  version: v4.2.2
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -1349,7 +1349,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -1910,7 +1910,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.0
+  version: v4.2.2
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -1929,7 +1929,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -2437,7 +2437,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v5.2.0
+  version: v6.0.2
   tables:
     - github_repositories
   skip_tables:
@@ -2461,7 +2461,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.0
+  version: v4.2.2
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -2477,7 +2477,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -3068,7 +3068,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v5.2.0
+  version: v6.0.2
   tables:
     - github_teams
     - github_team_members
@@ -3089,7 +3089,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.0
+  version: v4.2.2
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -3105,7 +3105,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -3734,7 +3734,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.0
+  version: v4.2.2
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -3750,7 +3750,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -4269,7 +4269,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v17.4.0
+  version: v18.3.0
   tables:
     - aws_acm*
   destinations:
@@ -4292,7 +4292,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.0
+  version: v4.2.2
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -4308,7 +4308,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -4861,7 +4861,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v17.4.0
+  version: v18.3.0
   tables:
     - aws_cloudformation_stacks
     - aws_cloudformation_stack_resources
@@ -4887,7 +4887,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.0
+  version: v4.2.2
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -4903,7 +4903,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -5582,7 +5582,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v17.4.0
+  version: v18.3.0
   tables:
     - aws_cloudwatch_alarms
   destinations:
@@ -5605,7 +5605,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.0
+  version: v4.2.2
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -5621,7 +5621,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -5970,7 +5970,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v17.4.0
+  version: v18.3.0
   tables:
     - aws_inspector_findings
     - aws_inspector2_findings
@@ -5994,7 +5994,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.0
+  version: v4.2.2
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -6010,7 +6010,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -6715,7 +6715,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v17.4.0
+  version: v18.3.0
   tables:
     - aws_elbv1_*
     - aws_elbv2_*
@@ -6739,7 +6739,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.0
+  version: v4.2.2
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -6755,7 +6755,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -7130,7 +7130,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v17.4.0
+  version: v18.3.0
   tables:
     - aws_accessanalyzer_analyzers
     - aws_accessanalyzer_analyzer_archive_rules
@@ -7154,7 +7154,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.0
+  version: v4.2.2
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -7170,7 +7170,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -7666,7 +7666,7 @@ spec:
 spec:
   name: snyk
   path: cloudquery/snyk
-  version: v3.0.0
+  version: v3.0.2
   tables:
     - snyk_dependencies
     - snyk_groups
@@ -7689,7 +7689,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.0
+  version: v4.2.2
   migrate_mode: forced
   spec:
     connection_string: \${file:/var/scratch/connection_string}
@@ -7705,7 +7705,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -19,7 +19,7 @@ describe('Config generation, and converting to YAML', () => {
 		  name: postgresql
 		  registry: github
 		  path: cloudquery/postgresql
-		  version: v4.2.0
+		  version: v4.2.2
 		  migrate_mode: forced
 		  spec:
 		    connection_string: \${file:/var/scratch/connection_string}
@@ -36,7 +36,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v17.4.0
+		  version: v18.3.0
 		  tables:
 		    - aws_s3_buckets
 		  destinations:
@@ -68,7 +68,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v17.4.0
+		  version: v18.3.0
 		  tables:
 		    - '*'
 		  skip_tables:
@@ -105,7 +105,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v17.4.0
+		  version: v18.3.0
 		  tables:
 		    - aws_accessanalyzer_analyzers
 		    - aws_accessanalyzer_analyzer_archive_rules
@@ -135,7 +135,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: github
 		  path: cloudquery/github
-		  version: v5.2.0
+		  version: v6.0.2
 		  tables:
 		    - github_repositories
 		  destinations:
@@ -160,7 +160,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: fastly
 		  path: cloudquery/fastly
-		  version: v1.3.1
+		  version: v2.0.2
 		  tables:
 		    - '*'
 		  destinations:
@@ -199,7 +199,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: snyk
 		  path: cloudquery/snyk
-		  version: v3.0.0
+		  version: v3.0.2
 		  tables:
 		    - '*'
 		  destinations:

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -4,35 +4,35 @@ export const Versions = {
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=cli
 	 */
-	CloudqueryCli: '3.5.0',
+	CloudqueryCli: '3.5.2',
 
 	/**
 	 * The version of the CloudQuery Postgres destination plugin to install.
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql
 	 */
-	CloudqueryPostgres: '4.2.0',
+	CloudqueryPostgres: '4.2.2',
 
 	/**
 	 * The version of the CloudQuery AWS source plugin to install.
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
 	 */
-	CloudqueryAws: '17.4.0',
+	CloudqueryAws: '18.3.0',
 
 	/**
 	 * The version of the CloudQuery GitHub source plugin to install.
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
 	 */
-	CloudqueryGithub: '5.2.0',
+	CloudqueryGithub: '6.0.2',
 
 	/**
 	 * The version of the CloudQuery Fastly source plugin to install.
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-fastly
 	 */
-	CloudqueryFastly: '1.3.1',
+	CloudqueryFastly: '2.0.2',
 
 	/**
 	 * The version of the our custom Galaxies source plugin to install.
@@ -46,7 +46,7 @@ export const Versions = {
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-snyk
 	 */
-	CloudquerySnyk: '3.0.0',
+	CloudquerySnyk: '3.0.2',
 
 	/**
 	 * The version of the CloudQuery Snyk source plugin to install.

--- a/packages/cloudquery/.env.example
+++ b/packages/cloudquery/.env.example
@@ -1,17 +1,17 @@
 # See https://github.com/cloudquery/cloudquery/releases?q=cli
-CQ_CLI=3.5.0
+CQ_CLI=3.5.2
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql
-CQ_POSTGRES=4.2.0
+CQ_POSTGRES=4.2.2
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
-CQ_AWS=17.4.0
+CQ_AWS=18.3.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
-CQ_GITHUB=5.2.0
+CQ_GITHUB=6.0.2
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-snyk
-CQ_SNYK=3.0.0
+CQ_SNYK=3.0.2
 
 # See https://github.com/settings/tokens?type=beta
 GITHUB_ACCESS_TOKEN=


### PR DESCRIPTION
## What does this change?
Bumps the versions of CloudQuery things being used.

The AWS and GitHub source plugins see a major version update, i.e. a breaking change. Looking at the notes for the [AWS plugin](https://github.com/cloudquery/cloudquery/releases/tag/plugins-source-aws-v18.0.0) and the [GitHub plugin](https://github.com/cloudquery/cloudquery/releases/tag/plugins-source-github-v6.0.0), the kind of breaking change would not impact us.