### PR TITLE
fix: Allow long running tasks to complete

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -287,7 +287,7 @@ spec:
             "Name": "CloudquerySource-AllFirelens",
           },
         ],
-        "Cpu": "256",
+        "Cpu": "1024",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "CloudquerySourceAllTaskDefinitionExecutionRole57AE7309",
@@ -295,7 +295,7 @@ spec:
           ],
         },
         "Family": "CloudQueryCloudquerySourceAllTaskDefinitionC1F1D919",
-        "Memory": "512",
+        "Memory": "2048",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -130,6 +130,26 @@ spec:
     - aws_xray_sampling_rules
     - aws_xray_resource_policies
     - aws_xray_groups
+    - aws_organizations
+    - aws_organizations_accounts
+    - aws_organizations_delegated_services
+    - aws_organizations_delegated_administrators
+    - aws_organizations_organizational_units
+    - aws_organizations_policies
+    - aws_organizations_roots
+    - aws_accessanalyzer_analyzers
+    - aws_accessanalyzer_analyzer_archive_rules
+    - aws_accessanalyzer_analyzer_findings
+    - aws_cloudformation_stacks
+    - aws_cloudformation_stack_resources
+    - aws_cloudformation_stack_templates
+    - aws_cloudformation_template_summaries
+    - aws_elbv1_*
+    - aws_elbv2_*
+    - aws_acm*
+    - aws_cloudwatch_alarms
+    - aws_inspector_findings
+    - aws_inspector2_findings
   destinations:
     - postgresql
   spec:

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -88,37 +88,6 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
         "ContainerDefinitions": [
           {
             "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-AllAwsCli",
-          },
-          {
-            "Command": [
               "/bin/sh",
               "-c",
               "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
@@ -184,14 +153,10 @@ spec:
   version: v4.2.2
   migrate_mode: forced
   spec:
-    connection_string: \${file:/var/scratch/connection_string}
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-AllAwsCli",
-              },
             ],
             "EntryPoint": [
               "",
@@ -211,14 +176,51 @@ spec:
                 },
               },
             },
-            "MountPoints": [
+            "Name": "CloudquerySource-AllContainer",
+            "Secrets": [
               {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
               },
             ],
-            "Name": "CloudquerySource-AllContainer",
           },
           {
             "Environment": [
@@ -301,12 +303,6 @@ spec:
             "Arn",
           ],
         },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -465,6 +461,16 @@ spec:
           "Statement": [
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -612,7 +618,11 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/cloudquery",
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
                   ],
                 ],
               },
@@ -708,37 +718,6 @@ spec:
         "ContainerDefinitions": [
           {
             "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-DeployToolsListOrgsAwsCli",
-          },
-          {
-            "Command": [
               "/bin/sh",
               "-c",
               "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
@@ -776,14 +755,10 @@ spec:
   version: v4.2.2
   migrate_mode: forced
   spec:
-    connection_string: \${file:/var/scratch/connection_string}
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-DeployToolsListOrgsAwsCli",
-              },
             ],
             "EntryPoint": [
               "",
@@ -803,14 +778,51 @@ spec:
                 },
               },
             },
-            "MountPoints": [
+            "Name": "CloudquerySource-DeployToolsListOrgsContainer",
+            "Secrets": [
               {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
               },
             ],
-            "Name": "CloudquerySource-DeployToolsListOrgsContainer",
           },
           {
             "Environment": [
@@ -893,12 +905,6 @@ spec:
             "Arn",
           ],
         },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -1029,6 +1035,16 @@ spec:
       "Properties": {
         "PolicyDocument": {
           "Statement": [
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
             {
               "Action": [
                 "logs:CreateLogStream",
@@ -1183,7 +1199,11 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/cloudquery",
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
                   ],
                 ],
               },
@@ -1279,37 +1299,6 @@ spec:
         "ContainerDefinitions": [
           {
             "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-FastlyServicesAwsCli",
-          },
-          {
-            "Command": [
               "/bin/sh",
               "-c",
               "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
@@ -1336,14 +1325,10 @@ spec:
   version: v4.2.2
   migrate_mode: forced
   spec:
-    connection_string: \${file:/var/scratch/connection_string}
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-FastlyServicesAwsCli",
-              },
             ],
             "EntryPoint": [
               "",
@@ -1363,13 +1348,6 @@ spec:
                 },
               },
             },
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
-              },
-            ],
             "Name": "CloudquerySource-FastlyServicesContainer",
             "Secrets": [
               {
@@ -1391,6 +1369,48 @@ spec:
                         "Ref": "AWS::AccountId",
                       },
                       ":secret:/TEST/deploy/cloudquery/fastly-credentials:api-key::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
                     ],
                   ],
                 },
@@ -1478,12 +1498,6 @@ spec:
             "Arn",
           ],
         },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -1604,6 +1618,16 @@ spec:
                     ":secret:/TEST/deploy/cloudquery/fastly-credentials-??????",
                   ],
                 ],
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
               },
             },
             {
@@ -1761,7 +1785,11 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/cloudquery",
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
                   ],
                 ],
               },
@@ -1831,37 +1859,6 @@ spec:
         "ContainerDefinitions": [
           {
             "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-GalaxiesAwsCli",
-          },
-          {
-            "Command": [
               "/bin/sh",
               "-c",
               {
@@ -1913,16 +1910,12 @@ spec:
   version: v4.2.2
   migrate_mode: forced
   spec:
-    connection_string: \${file:/var/scratch/connection_string}
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
                   ],
                 ],
-              },
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-GalaxiesAwsCli",
               },
             ],
             "EntryPoint": [
@@ -1943,14 +1936,51 @@ spec:
                 },
               },
             },
-            "MountPoints": [
+            "Name": "CloudquerySource-GalaxiesContainer",
+            "Secrets": [
               {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
               },
             ],
-            "Name": "CloudquerySource-GalaxiesContainer",
           },
           {
             "Environment": [
@@ -2033,12 +2063,6 @@ spec:
             "Arn",
           ],
         },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -2197,6 +2221,16 @@ spec:
           "Statement": [
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -2330,7 +2364,11 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/cloudquery",
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
                   ],
                 ],
               },
@@ -2400,37 +2438,6 @@ spec:
         "ContainerDefinitions": [
           {
             "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-GitHubRepositoriesAwsCli",
-          },
-          {
-            "Command": [
               "/bin/sh",
               "-c",
               "echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
@@ -2464,14 +2471,10 @@ spec:
   version: v4.2.2
   migrate_mode: forced
   spec:
-    connection_string: \${file:/var/scratch/connection_string}
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-GitHubRepositoriesAwsCli",
-              },
             ],
             "EntryPoint": [
               "",
@@ -2491,13 +2494,6 @@ spec:
                 },
               },
             },
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
-              },
-            ],
             "Name": "CloudquerySource-GitHubRepositoriesContainer",
             "Secrets": [
               {
@@ -2565,6 +2561,48 @@ spec:
                         "Ref": "AWS::AccountId",
                       },
                       ":secret:/TEST/deploy/cloudquery/github-credentials:installation-id::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
                     ],
                   ],
                 },
@@ -2652,12 +2690,6 @@ spec:
             "Arn",
           ],
         },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -2843,6 +2875,16 @@ spec:
             },
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -2961,7 +3003,11 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/cloudquery",
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
                   ],
                 ],
               },
@@ -3031,37 +3077,6 @@ spec:
         "ContainerDefinitions": [
           {
             "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-GitHubTeamsAwsCli",
-          },
-          {
-            "Command": [
               "/bin/sh",
               "-c",
               "echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
@@ -3092,14 +3107,10 @@ spec:
   version: v4.2.2
   migrate_mode: forced
   spec:
-    connection_string: \${file:/var/scratch/connection_string}
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-GitHubTeamsAwsCli",
-              },
             ],
             "EntryPoint": [
               "",
@@ -3119,13 +3130,6 @@ spec:
                 },
               },
             },
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
-              },
-            ],
             "Name": "CloudquerySource-GitHubTeamsContainer",
             "Secrets": [
               {
@@ -3193,6 +3197,48 @@ spec:
                         "Ref": "AWS::AccountId",
                       },
                       ":secret:/TEST/deploy/cloudquery/github-credentials:installation-id::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
                     ],
                   ],
                 },
@@ -3280,12 +3326,6 @@ spec:
             "Arn",
           ],
         },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -3471,6 +3511,16 @@ spec:
             },
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -3589,7 +3639,11 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/cloudquery",
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
                   ],
                 ],
               },
@@ -3685,37 +3739,6 @@ spec:
         "ContainerDefinitions": [
           {
             "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-GuardianCustomSnykProjectsAwsCli",
-          },
-          {
-            "Command": [
               "/bin/sh",
               "-c",
               "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
@@ -3737,14 +3760,10 @@ spec:
   version: v4.2.2
   migrate_mode: forced
   spec:
-    connection_string: \${file:/var/scratch/connection_string}
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-GuardianCustomSnykProjectsAwsCli",
-              },
             ],
             "EntryPoint": [
               "",
@@ -3764,13 +3783,6 @@ spec:
                 },
               },
             },
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
-              },
-            ],
             "Name": "CloudquerySource-GuardianCustomSnykProjectsContainer",
             "Secrets": [
               {
@@ -3792,6 +3804,48 @@ spec:
                         "Ref": "AWS::AccountId",
                       },
                       ":secret:/TEST/deploy/cloudquery/snyk-credentials:api-key::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
                     ],
                   ],
                 },
@@ -3879,12 +3933,6 @@ spec:
             "Arn",
           ],
         },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -4044,6 +4092,16 @@ spec:
             },
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -4162,7 +4220,11 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/cloudquery",
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
                   ],
                 ],
               },
@@ -4232,37 +4294,6 @@ spec:
         "ContainerDefinitions": [
           {
             "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-OrgWideCertificatesAwsCli",
-          },
-          {
-            "Command": [
               "/bin/sh",
               "-c",
               "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
@@ -4295,14 +4326,10 @@ spec:
   version: v4.2.2
   migrate_mode: forced
   spec:
-    connection_string: \${file:/var/scratch/connection_string}
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-OrgWideCertificatesAwsCli",
-              },
             ],
             "EntryPoint": [
               "",
@@ -4322,14 +4349,51 @@ spec:
                 },
               },
             },
-            "MountPoints": [
+            "Name": "CloudquerySource-OrgWideCertificatesContainer",
+            "Secrets": [
               {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
               },
             ],
-            "Name": "CloudquerySource-OrgWideCertificatesContainer",
           },
           {
             "Environment": [
@@ -4412,12 +4476,6 @@ spec:
             "Arn",
           ],
         },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -4576,6 +4634,16 @@ spec:
           "Statement": [
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -4728,7 +4796,11 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/cloudquery",
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
                   ],
                 ],
               },
@@ -4824,37 +4896,6 @@ spec:
         "ContainerDefinitions": [
           {
             "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-OrgWideCloudFormationAwsCli",
-          },
-          {
-            "Command": [
               "/bin/sh",
               "-c",
               "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
@@ -4890,14 +4931,10 @@ spec:
   version: v4.2.2
   migrate_mode: forced
   spec:
-    connection_string: \${file:/var/scratch/connection_string}
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-OrgWideCloudFormationAwsCli",
-              },
             ],
             "EntryPoint": [
               "",
@@ -4917,14 +4954,51 @@ spec:
                 },
               },
             },
-            "MountPoints": [
+            "Name": "CloudquerySource-OrgWideCloudFormationContainer",
+            "Secrets": [
               {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
               },
             ],
-            "Name": "CloudquerySource-OrgWideCloudFormationContainer",
           },
           {
             "Environment": [
@@ -5007,12 +5081,6 @@ spec:
             "Arn",
           ],
         },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -5143,6 +5211,16 @@ spec:
       "Properties": {
         "PolicyDocument": {
           "Statement": [
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
             {
               "Action": [
                 "logs:CreateLogStream",
@@ -5297,7 +5375,11 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/cloudquery",
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
                   ],
                 ],
               },
@@ -5517,6 +5599,16 @@ spec:
           "Statement": [
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -5543,37 +5635,6 @@ spec:
     "CloudquerySourceOrgWideCloudwatchAlarmsTaskDefinitionF28C916F": {
       "Properties": {
         "ContainerDefinitions": [
-          {
-            "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-OrgWideCloudwatchAlarmsAwsCli",
-          },
           {
             "Command": [
               "/bin/sh",
@@ -5608,14 +5669,10 @@ spec:
   version: v4.2.2
   migrate_mode: forced
   spec:
-    connection_string: \${file:/var/scratch/connection_string}
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-OrgWideCloudwatchAlarmsAwsCli",
-              },
             ],
             "EntryPoint": [
               "",
@@ -5635,14 +5692,51 @@ spec:
                 },
               },
             },
-            "MountPoints": [
+            "Name": "CloudquerySource-OrgWideCloudwatchAlarmsContainer",
+            "Secrets": [
               {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
               },
             ],
-            "Name": "CloudquerySource-OrgWideCloudwatchAlarmsContainer",
           },
           {
             "Environment": [
@@ -5725,12 +5819,6 @@ spec:
             "Arn",
           ],
         },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -5825,7 +5913,11 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/cloudquery",
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
                   ],
                 ],
               },
@@ -5933,37 +6025,6 @@ spec:
         "ContainerDefinitions": [
           {
             "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-OrgWideInspectorAwsCli",
-          },
-          {
-            "Command": [
               "/bin/sh",
               "-c",
               "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
@@ -5997,14 +6058,10 @@ spec:
   version: v4.2.2
   migrate_mode: forced
   spec:
-    connection_string: \${file:/var/scratch/connection_string}
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-OrgWideInspectorAwsCli",
-              },
             ],
             "EntryPoint": [
               "",
@@ -6024,14 +6081,51 @@ spec:
                 },
               },
             },
-            "MountPoints": [
+            "Name": "CloudquerySource-OrgWideInspectorContainer",
+            "Secrets": [
               {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
               },
             ],
-            "Name": "CloudquerySource-OrgWideInspectorContainer",
           },
           {
             "Environment": [
@@ -6114,12 +6208,6 @@ spec:
             "Arn",
           ],
         },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -6278,6 +6366,16 @@ spec:
           "Statement": [
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -6430,7 +6528,11 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/cloudquery",
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
                   ],
                 ],
               },
@@ -6650,6 +6752,16 @@ spec:
           "Statement": [
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -6676,37 +6788,6 @@ spec:
     "CloudquerySourceOrgWideLoadBalancersTaskDefinitionF1D11F23": {
       "Properties": {
         "ContainerDefinitions": [
-          {
-            "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-OrgWideLoadBalancersAwsCli",
-          },
           {
             "Command": [
               "/bin/sh",
@@ -6742,14 +6823,10 @@ spec:
   version: v4.2.2
   migrate_mode: forced
   spec:
-    connection_string: \${file:/var/scratch/connection_string}
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-OrgWideLoadBalancersAwsCli",
-              },
             ],
             "EntryPoint": [
               "",
@@ -6769,14 +6846,51 @@ spec:
                 },
               },
             },
-            "MountPoints": [
+            "Name": "CloudquerySource-OrgWideLoadBalancersContainer",
+            "Secrets": [
               {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
               },
             ],
-            "Name": "CloudquerySource-OrgWideLoadBalancersContainer",
           },
           {
             "Environment": [
@@ -6859,12 +6973,6 @@ spec:
             "Arn",
           ],
         },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -6997,7 +7105,11 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/cloudquery",
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
                   ],
                 ],
               },
@@ -7093,37 +7205,6 @@ spec:
         "ContainerDefinitions": [
           {
             "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-SecurityAccessAnalyserAwsCli",
-          },
-          {
-            "Command": [
               "/bin/sh",
               "-c",
               "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
@@ -7157,14 +7238,10 @@ spec:
   version: v4.2.2
   migrate_mode: forced
   spec:
-    connection_string: \${file:/var/scratch/connection_string}
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-SecurityAccessAnalyserAwsCli",
-              },
             ],
             "EntryPoint": [
               "",
@@ -7184,14 +7261,51 @@ spec:
                 },
               },
             },
-            "MountPoints": [
+            "Name": "CloudquerySource-SecurityAccessAnalyserContainer",
+            "Secrets": [
               {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
               },
             ],
-            "Name": "CloudquerySource-SecurityAccessAnalyserContainer",
           },
           {
             "Environment": [
@@ -7274,12 +7388,6 @@ spec:
             "Arn",
           ],
         },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -7410,6 +7518,16 @@ spec:
       "Properties": {
         "PolicyDocument": {
           "Statement": [
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
             {
               "Action": [
                 "logs:CreateLogStream",
@@ -7559,7 +7677,11 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/cloudquery",
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
                   ],
                 ],
               },
@@ -7629,37 +7751,6 @@ spec:
         "ContainerDefinitions": [
           {
             "Command": [
-              "/bin/bash",
-              "-c",
-              "PG_PASSWORD=$(/usr/local/bin/aws rds generate-db-auth-token --hostname $DB_HOST --port 5432 --region eu-west-1 --username cloudquery);echo "user=cloudquery password=$PG_PASSWORD host=$DB_HOST port=5432 dbname=postgres sslmode=verify-full" > /var/scratch/connection_string",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Environment": [
-              {
-                "Name": "DB_HOST",
-                "Value": {
-                  "Fn::GetAtt": [
-                    "PostgresInstance16DE4286E",
-                    "Endpoint.Address",
-                  ],
-                },
-              },
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/aws-cli/aws-cli",
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": false,
-                "SourceVolume": "scratch",
-              },
-            ],
-            "Name": "CloudquerySource-SnykAllAwsCli",
-          },
-          {
-            "Command": [
               "/bin/sh",
               "-c",
               "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
@@ -7692,14 +7783,10 @@ spec:
   version: v4.2.2
   migrate_mode: forced
   spec:
-    connection_string: \${file:/var/scratch/connection_string}
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "DependsOn": [
-              {
-                "Condition": "SUCCESS",
-                "ContainerName": "CloudquerySource-SnykAllAwsCli",
-              },
             ],
             "EntryPoint": [
               "",
@@ -7719,13 +7806,6 @@ spec:
                 },
               },
             },
-            "MountPoints": [
-              {
-                "ContainerPath": "/var/scratch",
-                "ReadOnly": true,
-                "SourceVolume": "scratch",
-              },
-            ],
             "Name": "CloudquerySource-SnykAllContainer",
             "Secrets": [
               {
@@ -7747,6 +7827,48 @@ spec:
                         "Ref": "AWS::AccountId",
                       },
                       ":secret:/TEST/deploy/cloudquery/snyk-credentials:api-key::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
                     ],
                   ],
                 },
@@ -7834,12 +7956,6 @@ spec:
             "Arn",
           ],
         },
-        "Volumes": [
-          {
-            "Host": {},
-            "Name": "scratch",
-          },
-        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },
@@ -8025,6 +8141,16 @@ spec:
             },
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -8143,7 +8269,11 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/cloudquery",
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
                   ],
                 ],
               },

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -96,7 +96,7 @@ spec:
   path: cloudquery/aws
   version: v18.3.0
   tables:
-    - '*'
+    - aws_*
   skip_tables:
     - aws_ec2_vpc_endpoint_services
     - aws_cloudtrail_events

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -152,6 +152,7 @@ spec:
     - aws_inspector2_findings
   destinations:
     - postgresql
+  concurrency: 2000
   spec:
     regions:
       - eu-west-1

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -130,6 +130,8 @@ spec:
     - aws_xray_sampling_rules
     - aws_xray_resource_policies
     - aws_xray_groups
+    - aws_stepfunctions_map_runs
+    - aws_stepfunctions_map_run_executions
     - aws_organizations
     - aws_organizations_accounts
     - aws_organizations_delegated_services

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -254,6 +254,10 @@ export class CloudQuery extends GuStack {
 			}),
 			managedPolicies: [readonlyPolicy],
 			policies: [standardDenyPolicy, cloudqueryAccess('*')],
+
+			// This task is quite expensive, and requires more power than the default (500MB memory, 0.25 vCPU).
+			memoryLimitMiB: 2048,
+			cpu: 1024,
 		};
 
 		const githubCredentials = SecretsManager.fromSecretPartialArn(

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -246,6 +246,11 @@ export class CloudQuery extends GuStack {
 						(_) => _.config.spec.tables,
 					) as string[]),
 				],
+
+				// Defaulted to 500000 by CloudQuery, concurrency controls the maximum number of Go routines to use.
+				// The amount of memory used is a function of this value.
+				// See https://www.cloudquery.io/docs/reference/source-spec#concurrency.
+				concurrency: 2000,
 			}),
 			managedPolicies: [readonlyPolicy],
 			policies: [standardDenyPolicy, cloudqueryAccess('*')],

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -84,7 +84,7 @@ export class CloudQuery extends GuStack {
 			port,
 			vpc,
 			vpcSubnets: { subnets: privateSubnets },
-			iamAuthentication: true,
+			iamAuthentication: true, // We're not using IAM auth for ECS tasks, however we do use IAM auth when connecting to RDS locally.
 			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 			storageEncrypted: true,
 			securityGroups: [dbSecurityGroup],

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -137,7 +137,7 @@ export class CloudQuery extends GuStack {
 				description: 'Data fetched across all accounts in the organisation.',
 				schedule: Schedule.rate(Duration.days(1)),
 				config: awsSourceConfigForOrganisation({
-					tables: ['*'],
+					tables: ['aws_*'],
 					skipTables: skipTables,
 				}),
 				managedPolicies: [readonlyPolicy],

--- a/packages/cdk/lib/ecs/cluster.ts
+++ b/packages/cdk/lib/ecs/cluster.ts
@@ -56,6 +56,16 @@ export interface CloudquerySource {
 	 * Additional commands to run within the CloudQuery container, executed first.
 	 */
 	additionalCommands?: string[];
+
+	/**
+	 * The amount (in MiB) of memory used by the task.
+	 */
+	memoryLimitMiB?: 512 | 1024 | 2048 | 3072 | 4096 | 8192 | 16384 | 32768;
+
+	/**
+	 * The number of cpu units used by the task.
+	 */
+	cpu?: 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384;
 }
 
 interface CloudqueryClusterProps extends AppIdentity {
@@ -124,6 +134,8 @@ export class CloudqueryCluster extends Cluster {
 				policies = [],
 				secrets,
 				additionalCommands,
+				memoryLimitMiB,
+				cpu,
 			}) => {
 				new ScheduledCloudqueryTask(scope, `CloudquerySource-${name}`, {
 					...taskProps,
@@ -133,6 +145,8 @@ export class CloudqueryCluster extends Cluster {
 					sourceConfig: config,
 					secrets,
 					additionalCommands,
+					memoryLimitMiB,
+					cpu,
 				});
 			},
 		);

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -22,7 +22,9 @@ describe('Config generation, and converting to YAML', () => {
 		  version: v4.2.2
 		  migrate_mode: forced
 		  spec:
-		    connection_string: \${file:/var/scratch/connection_string}
+		    connection_string: >-
+		      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+		      dbname=postgres sslmode=verify-full
 		"
 	`);
 	});

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -1,7 +1,13 @@
 import { GuardianOrganisationalUnits } from '@guardian/private-infrastructure-config';
 import { Versions } from './versions';
 
-export type CloudqueryConfig = Record<string, unknown>;
+export type CloudqueryConfig = {
+	spec: {
+		tables?: string[];
+		[k: string]: unknown;
+	};
+	[k: string]: unknown;
+};
 
 interface CloudqueryTableConfig {
 	tables?: string[];

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -21,7 +21,14 @@ export function postgresDestinationConfig(): CloudqueryConfig {
 			version: `v${Versions.CloudqueryPostgres}`,
 			migrate_mode: 'forced',
 			spec: {
-				connection_string: '${file:/var/scratch/connection_string}',
+				connection_string: [
+					'user=${DB_USERNAME}',
+					'password=${DB_PASSWORD}',
+					'host=${DB_HOST}',
+					'port=5432',
+					'dbname=postgres',
+					'sslmode=verify-full',
+				].join(' '),
 			},
 		},
 	};

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -300,4 +300,9 @@ export const skipTables = [
 	'aws_xray_sampling_rules',
 	'aws_xray_resource_policies',
 	'aws_xray_groups',
+
+	// These appear to be heavily rate limited, and not too interesting (yet).
+	// Don't collect them to reduce execution time.
+	'aws_stepfunctions_map_runs',
+	'aws_stepfunctions_map_run_executions',
 ];

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -12,6 +12,7 @@ export type CloudqueryConfig = {
 interface CloudqueryTableConfig {
 	tables?: string[];
 	skipTables?: string[];
+	concurrency?: number;
 }
 
 /**
@@ -44,7 +45,7 @@ export function awsSourceConfig(
 	tableConfig: CloudqueryTableConfig,
 	extraConfig: Record<string, unknown> = {},
 ): CloudqueryConfig {
-	const { tables, skipTables } = tableConfig;
+	const { tables, skipTables, concurrency } = tableConfig;
 
 	if (!tables && !skipTables) {
 		throw new Error('Must specify either tables or skipTables');
@@ -59,6 +60,7 @@ export function awsSourceConfig(
 			tables,
 			skip_tables: skipTables,
 			destinations: ['postgresql'],
+			concurrency,
 			spec: {
 				regions: [
 					// All regions we support.

--- a/packages/cdk/lib/ecs/task.ts
+++ b/packages/cdk/lib/ecs/task.ts
@@ -104,8 +104,14 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 
 		const destinationConfig = postgresDestinationConfig();
 
-		// TODO remove once IAM Auth is working
-		// CloudQuery is currently using the root credentials to connect to the database
+		/*
+		This error shouldn't ever be thrown as AWS CDK creates a secret by default,
+		it is just typed as optional.
+
+		See https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_rds.DatabaseInstance.html#credentials.
+
+		TODO: Remove this once IAM auth is working.
+		 */
 		if (!db.secret) {
 			throw new Error('DB Secret is missing');
 		}

--- a/packages/cdk/lib/ecs/task.ts
+++ b/packages/cdk/lib/ecs/task.ts
@@ -96,11 +96,16 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			enabled,
 			secrets,
 			additionalCommands = [],
+			memoryLimitMiB,
+			cpu,
 		} = props;
 		const { region, stack, stage } = scope;
 		const thisRepo = 'guardian/service-catalogue'; // TODO get this from GuStack
 
-		const task = new FargateTaskDefinition(scope, `${id}TaskDefinition`);
+		const task = new FargateTaskDefinition(scope, `${id}TaskDefinition`, {
+			memoryLimitMiB,
+			cpu,
+		});
 
 		const destinationConfig = postgresDestinationConfig();
 


### PR DESCRIPTION
## What does this change?
IAM authentication for RDS has the following [behaviour](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.html):
  - The generated password expires after 15 minutes
  - A connection established within 15 minutes is valid for as long as the connection is kept
  - Attempts to establish a connection after 15 minutes are rejected

Most of the CloudQuery tasks finish well before 15 minutes[^1], however there are some that take over 2 hours (see https://github.com/guardian/service-catalogue/pull/209).

We're seeing these tasks fail, with a log line of:

```log
failed to connect to `host=REDACTED user=cloudquery database=postgres`: server error (FATAL: PAM authentication failed for user \"cloudquery\" (SQLSTATE 28000))
```

It appears that CloudQuery does not hold a single connection, but instead establishes multiple, and the latter ones are made after 15 minutes.

Temporarily revert to static (root) credentials to get these long running tasks functional again.

Additionally, I observed the default of 500MB memory and 0.25 vCPU quickly resulted in the task experiencing an OOM and terminating. To correct this, the "all AWS" task has:
  - A [`concurrency` setting](https://www.cloudquery.io/docs/reference/source-spec#concurrency) of 2000
  - 2GB memory
  - 1 vCPU

These were selected entirely at random. I'd imagine there are some observability metrics we can use in the future to tune this.

## How has it been verified?
I've [deployed](https://riffraff.gutools.co.uk/deployment/view/2a929c91-8368-4378-8451-606753eec403) this branch, manually started a long running job (the "all AWS" one), and observed it run to completion in 3h 6m 25s[^2].

## TODO (async)
- [ ] Raise an issue/PR within CloudQuery

[^1]: See https://github.com/guardian/service-catalogue/pull/203 for a duration breakdown
[^2]: Between 21/06/2023, 2:55:31 UTC and 21/06/2023, 6:01:56 UTC