### PR TITLE
Alert if a cluster task fails

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -84,6 +84,16 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
       },
       "Type": "AWS::SNS::TopicPolicy",
     },
+    "CloudQueryAlertTopicdevxoperationsguardiancouk4BB39369": {
+      "Properties": {
+        "Endpoint": "devx.operations@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": {
+          "Ref": "CloudQueryAlertTopicBFD81410",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
     "CloudquerySourceAllScheduledEventRuleAE930F8B": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -268,7 +268,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -282,7 +282,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -296,7 +296,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },
@@ -918,7 +918,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -932,7 +932,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -946,7 +946,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },
@@ -1546,7 +1546,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -1560,7 +1560,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -1574,7 +1574,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },
@@ -2191,7 +2191,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -2205,7 +2205,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -2219,7 +2219,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },
@@ -2808,7 +2808,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -2822,7 +2822,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -2836,7 +2836,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },
@@ -3697,7 +3697,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -3711,7 +3711,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -3725,7 +3725,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },
@@ -4173,7 +4173,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -4187,7 +4187,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -4201,7 +4201,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },
@@ -4861,7 +4861,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -4875,7 +4875,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -4889,7 +4889,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },
@@ -5520,7 +5520,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -5534,7 +5534,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -5548,7 +5548,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },
@@ -6115,7 +6115,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -6129,7 +6129,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -6143,7 +6143,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },
@@ -6772,7 +6772,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -6786,7 +6786,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -6800,7 +6800,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },
@@ -7562,7 +7562,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -7576,7 +7576,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -7590,7 +7590,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },
@@ -8003,7 +8003,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -8017,7 +8017,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -8031,7 +8031,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },
@@ -8820,7 +8820,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -8834,7 +8834,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -8848,7 +8848,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },
@@ -9283,7 +9283,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -9297,7 +9297,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -9311,7 +9311,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":password::",
                     ],
                   ],
                 },

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -258,7 +258,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -272,7 +272,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -286,7 +286,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -908,7 +908,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -922,7 +922,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -936,7 +936,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -1536,7 +1536,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -1550,7 +1550,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -1564,7 +1564,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -2181,7 +2181,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -2195,7 +2195,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -2209,7 +2209,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -2798,7 +2798,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -2812,7 +2812,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -2826,7 +2826,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -3687,7 +3687,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -3701,7 +3701,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -3715,7 +3715,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -4163,7 +4163,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -4177,7 +4177,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -4191,7 +4191,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -4851,7 +4851,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -4865,7 +4865,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -4879,7 +4879,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -5510,7 +5510,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -5524,7 +5524,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -5538,7 +5538,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -6105,7 +6105,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -6119,7 +6119,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -6133,7 +6133,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -6762,7 +6762,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -6776,7 +6776,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -6790,7 +6790,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -7552,7 +7552,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -7566,7 +7566,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -7580,7 +7580,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -7993,7 +7993,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -8007,7 +8007,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -8021,7 +8021,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -8810,7 +8810,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -8824,7 +8824,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -8838,7 +8838,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -9273,7 +9273,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":username::",
+                      ":host::",
                     ],
                   ],
                 },
@@ -9287,7 +9287,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":host::",
+                      ":username::",
                     ],
                   ],
                 },
@@ -9301,7 +9301,7 @@ spec:
                       {
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
-                      ":password::",
+                      ":host::",
                     ],
                   ],
                 },

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -745,7 +745,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-All exited",
             ],
             "taskDefinitionArn": [
               {
@@ -1369,7 +1369,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-DelegatedToSecurityAccount exited",
             ],
             "taskDefinitionArn": [
               {
@@ -2002,7 +2002,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-DeployToolsListOrgs exited",
             ],
             "taskDefinitionArn": [
               {
@@ -2640,7 +2640,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-FastlyServices exited",
             ],
             "taskDefinitionArn": [
               {
@@ -3271,7 +3271,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-Galaxies exited",
             ],
             "taskDefinitionArn": [
               {
@@ -3957,7 +3957,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-GitHubIssues exited",
             ],
             "taskDefinitionArn": [
               {
@@ -4648,7 +4648,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-GitHubRepositories exited",
             ],
             "taskDefinitionArn": [
               {
@@ -5336,7 +5336,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-GitHubTeams exited",
             ],
             "taskDefinitionArn": [
               {
@@ -5969,7 +5969,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-GuardianCustomSnykProjects exited",
             ],
             "taskDefinitionArn": [
               {
@@ -6597,7 +6597,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-OrgWideCertificates exited",
             ],
             "taskDefinitionArn": [
               {
@@ -7228,7 +7228,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-OrgWideCloudFormation exited",
             ],
             "taskDefinitionArn": [
               {
@@ -7856,7 +7856,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-OrgWideCloudwatchAlarms exited",
             ],
             "taskDefinitionArn": [
               {
@@ -8485,7 +8485,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-OrgWideInspector exited",
             ],
             "taskDefinitionArn": [
               {
@@ -9114,7 +9114,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-OrgWideLoadBalancers exited",
             ],
             "taskDefinitionArn": [
               {
@@ -9758,7 +9758,7 @@ spec:
               "STOPPED",
             ],
             "stoppedReason": [
-              "Essential container in task exited",
+              "Task CloudquerySource-SnykAll exited",
             ],
             "taskDefinitionArn": [
               {

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -35,6 +35,55 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "CloudQueryAlertTopicBFD81410": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "CloudQueryAlertTopicPolicy04C6710E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+              "Resource": {
+                "Ref": "CloudQueryAlertTopicBFD81410",
+              },
+              "Sid": "0",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Topics": [
+          {
+            "Ref": "CloudQueryAlertTopicBFD81410",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::TopicPolicy",
+    },
     "CloudquerySourceAllScheduledEventRuleAE930F8B": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",
@@ -661,6 +710,58 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
+    "CloudquerySourceAllTaskErrorRule93531B8F": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAllTaskDefinition8F8AA120",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "CloudquerySourceDelegatedToSecurityAccountScheduledEventRuleC7320B4E": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",
@@ -1232,6 +1333,58 @@ spec:
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceDelegatedToSecurityAccountTaskErrorRule814688AE": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionD407788D",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
     },
     "CloudquerySourceDeployToolsListOrgsScheduledEventRuleDF9BD8AF": {
       "Properties": {
@@ -1813,6 +1966,58 @@ spec:
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceDeployToolsListOrgsTaskErrorRuleA3FA98EF": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceDeployToolsListOrgsTaskDefinitionDE2A34D9",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
     },
     "CloudquerySourceFastlyServicesScheduledEventRule1F83E593": {
       "Properties": {
@@ -2400,6 +2605,58 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
+    "CloudquerySourceFastlyServicesTaskErrorRule0FE4E6C2": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceFastlyServicesTaskDefinitionDCCD3FD4",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "CloudquerySourceGalaxiesScheduledEventRuleCC774CB8": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",
@@ -2978,6 +3235,58 @@ spec:
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGalaxiesTaskErrorRule593B0339": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceGalaxiesTaskDefinition0777FEFC",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
     },
     "CloudquerySourceGitHubIssuesScheduledEventRuleAF7C253C": {
       "Properties": {
@@ -3612,6 +3921,58 @@ spec:
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGitHubIssuesTaskErrorRuleB525D0C4": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceGitHubIssuesTaskDefinitionFA21D536",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
     },
     "CloudquerySourceGitHubRepositoriesScheduledEventRuleC7F5836E": {
       "Properties": {
@@ -4252,6 +4613,58 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
+    "CloudquerySourceGitHubRepositoriesTaskErrorRule16B8D95D": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinition921DC1BC",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "CloudquerySourceGitHubTeamsScheduledEventRule051F542B": {
       "Properties": {
         "ScheduleExpression": "cron(0 10 ? * 1 *)",
@@ -4888,6 +5301,58 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
+    "CloudquerySourceGitHubTeamsTaskErrorRule8F803D44": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceGitHubTeamsTaskDefinitionB01C9D3C",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "CloudquerySourceGuardianCustomSnykProjectsScheduledEventRule92FBDA90": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",
@@ -5469,6 +5934,58 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
+    "CloudquerySourceGuardianCustomSnykProjectsTaskErrorRule8E998BEC": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionEB2B4EBC",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "CloudquerySourceOrgWideCertificatesScheduledEventRule2D4505F4": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",
@@ -6044,6 +6561,58 @@ spec:
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceOrgWideCertificatesTaskErrorRuleBEBBDB94": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceOrgWideCertificatesTaskDefinition47A214D9",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
     },
     "CloudquerySourceOrgWideCloudFormationScheduledEventRule83F64E14": {
       "Properties": {
@@ -6624,6 +7193,58 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
+    "CloudquerySourceOrgWideCloudFormationTaskErrorRule976BA39D": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceOrgWideCloudFormationTaskDefinitionDA4F8A51",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "CloudquerySourceOrgWideCloudwatchAlarmsScheduledEventRuleB72D02A5": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",
@@ -7199,6 +7820,58 @@ spec:
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceOrgWideCloudwatchAlarmsTaskErrorRuleFFE53B33": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceOrgWideCloudwatchAlarmsTaskDefinitionF28C916F",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
     },
     "CloudquerySourceOrgWideInspectorScheduledEventRule0152ABA6": {
       "Properties": {
@@ -7777,6 +8450,58 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
+    "CloudquerySourceOrgWideInspectorTaskErrorRuleDD0BA774": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceOrgWideInspectorTaskDefinition25FAB51D",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "CloudquerySourceOrgWideLoadBalancersScheduledEventRule1B13EFF3": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",
@@ -8353,6 +9078,58 @@ spec:
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceOrgWideLoadBalancersTaskErrorRuleD5C43212": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceOrgWideLoadBalancersTaskDefinitionF1D11F23",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
     },
     "CloudquerySourceSnykAllScheduledEventRule73601A00": {
       "Properties": {
@@ -8945,6 +9722,58 @@ spec:
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceSnykAllTaskErrorRule3E369596": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Essential container in task exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceSnykAllTaskDefinitionC8C1F3EC",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
     },
     "PostgresAccessSecurityGroupCloudqueryE959A23F": {
       "Properties": {

--- a/packages/cdk/lib/ecs/cluster.ts
+++ b/packages/cdk/lib/ecs/cluster.ts
@@ -8,6 +8,7 @@ import type { Schedule } from 'aws-cdk-lib/aws-events';
 import type { IManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
+import { Topic } from 'aws-cdk-lib/aws-sns';
 import type { CloudqueryConfig } from './config';
 import { ScheduledCloudqueryTask } from './task';
 
@@ -117,12 +118,15 @@ export class CloudqueryCluster extends Cluster {
 			resources: [loggingStreamArn],
 		});
 
+		const topic = new Topic(scope, 'CloudQueryAlertTopic');
+
 		const taskProps = {
 			app,
 			cluster: this,
 			db,
 			dbAccess,
 			loggingStreamName,
+			topic,
 		};
 
 		sources.forEach(

--- a/packages/cdk/lib/ecs/cluster.ts
+++ b/packages/cdk/lib/ecs/cluster.ts
@@ -9,6 +9,7 @@ import type { IManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
 import { Topic } from 'aws-cdk-lib/aws-sns';
+import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 import type { CloudqueryConfig } from './config';
 import { ScheduledCloudqueryTask } from './task';
 
@@ -119,6 +120,10 @@ export class CloudqueryCluster extends Cluster {
 		});
 
 		const topic = new Topic(scope, 'CloudQueryAlertTopic');
+
+		topic.addSubscription(
+			new EmailSubscription('devx.operations@guardian.co.uk'),
+		);
 
 		const taskProps = {
 			app,

--- a/packages/cdk/lib/ecs/task.ts
+++ b/packages/cdk/lib/ecs/task.ts
@@ -197,7 +197,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 						],
 					},
 					lastStatus: ['STOPPED'],
-					stoppedReason: [`Essential container in task exited`],
+					stoppedReason: [`Task ${id} exited`],
 					taskDefinitionArn: [task.taskDefinitionArn],
 				},
 				detailType: ['ECS Task State Change'],

--- a/packages/cdk/lib/ecs/task.ts
+++ b/packages/cdk/lib/ecs/task.ts
@@ -135,9 +135,9 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			entryPoint: [''],
 			secrets: {
 				...secrets,
-				DB_USERNAME: Secret.fromSecretsManager(db.secret, 'username'),
-				DB_HOST: Secret.fromSecretsManager(db.secret, 'host'),
-				DB_PASSWORD: Secret.fromSecretsManager(db.secret, 'password'),
+				DB_USERNAME: Secret.fromSecretsManager(db.secret, 'host'),
+				DB_HOST: Secret.fromSecretsManager(db.secret, 'username'),
+				DB_PASSWORD: Secret.fromSecretsManager(db.secret, 'host'),
 			},
 			command: [
 				'/bin/sh',

--- a/packages/cdk/lib/ecs/task.ts
+++ b/packages/cdk/lib/ecs/task.ts
@@ -70,7 +70,7 @@ export interface ScheduledCloudqueryTaskProps
 	sourceConfig: CloudqueryConfig;
 
 	/**
-	 * The topic used to notify someone if a task f
+	 * The topic used to notify someone if a task fails
 	 */
 	topic: Topic;
 

--- a/packages/cdk/lib/ecs/task.ts
+++ b/packages/cdk/lib/ecs/task.ts
@@ -135,9 +135,9 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			entryPoint: [''],
 			secrets: {
 				...secrets,
-				DB_USERNAME: Secret.fromSecretsManager(db.secret, 'host'),
-				DB_HOST: Secret.fromSecretsManager(db.secret, 'username'),
-				DB_PASSWORD: Secret.fromSecretsManager(db.secret, 'host'),
+				DB_USERNAME: Secret.fromSecretsManager(db.secret, 'username'),
+				DB_HOST: Secret.fromSecretsManager(db.secret, 'host'),
+				DB_PASSWORD: Secret.fromSecretsManager(db.secret, 'password'),
 			},
 			command: [
 				'/bin/sh',


### PR DESCRIPTION
## What does this change?

If a scheduled CloudQuery task fails, we are not notified. This change introduces an EventBridge rule, where if the container stops with an error code, we get a message telling us which, when, and why. Currently, this message is a rather nasty JSON blob, but it does contain all the information required to figure out what is going on.

Further work should be done in a subsequent PR to turn the alert message into something a bit nicer, maybe we could send the message to a lambda that reformats it and passes it along to Anghammarad. But this is a significant amount of scope creep and needs to be prioritised against our other work. For now (aka the next couple of days), it meets the minimum requirements

## Why?

We need to know if our data is stale, as we rely on it for OKR purposes. We also need to provide up to date information to other teams.

## How has it been verified?

I swapped around some of the DB credentials to force a failure, and attached my internal email to the alert topic. Since deployment, every attempted run of a container has failed and sent me a message