### PR TITLE
Bump Github source plugin version

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -3572,7 +3572,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v6.0.2
+  version: v6.0.3
   tables:
     - github_issues
   destinations:
@@ -4043,7 +4043,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v6.0.2
+  version: v6.0.3
   tables:
     - github_repositories
   skip_tables:
@@ -4734,7 +4734,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v6.0.2
+  version: v6.0.3
   tables:
     - github_teams
     - github_team_members

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -137,7 +137,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: github
 		  path: cloudquery/github
-		  version: v6.0.2
+		  version: v6.0.3
 		  tables:
 		    - github_repositories
 		  destinations:

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -25,7 +25,7 @@ export const Versions = {
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
 	 */
-	CloudqueryGithub: '6.0.2',
+	CloudqueryGithub: '6.0.3',
 
 	/**
 	 * The version of the CloudQuery Fastly source plugin to install.


### PR DESCRIPTION
A bug in the Github Cloudquery source plugin was preventing us from fetching all the data. For full details see:

https://github.com/cloudquery/cloudquery/pull/11727

The fix has now gone [live](https://github.com/cloudquery/cloudquery/pull/11582#issuecomment-1619980238) so we can use it!:



