### PR TITLE
chore(deps): Bump CloudQuery CLI from 3.5.2 to 3.9.0

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -243,7 +243,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -893,7 +893,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -1521,7 +1521,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -2143,7 +2143,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -2783,7 +2783,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -3603,7 +3603,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -4080,7 +4080,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -4768,7 +4768,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -5473,7 +5473,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -6091,7 +6091,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -6748,7 +6748,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -7538,7 +7538,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -7979,7 +7979,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -8796,7 +8796,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -9236,7 +9236,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.5.2",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -4,7 +4,7 @@ export const Versions = {
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=cli
 	 */
-	CloudqueryCli: '3.5.2',
+	CloudqueryCli: '3.9.0',
 
 	/**
 	 * The version of the CloudQuery Postgres destination plugin to install.

--- a/packages/cloudquery/.env.example
+++ b/packages/cloudquery/.env.example
@@ -1,5 +1,5 @@
 # See https://github.com/cloudquery/cloudquery/releases?q=cli
-CQ_CLI=3.5.2
+CQ_CLI=3.9.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql
 CQ_POSTGRES=4.2.2


### PR DESCRIPTION
## What does this change?
Update the [CloudQuery CLI](https://github.com/cloudquery/cloudquery/releases?q=cli).

## Why?
Just keeping up to date.

## How has it been verified?
I've [deployed this](https://riffraff.gutools.co.uk/deployment/view/e5c89264-0a90-411c-9924-5f292b98f56f), manually run the GitHub tasks, and can see data coming in. For example:

```sql
SELECT COUNT(*) FROM github_repositories;
-- 3300
```