### PR TITLE
fix(github): Stop collecting `github_repository_dependabot_alerts`

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -4050,6 +4050,7 @@ spec:
     - github_releases
     - github_release_assets
     - github_repository_branches
+    - github_repository_dependabot_alerts
     - github_repository_dependabot_secrets
   destinations:
     - postgresql

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -302,6 +302,7 @@ export class CloudQuery extends GuStack {
 						'github_releases',
 						'github_release_assets',
 						'github_repository_branches',
+						'github_repository_dependabot_alerts',
 						'github_repository_dependabot_secrets',
 					],
 				}),


### PR DESCRIPTION
## What does this change?
We're not (yet) interested in this table, and it takes a long time to crawl.

## Why?
The `GitHubRepositories` task runs once a day, and with `github_repository_dependabot_alerts` being collected, the task takes over 24 hours to run!

![image](https://github.com/guardian/service-catalogue/assets/836140/36863cf1-b259-41e1-a841-48f8e63ef81c)

## How has it been verified?
N/A