### PR TITLE
feat: Collect GitHub organisation information

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -4737,9 +4737,14 @@ spec:
   path: cloudquery/github
   version: v6.0.3
   tables:
+    - github_organizations
+    - github_organization_members
     - github_teams
     - github_team_members
     - github_team_repositories
+  skip_tables:
+    - github_organization_dependabot_alerts
+    - github_organization_dependabot_secrets
   destinations:
     - postgresql
   concurrency: 1000

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -315,9 +315,21 @@ export class CloudQuery extends GuStack {
 				schedule: Schedule.cron({ weekDay: '1', hour: '10', minute: '0' }),
 				config: githubSourceConfig({
 					tables: [
+						'github_organizations',
+						'github_organization_members',
 						'github_teams',
 						'github_team_members',
 						'github_team_repositories',
+					],
+					skipTables: [
+						/*
+						These tables are children of github_organizations.
+						CloudQuery collects child tables automatically.
+						We don't use them as they take a long time to collect, so skip them.
+						See https://www.cloudquery.io/docs/advanced-topics/performance-tuning#improve-performance-by-skipping-relations
+						 */
+						'github_organization_dependabot_alerts',
+						'github_organization_dependabot_secrets',
 					],
 				}),
 				secrets: githubSecrets,


### PR DESCRIPTION
## What does this change, and why?
Collects more GitHub data. The [`github_organization_members` table](https://www.cloudquery.io/docs/plugins/sources/github/tables/github_organization_members) allows us to dashboard the total number of users. The [`github_organizations` table](https://www.cloudquery.io/docs/plugins/sources/github/tables/github_organizations) provides interesting things, such as any defaults we've set.

## How has it been verified?
I have previously deployed these changes to build [this dashboard](https://metrics.gutools.co.uk/d/mhkYgTQVz/github?orgId=1); the "Total users" stat is a count of rows in the `github_organization_members` table 😬.