### PR TITLE
feat: Task to collect (filtered) GitHub branch data

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -3305,6 +3305,709 @@ spec:
       },
       "Type": "AWS::Events::Rule",
     },
+    "CloudquerySourceGitHubBranchesScheduledEventRuleD1D634B8": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 day)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "cloudqueryCluster5370C11B",
+                "Arn",
+              ],
+            },
+            "EcsParameters": {
+              "LaunchType": "FARGATE",
+              "NetworkConfiguration": {
+                "AwsVpcConfiguration": {
+                  "AssignPublicIp": "DISABLED",
+                  "SecurityGroups": [
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "GroupId",
+                      ],
+                    },
+                  ],
+                  "Subnets": {
+                    "Ref": "PrivateSubnets",
+                  },
+                },
+              },
+              "TaskCount": 1,
+              "TaskDefinitionArn": {
+                "Ref": "CloudquerySourceGitHubBranchesTaskDefinition204DF243",
+              },
+            },
+            "Id": "Target0",
+            "Input": "{}",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CloudquerySourceGitHubBranchesTaskDefinitionEventsRoleEF67FE16",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CloudquerySourceGitHubBranchesTaskDefinition204DF243": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/sh",
+              "-c",
+              "echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;echo $GITHUB_REPOSITORIES > /github-repositories;wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+spec:
+  name: github
+  path: cloudquery/github
+  version: v6.0.3
+  tables:
+    - github_repository_branches
+  destinations:
+    - postgresql
+  concurrency: 1000
+  spec:
+    orgs:
+      - guardian
+    app_auth:
+      - org: guardian
+        private_key_path: /github-private-key
+        app_id: \${file:/github-app-id}
+        installation_id: \${file:/github-installation-id}
+    repos: \${file:/github-repositories}
+' > /source.yaml;printf 'kind: destination
+spec:
+  name: postgresql
+  registry: github
+  path: cloudquery/postgresql
+  version: v4.2.2
+  migrate_mode: forced
+  spec:
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
+' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Essential": true,
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-GitHubBranchesContainer",
+            "Secrets": [
+              {
+                "Name": "GITHUB_PRIVATE_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":secretsmanager:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":secret:/TEST/deploy/cloudquery/github-credentials:private-key::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "GITHUB_APP_ID",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":secretsmanager:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":secret:/TEST/deploy/cloudquery/github-credentials:app-id::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "GITHUB_INSTALLATION_ID",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":secretsmanager:",
+                      {
+                        "Ref": "AWS::Region",
+                      },
+                      ":",
+                      {
+                        "Ref": "AWS::AccountId",
+                      },
+                      ":secret:/TEST/deploy/cloudquery/github-credentials:installation-id::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "GITHUB_REPOSITORIES",
+                "ValueFrom": {
+                  "Ref": "githubrecentlyupdated500ED9D1",
+                },
+              },
+              {
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            "Environment": [
+              {
+                "Name": "STACK",
+                "Value": "deploy",
+              },
+              {
+                "Name": "STAGE",
+                "Value": "TEST",
+              },
+              {
+                "Name": "APP",
+                "Value": "cloudquery",
+              },
+              {
+                "Name": "GU_REPO",
+                "Value": "guardian/service-catalogue",
+              },
+            ],
+            "Essential": true,
+            "FirelensConfiguration": {
+              "Options": {
+                "config-file-type": "file",
+                "config-file-value": "/custom.conf",
+                "enable-ecs-log-metadata": "true",
+              },
+              "Type": "fluentbit",
+            },
+            "Image": "ghcr.io/guardian/hackday-firelens:main",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudquerySourceGitHubBranchesTaskDefinitionCloudquerySourceGitHubBranchesFirelensLogGroup0CD46554",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+              },
+            },
+            "Name": "CloudquerySource-GitHubBranchesFirelens",
+          },
+        ],
+        "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceGitHubBranchesTaskDefinitionExecutionRole543AE56F",
+            "Arn",
+          ],
+        },
+        "Family": "CloudQueryCloudquerySourceGitHubBranchesTaskDefinitionF2DDA423",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceGitHubBranchesTaskDefinitionTaskRole7B133DE0",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "CloudquerySourceGitHubBranchesTaskDefinitionCloudquerySourceGitHubBranchesFirelensLogGroup0CD46554": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudquerySourceGitHubBranchesTaskDefinitionEventsRoleDefaultPolicy0BE713BE": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ecs:RunTask",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": {
+                    "Fn::GetAtt": [
+                      "cloudqueryCluster5370C11B",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CloudquerySourceGitHubBranchesTaskDefinition204DF243",
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGitHubBranchesTaskDefinitionExecutionRole543AE56F",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGitHubBranchesTaskDefinitionTaskRole7B133DE0",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceGitHubBranchesTaskDefinitionEventsRoleDefaultPolicy0BE713BE",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceGitHubBranchesTaskDefinitionEventsRoleEF67FE16",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGitHubBranchesTaskDefinitionEventsRoleEF67FE16": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceGitHubBranchesTaskDefinitionExecutionRole543AE56F": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceGitHubBranchesTaskDefinitionExecutionRoleDefaultPolicy51A2898F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":secretsmanager:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":secret:/TEST/deploy/cloudquery/github-credentials-??????",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "githubrecentlyupdated500ED9D1",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceGitHubBranchesTaskDefinitionCloudquerySourceGitHubBranchesFirelensLogGroup0CD46554",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceGitHubBranchesTaskDefinitionExecutionRoleDefaultPolicy51A2898F",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceGitHubBranchesTaskDefinitionExecutionRole543AE56F",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGitHubBranchesTaskDefinitionTaskRole7B133DE0": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceGitHubBranchesTaskDefinitionTaskRoleDefaultPolicyB14AD52E": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":kinesis:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceGitHubBranchesTaskDefinitionTaskRoleDefaultPolicyB14AD52E",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceGitHubBranchesTaskDefinitionTaskRole7B133DE0",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceGitHubBranchesTaskErrorRuleD6C59FDE": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "cloudqueryCluster5370C11B",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Task CloudquerySource-GitHubBranches exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceGitHubBranchesTaskDefinition204DF243",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "CloudquerySourceGitHubIssuesScheduledEventRuleAF7C253C": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",
@@ -3540,6 +4243,16 @@ spec:
               ],
               "Effect": "Allow",
               "Resource": {
+                "Ref": "githubrecentlyupdated500ED9D1",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
               },
             },
@@ -3575,7 +4288,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+              "echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;echo $GITHUB_REPOSITORIES > /github-repositories;wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
 spec:
   name: github
   path: cloudquery/github
@@ -3693,6 +4406,12 @@ spec:
                       ":secret:/TEST/deploy/cloudquery/github-credentials:installation-id::",
                     ],
                   ],
+                },
+              },
+              {
+                "Name": "GITHUB_REPOSITORIES",
+                "ValueFrom": {
+                  "Ref": "githubrecentlyupdated500ED9D1",
                 },
               },
               {
@@ -4046,7 +4765,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+              "echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;echo $GITHUB_REPOSITORIES > /github-repositories;wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
 spec:
   name: github
   path: cloudquery/github
@@ -4170,6 +4889,12 @@ spec:
                       ":secret:/TEST/deploy/cloudquery/github-credentials:installation-id::",
                     ],
                   ],
+                },
+              },
+              {
+                "Name": "GITHUB_REPOSITORIES",
+                "ValueFrom": {
+                  "Ref": "githubrecentlyupdated500ED9D1",
                 },
               },
               {
@@ -4487,6 +5212,16 @@ spec:
               ],
               "Effect": "Allow",
               "Resource": {
+                "Ref": "githubrecentlyupdated500ED9D1",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
               },
             },
@@ -4738,7 +5473,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+              "echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;echo $GITHUB_REPOSITORIES > /github-repositories;wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
 spec:
   name: github
   path: cloudquery/github
@@ -4863,6 +5598,12 @@ spec:
                       ":secret:/TEST/deploy/cloudquery/github-credentials:installation-id::",
                     ],
                   ],
+                },
+              },
+              {
+                "Name": "GITHUB_REPOSITORIES",
+                "ValueFrom": {
+                  "Ref": "githubrecentlyupdated500ED9D1",
                 },
               },
               {
@@ -5171,6 +5912,16 @@ spec:
                     ":secret:/TEST/deploy/cloudquery/github-credentials-??????",
                   ],
                 ],
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "githubrecentlyupdated500ED9D1",
               },
             },
             {

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -240,6 +240,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -890,6 +891,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -1518,6 +1520,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -2140,6 +2143,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -2777,6 +2781,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -3386,6 +3391,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -4313,6 +4319,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -4796,6 +4803,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -5505,6 +5513,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -6226,6 +6235,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -6844,6 +6854,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -7501,6 +7512,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -8291,6 +8303,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -8732,6 +8745,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -9549,6 +9563,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -9989,6 +10004,7 @@ spec:
   path: cloudquery/postgresql
   version: v4.2.2
   migrate_mode: forced
+  write_mode: overwrite-delete-stale
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -293,12 +293,14 @@ export class CloudQuery extends GuStack {
 				githubCredentials,
 				'installation-id',
 			),
+			GITHUB_REPOSITORIES: Secret.fromSecretsManager(githubRecentlyUpdated),
 		};
 
 		const additionalGithubCommands = [
 			'echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key',
 			'echo $GITHUB_APP_ID > /github-app-id',
 			'echo $GITHUB_INSTALLATION_ID > /github-installation-id',
+			'echo $GITHUB_REPOSITORIES > /github-repositories',
 		];
 
 		const githubSources: CloudquerySource[] = [
@@ -354,6 +356,18 @@ export class CloudQuery extends GuStack {
 				schedule: Schedule.rate(Duration.days(1)),
 				config: githubSourceConfig({
 					tables: ['github_issues'],
+				}),
+				secrets: githubSecrets,
+				additionalCommands: additionalGithubCommands,
+			},
+			{
+				name: 'GitHubBranches',
+				description:
+					'Collect GitHub branch data from recently updated repositories',
+				schedule: Schedule.rate(Duration.days(1)),
+				config: githubSourceConfig({
+					tables: ['github_repository_branches'],
+					limitRepositories: true,
 				}),
 				secrets: githubSecrets,
 				additionalCommands: additionalGithubCommands,

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -371,6 +371,11 @@ export class CloudQuery extends GuStack {
 				}),
 				secrets: githubSecrets,
 				additionalCommands: additionalGithubCommands,
+
+				// We're only collecting data from recently updated repositories.
+				// Use `overwrite` mode to preserve data from repositories that haven't been updated recently.
+				// See https://www.cloudquery.io/docs/reference/destination-spec#write_mode
+				writeMode: 'overwrite',
 			},
 		];
 

--- a/packages/cdk/lib/ecs/cluster.ts
+++ b/packages/cdk/lib/ecs/cluster.ts
@@ -10,7 +10,7 @@ import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
-import type { CloudqueryConfig } from './config';
+import type { CloudqueryConfig, PostgresWriteMode } from './config';
 import { ScheduledCloudqueryTask } from './task';
 
 export interface CloudquerySource {
@@ -68,6 +68,11 @@ export interface CloudquerySource {
 	 * The number of cpu units used by the task.
 	 */
 	cpu?: 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384;
+
+	/**
+	 * @see https://www.cloudquery.io/docs/reference/destination-spec#write_mode
+	 */
+	writeMode?: PostgresWriteMode;
 }
 
 interface CloudqueryClusterProps extends AppIdentity {
@@ -145,6 +150,7 @@ export class CloudqueryCluster extends Cluster {
 				additionalCommands,
 				memoryLimitMiB,
 				cpu,
+				writeMode = 'overwrite-delete-stale',
 			}) => {
 				new ScheduledCloudqueryTask(scope, `CloudquerySource-${name}`, {
 					...taskProps,
@@ -156,6 +162,7 @@ export class CloudqueryCluster extends Cluster {
 					additionalCommands,
 					memoryLimitMiB,
 					cpu,
+					writeMode,
 				});
 			},
 		);

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -12,7 +12,7 @@ import {
 
 describe('Config generation, and converting to YAML', () => {
 	it('Should create a destination configuration', () => {
-		const config = postgresDestinationConfig();
+		const config = postgresDestinationConfig('overwrite-delete-stale');
 		expect(dump(config)).toMatchInlineSnapshot(`
 		"kind: destination
 		spec:
@@ -21,6 +21,7 @@ describe('Config generation, and converting to YAML', () => {
 		  path: cloudquery/postgresql
 		  version: v4.2.2
 		  migrate_mode: forced
+		  write_mode: overwrite-delete-stale
 		  spec:
 		    connection_string: >-
 		      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -121,10 +121,18 @@ export function awsSourceConfigForAccount(
 	});
 }
 
+export interface GithubCloudqueryTableConfig extends CloudqueryTableConfig {
+	/**
+	 * If true, only a subset of repositories will be queried.
+	 * @default false
+	 */
+	limitRepositories?: boolean;
+}
+
 export function githubSourceConfig(
-	tableConfig: CloudqueryTableConfig,
+	tableConfig: GithubCloudqueryTableConfig,
 ): CloudqueryConfig {
-	const { tables, skipTables } = tableConfig;
+	const { tables, skipTables, limitRepositories = false } = tableConfig;
 
 	if (!tables && !skipTables) {
 		throw new Error('Must specify either tables or skipTables');
@@ -152,6 +160,9 @@ export function githubSourceConfig(
 						installation_id: '${file:/github-installation-id}',
 					},
 				],
+				...(limitRepositories && {
+					repos: '${file:/github-repositories}',
+				}),
 			},
 		},
 	};

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -16,9 +16,19 @@ interface CloudqueryTableConfig {
 }
 
 /**
+ * @see https://www.cloudquery.io/docs/reference/destination-spec#write_mode
+ */
+export type PostgresWriteMode =
+	| 'overwrite-delete-stale'
+	| 'overwrite'
+	| 'append';
+
+/**
  * Create a CloudQuery destination configuration for Postgres.
  */
-export function postgresDestinationConfig(): CloudqueryConfig {
+export function postgresDestinationConfig(
+	writeMode: PostgresWriteMode,
+): CloudqueryConfig {
 	return {
 		kind: 'destination',
 		spec: {
@@ -27,6 +37,7 @@ export function postgresDestinationConfig(): CloudqueryConfig {
 			path: 'cloudquery/postgresql',
 			version: `v${Versions.CloudqueryPostgres}`,
 			migrate_mode: 'forced',
+			write_mode: writeMode,
 			spec: {
 				connection_string: [
 					'user=${DB_USERNAME}',

--- a/packages/cdk/lib/ecs/task.ts
+++ b/packages/cdk/lib/ecs/task.ts
@@ -19,7 +19,7 @@ import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
 import type { Topic } from 'aws-cdk-lib/aws-sns';
 import { dump } from 'js-yaml';
-import type { CloudqueryConfig } from './config';
+import type { CloudqueryConfig, PostgresWriteMode } from './config';
 import { postgresDestinationConfig } from './config';
 import { Versions } from './versions';
 
@@ -86,6 +86,11 @@ export interface ScheduledCloudqueryTaskProps
 	 * Additional commands to run within the CloudQuery container, executed first.
 	 */
 	additionalCommands?: string[];
+
+	/**
+	 * @see https://www.cloudquery.io/docs/reference/destination-spec#write_mode
+	 */
+	writeMode: PostgresWriteMode;
 }
 
 export class ScheduledCloudqueryTask extends ScheduledFargateTask {
@@ -107,6 +112,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			additionalCommands = [],
 			memoryLimitMiB,
 			cpu,
+			writeMode,
 		} = props;
 		const { region, stack, stage } = scope;
 		const thisRepo = 'guardian/service-catalogue'; // TODO get this from GuStack
@@ -116,7 +122,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			cpu,
 		});
 
-		const destinationConfig = postgresDestinationConfig();
+		const destinationConfig = postgresDestinationConfig(writeMode);
 
 		/*
 		This error shouldn't ever be thrown as AWS CDK creates a secret by default,


### PR DESCRIPTION
## What does this change?
Builds on #230, adding a task to collect [GitHub branch data](https://www.cloudquery.io/docs/plugins/sources/github/tables/github_repository_branches).

## Why?
???

## How has it been verified?
???