### PR TITLE
Collect GitHub branch data

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -4046,10 +4046,10 @@ spec:
   version: v6.0.3
   tables:
     - github_repositories
+    - github_repository_branches
   skip_tables:
     - github_releases
     - github_release_assets
-    - github_repository_branches
     - github_repository_dependabot_alerts
     - github_repository_dependabot_secrets
   destinations:

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -294,14 +294,13 @@ export class CloudQuery extends GuStack {
 				description: 'Collect GitHub repository data',
 				schedule: Schedule.rate(Duration.days(1)),
 				config: githubSourceConfig({
-					tables: ['github_repositories'],
+					tables: ['github_repositories', 'github_repository_branches'],
 
 					// We're not (yet) interested in the following tables, so do not collect them to reduce API quota usage.
 					// See https://www.cloudquery.io/docs/advanced-topics/performance-tuning#improve-performance-by-skipping-relations
 					skipTables: [
 						'github_releases',
 						'github_release_assets',
-						'github_repository_branches',
 						'github_repository_dependabot_alerts',
 						'github_repository_dependabot_secrets',
 					],


### PR DESCRIPTION
## What does this change?
Start collecting data for all branches, on all repositories as we're interested in this data now.

This data helps understand if a repository is reliably integrated with Snyk. We can compare the commit sha of a repository's default branch, with a Snyk project's commit tag. Where they match, we conclude a repository is reliably integrated with Snyk.

## Why?
In addition to the aforementioned Snyk checks, this PR is also a simplification of #232, which itself has demonstrated that #229 is not needed.

## How has it been verified?
I've [deployed](https://riffraff.gutools.co.uk/deployment/view/d6835314-0835-4e7c-885a-8e943317da2e) this branch, and manually started the task.

The task completes successfully, and there are some compelling statistics that suggest #229 (and it's related PRs) is not needed:
- The task completes in <7 minutes[^1]
- There are 3,393 repositories in the organisation
   ```sql
   select count(distinct full_name) from github_repositories;
   ```
- There are 25,678 branches
   ```sql
   select count(*) from github_repository_branches;
   ```
- We have branch data for 3317 repositories (97.76%)
   ```sql
   select count(distinct repository_id) from github_repository_branches;
   ```
- We have data from the default branch of 3312 repositories (97.61%), with 81 missing (2.39%)
   ```sql
   with repo_commits as (
       select  r.full_name
               , r.updated_at
               , r.pushed_at
               , r.archived
               , b.name             as branch_name
               , b.commit ->> 'sha' as sha
       from github_repositories r
           left join github_repository_branches b
               on r.id = b.repository_id
                      and b.name = r.default_branch
   )
   select  count(full_name)
           , case sha
               when sha then 'true'
               else 'false'
           end as commit_collected
   from repo_commits
   group by commit_collected;
   ```

The logs do not point to any errors being encountered, so we'd need to analyse the data to understand the cause of the missing data - presumably the GitHub API isn't returning anything. In any case, I think this is enough to avoid adding the lambda in https://github.com/guardian/service-catalogue/pull/229, and the related PRs.

[^1]: Started 11/07/2023, 12:57:14 UTC. Stopped 11/07/2023, 13:03:16 UTC.