### PR TITLE
fix: Collect all `aws_organization` tables

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -191,13 +191,7 @@ spec:
     - aws_xray_groups
     - aws_stepfunctions_map_runs
     - aws_stepfunctions_map_run_executions
-    - aws_organizations
-    - aws_organizations_accounts
-    - aws_organizations_delegated_services
-    - aws_organizations_delegated_administrators
-    - aws_organizations_organizational_units
-    - aws_organizations_policies
-    - aws_organizations_roots
+    - aws_organization*
     - aws_accessanalyzer_*
     - aws_securityhub_*
     - aws_cloudformation_stacks
@@ -1483,13 +1477,7 @@ spec:
   path: cloudquery/aws
   version: v18.3.0
   tables:
-    - aws_organizations
-    - aws_organizations_accounts
-    - aws_organizations_delegated_services
-    - aws_organizations_delegated_administrators
-    - aws_organizations_organizational_units
-    - aws_organizations_policies
-    - aws_organizations_roots
+    - aws_organization*
   destinations:
     - postgresql
   spec:

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -153,7 +153,7 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
 spec:
   name: aws
   path: cloudquery/aws
-  version: v18.3.0
+  version: v20.0.0
   tables:
     - aws_*
   skip_tables:
@@ -225,7 +225,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -237,7 +237,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -851,7 +851,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v18.3.0
+  version: v20.0.0
   tables:
     - aws_accessanalyzer_*
     - aws_securityhub_*
@@ -875,7 +875,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -887,7 +887,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -1475,7 +1475,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v18.3.0
+  version: v20.0.0
   tables:
     - aws_organization*
   destinations:
@@ -1497,7 +1497,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -1509,7 +1509,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -2119,7 +2119,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -2131,7 +2131,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -2756,7 +2756,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -2771,7 +2771,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -3579,7 +3579,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -3591,7 +3591,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -4056,7 +4056,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -4068,7 +4068,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -4749,7 +4749,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -4761,7 +4761,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -5454,7 +5454,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -5466,7 +5466,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -6049,7 +6049,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v18.3.0
+  version: v20.0.0
   tables:
     - aws_acm*
   destinations:
@@ -6072,7 +6072,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -6084,7 +6084,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -6703,7 +6703,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v18.3.0
+  version: v20.0.0
   tables:
     - aws_cloudformation_stacks
     - aws_cloudformation_stack_resources
@@ -6729,7 +6729,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -6741,7 +6741,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -7496,7 +7496,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v18.3.0
+  version: v20.0.0
   tables:
     - aws_cloudwatch_alarms
   destinations:
@@ -7519,7 +7519,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -7531,7 +7531,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -7936,7 +7936,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v18.3.0
+  version: v20.0.0
   tables:
     - aws_inspector_findings
     - aws_inspector2_findings
@@ -7960,7 +7960,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -7972,7 +7972,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -8753,7 +8753,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v18.3.0
+  version: v20.0.0
   tables:
     - aws_elbv1_*
     - aws_elbv2_*
@@ -8777,7 +8777,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -8789,7 +8789,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -9217,7 +9217,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v4.2.2
+  version: v5.0.0
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -9229,7 +9229,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.9.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.9.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -139,13 +139,12 @@ export class CloudQuery extends GuStack {
 				schedule: Schedule.rate(Duration.days(1)),
 				config: awsSourceConfigForAccount(GuardianAwsAccounts.DeployTools, {
 					tables: [
-						'aws_organizations',
-						'aws_organizations_accounts',
-						'aws_organizations_delegated_services',
-						'aws_organizations_delegated_administrators',
-						'aws_organizations_organizational_units',
-						'aws_organizations_policies',
-						'aws_organizations_roots',
+						/*
+						Collect all AWS Organisation tables, including account names, and which OU they belong to.
+						A wildcard is used, as there are a lot of tables!
+						See https://www.cloudquery.io/docs/advanced-topics/performance-tuning#use-wildcard-matching
+						 */
+						'aws_organization*',
 					],
 				}),
 				managedPolicies: [readonlyPolicy],

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -19,7 +19,7 @@ describe('Config generation, and converting to YAML', () => {
 		  name: postgresql
 		  registry: github
 		  path: cloudquery/postgresql
-		  version: v4.2.2
+		  version: v5.0.0
 		  migrate_mode: forced
 		  spec:
 		    connection_string: >-
@@ -38,7 +38,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v18.3.0
+		  version: v20.0.0
 		  tables:
 		    - aws_s3_buckets
 		  destinations:
@@ -70,7 +70,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v18.3.0
+		  version: v20.0.0
 		  tables:
 		    - '*'
 		  skip_tables:
@@ -107,7 +107,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v18.3.0
+		  version: v20.0.0
 		  tables:
 		    - aws_accessanalyzer_analyzers
 		    - aws_accessanalyzer_analyzer_archive_rules

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -4,21 +4,21 @@ export const Versions = {
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=cli
 	 */
-	CloudqueryCli: '3.9.0',
+	CloudqueryCli: '3.9.1',
 
 	/**
 	 * The version of the CloudQuery Postgres destination plugin to install.
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql
 	 */
-	CloudqueryPostgres: '4.2.2',
+	CloudqueryPostgres: '5.0.0',
 
 	/**
 	 * The version of the CloudQuery AWS source plugin to install.
 	 *
 	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
 	 */
-	CloudqueryAws: '18.3.0',
+	CloudqueryAws: '20.0.0',
 
 	/**
 	 * The version of the CloudQuery GitHub source plugin to install.

--- a/packages/cloudquery/.env.example
+++ b/packages/cloudquery/.env.example
@@ -2,10 +2,10 @@
 CQ_CLI=3.9.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql
-CQ_POSTGRES=4.2.2
+CQ_POSTGRES=5.0.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
-CQ_AWS=18.3.0
+CQ_AWS=20.0.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
 CQ_GITHUB=6.0.2


### PR DESCRIPTION
## What does this change?
Collect all AWS Org data, as we've started to become more interested in it. In particular the `aws_organizations_account_parents` table tells us which OU an account is in.

Uses [wildcard](https://www.cloudquery.io/docs/advanced-topics/performance-tuning#use-wildcard-matching) matching as there are a lot of [tables](https://www.cloudquery.io/docs/plugins/sources/aws/tables):

![image](https://github.com/guardian/service-catalogue/assets/836140/072271b7-c3e5-4b50-aa4e-53274fd586ec)

## Why?
As we organise OUs by department, knowing which account is in which OU helps us determine how each department is performing.

## How has it been verified?
I've collected `aws_organization*` locally, and can confirm the data is expected.