### PR TITLE
fix: Collect AWS org data once a month

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -1392,7 +1392,7 @@ spec:
     },
     "CloudquerySourceDeployToolsListOrgsScheduledEventRuleDF9BD8AF": {
       "Properties": {
-        "ScheduleExpression": "rate(1 day)",
+        "ScheduleExpression": "cron(* 10 1 1 ? *)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/packages/cdk/lib/cloudquery.ts
+++ b/packages/cdk/lib/cloudquery.ts
@@ -136,7 +136,7 @@ export class CloudQuery extends GuStack {
 				name: 'DeployToolsListOrgs',
 				description:
 					'Data fetched from the Deploy Tools account (delegated from Root).',
-				schedule: Schedule.rate(Duration.days(1)),
+				schedule: Schedule.cron({ month: '1', day: '1', hour: '10' }), // Run on the first of the month at 10am
 				config: awsSourceConfigForAccount(GuardianAwsAccounts.DeployTools, {
 					tables: [
 						/*


### PR DESCRIPTION
## What does this change, and why?
Changes the schedule for the AWS org data. This data doesn't change that often, certainly not daily, so collect it at a slower rate of once a month.

## How has it been verified?
N/A