### PR TITLE
refactor: Use the same CloudQuery versions locally and in PROD

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,9 @@
+# ---- DO NOT COMMIT SECRETS TO THIS FILE ----
+
+# Environment variables shared between INFRA and DEV.
+
 # See https://github.com/cloudquery/cloudquery/releases?q=cli
-CQ_CLI=3.9.0
+CQ_CLI=3.9.1
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql
 CQ_POSTGRES=5.0.0
@@ -8,10 +12,19 @@ CQ_POSTGRES=5.0.0
 CQ_AWS=20.0.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
-CQ_GITHUB=6.0.2
+CQ_GITHUB=6.0.3
+
+# See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-fastly
+CQ_FASTLY=2.0.2
+
+# See https://github.com/guardian/cq-source-galaxies
+CQ_GUARDIAN_GALAXIES=1.1.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-snyk
 CQ_SNYK=3.0.2
+
+# See https://github.com/guardian/cq-source-snyk-full-project
+CQ_GUARDIAN_SNYK=0.1.1
 
 # See https://github.com/settings/tokens?type=beta
 GITHUB_ACCESS_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -175,7 +175,6 @@ web_modules/
 .yarn-integrity
 
 # dotenv environment variable files
-.env
 .env.development.local
 .env.test.local
 .env.production.local

--- a/README.md
+++ b/README.md
@@ -36,3 +36,9 @@ The following packages form part of Service Catalogue:
 
 To learn how to use cloudquery, see the [docs](docs/getting-started.md) for an introduction.
 
+## Updating CloudQuery
+To update the version of CloudQuery, and its plugins:
+1. Edit the [`.env` file at the root of the repository](.env)
+2. [Run CloudQuery locally](packages/cloudquery/README.md) to ensure it works
+3. Update the CDK snapshot tests: `npm test --workspace=cdk -- -u`
+4. Raise a PR

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,9 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires -- can't use import here
+const dotenv = require('dotenv');
+
+// Load environment variables from .env file at the root of the repository
+dotenv.config({ path: `${__dirname}/.env` });
+
 module.exports = {
 	verbose: true,
 	testEnvironment: 'node',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,25 +1,16 @@
-const generateProject = (name) => {
-	return {
-		displayName: name,
-		transform: {
-			'^.+\\.tsx?$': 'ts-jest',
-		},
-		transformIgnorePatterns: [
-			'node_modules/(?!@guardian/private-infrastructure-config)',
-		],
-		testMatch: [`<rootDir>/packages/${name}/**/*.test.ts`],
-		setupFilesAfterEnv: [`./packages/${name}/jest.setup.js`],
-		moduleNameMapper: {
-			'^common$': '<rootDir>/packages/common/src',
-			'^common/(.*)$': '<rootDir>/packages/common/src/$1',
-		},
-	};
-};
-
 module.exports = {
 	verbose: true,
 	testEnvironment: 'node',
 	projects: [
-		'cdk',
-	].map(generateProject),
+		{
+			displayName: 'cdk',
+			transform: {
+				'^.+\\.tsx?$': 'ts-jest',
+			},
+			transformIgnorePatterns: [
+				'node_modules/(?!@guardian/private-infrastructure-config)',
+			],
+			setupFilesAfterEnv: [`<rootDir>/packages/cdk/jest.setup.js`],
+		},
+	],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@guardian/eslint-config-typescript": "^2.0.0",
         "@guardian/prettier": "^2.1.5",
         "@guardian/tsconfig": "^0.2.0",
-        "aws-sdk-client-mock": "^2.0.0",
         "dotenv": "^16.0.1",
         "esbuild": "^0.15.16",
         "eslint-plugin-prettier": "^4.2.1"
@@ -1123,29 +1122,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "node_modules/@sinonjs/samsam": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "dev": true,
-      "license": "(Unlicense OR Apache-2.0)"
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "license": "MIT"
@@ -1266,19 +1242,6 @@
     },
     "node_modules/@types/semver": {
       "version": "7.3.13",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/sinon": {
-      "version": "10.0.13",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/sinonjs__fake-timers": "*"
-      }
-    },
-    "node_modules/@types/sinonjs__fake-timers": {
-      "version": "8.1.2",
       "dev": true,
       "license": "MIT"
     },
@@ -1671,16 +1634,6 @@
       },
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/aws-sdk-client-mock": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/sinon": "^10.0.10",
-        "sinon": "^14.0.2",
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/aws-sdk/node_modules/uuid": {
@@ -2162,14 +2115,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/diff": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -3705,11 +3650,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "license": "ISC"
@@ -4377,11 +4317,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/just-extend": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "license": "MIT",
@@ -4430,11 +4365,6 @@
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
       "dev": true,
       "license": "MIT"
     },
@@ -4573,42 +4503,6 @@
       "version": "1.0.5",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nise": {
-      "version": "5.1.3",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^7.0.4",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
-      }
-    },
-    "node_modules/nise/node_modules/@sinonjs/commons": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
-      "version": "7.1.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/nise/node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
-      "version": "1.8.6",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -4947,14 +4841,6 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "license": "MIT"
-    },
-    "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -5446,31 +5332,6 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "license": "ISC"
-    },
-    "node_modules/sinon": {
-      "version": "14.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^9.1.2",
-        "@sinonjs/samsam": "^7.0.1",
-        "diff": "^5.0.0",
-        "nise": "^5.1.2",
-        "supports-color": "^7.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/@sinonjs/commons": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -7460,28 +7321,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "@sinonjs/samsam": {
-      "version": "7.0.1",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^2.0.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "2.0.0",
-          "dev": true,
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
-      }
-    },
-    "@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "dev": true
-    },
     "@tsconfig/node10": {
       "version": "1.0.9"
     },
@@ -7582,17 +7421,6 @@
     },
     "@types/semver": {
       "version": "7.3.13",
-      "dev": true
-    },
-    "@types/sinon": {
-      "version": "10.0.13",
-      "dev": true,
-      "requires": {
-        "@types/sinonjs__fake-timers": "*"
-      }
-    },
-    "@types/sinonjs__fake-timers": {
-      "version": "8.1.2",
       "dev": true
     },
     "@types/stack-utils": {
@@ -7807,15 +7635,6 @@
           "version": "8.0.0",
           "dev": true
         }
-      }
-    },
-    "aws-sdk-client-mock": {
-      "version": "2.0.1",
-      "dev": true,
-      "requires": {
-        "@types/sinon": "^10.0.10",
-        "sinon": "^14.0.2",
-        "tslib": "^2.1.0"
       }
     },
     "babel-jest": {
@@ -8455,10 +8274,6 @@
     },
     "detect-newline": {
       "version": "3.1.0"
-    },
-    "diff": {
-      "version": "5.1.0",
-      "dev": true
     },
     "diff-sequences": {
       "version": "29.3.1"
@@ -9404,10 +9219,6 @@
         "is-docker": "^2.0.0"
       }
     },
-    "isarray": {
-      "version": "0.0.1",
-      "dev": true
-    },
     "isexe": {
       "version": "2.0.0"
     },
@@ -9855,10 +9666,6 @@
         "universalify": "^2.0.0"
       }
     },
-    "just-extend": {
-      "version": "4.2.1",
-      "dev": true
-    },
     "kleur": {
       "version": "3.0.3"
     },
@@ -9887,10 +9694,6 @@
     },
     "lodash.camelcase": {
       "version": "4.3.0",
-      "dev": true
-    },
-    "lodash.get": {
-      "version": "4.4.2",
       "dev": true
     },
     "lodash.kebabcase": {
@@ -9981,42 +9784,6 @@
     "nice-try": {
       "version": "1.0.5",
       "dev": true
-    },
-    "nise": {
-      "version": "5.1.3",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^7.0.4",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "2.0.0",
-          "dev": true,
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        },
-        "@sinonjs/fake-timers": {
-          "version": "7.1.2",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^1.7.0"
-          },
-          "dependencies": {
-            "@sinonjs/commons": {
-              "version": "1.8.6",
-              "dev": true,
-              "requires": {
-                "type-detect": "4.0.8"
-              }
-            }
-          }
-        }
-      }
     },
     "node-int64": {
       "version": "0.4.0"
@@ -10228,13 +9995,6 @@
     },
     "path-parse": {
       "version": "1.0.7"
-    },
-    "path-to-regexp": {
-      "version": "1.8.0",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -10509,27 +10269,6 @@
     },
     "signal-exit": {
       "version": "3.0.7"
-    },
-    "sinon": {
-      "version": "14.0.2",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^9.1.2",
-        "@sinonjs/samsam": "^7.0.1",
-        "diff": "^5.0.0",
-        "nise": "^5.1.2",
-        "supports-color": "^7.2.0"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "2.0.0",
-          "dev": true,
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
-      }
     },
     "sisteransi": {
       "version": "1.0.5"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "npm run test --workspaces --if-present",
     "synth": "npm run synth --workspace=cdk",
-    "typecheck": "npm run typecheck --workspaces",
+    "typecheck": "npm run typecheck --workspaces --if-present",
     "build": "npm run build --workspaces --if-present",
     "lint": "eslint packages/** --ext .ts --no-error-on-unmatched-pattern"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@guardian/eslint-config-typescript": "^2.0.0",
     "@guardian/prettier": "^2.1.5",
     "@guardian/tsconfig": "^0.2.0",
-    "aws-sdk-client-mock": "^2.0.0",
     "dotenv": "^16.0.1",
     "esbuild": "^0.15.16",
     "eslint-plugin-prettier": "^4.2.1"

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -197,7 +197,7 @@ export function galaxiesSourceConfig(bucketName: string): CloudqueryConfig {
 		spec: {
 			name: 'galaxies',
 			path: 'guardian/galaxies',
-			version: Versions.CloudqueryGalaxies,
+			version: `v${Versions.CloudqueryGalaxies}`,
 			destinations: ['postgresql'],
 			tables: [
 				'galaxies_people_table',

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -1,57 +1,22 @@
+const envOrError = (name: string): string => {
+	const value = process.env[name];
+	if (!value) {
+		throw new Error(`Missing environment variable ${name}`);
+	}
+	return value;
+};
+
+/**
+ * The versions of various CloudQuery plugins.
+ * See the `.env` file at the root of the repository.
+ */
 export const Versions = {
-	/**
-	 * The version of the CloudQuery CLI to install.
-	 *
-	 * @see https://github.com/cloudquery/cloudquery/releases?q=cli
-	 */
-	CloudqueryCli: '3.9.1',
-
-	/**
-	 * The version of the CloudQuery Postgres destination plugin to install.
-	 *
-	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql
-	 */
-	CloudqueryPostgres: '5.0.0',
-
-	/**
-	 * The version of the CloudQuery AWS source plugin to install.
-	 *
-	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
-	 */
-	CloudqueryAws: '20.0.0',
-
-	/**
-	 * The version of the CloudQuery GitHub source plugin to install.
-	 *
-	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
-	 */
-	CloudqueryGithub: '6.0.3',
-
-	/**
-	 * The version of the CloudQuery Fastly source plugin to install.
-	 *
-	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-fastly
-	 */
-	CloudqueryFastly: '2.0.2',
-
-	/**
-	 * The version of the our custom Galaxies source plugin to install.
-	 *
-	 * @see https://github.com/guardian/cq-source-galaxies
-	 */
-	CloudqueryGalaxies: 'v1.1.0',
-
-	/**
-	 * The version of the CloudQuery Snyk source plugin to install.
-	 *
-	 * @see https://github.com/cloudquery/cloudquery/releases?q=plugins-source-snyk
-	 */
-	CloudquerySnyk: '3.0.2',
-
-	/**
-	 * The version of the CloudQuery Snyk source plugin to install.
-	 *
-	 * @see https://github.com/guardian/cq-source-snyk-full-project
-	 */
-	CloudquerySnykGuardian: '0.1.1',
+	CloudqueryCli: envOrError('CQ_CLI'),
+	CloudqueryPostgres: envOrError('CQ_POSTGRES'),
+	CloudqueryAws: envOrError('CQ_AWS'),
+	CloudqueryGithub: envOrError('CQ_GITHUB'),
+	CloudqueryFastly: envOrError('CQ_FASTLY'),
+	CloudqueryGalaxies: envOrError('CQ_GUARDIAN_GALAXIES'),
+	CloudquerySnyk: envOrError('CQ_SNYK'),
+	CloudquerySnykGuardian: envOrError('CQ_GUARDIAN_SNYK'),
 };

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -4,8 +4,7 @@
   "scripts": {
     "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects cdk",
     "typecheck": "tsc -noEmit",
-    "cdk": "cdk",
-    "synth": "cdk synth --path-metadata false --version-reporting false"
+    "synth": "DOTENV_CONFIG_PATH=../../.env cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",

--- a/packages/cloudquery/package.json
+++ b/packages/cloudquery/package.json
@@ -2,10 +2,6 @@
   "name": "cloudquery",
   "version": "0.0.0",
   "scripts": {
-    "start": "./script/start",
-    "test": "echo not implmented",
-    "build": "echo not implmented",
-    "lint": "echo not implmented",
-    "typecheck": "echo not implmented"
+    "start": "./script/start"
   }
 }

--- a/packages/cloudquery/script/setup
+++ b/packages/cloudquery/script/setup
@@ -3,12 +3,16 @@
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=$DIR/../../..
 
-echo "Creating .env file from .env.example"
-cp $DIR/../.env.example $DIR/../.env
+ENV_FILE=$ROOT_DIR/.env
+LOCAL_ENV_FILE=$ROOT_DIR/.env.local
 
-echo "Visit https://github.com/settings/tokens?type=beta to create a GitHub token, and add it to the .env file"
-echo "Visit https://docs.snyk.io/snyk-api-info/authentication-for-api to create a Snyk token, and add it to the .env file"
+echo "Creating $LOCAL_ENV_FILE file from $ENV_FILE}"
+cp $ENV_FILE $LOCAL_ENV_FILE
+
+echo "Visit https://github.com/settings/tokens?type=beta to create a GitHub token, and add it to $LOCAL_ENV_FILE"
+echo "Visit https://docs.snyk.io/snyk-api-info/authentication-for-api to create a Snyk token, and add it to $LOCAL_ENV_FILE"
 
 echo "Checking AWS credentials"
 STATUS=$(aws sts get-caller-identity --profile developerPlayground 2>&1 || true)

--- a/packages/cloudquery/script/start
+++ b/packages/cloudquery/script/start
@@ -3,6 +3,9 @@
 set -e
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ROOT_DIR=$DIR/../../..
+
+LOCAL_ENV_FILE=$ROOT_DIR/.env.local
 
 echo "Checking AWS credentials"
 STATUS=$(aws sts get-caller-identity --profile developerPlayground 2>&1 || true)
@@ -17,7 +20,7 @@ else
 fi
 
 if curl -s --unix-socket /var/run/docker.sock http/_ping 2>&1 >/dev/null; then
-  docker compose -f "${DIR}/../docker-compose.yaml" up -d
+  docker compose -f "${DIR}/../docker-compose.yaml" --env-file $LOCAL_ENV_FILE up -d
 else
   echo "Docker is not running. Please start Docker."
   exit 1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,9 @@
 {
   "extends": "@guardian/tsconfig/tsconfig.json",
   "compilerOptions": {
-
     "module": "commonjs",
     "esModuleInterop": true,
-
-
-
-
     "baseUrl": ".",
-    "paths": {
-      "common": ["packages/common/src"],
-      "common/*": ["packages/common/src/*"]
-    }
   },
   "ts-node": {
     "require": ["tsconfig-paths/register", "dotenv/config"]


### PR DESCRIPTION
## What does this change?
Aimed at improving the story of version upgrades, this PR refactors how we define the versions of CloudQuery being used. Currently, we track the PROD and DEV versions independently, and we're not in sync. In this change, we use the root `.env` file to track the versions for all environments. This should make it easier to verify version bumps.

## Why?
Keeping two files in sync isn't very fun!

## How has it been verified?
- Followed the README for running CloudQuery locally, and it still works as before
- The CDK snapshot tests passing _and_ not being updated demonstrates this is a no-op for our AWS infrastructure
