### PR TITLE
chore(deps): Update CloudQuery AWS plugin

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ CQ_CLI=3.9.1
 CQ_POSTGRES=5.0.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
-CQ_AWS=20.0.0
+CQ_AWS=22.0.1
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
 CQ_GITHUB=6.0.3

--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -153,7 +153,7 @@ exports[`The CloudQuery stack matches the snapshot 1`] = `
 spec:
   name: aws
   path: cloudquery/aws
-  version: v20.0.0
+  version: v22.0.1
   tables:
     - aws_*
   skip_tables:
@@ -851,7 +851,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v20.0.0
+  version: v22.0.1
   tables:
     - aws_accessanalyzer_*
     - aws_securityhub_*
@@ -1475,7 +1475,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v20.0.0
+  version: v22.0.1
   tables:
     - aws_organization*
   destinations:
@@ -6049,7 +6049,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v20.0.0
+  version: v22.0.1
   tables:
     - aws_acm*
   destinations:
@@ -6703,7 +6703,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v20.0.0
+  version: v22.0.1
   tables:
     - aws_cloudformation_stacks
     - aws_cloudformation_stack_resources
@@ -7496,7 +7496,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v20.0.0
+  version: v22.0.1
   tables:
     - aws_cloudwatch_alarms
   destinations:
@@ -7936,7 +7936,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v20.0.0
+  version: v22.0.1
   tables:
     - aws_inspector_findings
     - aws_inspector2_findings
@@ -8753,7 +8753,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v20.0.0
+  version: v22.0.1
   tables:
     - aws_elbv1_*
     - aws_elbv2_*

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -38,7 +38,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v20.0.0
+		  version: v22.0.1
 		  tables:
 		    - aws_s3_buckets
 		  destinations:
@@ -70,7 +70,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v20.0.0
+		  version: v22.0.1
 		  tables:
 		    - '*'
 		  skip_tables:
@@ -107,7 +107,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v20.0.0
+		  version: v22.0.1
 		  tables:
 		    - aws_accessanalyzer_analyzers
 		    - aws_accessanalyzer_analyzer_archive_rules


### PR DESCRIPTION
This PR builds on #240, as a way to demonstrate those changes in practice.

## What does this change?
This version includes a fix for the collection of ACM certificates. See https://github.com/cloudquery/cloudquery/issues/12416 for more details.

## Why?
The `aws_acm_certificates` table is used by @guardian/devx-reliability's dashboards.

## How has it been verified?
I've run CloudQuery locally. Running AWS source v20.0.0 does not collect any ACM certificates. Running AWS source v22.0.1, the ACM table has entries again.