### PR TITLE
Add Galaxies profile info table

### DIFF
--- a/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/cloudquery.test.ts.snap
@@ -2725,6 +2725,7 @@ spec:
     - galaxies_people_table
     - galaxies_teams_table
     - galaxies_streams_table
+    - galaxies_people_profile_info_table
   spec:
     bucket: ",
                     {

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -188,6 +188,7 @@ describe('Config generation, and converting to YAML', () => {
 		    - galaxies_people_table
 		    - galaxies_teams_table
 		    - galaxies_streams_table
+		    - galaxies_people_profile_info_table
 		  spec:
 		    bucket: my-galaxies-bucket
 		"

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -203,6 +203,7 @@ export function galaxiesSourceConfig(bucketName: string): CloudqueryConfig {
 				'galaxies_people_table',
 				'galaxies_teams_table',
 				'galaxies_streams_table',
+				'galaxies_people_profile_info_table',
 			],
 			spec: {
 				bucket: bucketName,


### PR DESCRIPTION
This table links a P+E email ID to a Github ID, which is useful to understand ownership of services.

Note, there wasn't a pre-existing Cloudformation version here so I've released a v1.1.0 to match what we expect in `cq-source-galaxies`. I have no idea how this could have worked before without this.

@see https://github.com/guardian/cq-source-galaxies/pull/1
