### PR TITLE
introduce full_name column to view_repo_ownership

### DIFF
--- a/packages/repocop/repocop.ipynb
+++ b/packages/repocop/repocop.ipynb
@@ -86,8 +86,8 @@
     "topics_df = select('github_repositories', ['full_name', 'topics'], engine)\n",
     "teams_df = select('github_teams', ['name', 'slug'], engine)\n",
     "#select function doesn't work on views, so we have to use read_sql_query\n",
-    "ownership_df = pd.read_sql_query(\"select repo_name, github_team_name, github_team_id from view_repo_ownership\", con=conn)\n",
-    "ownership_df = ownership_df.merge(teams_df, how='left', left_on='github_team_name', right_on='name')[['repo_name', 'github_team_name', 'slug']]"
+    "ownership_df = pd.read_sql_query(\"select full_name, github_team_name, github_team_id from view_repo_ownership\", con=conn)\n",
+    "ownership_df = ownership_df.merge(teams_df, how='left', left_on='github_team_name', right_on='name')[['full_name', 'github_team_name', 'slug']]"
    ]
   },
   {
@@ -132,7 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "repository_rule_df =  repository_01_df.merge(repository_06_df, how='left', left_on='full_name', right_on='repo_name')[['full_name', 'repository_01', 'repository_06']]\n",
+    "repository_rule_df =  repository_01_df.merge(repository_06_df, how='left', left_on='full_name', right_on='full_name')[['full_name', 'repository_01', 'repository_06']]\n",
     "repository_rule_df.head()"
    ]
   },

--- a/packages/repocop/rules.py
+++ b/packages/repocop/rules.py
@@ -12,18 +12,18 @@ def repository_01(default_branch_df: DataFrame) -> DataFrame:
     default_branch_df['repository_01'] = default_branch_df['default_branch'] == 'main'
     return default_branch_df[['full_name', 'repository_01']]
 
-#owner_df requires columns 'repo_name', 'slug'
+#owner_df requires columns 'full_name', 'slug'
 #topics_df requires columns 'full_name', 'topics'
 def repository_06(owner_df, topics_df, production_topics, non_pe_teams)-> DataFrame:
     """Repository 06: Repository is owned by a team outside of P&E or has a production topic"""
     #make sure that the required columns exist
-    assert 'repo_name' in owner_df.columns, 'repo_name column is missing from owner_df'
+    assert 'full_name' in owner_df.columns, 'full_name column is missing from owner_df'
     assert 'slug' in owner_df.columns, 'slug column is missing from owner_df'
     assert 'full_name' in topics_df.columns, 'full_name column is missing from topics_df'
     assert 'topics' in topics_df.columns, 'topics column is missing from topics_df'
-    aggregated_name_and_owners = owner_df.groupby(['repo_name'])['slug'].apply(set).reset_index(name='slugs')
-    merged_df = aggregated_name_and_owners.merge(topics_df, how='left', left_on='repo_name', right_on='full_name')[['repo_name', 'slugs', 'topics']]
+    aggregated_name_and_owners = owner_df.groupby(['full_name'])['slug'].apply(set).reset_index(name='slugs')
+    merged_df = aggregated_name_and_owners.merge(topics_df, how='left', left_on='full_name', right_on='full_name')[['full_name', 'slugs', 'topics']]
     merged_df['has_production_topic'] = merged_df.dropna().apply(lambda row: any(item in production_topics for item in row['topics']), axis=1)
     merged_df['outside_p_and_e'] = merged_df.apply(lambda row: all(item in non_pe_teams for item in row['slugs']), axis=1)
     merged_df['repository_06'] = merged_df.apply(lambda row: (row['outside_p_and_e']) or row['has_production_topic'], axis=1)
-    return merged_df[['repo_name','repository_06']]
+    return merged_df[['full_name','repository_06']]

--- a/packages/repocop/test_rules.py
+++ b/packages/repocop/test_rules.py
@@ -38,7 +38,7 @@ def test_repo_06():
         ['p_and_e1', 'internal_team2'],
         ['p_and_e1', 'outside_team1'],
         ['p_and_e2', 'internal_team1'],
-    ], columns=['repo_name', 'slug'])
+    ], columns=['full_name', 'slug'])
 
     production_topics = ['production']
     oustide_teams = ['outside_team1', 'outside_team2']
@@ -47,7 +47,7 @@ def test_repo_06():
     true_count= (gh_df['repository_06']).sum()
     false_count = (~gh_df['repository_06']).sum()
 
-    p_and_e2_repo_follows_rule =gh_df.loc[gh_df['repo_name'] == 'p_and_e2', 'repository_06'].isin([True]).bool()
+    p_and_e2_repo_follows_rule =gh_df.loc[gh_df['full_name'] == 'p_and_e2', 'repository_06'].isin([True]).bool()
     assert p_and_e2_repo_follows_rule is False
     assert true_count == 3
     assert false_count == 1

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -52,7 +52,8 @@ on conflict (team_name) do nothing;
 create or replace view view_repo_ownership as
 select ght.id        as "github_team_id"
      , ght.name      as "github_team_name"
-     , tr.full_name  as "repo_name"
+     , tr.full_name  as "repo_name" --deprecated. use full_name below for consistency with other tables
+     , tr.full_name  as "full_name"
      , tr.role_name
      , tr.archived
      , gtt.team_name as "galaxies_team"


### PR DESCRIPTION
## What does this change?

Add a `full_name` column, that contains the same values as `repo_name`. refactor repocop collector to reflect this.

## Why?

To keep column names more consistent with the github source data. Eventually, the `repo_name` column will be removed

## How has it been verified?

- this change can be seen in the production db.
- unit tests are happy
- writing to the repocop table succeeds

## Anything else

A lot of these python queries can be simplified further in a follow-up, now that the names match. This PR captures the minimum required work to migrate from one column to the other
