### PR TITLE
Fix the Snyk action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -14,6 +14,7 @@ jobs:
       SKIP_NODE: false
       SKIP_PYTHON: false
       PYTHON_VERSION: '3.11'
+      PIP_REQUIREMENTS_FILES: packages/repocop/requirements-dev.txt
       EXCLUDE: cdk
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -12,6 +12,8 @@ jobs:
     with:
       ORG: guardian-devtools
       SKIP_NODE: false
+      SKIP_PYTHON: false
+      PYTHON_VERSION: '3.11'
       EXCLUDE: cdk
     secrets:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?

The repocop folder contains a python 3 project. I've modified the snyk.yml to take this into account when scanning the repo for manifests, and pointed it at the dependency manifest

## Why?

So we can keep on top of our vulnerabilities

## How has it been verified?

The repocop project shows up in snyk
