### PR TITLE
Rebuild and rename stack

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -1,10 +1,10 @@
 import 'source-map-support/register';
 import { GuRootExperimental } from '@guardian/cdk/lib/experimental/constructs/root';
-import { CloudQuery } from '../lib/cloudquery';
+import { ServiceCatalogue } from '../lib/service-catalogue';
 
 const app = new GuRootExperimental();
 
-new CloudQuery(app, 'CloudQuery-INFRA', {
+new ServiceCatalogue(app, 'ServiceCatalogue-INFRA', {
 	stack: 'deploy',
 	stage: 'INFRA',
 	env: { region: 'eu-west-1' },

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The CloudQuery stack matches the snapshot 1`] = `
+exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -109,7 +109,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -121,7 +121,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -316,7 +316,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -342,7 +342,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-AllFirelens",
@@ -424,7 +424,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -729,7 +729,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -781,7 +781,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -793,7 +793,7 @@ spec:
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -966,7 +966,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -992,7 +992,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-DelegatedToSecurityAccountFirelens",
@@ -1083,7 +1083,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -1353,7 +1353,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -1405,7 +1405,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -1417,7 +1417,7 @@ spec:
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -1588,7 +1588,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -1614,7 +1614,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-DeployToolsListOrgsFirelens",
@@ -1705,7 +1705,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -1980,7 +1980,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -2032,7 +2032,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -2044,7 +2044,7 @@ spec:
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -2172,7 +2172,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":secret:/TEST/deploy/cloudquery/fastly-credentials:api-key::",
+                      ":secret:/TEST/deploy/service-catalogue/fastly-credentials:api-key::",
                     ],
                   ],
                 },
@@ -2233,7 +2233,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -2259,7 +2259,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-FastlyServicesFirelens",
@@ -2315,7 +2315,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -2419,7 +2419,7 @@ spec:
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":secret:/TEST/deploy/cloudquery/fastly-credentials-??????",
+                    ":secret:/TEST/deploy/service-catalogue/fastly-credentials-??????",
                   ],
                 ],
               },
@@ -2618,7 +2618,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -2670,7 +2670,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -2682,7 +2682,7 @@ spec:
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -2851,7 +2851,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -2877,7 +2877,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-GalaxiesFirelens",
@@ -2994,7 +2994,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -3250,7 +3250,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -3302,7 +3302,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -3314,7 +3314,7 @@ spec:
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -3413,7 +3413,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -3517,7 +3517,7 @@ spec:
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":secret:/TEST/deploy/cloudquery/github-credentials-??????",
+                    ":secret:/TEST/deploy/service-catalogue/github-credentials-??????",
                   ],
                 ],
               },
@@ -3633,7 +3633,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":secret:/TEST/deploy/cloudquery/github-credentials:private-key::",
+                      ":secret:/TEST/deploy/service-catalogue/github-credentials:private-key::",
                     ],
                   ],
                 },
@@ -3656,7 +3656,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":secret:/TEST/deploy/cloudquery/github-credentials:app-id::",
+                      ":secret:/TEST/deploy/service-catalogue/github-credentials:app-id::",
                     ],
                   ],
                 },
@@ -3679,7 +3679,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":secret:/TEST/deploy/cloudquery/github-credentials:installation-id::",
+                      ":secret:/TEST/deploy/service-catalogue/github-credentials:installation-id::",
                     ],
                   ],
                 },
@@ -3740,7 +3740,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -3766,7 +3766,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-GitHubIssuesFirelens",
@@ -3936,7 +3936,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -3988,7 +3988,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -4000,7 +4000,7 @@ spec:
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -4110,7 +4110,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":secret:/TEST/deploy/cloudquery/github-credentials:private-key::",
+                      ":secret:/TEST/deploy/service-catalogue/github-credentials:private-key::",
                     ],
                   ],
                 },
@@ -4133,7 +4133,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":secret:/TEST/deploy/cloudquery/github-credentials:app-id::",
+                      ":secret:/TEST/deploy/service-catalogue/github-credentials:app-id::",
                     ],
                   ],
                 },
@@ -4156,7 +4156,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":secret:/TEST/deploy/cloudquery/github-credentials:installation-id::",
+                      ":secret:/TEST/deploy/service-catalogue/github-credentials:installation-id::",
                     ],
                   ],
                 },
@@ -4217,7 +4217,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -4243,7 +4243,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-GitHubRepositoriesFirelens",
@@ -4360,7 +4360,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -4464,7 +4464,7 @@ spec:
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":secret:/TEST/deploy/cloudquery/github-credentials-??????",
+                    ":secret:/TEST/deploy/service-catalogue/github-credentials-??????",
                   ],
                 ],
               },
@@ -4628,7 +4628,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -4680,7 +4680,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -4692,7 +4692,7 @@ spec:
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -4803,7 +4803,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":secret:/TEST/deploy/cloudquery/github-credentials:private-key::",
+                      ":secret:/TEST/deploy/service-catalogue/github-credentials:private-key::",
                     ],
                   ],
                 },
@@ -4826,7 +4826,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":secret:/TEST/deploy/cloudquery/github-credentials:app-id::",
+                      ":secret:/TEST/deploy/service-catalogue/github-credentials:app-id::",
                     ],
                   ],
                 },
@@ -4849,7 +4849,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":secret:/TEST/deploy/cloudquery/github-credentials:installation-id::",
+                      ":secret:/TEST/deploy/service-catalogue/github-credentials:installation-id::",
                     ],
                   ],
                 },
@@ -4910,7 +4910,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -4936,7 +4936,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-GitHubTeamsFirelens",
@@ -5053,7 +5053,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -5157,7 +5157,7 @@ spec:
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":secret:/TEST/deploy/cloudquery/github-credentials-??????",
+                    ":secret:/TEST/deploy/service-catalogue/github-credentials-??????",
                   ],
                 ],
               },
@@ -5321,7 +5321,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -5373,7 +5373,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -5385,7 +5385,7 @@ spec:
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -5508,7 +5508,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":secret:/TEST/deploy/cloudquery/snyk-credentials:api-key::",
+                      ":secret:/TEST/deploy/service-catalogue/snyk-credentials:api-key::",
                     ],
                   ],
                 },
@@ -5569,7 +5569,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -5595,7 +5595,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-GuardianCustomSnykProjectsFirelens",
@@ -5686,7 +5686,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -5790,7 +5790,7 @@ spec:
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":secret:/TEST/deploy/cloudquery/snyk-credentials-??????",
+                    ":secret:/TEST/deploy/service-catalogue/snyk-credentials-??????",
                   ],
                 ],
               },
@@ -5954,7 +5954,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -6006,7 +6006,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -6018,7 +6018,7 @@ spec:
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -6164,7 +6164,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -6190,7 +6190,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-OrgWideCertificatesFirelens",
@@ -6307,7 +6307,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -6582,7 +6582,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -6634,7 +6634,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -6646,7 +6646,7 @@ spec:
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -6821,7 +6821,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -6847,7 +6847,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-OrgWideCloudFormationFirelens",
@@ -6938,7 +6938,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -7213,7 +7213,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -7265,7 +7265,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -7277,7 +7277,7 @@ spec:
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -7376,7 +7376,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -7611,7 +7611,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -7637,7 +7637,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-OrgWideCloudwatchAlarmsFirelens",
@@ -7841,7 +7841,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -7893,7 +7893,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -7905,7 +7905,7 @@ spec:
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -8052,7 +8052,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -8078,7 +8078,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-OrgWideInspectorFirelens",
@@ -8160,7 +8160,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -8470,7 +8470,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -8522,7 +8522,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -8534,7 +8534,7 @@ spec:
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -8633,7 +8633,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -8869,7 +8869,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -8895,7 +8895,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-OrgWideLoadBalancersFirelens",
@@ -9099,7 +9099,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -9151,7 +9151,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudqueryCluster5370C11B",
+                "servicecatalogueCluster5FC34DC5",
                 "Arn",
               ],
             },
@@ -9163,7 +9163,7 @@ spec:
                   "SecurityGroups": [
                     {
                       "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                         "GroupId",
                       ],
                     },
@@ -9271,7 +9271,7 @@ spec:
                       {
                         "Ref": "AWS::AccountId",
                       },
-                      ":secret:/TEST/deploy/cloudquery/snyk-credentials:api-key::",
+                      ":secret:/TEST/deploy/service-catalogue/snyk-credentials:api-key::",
                     ],
                   ],
                 },
@@ -9332,7 +9332,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "cloudquery",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -9358,7 +9358,7 @@ spec:
                 "awslogs-region": {
                   "Ref": "AWS::Region",
                 },
-                "awslogs-stream-prefix": "deploy/TEST/cloudquery",
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
               },
             },
             "Name": "CloudquerySource-SnykAllFirelens",
@@ -9475,7 +9475,7 @@ spec:
                 "ArnEquals": {
                   "ecs:cluster": {
                     "Fn::GetAtt": [
-                      "cloudqueryCluster5370C11B",
+                      "servicecatalogueCluster5FC34DC5",
                       "Arn",
                     ],
                   },
@@ -9579,7 +9579,7 @@ spec:
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":secret:/TEST/deploy/cloudquery/snyk-credentials-??????",
+                    ":secret:/TEST/deploy/service-catalogue/snyk-credentials-??????",
                   ],
                 ],
               },
@@ -9743,7 +9743,7 @@ spec:
             "clusterArn": [
               {
                 "Fn::GetAtt": [
-                  "cloudqueryCluster5370C11B",
+                  "servicecatalogueCluster5FC34DC5",
                   "Arn",
                 ],
               },
@@ -9787,9 +9787,30 @@ spec:
       },
       "Type": "AWS::Events::Rule",
     },
-    "PostgresAccessSecurityGroupCloudqueryE959A23F": {
+    "PostgresAccessSecurityGroupParam38DFE001": {
       "Properties": {
-        "GroupDescription": "CloudQuery/PostgresAccessSecurityGroupCloudquery",
+        "DataType": "text",
+        "Name": "/TEST/deploy/service-catalogue/postgres-access-security-group",
+        "Tags": {
+          "Stack": "deploy",
+          "Stage": "TEST",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/service-catalogue",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": {
+          "Fn::GetAtt": [
+            "PostgresAccessSecurityGroupServicecatalogue03C78F14",
+            "GroupId",
+          ],
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
+    "PostgresAccessSecurityGroupServicecatalogue03C78F14": {
+      "Properties": {
+        "GroupDescription": "CloudQuery/PostgresAccessSecurityGroupServicecatalogue",
         "SecurityGroupEgress": [
           {
             "CidrIp": "0.0.0.0/0",
@@ -9800,7 +9821,7 @@ spec:
         "Tags": [
           {
             "Key": "App",
-            "Value": "cloudquery",
+            "Value": "service-catalogue",
           },
           {
             "Key": "gu:cdk:version",
@@ -9824,27 +9845,6 @@ spec:
         },
       },
       "Type": "AWS::EC2::SecurityGroup",
-    },
-    "PostgresAccessSecurityGroupParam38DFE001": {
-      "Properties": {
-        "DataType": "text",
-        "Name": "/TEST/deploy/cloudquery/postgres-access-security-group",
-        "Tags": {
-          "Stack": "deploy",
-          "Stage": "TEST",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/service-catalogue",
-        },
-        "Tier": "Standard",
-        "Type": "String",
-        "Value": {
-          "Fn::GetAtt": [
-            "PostgresAccessSecurityGroupCloudqueryE959A23F",
-            "GroupId",
-          ],
-        },
-      },
-      "Type": "AWS::SSM::Parameter",
     },
     "PostgresInstance16DE4286E": {
       "DeletionPolicy": "Snapshot",
@@ -9906,7 +9906,7 @@ spec:
         "VPCSecurityGroups": [
           {
             "Fn::GetAtt": [
-              "PostgresSecurityGroupCloudquery65E31BB8",
+              "PostgresSecurityGroupServicecatalogueD2F089D5",
               "GroupId",
             ],
           },
@@ -9999,7 +9999,7 @@ spec:
     "PostgresInstanceEndpointAddress6E14162C": {
       "Properties": {
         "DataType": "text",
-        "Name": "/TEST/deploy/cloudquery/postgres-instance-endpoint-address",
+        "Name": "/TEST/deploy/service-catalogue/postgres-instance-endpoint-address",
         "Tags": {
           "Stack": "deploy",
           "Stage": "TEST",
@@ -10017,9 +10017,9 @@ spec:
       },
       "Type": "AWS::SSM::Parameter",
     },
-    "PostgresSecurityGroupCloudquery65E31BB8": {
+    "PostgresSecurityGroupServicecatalogueD2F089D5": {
       "Properties": {
-        "GroupDescription": "CloudQuery/PostgresSecurityGroupCloudquery",
+        "GroupDescription": "CloudQuery/PostgresSecurityGroupServicecatalogue",
         "SecurityGroupEgress": [
           {
             "CidrIp": "0.0.0.0/0",
@@ -10039,7 +10039,7 @@ spec:
         "Tags": [
           {
             "Key": "App",
-            "Value": "cloudquery",
+            "Value": "service-catalogue",
           },
           {
             "Key": "gu:cdk:version",
@@ -10064,20 +10064,20 @@ spec:
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "PostgresSecurityGroupCloudqueryfromCloudQueryPostgresAccessSecurityGroupCloudqueryAE627D46543299D711F8": {
+    "PostgresSecurityGroupServicecataloguefromCloudQueryPostgresAccessSecurityGroupServicecatalogue06C390A15432355F6AD5": {
       "Properties": {
-        "Description": "from CloudQueryPostgresAccessSecurityGroupCloudqueryAE627D46:5432",
+        "Description": "from CloudQueryPostgresAccessSecurityGroupServicecatalogue06C390A1:5432",
         "FromPort": 5432,
         "GroupId": {
           "Fn::GetAtt": [
-            "PostgresSecurityGroupCloudquery65E31BB8",
+            "PostgresSecurityGroupServicecatalogueD2F089D5",
             "GroupId",
           ],
         },
         "IpProtocol": "tcp",
         "SourceSecurityGroupId": {
           "Fn::GetAtt": [
-            "PostgresAccessSecurityGroupCloudqueryE959A23F",
+            "PostgresAccessSecurityGroupServicecatalogue03C78F14",
             "GroupId",
           ],
         },
@@ -10085,10 +10085,10 @@ spec:
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "cloudquery94E245F6": {
+    "servicecatalogue26ECB16F": {
       "DependsOn": [
-        "cloudqueryServiceRoleDefaultPolicyDBB70D58",
-        "cloudqueryServiceRole55C3C96C",
+        "servicecatalogueServiceRoleDefaultPolicyA38CBB2F",
+        "servicecatalogueServiceRole5903EE6A",
       ],
       "Properties": {
         "Code": {
@@ -10111,7 +10111,7 @@ spec:
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
-            "cloudqueryServiceRole55C3C96C",
+            "servicecatalogueServiceRole5903EE6A",
             "Arn",
           ],
         },
@@ -10143,7 +10143,7 @@ spec:
           "SecurityGroupIds": [
             {
               "Fn::GetAtt": [
-                "PostgresAccessSecurityGroupCloudqueryE959A23F",
+                "PostgresAccessSecurityGroupServicecatalogue03C78F14",
                 "GroupId",
               ],
             },
@@ -10155,7 +10155,7 @@ spec:
       },
       "Type": "AWS::Lambda::Function",
     },
-    "cloudqueryCluster5370C11B": {
+    "servicecatalogueCluster5FC34DC5": {
       "Properties": {
         "Tags": [
           {
@@ -10178,30 +10178,30 @@ spec:
       },
       "Type": "AWS::ECS::Cluster",
     },
-    "cloudqueryClusterAF1C9455": {
+    "servicecatalogueClusterAF65BC89": {
       "Properties": {
         "CapacityProviders": [
           "FARGATE",
           "FARGATE_SPOT",
         ],
         "Cluster": {
-          "Ref": "cloudqueryCluster5370C11B",
+          "Ref": "servicecatalogueCluster5FC34DC5",
         },
         "DefaultCapacityProviderStrategy": [],
       },
       "Type": "AWS::ECS::ClusterCapacityProviderAssociations",
     },
-    "cloudqueryEventInvokeConfigDA0DA31B": {
+    "servicecatalogueEventInvokeConfig5642B219": {
       "Properties": {
         "FunctionName": {
-          "Ref": "cloudquery94E245F6",
+          "Ref": "servicecatalogue26ECB16F",
         },
         "MaximumRetryAttempts": 1,
         "Qualifier": "$LATEST",
       },
       "Type": "AWS::Lambda::EventInvokeConfig",
     },
-    "cloudqueryServiceRole55C3C96C": {
+    "servicecatalogueServiceRole5903EE6A": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -10266,7 +10266,7 @@ spec:
       },
       "Type": "AWS::IAM::Role",
     },
-    "cloudqueryServiceRoleDefaultPolicyDBB70D58": {
+    "servicecatalogueServiceRoleDefaultPolicyA38CBB2F": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -10402,16 +10402,35 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "cloudqueryServiceRoleDefaultPolicyDBB70D58",
+        "PolicyName": "servicecatalogueServiceRoleDefaultPolicyA38CBB2F",
         "Roles": [
           {
-            "Ref": "cloudqueryServiceRole55C3C96C",
+            "Ref": "servicecatalogueServiceRole5903EE6A",
           },
         ],
       },
       "Type": "AWS::IAM::Policy",
     },
-    "cloudquerycloudqueryrate1day04EA3DD54": {
+    "servicecatalogueservicecataloguerate1day0AllowEventRuleCloudQueryservicecatalogue6D2868B192080787": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "servicecatalogue26ECB16F",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "servicecatalogueservicecataloguerate1day0EBEAD0C4",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "servicecatalogueservicecataloguerate1day0EBEAD0C4": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",
         "State": "ENABLED",
@@ -10419,7 +10438,7 @@ spec:
           {
             "Arn": {
               "Fn::GetAtt": [
-                "cloudquery94E245F6",
+                "servicecatalogue26ECB16F",
                 "Arn",
               ],
             },
@@ -10428,25 +10447,6 @@ spec:
         ],
       },
       "Type": "AWS::Events::Rule",
-    },
-    "cloudquerycloudqueryrate1day0AllowEventRuleCloudQuerycloudquery5AB72A486877854B": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "cloudquery94E245F6",
-            "Arn",
-          ],
-        },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "cloudquerycloudqueryrate1day04EA3DD54",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
     },
   },
 }

--- a/packages/cdk/lib/ecs/cluster.ts
+++ b/packages/cdk/lib/ecs/cluster.ts
@@ -47,7 +47,7 @@ export interface CloudquerySource {
 	managedPolicies?: IManagedPolicy[];
 
 	/**
-	 * Any secrets to pass to the CloudQuery container.
+	 * Any secrets to pass to the ServiceCatalogue container.
 	 *
 	 * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.ContainerDefinitionOptions.html#secrets
 	 * @see https://repost.aws/knowledge-center/ecs-data-security-container-task
@@ -55,7 +55,7 @@ export interface CloudquerySource {
 	secrets?: Record<string, Secret>;
 
 	/**
-	 * Additional commands to run within the CloudQuery container, executed first.
+	 * Additional commands to run within the ServiceCatalogue container, executed first.
 	 */
 	additionalCommands?: string[];
 
@@ -77,7 +77,7 @@ interface CloudqueryClusterProps extends AppIdentity {
 	vpc: IVpc;
 
 	/**
-	 * The database for CloudQuery to write to.
+	 * The database for ServiceCatalogue to write to.
 	 */
 	db: DatabaseInstance;
 
@@ -93,7 +93,7 @@ interface CloudqueryClusterProps extends AppIdentity {
 }
 
 /**
- * An ECS cluster for running CloudQuery. The cluster and its tasks will be
+ * An ECS cluster for running ServiceCatalogue. The cluster and its tasks will be
  * created in the private subnets of the VPC provided.
  */
 export class CloudqueryCluster extends Cluster {

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -16,7 +16,7 @@ interface CloudqueryTableConfig {
 }
 
 /**
- * Create a CloudQuery destination configuration for Postgres.
+ * Create a ServiceCatalogue destination configuration for Postgres.
  */
 export function postgresDestinationConfig(): CloudqueryConfig {
 	return {
@@ -80,7 +80,7 @@ export function awsSourceConfig(
 }
 
 /**
- * Create a CloudQuery configuration for all AWS accounts in the organisation.
+ * Create a ServiceCatalogue configuration for all AWS accounts in the organisation.
  * @param tableConfig Which tables to include or exclude.
  *
  * @see https://www.cloudquery.io/docs/plugins/sources/aws/configuration#org
@@ -98,11 +98,11 @@ export function awsSourceConfigForOrganisation(
 }
 
 /**
- * Create a CloudQuery configuration for a single AWS account.
+ * Create a ServiceCatalogue configuration for a single AWS account.
  * Use this for those services running across the organisation which are aggregated in a single account.
  * For example, Access Analyzer.
  *
- * @param accountNumber The AWS account to query. CloudQuery will assume the role `cloudquery-access` in this account.
+ * @param accountNumber The AWS account to query. ServiceCatalogue will assume the role `cloudquery-access` in this account.
  * @param tableConfig Which tables to include or exclude.
  *
  * @see https://www.cloudquery.io/docs/plugins/sources/aws/configuration#account

--- a/packages/cdk/lib/ecs/task.ts
+++ b/packages/cdk/lib/ecs/task.ts
@@ -35,12 +35,12 @@ export interface ScheduledCloudqueryTaskProps
 	extends AppIdentity,
 		Omit<ScheduledFargateTaskProps, 'Cluster'> {
 	/**
-	 * THe Postgres database for CloudQuery to connect to.
+	 * THe Postgres database for ServiceCatalogue to connect to.
 	 */
 	db: DatabaseInstance;
 
 	/**
-	 * The security group to allow CloudQuery to connect to the database.
+	 * The security group to allow ServiceCatalogue to connect to the database.
 	 */
 	dbAccess: GuSecurityGroup;
 
@@ -65,7 +65,7 @@ export interface ScheduledCloudqueryTaskProps
 	policies: PolicyStatement[];
 
 	/**
-	 * The CloudQuery config to use to collect data from.
+	 * The ServiceCatalogue config to use to collect data from.
 	 */
 	sourceConfig: CloudqueryConfig;
 
@@ -75,7 +75,7 @@ export interface ScheduledCloudqueryTaskProps
 	topic: Topic;
 
 	/**
-	 * Any secrets to pass to the CloudQuery container.
+	 * Any secrets to pass to the ServiceCatalogue container.
 	 *
 	 * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.ContainerDefinitionOptions.html#secrets
 	 * @see https://repost.aws/knowledge-center/ecs-data-security-container-task
@@ -83,7 +83,7 @@ export interface ScheduledCloudqueryTaskProps
 	secrets?: Record<string, Secret>;
 
 	/**
-	 * Additional commands to run within the CloudQuery container, executed first.
+	 * Additional commands to run within the ServiceCatalogue container, executed first.
 	 */
 	additionalCommands?: string[];
 }

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -7,7 +7,7 @@ const envOrError = (name: string): string => {
 };
 
 /**
- * The versions of various CloudQuery plugins.
+ * The versions of various ServiceCatalogue plugins.
  * See the `.env` file at the root of the repository.
  */
 export const Versions = {

--- a/packages/cdk/lib/service-catalogue.test.ts
+++ b/packages/cdk/lib/service-catalogue.test.ts
@@ -1,11 +1,11 @@
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { CloudQuery } from './cloudquery';
+import { ServiceCatalogue } from './service-catalogue';
 
-describe('The CloudQuery stack', () => {
+describe('The ServiceCatalogue stack', () => {
 	it('matches the snapshot', () => {
 		const app = new App();
-		const stack = new CloudQuery(app, 'CloudQuery', {
+		const stack = new ServiceCatalogue(app, 'CloudQuery', {
 			stack: 'deploy',
 			stage: 'TEST',
 		});

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -52,7 +52,7 @@ import {
 	standardDenyPolicy,
 } from './ecs/policies';
 
-export class CloudQuery extends GuStack {
+export class ServiceCatalogue extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
 		super(scope, id, props);
 
@@ -113,7 +113,7 @@ export class CloudQuery extends GuStack {
 			Port.tcp(port),
 		);
 
-		// Used by downstream services that read CloudQuery data, namely Grafana.
+		// Used by downstream services that read ServiceCatalogue data, namely Grafana.
 		new StringParameter(this, 'PostgresAccessSecurityGroupParam', {
 			parameterName: `/${stage}/${stack}/${app}/postgres-access-security-group`,
 			simpleName: false,
@@ -248,7 +248,7 @@ export class CloudQuery extends GuStack {
 					) as string[]),
 				],
 
-				// Defaulted to 500000 by CloudQuery, concurrency controls the maximum number of Go routines to use.
+				// Defaulted to 500000 by ServiceCatalogue, concurrency controls the maximum number of Go routines to use.
 				// The amount of memory used is a function of this value.
 				// See https://www.cloudquery.io/docs/reference/source-spec#concurrency.
 				concurrency: 2000,
@@ -325,7 +325,7 @@ export class CloudQuery extends GuStack {
 					skipTables: [
 						/*
 						These tables are children of github_organizations.
-						CloudQuery collects child tables automatically.
+						ServiceCatalogue collects child tables automatically.
 						We don't use them as they take a long time to collect, so skip them.
 						See https://www.cloudquery.io/docs/advanced-topics/performance-tuning#improve-performance-by-skipping-relations
 						 */

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -57,7 +57,7 @@ export class ServiceCatalogue extends GuStack {
 		super(scope, id, props);
 
 		const { stage, stack } = this;
-		const app = props.app ?? 'cloudquery';
+		const app = props.app ?? 'service-catalogue';
 
 		const privateSubnets = GuVpc.subnetsFromParameter(this, {
 			type: SubnetType.PRIVATE,


### PR DESCRIPTION
## What does this change?
Changed the stack name to service-catalogue from cloudquery. 

## Why?
To better reflect the fact that it now includes repocop and cloudquery.
We had to rebuild the stack because the database from the old stack had been corrupted. We took the opportunity to change the stack name.

## How has it been verified?
We successfully deployed with riffraff.
