### PR TITLE
fix: Add `Name` tag to ECS task definitions

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -371,6 +371,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "All",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -400,6 +404,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "All",
           },
           {
             "Key": "Stack",
@@ -491,6 +499,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "All",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -524,6 +536,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "All",
           },
           {
             "Key": "Stack",
@@ -601,6 +617,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "All",
           },
           {
             "Key": "Stack",
@@ -835,6 +855,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "DelegatedToSecurityAccount",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -1021,6 +1045,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "DelegatedToSecurityAccount",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -1060,6 +1088,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "DelegatedToSecurityAccount",
           },
           {
             "Key": "Stack",
@@ -1150,6 +1182,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "DelegatedToSecurityAccount",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -1225,6 +1261,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "DelegatedToSecurityAccount",
           },
           {
             "Key": "Stack",
@@ -1459,6 +1499,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "DeployToolsListOrgs",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -1643,6 +1687,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "DeployToolsListOrgs",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -1682,6 +1730,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "DeployToolsListOrgs",
           },
           {
             "Key": "Stack",
@@ -1772,6 +1824,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "DeployToolsListOrgs",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -1847,6 +1903,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "DeployToolsListOrgs",
           },
           {
             "Key": "Stack",
@@ -2086,6 +2146,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "FastlyServices",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -2279,6 +2343,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "FastlyServices",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -2373,6 +2441,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "FastlyServices",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -2457,6 +2529,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "FastlyServices",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -2490,6 +2566,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "FastlyServices",
           },
           {
             "Key": "Stack",
@@ -2880,6 +2960,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "Galaxies",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -2909,6 +2993,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "Galaxies",
           },
           {
             "Key": "Stack",
@@ -2945,6 +3033,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "Galaxies",
           },
           {
             "Key": "Stack",
@@ -3035,6 +3127,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "Galaxies",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -3107,6 +3203,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "Galaxies",
           },
           {
             "Key": "Stack",
@@ -3330,6 +3430,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "GitHubIssues",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -3364,6 +3468,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "GitHubIssues",
           },
           {
             "Key": "Stack",
@@ -3452,6 +3560,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "GitHubIssues",
           },
           {
             "Key": "Stack",
@@ -3725,6 +3837,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "GitHubIssues",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -3764,6 +3880,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "GitHubIssues",
           },
           {
             "Key": "Stack",
@@ -4175,6 +4295,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "GitHubRepositories",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -4204,6 +4328,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "GitHubRepositories",
           },
           {
             "Key": "Stack",
@@ -4240,6 +4368,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "GitHubRepositories",
           },
           {
             "Key": "Stack",
@@ -4330,6 +4462,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "GitHubRepositories",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -4412,6 +4548,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "GitHubRepositories",
           },
           {
             "Key": "Stack",
@@ -4824,6 +4964,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "GitHubTeams",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -4853,6 +4997,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "GitHubTeams",
           },
           {
             "Key": "Stack",
@@ -4889,6 +5037,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "GitHubTeams",
           },
           {
             "Key": "Stack",
@@ -4979,6 +5131,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "GitHubTeams",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -5061,6 +5217,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "GitHubTeams",
           },
           {
             "Key": "Stack",
@@ -5269,6 +5429,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "GuardianCustomSnykProjects",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -5457,6 +5621,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "GuardianCustomSnykProjects",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -5496,6 +5664,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "GuardianCustomSnykProjects",
           },
           {
             "Key": "Stack",
@@ -5586,6 +5758,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "GuardianCustomSnykProjects",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -5668,6 +5844,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "GuardianCustomSnykProjects",
           },
           {
             "Key": "Stack",
@@ -6035,6 +6215,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "OrgWideCertificates",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -6064,6 +6248,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "OrgWideCertificates",
           },
           {
             "Key": "Stack",
@@ -6100,6 +6288,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "OrgWideCertificates",
           },
           {
             "Key": "Stack",
@@ -6190,6 +6382,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "OrgWideCertificates",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -6265,6 +6461,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "OrgWideCertificates",
           },
           {
             "Key": "Stack",
@@ -6504,6 +6704,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "OrgWideCloudFormation",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -6692,6 +6896,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "OrgWideCloudFormation",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -6731,6 +6939,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "OrgWideCloudFormation",
           },
           {
             "Key": "Stack",
@@ -6821,6 +7033,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "OrgWideCloudFormation",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -6896,6 +7112,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "OrgWideCloudFormation",
           },
           {
             "Key": "Stack",
@@ -7135,6 +7355,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "OrgWideCloudwatchAlarms",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -7169,6 +7393,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "OrgWideCloudwatchAlarms",
           },
           {
             "Key": "Stack",
@@ -7257,6 +7485,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "OrgWideCloudwatchAlarms",
           },
           {
             "Key": "Stack",
@@ -7482,6 +7714,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "OrgWideCloudwatchAlarms",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -7636,6 +7872,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "OrgWideCloudwatchAlarms",
           },
           {
             "Key": "Stack",
@@ -7923,6 +8163,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "OrgWideInspector",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -7952,6 +8196,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "OrgWideInspector",
           },
           {
             "Key": "Stack",
@@ -8043,6 +8291,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "OrgWideInspector",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -8076,6 +8328,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "OrgWideInspector",
           },
           {
             "Key": "Stack",
@@ -8153,6 +8409,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "OrgWideInspector",
           },
           {
             "Key": "Stack",
@@ -8392,6 +8652,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "OrgWideLoadBalancers",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -8426,6 +8690,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "OrgWideLoadBalancers",
           },
           {
             "Key": "Stack",
@@ -8514,6 +8782,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "OrgWideLoadBalancers",
           },
           {
             "Key": "Stack",
@@ -8740,6 +9012,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "OrgWideLoadBalancers",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -8782,6 +9058,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "OrgWideLoadBalancers",
           },
           {
             "Key": "Stack",
@@ -9194,6 +9474,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "SnykAll",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -9223,6 +9507,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "SnykAll",
           },
           {
             "Key": "Stack",
@@ -9259,6 +9547,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "SnykAll",
           },
           {
             "Key": "Stack",
@@ -9349,6 +9641,10 @@ spec:
             "Value": "guardian/service-catalogue",
           },
           {
+            "Key": "Name",
+            "Value": "SnykAll",
+          },
+          {
             "Key": "Stack",
             "Value": "deploy",
           },
@@ -9431,6 +9727,10 @@ spec:
           {
             "Key": "gu:repo",
             "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "SnykAll",
           },
           {
             "Key": "Stack",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -101,698 +101,6 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "CloudquerySourceAllScheduledEventRuleAE930F8B": {
-      "Properties": {
-        "ScheduleExpression": "rate(1 day)",
-        "State": "ENABLED",
-        "Targets": [
-          {
-            "Arn": {
-              "Fn::GetAtt": [
-                "servicecatalogueCluster5FC34DC5",
-                "Arn",
-              ],
-            },
-            "EcsParameters": {
-              "LaunchType": "FARGATE",
-              "NetworkConfiguration": {
-                "AwsVpcConfiguration": {
-                  "AssignPublicIp": "DISABLED",
-                  "SecurityGroups": [
-                    {
-                      "Fn::GetAtt": [
-                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
-                        "GroupId",
-                      ],
-                    },
-                  ],
-                  "Subnets": {
-                    "Ref": "PrivateSubnets",
-                  },
-                },
-              },
-              "TaskCount": 1,
-              "TaskDefinitionArn": {
-                "Ref": "CloudquerySourceAllTaskDefinition8F8AA120",
-              },
-            },
-            "Id": "Target0",
-            "Input": "{}",
-            "RoleArn": {
-              "Fn::GetAtt": [
-                "CloudquerySourceAllTaskDefinitionEventsRoleF0320BC8",
-                "Arn",
-              ],
-            },
-          },
-        ],
-      },
-      "Type": "AWS::Events::Rule",
-    },
-    "CloudquerySourceAllTaskDefinition8F8AA120": {
-      "Properties": {
-        "ContainerDefinitions": [
-          {
-            "Command": [
-              "/bin/sh",
-              "-c",
-              "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
-spec:
-  name: aws
-  path: cloudquery/aws
-  version: v22.6.0
-  tables:
-    - aws_*
-  skip_tables:
-    - aws_ec2_vpc_endpoint_services
-    - aws_cloudtrail_events
-    - aws_docdb_cluster_parameter_groups
-    - aws_docdb_engine_versions
-    - aws_ec2_instance_types
-    - aws_elasticache_engine_versions
-    - aws_elasticache_parameter_groups
-    - aws_elasticache_reserved_cache_nodes_offerings
-    - aws_elasticache_service_updates
-    - aws_neptune_cluster_parameter_groups
-    - aws_neptune_db_parameter_groups
-    - aws_rds_cluster_parameter_groups
-    - aws_rds_db_parameter_groups
-    - aws_rds_engine_versions
-    - aws_servicequotas_services
-    - aws_identitystore_users
-    - aws_identitystore_groups
-    - aws_quicksight_data_sets
-    - aws_quicksight_dashboards
-    - aws_quicksight_analyses
-    - aws_quicksight_users
-    - aws_quicksight_templates
-    - aws_quicksight_groups
-    - aws_quicksight_folders
-    - aws_quicksight_data_sources
-    - aws_amp_workspaces
-    - aws_ssoadmin_instances
-    - aws_glue_connections
-    - aws_computeoptimizer_ecs_service_recommendations
-    - aws_xray_sampling_rules
-    - aws_xray_resource_policies
-    - aws_xray_groups
-    - aws_stepfunctions_map_runs
-    - aws_stepfunctions_map_run_executions
-    - aws_organization*
-    - aws_accessanalyzer_*
-    - aws_securityhub_*
-    - aws_cloudformation_stacks
-    - aws_cloudformation_stack_resources
-    - aws_cloudformation_stack_templates
-    - aws_cloudformation_template_summaries
-    - aws_elbv1_*
-    - aws_elbv2_*
-    - aws_acm*
-    - aws_cloudwatch_alarms
-    - aws_inspector_findings
-    - aws_inspector2_findings
-  destinations:
-    - postgresql
-  concurrency: 2000
-  spec:
-    regions:
-      - eu-west-1
-      - eu-west-2
-      - us-east-1
-      - us-east-2
-      - us-west-1
-      - ap-southeast-2
-      - ca-central-1
-    org:
-      member_role_name: cloudquery-access
-      organization_units:
-        - ou-123
-' > /source.yaml;printf 'kind: destination
-spec:
-  name: postgresql
-  registry: github
-  path: cloudquery/postgresql
-  version: v5.0.5
-  migrate_mode: forced
-  spec:
-    connection_string: >-
-      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
-      dbname=postgres sslmode=verify-full
-' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-            ],
-            "EntryPoint": [
-              "",
-            ],
-            "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.0",
-            "LogConfiguration": {
-              "LogDriver": "awsfirelens",
-              "Options": {
-                "Name": "kinesis_streams",
-                "region": {
-                  "Ref": "AWS::Region",
-                },
-                "retry_limit": "2",
-                "stream": {
-                  "Ref": "LoggingStreamName",
-                },
-              },
-            },
-            "Name": "CloudquerySource-AllContainer",
-            "Secrets": [
-              {
-                "Name": "DB_USERNAME",
-                "ValueFrom": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
-                      },
-                      ":username::",
-                    ],
-                  ],
-                },
-              },
-              {
-                "Name": "DB_HOST",
-                "ValueFrom": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
-                      },
-                      ":host::",
-                    ],
-                  ],
-                },
-              },
-              {
-                "Name": "DB_PASSWORD",
-                "ValueFrom": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
-                      },
-                      ":password::",
-                    ],
-                  ],
-                },
-              },
-            ],
-          },
-          {
-            "Environment": [
-              {
-                "Name": "STACK",
-                "Value": "deploy",
-              },
-              {
-                "Name": "STAGE",
-                "Value": "TEST",
-              },
-              {
-                "Name": "APP",
-                "Value": "service-catalogue",
-              },
-              {
-                "Name": "GU_REPO",
-                "Value": "guardian/service-catalogue",
-              },
-            ],
-            "Essential": true,
-            "FirelensConfiguration": {
-              "Options": {
-                "config-file-type": "file",
-                "config-file-value": "/custom.conf",
-                "enable-ecs-log-metadata": "true",
-              },
-              "Type": "fluentbit",
-            },
-            "Image": "ghcr.io/guardian/hackday-firelens:main",
-            "LogConfiguration": {
-              "LogDriver": "awslogs",
-              "Options": {
-                "awslogs-group": {
-                  "Ref": "CloudquerySourceAllTaskDefinitionCloudquerySourceAllFirelensLogGroupF1C1A97B",
-                },
-                "awslogs-region": {
-                  "Ref": "AWS::Region",
-                },
-                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
-              },
-            },
-            "Name": "CloudquerySource-AllFirelens",
-          },
-        ],
-        "Cpu": "1024",
-        "ExecutionRoleArn": {
-          "Fn::GetAtt": [
-            "CloudquerySourceAllTaskDefinitionExecutionRole57AE7309",
-            "Arn",
-          ],
-        },
-        "Family": "ServiceCatalogueCloudquerySourceAllTaskDefinitionE250D25B",
-        "Memory": "2048",
-        "NetworkMode": "awsvpc",
-        "RequiresCompatibilities": [
-          "FARGATE",
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Name",
-            "Value": "All",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "TaskRoleArn": {
-          "Fn::GetAtt": [
-            "CloudquerySourceAllTaskDefinitionTaskRole4E4F856D",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::ECS::TaskDefinition",
-    },
-    "CloudquerySourceAllTaskDefinitionCloudquerySourceAllFirelensLogGroupF1C1A97B": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "RetentionInDays": 1,
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Name",
-            "Value": "All",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::Logs::LogGroup",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "CloudquerySourceAllTaskDefinitionEventsRoleDefaultPolicy394A66F6": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "ecs:RunTask",
-              "Condition": {
-                "ArnEquals": {
-                  "ecs:cluster": {
-                    "Fn::GetAtt": [
-                      "servicecatalogueCluster5FC34DC5",
-                      "Arn",
-                    ],
-                  },
-                },
-              },
-              "Effect": "Allow",
-              "Resource": {
-                "Ref": "CloudquerySourceAllTaskDefinition8F8AA120",
-              },
-            },
-            {
-              "Action": "iam:PassRole",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "CloudquerySourceAllTaskDefinitionExecutionRole57AE7309",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": "iam:PassRole",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "CloudquerySourceAllTaskDefinitionTaskRole4E4F856D",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CloudquerySourceAllTaskDefinitionEventsRoleDefaultPolicy394A66F6",
-        "Roles": [
-          {
-            "Ref": "CloudquerySourceAllTaskDefinitionEventsRoleF0320BC8",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CloudquerySourceAllTaskDefinitionEventsRoleF0320BC8": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "events.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Name",
-            "Value": "All",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CloudquerySourceAllTaskDefinitionExecutionRole57AE7309": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "ecs-tasks.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Name",
-            "Value": "All",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CloudquerySourceAllTaskDefinitionExecutionRoleDefaultPolicy82390649": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "secretsmanager:GetSecretValue",
-                "secretsmanager:DescribeSecret",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
-              },
-            },
-            {
-              "Action": [
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "CloudquerySourceAllTaskDefinitionCloudquerySourceAllFirelensLogGroupF1C1A97B",
-                  "Arn",
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CloudquerySourceAllTaskDefinitionExecutionRoleDefaultPolicy82390649",
-        "Roles": [
-          {
-            "Ref": "CloudquerySourceAllTaskDefinitionExecutionRole57AE7309",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CloudquerySourceAllTaskDefinitionTaskRole4E4F856D": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "ecs-tasks.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Name",
-            "Value": "All",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "CloudquerySourceAllTaskDefinitionTaskRoleDefaultPolicy53CB4BC7": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "kinesis:Describe*",
-                "kinesis:Put*",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":kinesis:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":stream/",
-                    {
-                      "Ref": "LoggingStreamName",
-                    },
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "cloudformation:GetTemplate",
-                "dynamodb:GetItem",
-                "dynamodb:BatchGetItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "ec2:GetConsoleOutput",
-                "ec2:GetConsoleScreenshot",
-                "ecr:BatchGetImage",
-                "ecr:GetAuthorizationToken",
-                "ecr:GetDownloadUrlForLayer",
-                "kinesis:Get*",
-                "lambda:GetFunction",
-                "logs:GetLogEvents",
-                "sdb:Select*",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Deny",
-              "Resource": "*",
-            },
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Resource": "arn:aws:iam::*:role/cloudquery-access",
-            },
-            {
-              "Action": "rds-db:connect",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":rds-db:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":dbuser:",
-                    {
-                      "Fn::GetAtt": [
-                        "PostgresInstance16DE4286E",
-                        "DbiResourceId",
-                      ],
-                    },
-                    "/{{resolve:secretsmanager:",
-                    {
-                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
-                    },
-                    ":SecretString:username::}}",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "CloudquerySourceAllTaskDefinitionTaskRoleDefaultPolicy53CB4BC7",
-        "Roles": [
-          {
-            "Ref": "CloudquerySourceAllTaskDefinitionTaskRole4E4F856D",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "CloudquerySourceAllTaskErrorRule93531B8F": {
-      "Properties": {
-        "Description": "Rule for events indicating an ECS task exited due to an error.",
-        "EventPattern": {
-          "detail": {
-            "clusterArn": [
-              {
-                "Fn::GetAtt": [
-                  "servicecatalogueCluster5FC34DC5",
-                  "Arn",
-                ],
-              },
-            ],
-            "containers": {
-              "exitCode": [
-                1,
-                137,
-                139,
-                255,
-              ],
-            },
-            "lastStatus": [
-              "STOPPED",
-            ],
-            "stoppedReason": [
-              "Task CloudquerySource-All exited",
-            ],
-            "taskDefinitionArn": [
-              {
-                "Ref": "CloudquerySourceAllTaskDefinition8F8AA120",
-              },
-            ],
-          },
-          "detail-type": [
-            "ECS Task State Change",
-          ],
-          "source": [
-            "aws.ecs",
-          ],
-        },
-        "State": "ENABLED",
-        "Targets": [
-          {
-            "Arn": {
-              "Ref": "CloudQueryAlertTopicBFD81410",
-            },
-            "Id": "Target0",
-          },
-        ],
-      },
-      "Type": "AWS::Events::Rule",
-    },
     "CloudquerySourceDelegatedToSecurityAccountScheduledEventRuleC7320B4E": {
       "Properties": {
         "ScheduleExpression": "rate(1 day)",
@@ -9217,6 +8525,698 @@ spec:
             "taskDefinitionArn": [
               {
                 "Ref": "CloudquerySourceOrgWideLoadBalancersTaskDefinitionF1D11F23",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CloudquerySourceRemainingAwsDataScheduledEventRuleAE2A0ED1": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 day)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "servicecatalogueCluster5FC34DC5",
+                "Arn",
+              ],
+            },
+            "EcsParameters": {
+              "LaunchType": "FARGATE",
+              "NetworkConfiguration": {
+                "AwsVpcConfiguration": {
+                  "AssignPublicIp": "DISABLED",
+                  "SecurityGroups": [
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
+                        "GroupId",
+                      ],
+                    },
+                  ],
+                  "Subnets": {
+                    "Ref": "PrivateSubnets",
+                  },
+                },
+              },
+              "TaskCount": 1,
+              "TaskDefinitionArn": {
+                "Ref": "CloudquerySourceRemainingAwsDataTaskDefinition8790EDD9",
+              },
+            },
+            "Id": "Target0",
+            "Input": "{}",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CloudquerySourceRemainingAwsDataTaskDefinitionEventsRole7E7383AF",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CloudquerySourceRemainingAwsDataTaskDefinition8790EDD9": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/sh",
+              "-c",
+              "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+spec:
+  name: aws
+  path: cloudquery/aws
+  version: v22.6.0
+  tables:
+    - aws_*
+  skip_tables:
+    - aws_ec2_vpc_endpoint_services
+    - aws_cloudtrail_events
+    - aws_docdb_cluster_parameter_groups
+    - aws_docdb_engine_versions
+    - aws_ec2_instance_types
+    - aws_elasticache_engine_versions
+    - aws_elasticache_parameter_groups
+    - aws_elasticache_reserved_cache_nodes_offerings
+    - aws_elasticache_service_updates
+    - aws_neptune_cluster_parameter_groups
+    - aws_neptune_db_parameter_groups
+    - aws_rds_cluster_parameter_groups
+    - aws_rds_db_parameter_groups
+    - aws_rds_engine_versions
+    - aws_servicequotas_services
+    - aws_identitystore_users
+    - aws_identitystore_groups
+    - aws_quicksight_data_sets
+    - aws_quicksight_dashboards
+    - aws_quicksight_analyses
+    - aws_quicksight_users
+    - aws_quicksight_templates
+    - aws_quicksight_groups
+    - aws_quicksight_folders
+    - aws_quicksight_data_sources
+    - aws_amp_workspaces
+    - aws_ssoadmin_instances
+    - aws_glue_connections
+    - aws_computeoptimizer_ecs_service_recommendations
+    - aws_xray_sampling_rules
+    - aws_xray_resource_policies
+    - aws_xray_groups
+    - aws_stepfunctions_map_runs
+    - aws_stepfunctions_map_run_executions
+    - aws_organization*
+    - aws_accessanalyzer_*
+    - aws_securityhub_*
+    - aws_cloudformation_stacks
+    - aws_cloudformation_stack_resources
+    - aws_cloudformation_stack_templates
+    - aws_cloudformation_template_summaries
+    - aws_elbv1_*
+    - aws_elbv2_*
+    - aws_acm*
+    - aws_cloudwatch_alarms
+    - aws_inspector_findings
+    - aws_inspector2_findings
+  destinations:
+    - postgresql
+  concurrency: 2000
+  spec:
+    regions:
+      - eu-west-1
+      - eu-west-2
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - ap-southeast-2
+      - ca-central-1
+    org:
+      member_role_name: cloudquery-access
+      organization_units:
+        - ou-123
+' > /source.yaml;printf 'kind: destination
+spec:
+  name: postgresql
+  registry: github
+  path: cloudquery/postgresql
+  version: v5.0.5
+  migrate_mode: forced
+  spec:
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
+' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Essential": true,
+            "Image": "ghcr.io/cloudquery/cloudquery:3.14.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-RemainingAwsDataContainer",
+            "Secrets": [
+              {
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            "Environment": [
+              {
+                "Name": "STACK",
+                "Value": "deploy",
+              },
+              {
+                "Name": "STAGE",
+                "Value": "TEST",
+              },
+              {
+                "Name": "APP",
+                "Value": "service-catalogue",
+              },
+              {
+                "Name": "GU_REPO",
+                "Value": "guardian/service-catalogue",
+              },
+            ],
+            "Essential": true,
+            "FirelensConfiguration": {
+              "Options": {
+                "config-file-type": "file",
+                "config-file-value": "/custom.conf",
+                "enable-ecs-log-metadata": "true",
+              },
+              "Type": "fluentbit",
+            },
+            "Image": "ghcr.io/guardian/hackday-firelens:main",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudquerySourceRemainingAwsDataTaskDefinitionCloudquerySourceRemainingAwsDataFirelensLogGroupBC28DA66",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
+              },
+            },
+            "Name": "CloudquerySource-RemainingAwsDataFirelens",
+          },
+        ],
+        "Cpu": "1024",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceRemainingAwsDataTaskDefinitionExecutionRoleDC6B9AB5",
+            "Arn",
+          ],
+        },
+        "Family": "ServiceCatalogueCloudquerySourceRemainingAwsDataTaskDefinitionE7E84FF0",
+        "Memory": "2048",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "RemainingAwsData",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceRemainingAwsDataTaskDefinitionTaskRoleDB59F8F3",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "CloudquerySourceRemainingAwsDataTaskDefinitionCloudquerySourceRemainingAwsDataFirelensLogGroupBC28DA66": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "RemainingAwsData",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudquerySourceRemainingAwsDataTaskDefinitionEventsRole7E7383AF": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "RemainingAwsData",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceRemainingAwsDataTaskDefinitionEventsRoleDefaultPolicyEA0EC3BA": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ecs:RunTask",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": {
+                    "Fn::GetAtt": [
+                      "servicecatalogueCluster5FC34DC5",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CloudquerySourceRemainingAwsDataTaskDefinition8790EDD9",
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceRemainingAwsDataTaskDefinitionExecutionRoleDC6B9AB5",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceRemainingAwsDataTaskDefinitionTaskRoleDB59F8F3",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceRemainingAwsDataTaskDefinitionEventsRoleDefaultPolicyEA0EC3BA",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceRemainingAwsDataTaskDefinitionEventsRole7E7383AF",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceRemainingAwsDataTaskDefinitionExecutionRoleDC6B9AB5": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "RemainingAwsData",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceRemainingAwsDataTaskDefinitionExecutionRoleDefaultPolicyA56237EA": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceRemainingAwsDataTaskDefinitionCloudquerySourceRemainingAwsDataFirelensLogGroupBC28DA66",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceRemainingAwsDataTaskDefinitionExecutionRoleDefaultPolicyA56237EA",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceRemainingAwsDataTaskDefinitionExecutionRoleDC6B9AB5",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceRemainingAwsDataTaskDefinitionTaskRoleDB59F8F3": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "RemainingAwsData",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceRemainingAwsDataTaskDefinitionTaskRoleDefaultPolicyA7859C69": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":kinesis:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "cloudformation:GetTemplate",
+                "dynamodb:GetItem",
+                "dynamodb:BatchGetItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "ec2:GetConsoleOutput",
+                "ec2:GetConsoleScreenshot",
+                "ecr:BatchGetImage",
+                "ecr:GetAuthorizationToken",
+                "ecr:GetDownloadUrlForLayer",
+                "kinesis:Get*",
+                "lambda:GetFunction",
+                "logs:GetLogEvents",
+                "sdb:Select*",
+                "sqs:ReceiveMessage",
+              ],
+              "Effect": "Deny",
+              "Resource": "*",
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": "arn:aws:iam::*:role/cloudquery-access",
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceRemainingAwsDataTaskDefinitionTaskRoleDefaultPolicyA7859C69",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceRemainingAwsDataTaskDefinitionTaskRoleDB59F8F3",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceRemainingAwsDataTaskErrorRule4BBB40E1": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Task CloudquerySource-RemainingAwsData exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceRemainingAwsDataTaskDefinition8790EDD9",
               },
             ],
           },

--- a/packages/cdk/lib/ecs/cluster.ts
+++ b/packages/cdk/lib/ecs/cluster.ts
@@ -16,6 +16,7 @@ import { ScheduledCloudqueryTask } from './task';
 export interface CloudquerySource {
 	/**
 	 * The name of the source.
+	 * This will get added to the `Name` tag of the task definition.
 	 */
 	name: string;
 
@@ -148,6 +149,7 @@ export class CloudqueryCluster extends Cluster {
 			}) => {
 				new ScheduledCloudqueryTask(scope, `CloudquerySource-${name}`, {
 					...taskProps,
+					name,
 					managedPolicies,
 					policies: [logShippingPolicy, ...policies],
 					schedule,

--- a/packages/cdk/lib/ecs/task.ts
+++ b/packages/cdk/lib/ecs/task.ts
@@ -1,5 +1,6 @@
 import type { AppIdentity, GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
+import { Tags } from 'aws-cdk-lib';
 import type { Cluster } from 'aws-cdk-lib/aws-ecs';
 import {
 	ContainerImage,
@@ -34,6 +35,12 @@ const firelensImage = ContainerImage.fromRegistry(
 export interface ScheduledCloudqueryTaskProps
 	extends AppIdentity,
 		Omit<ScheduledFargateTaskProps, 'Cluster'> {
+	/**
+	 * The name of the source.
+	 * This will get added to the `Name` tag of the task definition.
+	 */
+	name: string;
+
 	/**
 	 * THe Postgres database for ServiceCatalogue to connect to.
 	 */
@@ -92,6 +99,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 	public readonly sourceConfig: CloudqueryConfig;
 	constructor(scope: GuStack, id: string, props: ScheduledCloudqueryTaskProps) {
 		const {
+			name,
 			db,
 			cluster,
 			app,
@@ -115,6 +123,11 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			memoryLimitMiB,
 			cpu,
 		});
+
+		/*
+		A scheduled task (i.e. `this`) cannot be tagged, so we tag the task definition instead.
+		 */
+		Tags.of(task).add('Name', name);
 
 		const destinationConfig = postgresDestinationConfig();
 

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -245,7 +245,7 @@ export class ServiceCatalogue extends GuStack {
 		];
 
 		const remainingAwsSources: CloudquerySource = {
-			name: 'All',
+			name: 'RemainingAwsData',
 			description: 'Data fetched across all accounts in the organisation.',
 			schedule: nonProdSchedule ?? Schedule.rate(Duration.days(1)),
 			config: awsSourceConfigForOrganisation({


### PR DESCRIPTION
## What does this change?
To help distinguish between each task, add a `Name` tag.

Additionally, rename the "All" task to "RemainingAwsData" for clarity (this creates quite the snapshot diff!)