### PR TITLE
chore: Configure Dependabot to target the default branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    target-branch: "dependency-updates"
     ignore:
       # The version of AWS CDK libraries must match those from @guardian/cdk.
       # We'd never be able to update them here independently, so just ignore them.


### PR DESCRIPTION
## What does this change?
We previously used the "dependency-updates" branch to batch multiple dependency updates into one PR to reduce the amount of PRs to review (1 mega PR, vs multiple small ones).

We've since removed this process[^1], so we need to raise PRs to `main`.

[^1]: I can't remember why and can't find when...