### PR TITLE
fix: Enable deletion protection for PROD RDS database

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -17,4 +17,5 @@ new ServiceCatalogue(app, 'ServiceCatalogue-CODE', {
 	stage: 'CODE',
 	env: { region: 'eu-west-1' },
 	schedule: Schedule.rate(Duration.days(30)),
+	rdsDeletionProtection: false,
 });

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -9945,6 +9945,7 @@ spec:
         "DBSubnetGroupName": {
           "Ref": "PostgresInstance1SubnetGroupCAC045A5",
         },
+        "DeletionProtection": true,
         "EnableIAMDatabaseAuthentication": true,
         "Engine": "postgres",
         "MasterUserPassword": {

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -57,6 +57,13 @@ interface ServiceCatalogueProps extends GuStackProps {
 	//For code environments, data accuracy is not the main priority.
 	// To keep costs low, we can choose to run all the tasks on the same cadence, less frequently than on prod
 	schedule?: Schedule;
+
+	/**
+	 * Enable deletion protection for the RDS instance?
+	 *
+	 * @default true
+	 */
+	rdsDeletionProtection?: boolean;
 }
 
 export class ServiceCatalogue extends GuStack {
@@ -65,6 +72,8 @@ export class ServiceCatalogue extends GuStack {
 
 		const { stage, stack } = this;
 		const app = props.app ?? 'service-catalogue';
+
+		const { rdsDeletionProtection = true } = props;
 
 		const nonProdSchedule = props.schedule;
 
@@ -100,6 +109,7 @@ export class ServiceCatalogue extends GuStack {
 			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 			storageEncrypted: true,
 			securityGroups: [dbSecurityGroup],
+			deletionProtection: rdsDeletionProtection,
 		};
 
 		const db = new DatabaseInstance(this, 'PostgresInstance1', dbProps);


### PR DESCRIPTION
## What does this change?
AWS defaults to no protection on RDS instances 😱. This change enables protection for the PROD database.

## Why?
RDS holds state, so being protected from accidental deletion is desired, at least for PROD.

## How has it been verified?
See the snapshot changes.