### PR TITLE
feat: Collect GitHub Workflow data

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -3401,6 +3401,7 @@ spec:
   tables:
     - github_repositories
     - github_repository_branches
+    - github_workflows
   skip_tables:
     - github_releases
     - github_release_assets

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -310,7 +310,11 @@ export class ServiceCatalogue extends GuStack {
 				description: 'Collect GitHub repository data',
 				schedule: nonProdSchedule ?? Schedule.rate(Duration.days(1)),
 				config: githubSourceConfig({
-					tables: ['github_repositories', 'github_repository_branches'],
+					tables: [
+						'github_repositories',
+						'github_repository_branches',
+						'github_workflows',
+					],
 
 					// We're not (yet) interested in the following tables, so do not collect them to reduce API quota usage.
 					// See https://www.cloudquery.io/docs/advanced-topics/performance-tuning#improve-performance-by-skipping-relations


### PR DESCRIPTION
## What does this change? And why?
The [`github_workflows` table](https://www.cloudquery.io/docs/plugins/sources/github/tables/github_workflows) has a `content` column, allow the workflow file's content to be queried.

With adoption of GitHub Actions for CI is growing, it'll be interesting to see how we're using GHA. Potential use-cases include:
  - A vuln. has been detected in a third-party action. Which repositories are impacted?
  - How is a repository integrated with Snyk? Via the departmental action? Or other means?

## How has it been verified?
Ran locally.