### PR TITLE
feat(cli): Simplify the `list-tasks` command output

### DIFF
--- a/packages/cloudquery/src/index.ts
+++ b/packages/cloudquery/src/index.ts
@@ -36,6 +36,12 @@ const parseCommandLineArguments = () => {
 							description: 'The App tag',
 							type: 'string',
 							demandOption: true,
+						})
+						.option('debug', {
+							description:
+								'Show more information about tasks, such as the ARN, and all their tags',
+							type: 'boolean',
+							default: false,
 						});
 				},
 			)
@@ -91,14 +97,19 @@ parseCommandLineArguments()
 		const command = argv._[0];
 		switch (command) {
 			case Commands.list: {
-				const { stack, stage, app } = argv;
+				const { stack, stage, app, debug } = argv;
 				const client = getEcsClient();
-				return listTasks(
+
+				const tasks = listTasks(
 					client,
 					stack as string,
 					stage as string,
 					app as string,
 				);
+
+				return debug
+					? tasks
+					: tasks.then((tasks) => tasks.map((task) => task['Name']));
 			}
 			case Commands.run: {
 				const { stack, stage, app, name } = argv;


### PR DESCRIPTION
## What does this change?
Currently, the `list-tasks` command returns a list of all tasks, their ARN, and tags.

This is quite a lot of information, and more than we typically want. Typically, we only want to know the task names.

This change adds a `debug` flag to the `list-tasks` command. When `true`, all the detail is printed.
When `false`, only the names are printed. This is the default.

## Why?
Offers a simpler DX.

## How has it been verified?
By running it locally:

```console
➜ npm run cli --workspace cloudquery list-tasks -- --stack deploy --stage CODE --app service-catalogue

> cloudquery@0.0.0 cli
> ts-node src/index.ts "list-tasks" "--stack" "deploy" "--stage" "CODE" "--app" "service-catalogue"

[
  "DelegatedToSecurityAccount",
  "DeployToolsListOrgs",
  "FastlyServices",
  "Galaxies",
  "GitHubIssues",
  "GitHubRepositories",
  "GitHubTeams",
  "GuardianCustomSnykProjects",
  "OrgWideCertificates",
  "OrgWideCloudFormation",
  "OrgWideCloudwatchAlarms",
  "OrgWideInspector",
  "OrgWideLoadBalancers",
  "RemainingAwsData",
  "SnykAll"
]
```