### PR TITLE
Rollback to CQ_AWS 22.6.0

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ CQ_CLI=3.14.4
 CQ_POSTGRES=5.0.6
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
-CQ_AWS=22.7.0
+CQ_AWS=22.6.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
 CQ_GITHUB=7.2.0


### PR DESCRIPTION
## What does this change?

## Why?

## How has it been verified?
