### PR TITLE
Add scheduled typescript lambda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,7 @@ jobs:
           contentDirectories: |
             cdk.out:
               - packages/cdk/cdk.out
+            repocop:
+              - packages/repocop/repocop.zip
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'

--- a/package-lock.json
+++ b/package-lock.json
@@ -6946,6 +6946,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/repocop": {
+      "resolved": "packages/repocop",
+      "link": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "license": "MIT",
@@ -8005,6 +8009,11 @@
         "@types/yargs": "^17.0.24",
         "yargs": "^17.7.2"
       }
+    },
+    "packages/repocop": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {}
     }
   }
 }

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -10,12 +10,19 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuSecurityGroup",
       "GuStringParameter",
       "GuLoggingStreamNameParameter",
+      "GuDistributionBucketParameter",
+      "GuScheduledLambda",
     ],
     "gu:cdk:version": "TEST",
   },
   "Parameters": {
     "ActionsStaticSiteBucketArnParam": {
       "Default": "/INFRA/deploy/cloudquery/actions-static-site-bucket-arn",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "LoggingStreamName": {
@@ -10872,6 +10879,250 @@ spec:
       },
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
+    },
+    "repocop20553EB8": {
+      "DependsOn": [
+        "repocopServiceRoleDefaultPolicyF20BF625",
+        "repocopServiceRole757D74E8",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "deploy/TEST/repocop/repocop.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "repocop",
+            "STACK": "deploy",
+            "STAGE": "TEST",
+          },
+        },
+        "Handler": "index.main",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "repocopServiceRole757D74E8",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "repocop",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "repocopServiceRole757D74E8": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "repocop",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "repocopServiceRoleDefaultPolicyF20BF625": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/deploy/TEST/repocop/repocop.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/repocop",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/repocop/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "repocopServiceRoleDefaultPolicyF20BF625",
+        "Roles": [
+          {
+            "Ref": "repocopServiceRole757D74E8",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "repocoprepocoprate7days027B60EF4": {
+      "Properties": {
+        "ScheduleExpression": "rate(7 days)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "repocop20553EB8",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "repocoprepocoprate7days0AllowEventRuleServiceCataloguerepocop7BEB5892B3FD7B7F": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "repocop20553EB8",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "repocoprepocoprate7days027B60EF4",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "servicecatalogueCluster5FC34DC5": {
       "Properties": {

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -1,3 +1,4 @@
+import { GuScheduledLambda } from '@guardian/cdk';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack, GuStringParameter } from '@guardian/cdk/lib/constructs/core';
 import {
@@ -6,6 +7,7 @@ import {
 	SubnetType,
 } from '@guardian/cdk/lib/constructs/ec2';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
+import type { GuScheduledLambdaProps } from '@guardian/cdk/lib/patterns/scheduled-lambda';
 import {
 	GuardianAwsAccounts,
 	GuardianPrivateNetworks,
@@ -21,6 +23,7 @@ import {
 } from 'aws-cdk-lib/aws-ec2';
 import { Secret } from 'aws-cdk-lib/aws-ecs';
 import { Schedule } from 'aws-cdk-lib/aws-events';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import type { DatabaseInstanceProps } from 'aws-cdk-lib/aws-rds';
 import { DatabaseInstance, DatabaseInstanceEngine } from 'aws-cdk-lib/aws-rds';
 import { Secret as SecretsManager } from 'aws-cdk-lib/aws-secretsmanager';
@@ -486,5 +489,16 @@ export class ServiceCatalogue extends GuStack {
 				...snykSources,
 			],
 		});
+
+		const repocopLampdaProps: GuScheduledLambdaProps = {
+			app: 'repocop',
+			fileName: 'repocop.zip',
+			handler: 'index.main',
+			monitoringConfiguration: { noMonitoring: true },
+			rules: [{ schedule: Schedule.rate(Duration.days(7)) }],
+			runtime: Runtime.NODEJS_18_X,
+		};
+
+		new GuScheduledLambda(this, 'repocop', repocopLampdaProps);
 	}
 }

--- a/packages/repocop/.gitignore
+++ b/packages/repocop/.gitignore
@@ -1,0 +1,1 @@
+index.js

--- a/packages/repocop/index.js
+++ b/packages/repocop/index.js
@@ -1,0 +1,5 @@
+"use strict";
+(() => {
+  // repocop.ts
+  console.log("Hello repocop");
+})();

--- a/packages/repocop/index.js
+++ b/packages/repocop/index.js
@@ -1,5 +1,0 @@
-"use strict";
-(() => {
-  // repocop.ts
-  console.log("Hello repocop");
-})();

--- a/packages/repocop/index.ts
+++ b/packages/repocop/index.ts
@@ -1,0 +1,3 @@
+export function main() {
+	console.log('Hello repocop');
+}

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "devDependencies": {},
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "build": "esbuild index.ts --bundle --outfile=index.js"
   }
 }

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "devDependencies": {},
   "scripts": {
-    "build": "esbuild index.ts --bundle --outfile=index.js"
+    "build": "esbuild index.ts --bundle --platform=node --target=node18 --outfile=index.js"
   }
 }

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "repocop",
+  "version": "1.0.0",
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "esbuild index.ts --bundle --outfile=index.js"
+  }
+}

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 set -e
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+ROOT_DIR="${DIR}/.."
 
 npm ci
 npm run typecheck
@@ -8,3 +10,5 @@ npm run lint
 npm run test
 npm run synth
 npm run build
+
+zip -j "$ROOT_DIR/packages/repocop/repocop.zip" packages/repocop/index.js


### PR DESCRIPTION
## What does this change?
Add a scheduled typescript lambda, scheduled one a week

## Why?
It is preparatory work to add repocop as a cloudquery based lambda

## How has it been verified?
Deploy to code 
[riffraff deployment](https://riffraff.gutools.co.uk/deployment/view/66e529c2-e4be-4ec4-99dd-e287fe7c7349)
[elk logs](https://logs.gutools.co.uk/s/devx/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'626e7830-dd3a-11ea-88b6-37713dba5739',key:app.keyword,negate:!f,params:(query:repocop),type:phrase),query:(match_phrase:(app.keyword:repocop))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'626e7830-dd3a-11ea-88b6-37713dba5739',key:lambdaEvent,negate:!t,type:exists,value:exists),query:(exists:(field:lambdaEvent)))),hideChart:!f,index:'626e7830-dd3a-11ea-88b6-37713dba5739',interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc))))
