### PR TITLE
Streamline docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ The following packages form part of Service Catalogue:
 
 * [cloudquery](packages/cloudquery/README.md): A set of Cloudquery (ECS) tasks to collect the data
 
-To learn how to use cloudquery, see the [docs](docs/getting-started.md) for an introduction.
+To learn how to use the production cloudquery data, see the [docs](docs/getting-started.md) for an introduction.
+
+To run cloudquery locally, see the package [README](packages/cloudquery/README.md).
 
 ## Updating CloudQuery
 To update the version of CloudQuery, and its plugins:

--- a/packages/cloudquery/README.md
+++ b/packages/cloudquery/README.md
@@ -29,8 +29,8 @@ section of the config)
 
 ## Running
 
-1. Put your GitHub PAT and Snyk token in the `.env.local` file at the repo root. It is ignored by git so is safe to edit
-for local development (n.b do not put them in the `.env` file, as you will probably commit a secret by accident)
+1. Put your GitHub PAT and Snyk tokens in the `.env.local` file at the repo root. It is ignored by git so is safe to edit
+for local development (n.b. do not put them in the `.env` file, as you will probably commit a secret by accident).
 2. Start Docker
 3. Run:
 

--- a/packages/cloudquery/README.md
+++ b/packages/cloudquery/README.md
@@ -18,8 +18,10 @@ It includes:
 - A Snyk token
 
 ## Setup
-
-In the project root, run the following, and follow the resulting instructions:
+1. Check [cloudquery.yaml](./dev-config/cloudquery.yaml) for the AWS profiles needed to run cloudquery (in the AWS
+section of the config)
+2. Get AWS credentials from Janus
+3. In the project root, run the following, and follow the resulting instructions:
 
 ```sh
 ./packages/cloudquery/script/setup
@@ -27,8 +29,9 @@ In the project root, run the following, and follow the resulting instructions:
 
 ## Running
 
-1. Start Docker
-2. Get AWS credentials from Janus (check [cloudquery.yaml](./dev-config/cloudquery.yaml) for the AWS profiles needed)
+1. Put your GitHub PAT and Snyk token in the `.env.local` file at the repo root. It is ignored by git so is safe to edit
+for local development (n.b do not put them in the `.env` file, as you will probably commit a secret by accident)
+2. Start Docker
 3. Run:
 
    ```sh
@@ -42,16 +45,26 @@ In the project root, run the following, and follow the resulting instructions:
    ```
 
    This will start the Docker containers, and CloudQuery will start collecting data.
-
-4. Open Grafana on [http://localhost:3000](http://localhost:3000), and start querying the data
-5. To restart on your local machine, delete the container in docker and go back to step 3.
+4. Wait for tables to start being populated. Usually the first tables show up after a few seconds, but this could take
+as long as a minute.
+5. Open Grafana on [http://localhost:3000](http://localhost:3000), and start querying the data
+6. To restart on your local machine, delete the container in docker and go back to step 3.
 
 > **Note**
-> You can also use other Postgres clients, such as `psql`, or even your IDE!
+> You can also use other Postgres clients, such as `psql` to query the data, or even your IDE!
 
 ## Links
 
 - [CloudQuery provided Grafana dashboards](https://github.com/cloudquery/cloudquery/tree/main/plugins/source/aws/dashboards)
+
+## Tips and tricks
+
+The local instance of cloudquery executes sequentially according to the order of the plugins in the config file. If
+you're particularly interested in Snyk data, you can move the Snyk plugin to the top of the list in the config file, and
+that data will be collected first.
+
+If cloudquery can't detect credentials for Snyk or GitHub, it will skip those jobs. If you're not interested in GitHub
+data, you don't need to generate a token. It will still collect data from other sources.
 
 ## TODO
 

--- a/packages/cloudquery/README.md
+++ b/packages/cloudquery/README.md
@@ -18,10 +18,8 @@ It includes:
 - A Snyk token
 
 ## Setup
-1. Check [cloudquery.yaml](./dev-config/cloudquery.yaml) for the AWS profiles needed to run cloudquery (in the AWS
-section of the config)
-2. Get AWS credentials from Janus
-3. In the project root, run the following, and follow the resulting instructions:
+1. Get developer playground credentials from Janus
+2. In the project root, run the following, and follow the resulting instructions:
 
 ```sh
 ./packages/cloudquery/script/setup

--- a/packages/cloudquery/script/setup
+++ b/packages/cloudquery/script/setup
@@ -2,8 +2,11 @@
 
 set -e
 
+red='\033[0;31m'
+clear='\033[0m'
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_DIR=$DIR/../../..
+ROOT_DIR=$(realpath "$DIR/../../..")
 
 ENV_FILE=$ROOT_DIR/.env
 LOCAL_ENV_FILE=$ROOT_DIR/.env.local
@@ -17,10 +20,10 @@ echo "Visit https://docs.snyk.io/snyk-api-info/authentication-for-api to create 
 echo "Checking AWS credentials"
 STATUS=$(aws sts get-caller-identity --profile developerPlayground 2>&1 || true)
 if [[ ${STATUS} =~ (ExpiredToken) ]]; then
-  echo "Credentials for the developerPlayground profile have expired. Please fetch new credentials."
+  echo -e "${red}Credentials for the developerPlayground profile have expired${clear}. Please fetch new credentials."
   exit 1
 elif [[ ${STATUS} =~ ("could not be found") ]]; then
-  echo "Credentials for the developerPlayground profile are missing. Please fetch some."
+  echo -e "${red}Credentials for the developerPlayground profile are missing${clear}. Please fetch some."
   exit 1
 else
   echo "AWS credentials are valid"


### PR DESCRIPTION
## What does this change?

This change improves the developer experience. Following the instructions now means that this works first time. I've also added some more information that will be useful for first time contributors.

I've also made the output from the script more readable, simplifying the paths displayed in the output, and showing error messages in a different colour

## Why?

Having pulled the repo fresh and trying to follow the setup instructions, I'd often have to go back and repeat steps. The steps are now in the correct order.

Often, when setting up the project, users did not understand that the setup script was failing. Showing the error message in a different colour will hopefully make that clearer

## How has it been verified?

Tested locally. Now a bad output looks like this. Much more error-y

<img width="655" alt="Screenshot 2023-09-05 at 10 30 17" src="https://github.com/guardian/service-catalogue/assets/67543397/d94ad35f-f488-48e9-b4d7-018056b61fb1">
