### PR TITLE
feat(repocop): Add logic to evaluate rules repository_01 and repository_02

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,17 @@ module.exports = {
 				'node_modules/(?!@guardian/private-infrastructure-config)',
 			],
 			setupFilesAfterEnv: [`<rootDir>/packages/cdk/jest.setup.js`],
+			testMatch: ['<rootDir>/packages/cdk/**/*.test.ts'],
+		},
+		{
+			displayName: 'repocop',
+			transform: {
+				'^.+\\.tsx?$': 'ts-jest',
+			},
+			transformIgnorePatterns: [
+				'node_modules/(?!@guardian/private-infrastructure-config)',
+			],
+			testMatch: ['<rootDir>/packages/repocop/**/*.test.ts'],
 		},
 	],
 };

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "esbuild src/index.ts --bundle --platform=node --target=node18 --outdir=dist --external:@aws-sdk --external:@prisma/client --external:prisma",
     "start": "ts-node src/run-locally.ts",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects repocop"
   },
   "prisma": {
     "schema": "prisma/schema.prisma"

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from "@prisma/client";
 import { getConfig } from "./config";
+import { repositoryRuleEvaluation } from "./rules/repository";
 
 export async function main() {
 	const config = await getConfig();
@@ -10,11 +11,27 @@ export async function main() {
 			},
 		}
 	});
-	console.log('Query prisma');
-	const queryResult = await prisma.github_repositories.findFirst({where: {
-		archived: false,
-	}})
 
-	if (queryResult)
-		console.log(queryResult.name || "not found")
+	// TODO Process ALL repositories
+	const repo = await prisma.github_repositories.findFirst();
+
+	if (!repo) {
+		console.log('No repositories found');
+	} else {
+		const branches = await prisma.github_repository_branches.findMany();
+		const ruleEvaluation = repositoryRuleEvaluation(repo, branches);
+
+		console.log('The results are in...');
+		console.log(JSON.stringify(ruleEvaluation, null, 2));
+
+		console.log('Clearing the table');
+		await prisma.repocop_github_repository_rules.deleteMany({});
+
+		console.log('Writing to table');
+		await prisma.repocop_github_repository_rules.createMany({
+			data: [ruleEvaluation]
+		});
+	}
+
+	console.log('Done');
 }

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -1,0 +1,185 @@
+import { github_repositories, github_repository_branches } from '@prisma/client';
+import { repository01, repository02 } from './repository';
+
+const nullRepo: github_repositories = {
+  cq_sync_time: null,
+  cq_source_name: null,
+  cq_id: "",
+  cq_parent_id: null,
+  org: "",
+  id: 0n,
+  node_id: null,
+  owner: null,
+  name: null,
+  full_name: null,
+  description: null,
+  homepage: null,
+  code_of_conduct: null,
+  default_branch: null,
+  master_branch: null,
+  created_at: null,
+  pushed_at: null,
+  updated_at: null,
+  html_url: null,
+  clone_url: null,
+  git_url: null,
+  mirror_url: null,
+  ssh_url: null,
+  svn_url: null,
+  language: null,
+  fork: null,
+  forks_count: null,
+  network_count: null,
+  open_issues_count: null,
+  open_issues: null,
+  stargazers_count: null,
+  subscribers_count: null,
+  watchers_count: null,
+  watchers: null,
+  size: null,
+  auto_init: null,
+  parent: null,
+  source: null,
+  template_repository: null,
+  organization: null,
+  permissions: null,
+  allow_rebase_merge: null,
+  allow_update_branch: null,
+  allow_squash_merge: null,
+  allow_merge_commit: null,
+  allow_auto_merge: null,
+  allow_forking: null,
+  delete_branch_on_merge: null,
+  use_squash_pr_title_as_default: null,
+  squash_merge_commit_title: null,
+  squash_merge_commit_message: null,
+  merge_commit_title: null,
+  merge_commit_message: null,
+  topics: [],
+  archived: null,
+  disabled: null,
+  license: null,
+  private: null,
+  has_issues: null,
+  has_wiki: null,
+  has_pages: null,
+  has_projects: null,
+  has_downloads: null,
+  has_discussions: null,
+  is_template: null,
+  license_template: null,
+  gitignore_template: null,
+  security_and_analysis: null,
+  team_id: null,
+  url: null,
+  archive_url: null,
+  assignees_url: null,
+  blobs_url: null,
+  branches_url: null,
+  collaborators_url: null,
+  comments_url: null,
+  commits_url: null,
+  compare_url: null,
+  contents_url: null,
+  contributors_url: null,
+  deployments_url: null,
+  downloads_url: null,
+  events_url: null,
+  forks_url: null,
+  git_commits_url: null,
+  git_refs_url: null,
+  git_tags_url: null,
+  hooks_url: null,
+  issue_comment_url: null,
+  issue_events_url: null,
+  issues_url: null,
+  keys_url: null,
+  labels_url: null,
+  languages_url: null,
+  merges_url: null,
+  milestones_url: null,
+  notifications_url: null,
+  pulls_url: null,
+  releases_url: null,
+  stargazers_url: null,
+  statuses_url: null,
+  subscribers_url: null,
+  subscription_url: null,
+  tags_url: null,
+  trees_url: null,
+  teams_url: null,
+  text_matches: null,
+  visibility: null,
+  role_name: null
+}
+
+const nullBranch: github_repository_branches = {
+  cq_sync_time: null,
+  cq_source_name: null,
+  cq_id: "",
+  cq_parent_id: null,
+  org: "guardian",
+  repository_id: BigInt(0),
+  protection: null,
+  name: "",
+  commit: null,
+  protected: null
+}
+
+const thePerfectRepo: github_repositories = {
+  ...nullRepo,
+  full_name: "repo1",
+  default_branch: "main",
+  topics: ["production"],
+  id: BigInt(1),
+};
+
+describe('repository_01 should be false when the default branch is not main', () => {
+  test('branch is not main', () => {
+    const badRepo = { ...thePerfectRepo, default_branch: 'notMain' };
+    const repos: github_repositories[] = [
+      thePerfectRepo,
+      badRepo,
+    ];
+    expect(repos.map(repository01)).toEqual([true, false]);
+  });
+});
+
+describe('Repositories should have branch protection', () => {
+  test('We should get an affirmative result when the default branch is protected', () => {
+    const protectedMainBranch: github_repository_branches = {
+      ...nullBranch,
+      repository_id: BigInt(1),
+      name: 'main',
+      protected: true,
+    };
+    const unprotectedSideBranch: github_repository_branches = {
+      ...protectedMainBranch,
+      name: 'side-branch',
+      protected: false,
+    };
+
+    const result = repository02(
+      thePerfectRepo,
+      [protectedMainBranch, unprotectedSideBranch],
+    );
+    expect(result).toEqual(true);
+  });
+  test('We should get a negative result when the default branch is not protected', () => {
+    const repo: github_repositories = {
+      ...nullRepo,
+      full_name: 'repo1',
+      default_branch: 'default',
+      id: BigInt(1),
+    };
+
+    const unprotectedMainBranch: github_repository_branches = {
+      ...nullBranch,
+      repository_id: BigInt(1),
+      name: 'default',
+      protected: false,
+      protection: {},
+    };
+    expect(repository02(repo, [unprotectedMainBranch])).toEqual(false);
+  });
+});

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -1,0 +1,33 @@
+import { github_repositories, github_repository_branches, repocop_github_repository_rules } from '@prisma/client';
+
+export function repository01(repo: github_repositories): boolean {
+  return repo.default_branch === 'main';
+}
+
+export function repository02(repo: github_repositories, branches: github_repository_branches[]): boolean {
+  const branch = branches.find((branch) => branch.repository_id === repo.id && branch.name === repo.default_branch)
+  if (branch === undefined) {
+    return false
+  }
+  else {
+    return branch!.protected!
+  }
+}
+
+export function repositoryRuleEvaluation(
+  repo: github_repositories,
+  allBranches: github_repository_branches[],
+): repocop_github_repository_rules {
+  return {
+    full_name: repo.full_name!,
+    repository_01: repository01(repo),
+    repository_02: repository02(repo, allBranches),
+
+    // TODO - implement these rules
+    repository_03: false,
+    repository_04: false,
+    repository_05: false,
+    repository_06: false,
+    repository_07: false,
+  };
+}

--- a/sql/dbuser.sql
+++ b/sql/dbuser.sql
@@ -2,3 +2,7 @@ CREATE USER repocop WITH LOGIN;
 GRANT USAGE ON SCHEMA public to repocop;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO repocop;
 GRANT rds_iam TO repocop;
+
+-- This table is created via a Prisma migration
+-- TODO what order should all the SQL be applied now?
+GRANT ALL ON public.repocop_github_repository_rules TO repocop;


### PR DESCRIPTION
## What does this change?
Heavily inspired by #260, this change provides an initial implementation applying RepoCop logic:
  1. Get one repo
  2. Get all branches
  3. Evaluate [rules repository_01 (default branch should be main), and repository_02 (branch protection on default branch)](https://github.com/guardian/recommendations/blob/main/best-practices.md)
  4. Write results to database

AND TESTS!

Note: We've disabled the linter on the repocop project, so there might be some formatting issues!

## Why?
This change completes the end to end demonstration of using Prisma for RepoCop. The next stage would be to implement the evaluation of the remaining rules. This will be done in a separate PR.

## How has it been verified?
Run the branch locally via `npm -w repocop start`, observe the logs, and observe the `repocop_github_repository_rules` table being written to.