### PR TITLE
feat(repocop): Evaluate all repositories

### DIFF
--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -19,6 +19,11 @@ export interface Config {
 	 * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/logging
 	 */
 	withQueryLogging: boolean;
+
+	/**
+	 * Repositories that should not be processed, for example, because they are not owned by a team in Product and Engineering.
+	 */
+	ignoredRepositoryPrefixes: string[];
 }
 
 interface DatabaseConfig {
@@ -72,6 +77,7 @@ export async function getConfig(): Promise<Config> {
 		stage: getEnvOrThrow('STAGE'),
 		databaseConnectionString: await getDatabaseConnectionString(databaseConfig),
 		withQueryLogging: queryLogging,
+		ignoredRepositoryPrefixes: ['guardian/interactive-', 'guardian/oz-'],
 	};
 }
 

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -1,6 +1,68 @@
+import type {
+	github_repositories,
+	github_repository_branches,
+	repocop_github_repository_rules,
+} from '@prisma/client';
 import { PrismaClient } from '@prisma/client';
 import { getConfig } from './config';
 import { repositoryRuleEvaluation } from './rules/repository';
+
+async function getRepositories(
+	client: PrismaClient,
+	ignoredRepositoryPrefixes: string[],
+): Promise<github_repositories[]> {
+	console.log('Discovering repositories');
+	const repositories = await client.github_repositories.findMany({
+		where: {
+			archived: false,
+
+			NOT: [
+				{
+					OR: ignoredRepositoryPrefixes.map((prefix) => {
+						return { full_name: { startsWith: prefix } };
+					}),
+				},
+			],
+		},
+	});
+	console.log(`Found ${repositories.length} repositories`);
+
+	return repositories;
+}
+
+async function getRepositoryBranches(
+	client: PrismaClient,
+	repository: github_repositories,
+): Promise<github_repository_branches[]> {
+	const branches = await client.github_repository_branches.findMany({
+		where: {
+			repository_id: repository.id,
+		},
+	});
+
+	// `full_name` is typed as nullable, in reality it is not, so the fallback to `id` shouldn't happen
+	const repoIdentifier = repository.full_name ?? repository.id;
+
+	console.log(
+		`Found ${branches.length} branches for repository ${repoIdentifier}`,
+	);
+
+	return branches;
+}
+
+async function evaluateRepositories(
+	client: PrismaClient,
+	ignoredRepositoryPrefixes: string[],
+): Promise<repocop_github_repository_rules[]> {
+	const repositories = await getRepositories(client, ignoredRepositoryPrefixes);
+
+	return await Promise.all(
+		repositories.map(async (repo) => {
+			const branches = await getRepositoryBranches(client, repo);
+			return repositoryRuleEvaluation(repo, branches);
+		}),
+	);
+}
 
 export async function main() {
 	const config = await getConfig();
@@ -20,26 +82,18 @@ export async function main() {
 		}),
 	});
 
-	// TODO Process ALL repositories
-	const repo = await prisma.github_repositories.findFirst();
+	const data = await evaluateRepositories(
+		prisma,
+		config.ignoredRepositoryPrefixes,
+	);
 
-	if (!repo) {
-		console.log('No repositories found');
-	} else {
-		const branches = await prisma.github_repository_branches.findMany();
-		const ruleEvaluation = repositoryRuleEvaluation(repo, branches);
+	console.log('Clearing the table');
+	await prisma.repocop_github_repository_rules.deleteMany({});
 
-		console.log('The results are in...');
-		console.log(JSON.stringify(ruleEvaluation, null, 2));
-
-		console.log('Clearing the table');
-		await prisma.repocop_github_repository_rules.deleteMany({});
-
-		console.log('Writing to table');
-		await prisma.repocop_github_repository_rules.createMany({
-			data: [ruleEvaluation],
-		});
-	}
+	console.log(`Writing ${data.length} records to table`);
+	await prisma.repocop_github_repository_rules.createMany({
+		data,
+	});
 
 	console.log('Done');
 }


### PR DESCRIPTION
## What does this change, and why?
We were previously evaluating one repository. This change evaluates all repositories, excluding those that are archived or outside of P&E. We're performing this filtering via SQL, which though isn't unit tested, does mean we hold less in memory, that is, it should be more performant.

## How has it been verified?
Ran locally. I've also [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/43f216e2-25f5-46c8-804a-7dd1e15cdb57), and successfully executed the lambda.