### PR TITLE
feat(repocop): Implement rule repository_04

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -1,11 +1,11 @@
 import type {
 	github_repositories,
 	github_repository_branches,
-	github_team_repositories,
 	repocop_github_repository_rules,
 } from '@prisma/client';
 import { PrismaClient } from '@prisma/client';
 import { getConfig } from './config';
+import { getRepositoryTeams } from './query';
 import { repositoryRuleEvaluation } from './rules/repository';
 
 async function getRepositories(
@@ -49,26 +49,6 @@ async function getRepositoryBranches(
 	);
 
 	return branches;
-}
-
-async function getRepositoryTeams(
-	client: PrismaClient,
-	repository: github_repositories,
-): Promise<github_team_repositories[]> {
-	const data = await client.github_team_repositories.findMany({
-		where: {
-			id: repository.id,
-		},
-	});
-
-	// `full_name` is typed as nullable, in reality it is not, so the fallback to `id` shouldn't happen
-	const repoIdentifier = repository.full_name ?? repository.id;
-
-	console.log(
-		`Found ${data.length} teams with access to repository ${repoIdentifier}`,
-	);
-
-	return data;
 }
 
 async function evaluateRepositories(

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -1,6 +1,7 @@
 import type {
 	github_repositories,
 	github_repository_branches,
+	github_team_repositories,
 	repocop_github_repository_rules,
 } from '@prisma/client';
 import { PrismaClient } from '@prisma/client';
@@ -50,6 +51,26 @@ async function getRepositoryBranches(
 	return branches;
 }
 
+async function getRepositoryTeams(
+	client: PrismaClient,
+	repository: github_repositories,
+): Promise<github_team_repositories[]> {
+	const data = await client.github_team_repositories.findMany({
+		where: {
+			id: repository.id,
+		},
+	});
+
+	// `full_name` is typed as nullable, in reality it is not, so the fallback to `id` shouldn't happen
+	const repoIdentifier = repository.full_name ?? repository.id;
+
+	console.log(
+		`Found ${data.length} teams with access to repository ${repoIdentifier}`,
+	);
+
+	return data;
+}
+
 async function evaluateRepositories(
 	client: PrismaClient,
 	ignoredRepositoryPrefixes: string[],
@@ -59,7 +80,8 @@ async function evaluateRepositories(
 	return await Promise.all(
 		repositories.map(async (repo) => {
 			const branches = await getRepositoryBranches(client, repo);
-			return repositoryRuleEvaluation(repo, branches);
+			const teams = await getRepositoryTeams(client, repo);
+			return repositoryRuleEvaluation(repo, branches, teams);
 		}),
 	);
 }

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -1,7 +1,7 @@
 import type { github_repositories, Prisma, PrismaClient } from '@prisma/client';
 import type { GetFindResult } from '@prisma/client/runtime/library';
 
-export type RepositoryTeams = GetFindResult<
+export type RepositoryTeam = GetFindResult<
 	Prisma.$github_team_repositoriesPayload,
 	{
 		select: { role_name: boolean; id: boolean };
@@ -12,9 +12,9 @@ export type RepositoryTeams = GetFindResult<
 export async function getRepositoryTeams(
 	client: PrismaClient,
 	repository: github_repositories,
-): Promise<RepositoryTeams[]> {
-	const data: RepositoryTeams[] =
-		await client.github_team_repositories.findMany({
+): Promise<RepositoryTeam[]> {
+	const data: RepositoryTeam[] = await client.github_team_repositories.findMany(
+		{
 			select: {
 				id: true,
 				role_name: true,
@@ -22,7 +22,8 @@ export async function getRepositoryTeams(
 			where: {
 				id: repository.id,
 			},
-		});
+		},
+	);
 
 	// `full_name` is typed as nullable, in reality it is not, so the fallback to `id` shouldn't happen
 	const repoIdentifier = repository.full_name ?? repository.id;

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -1,0 +1,35 @@
+import type { github_repositories, Prisma, PrismaClient } from '@prisma/client';
+import type { GetFindResult } from '@prisma/client/runtime/library';
+
+export type RepositoryTeams = GetFindResult<
+	Prisma.$github_team_repositoriesPayload,
+	{
+		select: { role_name: boolean; id: boolean };
+		where: { id: bigint };
+	}
+>;
+
+export async function getRepositoryTeams(
+	client: PrismaClient,
+	repository: github_repositories,
+): Promise<RepositoryTeams[]> {
+	const data: RepositoryTeams[] =
+		await client.github_team_repositories.findMany({
+			select: {
+				id: true,
+				role_name: true,
+			},
+			where: {
+				id: repository.id,
+			},
+		});
+
+	// `full_name` is typed as nullable, in reality it is not, so the fallback to `id` shouldn't happen
+	const repoIdentifier = repository.full_name ?? repository.id;
+
+	console.log(
+		`Found ${data.length} teams with access to repository ${repoIdentifier}`,
+	);
+
+	return data;
+}

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -2,7 +2,7 @@ import type {
 	github_repositories,
 	github_repository_branches,
 } from '@prisma/client';
-import type { RepositoryTeams } from '../query';
+import type { RepositoryTeam } from '../query';
 import { repository01, repository02, repository04 } from './repository';
 
 const nullRepo: github_repositories = {
@@ -193,7 +193,7 @@ describe('Repository admin access', () => {
 			id: 1234n,
 		};
 
-		const teams: RepositoryTeams[] = [
+		const teams: RepositoryTeam[] = [
 			{
 				role_name: 'read-only',
 				id: 1234n,
@@ -210,7 +210,7 @@ describe('Repository admin access', () => {
 			id: 1234n,
 		};
 
-		const teams: RepositoryTeams[] = [
+		const teams: RepositoryTeam[] = [
 			{
 				role_name: 'read-only',
 				id: 1234n,
@@ -232,7 +232,7 @@ describe('Repository admin access', () => {
 			topics: ['hackday'],
 		};
 
-		const teams: RepositoryTeams[] = [
+		const teams: RepositoryTeam[] = [
 			{
 				role_name: 'read-only',
 				id: 1234n,
@@ -254,7 +254,7 @@ describe('Repository admin access', () => {
 			topics: ['production'],
 		};
 
-		const teams: RepositoryTeams[] = [
+		const teams: RepositoryTeam[] = [
 			{
 				role_name: 'read-only',
 				id: 1234n,

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -1,8 +1,8 @@
 import type {
 	github_repositories,
 	github_repository_branches,
-	github_team_repositories,
 } from '@prisma/client';
+import type { RepositoryTeams } from '../query';
 import { repository01, repository02, repository04 } from './repository';
 
 const nullRepo: github_repositories = {
@@ -130,118 +130,6 @@ const nullBranch: github_repository_branches = {
 	protected: null,
 };
 
-const nullTeam: github_team_repositories = {
-	allow_forking: null,
-	allow_merge_commit: null,
-	allow_rebase_merge: null,
-	allow_squash_merge: null,
-	allow_update_branch: null,
-	archive_url: null,
-	archived: null,
-	assignees_url: null,
-	auto_init: null,
-	blobs_url: null,
-	branches_url: null,
-	clone_url: null,
-	code_of_conduct: null,
-	collaborators_url: null,
-	comments_url: null,
-	commits_url: null,
-	compare_url: null,
-	contents_url: null,
-	contributors_url: null,
-	cq_id: '',
-	cq_parent_id: null,
-	cq_source_name: null,
-	cq_sync_time: null,
-	created_at: null,
-	default_branch: null,
-	delete_branch_on_merge: null,
-	deployments_url: null,
-	description: null,
-	disabled: null,
-	downloads_url: null,
-	events_url: null,
-	fork: null,
-	forks_count: null,
-	forks_url: null,
-	full_name: null,
-	git_commits_url: null,
-	git_refs_url: null,
-	git_tags_url: null,
-	git_url: null,
-	gitignore_template: null,
-	has_discussions: null,
-	has_downloads: null,
-	has_issues: null,
-	has_pages: null,
-	has_projects: null,
-	has_wiki: null,
-	homepage: null,
-	hooks_url: null,
-	html_url: null,
-	id: 0n,
-	is_template: null,
-	issue_comment_url: null,
-	issue_events_url: null,
-	issues_url: null,
-	keys_url: null,
-	labels_url: null,
-	language: null,
-	languages_url: null,
-	license: null,
-	license_template: null,
-	master_branch: null,
-	merge_commit_message: null,
-	merge_commit_title: null,
-	merges_url: null,
-	milestones_url: null,
-	mirror_url: null,
-	name: null,
-	network_count: null,
-	node_id: null,
-	notifications_url: null,
-	open_issues: null,
-	open_issues_count: null,
-	org: '',
-	organization: null,
-	owner: null,
-	parent: null,
-	permissions: null,
-	private: null,
-	pulls_url: null,
-	pushed_at: null,
-	releases_url: null,
-	role_name: null,
-	security_and_analysis: null,
-	size: null,
-	source: null,
-	squash_merge_commit_message: null,
-	squash_merge_commit_title: null,
-	ssh_url: null,
-	stargazers_count: null,
-	stargazers_url: null,
-	statuses_url: null,
-	subscribers_count: null,
-	subscribers_url: null,
-	subscription_url: null,
-	svn_url: null,
-	tags_url: null,
-	team_id: 0n,
-	teams_url: null,
-	template_repository: null,
-	text_matches: null,
-	topics: [],
-	trees_url: null,
-	updated_at: null,
-	url: null,
-	use_squash_pr_title_as_default: null,
-	visibility: null,
-	watchers: null,
-	watchers_count: null,
-	allow_auto_merge: null,
-};
-
 const thePerfectRepo: github_repositories = {
 	...nullRepo,
 	full_name: 'repo1',
@@ -305,9 +193,8 @@ describe('Repository admin access', () => {
 			id: 1234n,
 		};
 
-		const teams: github_team_repositories[] = [
+		const teams: RepositoryTeams[] = [
 			{
-				...nullTeam,
 				role_name: 'read-only',
 				id: 1234n,
 			},
@@ -323,14 +210,12 @@ describe('Repository admin access', () => {
 			id: 1234n,
 		};
 
-		const teams: github_team_repositories[] = [
+		const teams: RepositoryTeams[] = [
 			{
-				...nullTeam,
 				role_name: 'read-only',
 				id: 1234n,
 			},
 			{
-				...nullTeam,
 				role_name: 'admin',
 				id: 1234n,
 			},
@@ -347,14 +232,12 @@ describe('Repository admin access', () => {
 			topics: ['hackday'],
 		};
 
-		const teams: github_team_repositories[] = [
+		const teams: RepositoryTeams[] = [
 			{
-				...nullTeam,
 				role_name: 'read-only',
 				id: 1234n,
 			},
 			{
-				...nullTeam,
 				role_name: 'admin',
 				id: 1234n,
 			},
@@ -371,14 +254,12 @@ describe('Repository admin access', () => {
 			topics: ['production'],
 		};
 
-		const teams: github_team_repositories[] = [
+		const teams: RepositoryTeams[] = [
 			{
-				...nullTeam,
 				role_name: 'read-only',
 				id: 1234n,
 			},
 			{
-				...nullTeam,
 				role_name: 'admin',
 				id: 1234n,
 			},

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -1,8 +1,9 @@
 import type {
 	github_repositories,
 	github_repository_branches,
+	github_team_repositories,
 } from '@prisma/client';
-import { repository01, repository02 } from './repository';
+import { repository01, repository02, repository04 } from './repository';
 
 const nullRepo: github_repositories = {
 	cq_sync_time: null,
@@ -129,6 +130,118 @@ const nullBranch: github_repository_branches = {
 	protected: null,
 };
 
+const nullTeam: github_team_repositories = {
+	allow_forking: null,
+	allow_merge_commit: null,
+	allow_rebase_merge: null,
+	allow_squash_merge: null,
+	allow_update_branch: null,
+	archive_url: null,
+	archived: null,
+	assignees_url: null,
+	auto_init: null,
+	blobs_url: null,
+	branches_url: null,
+	clone_url: null,
+	code_of_conduct: null,
+	collaborators_url: null,
+	comments_url: null,
+	commits_url: null,
+	compare_url: null,
+	contents_url: null,
+	contributors_url: null,
+	cq_id: '',
+	cq_parent_id: null,
+	cq_source_name: null,
+	cq_sync_time: null,
+	created_at: null,
+	default_branch: null,
+	delete_branch_on_merge: null,
+	deployments_url: null,
+	description: null,
+	disabled: null,
+	downloads_url: null,
+	events_url: null,
+	fork: null,
+	forks_count: null,
+	forks_url: null,
+	full_name: null,
+	git_commits_url: null,
+	git_refs_url: null,
+	git_tags_url: null,
+	git_url: null,
+	gitignore_template: null,
+	has_discussions: null,
+	has_downloads: null,
+	has_issues: null,
+	has_pages: null,
+	has_projects: null,
+	has_wiki: null,
+	homepage: null,
+	hooks_url: null,
+	html_url: null,
+	id: 0n,
+	is_template: null,
+	issue_comment_url: null,
+	issue_events_url: null,
+	issues_url: null,
+	keys_url: null,
+	labels_url: null,
+	language: null,
+	languages_url: null,
+	license: null,
+	license_template: null,
+	master_branch: null,
+	merge_commit_message: null,
+	merge_commit_title: null,
+	merges_url: null,
+	milestones_url: null,
+	mirror_url: null,
+	name: null,
+	network_count: null,
+	node_id: null,
+	notifications_url: null,
+	open_issues: null,
+	open_issues_count: null,
+	org: '',
+	organization: null,
+	owner: null,
+	parent: null,
+	permissions: null,
+	private: null,
+	pulls_url: null,
+	pushed_at: null,
+	releases_url: null,
+	role_name: null,
+	security_and_analysis: null,
+	size: null,
+	source: null,
+	squash_merge_commit_message: null,
+	squash_merge_commit_title: null,
+	ssh_url: null,
+	stargazers_count: null,
+	stargazers_url: null,
+	statuses_url: null,
+	subscribers_count: null,
+	subscribers_url: null,
+	subscription_url: null,
+	svn_url: null,
+	tags_url: null,
+	team_id: 0n,
+	teams_url: null,
+	template_repository: null,
+	text_matches: null,
+	topics: [],
+	trees_url: null,
+	updated_at: null,
+	url: null,
+	use_squash_pr_title_as_default: null,
+	visibility: null,
+	watchers: null,
+	watchers_count: null,
+	allow_auto_merge: null,
+};
+
 const thePerfectRepo: github_repositories = {
 	...nullRepo,
 	full_name: 'repo1',
@@ -181,5 +294,96 @@ describe('Repositories should have branch protection', () => {
 			protection: {},
 		};
 		expect(repository02(repo, [unprotectedMainBranch])).toEqual(false);
+	});
+});
+
+describe('Repository admin access', () => {
+	test('Should return false when there is no admin team', () => {
+		const repo: github_repositories = {
+			...nullRepo,
+			full_name: 'guardian/service-catalogue',
+			id: 1234n,
+		};
+
+		const teams: github_team_repositories[] = [
+			{
+				...nullTeam,
+				role_name: 'read-only',
+				id: 1234n,
+			},
+		];
+
+		expect(repository04(repo, teams)).toEqual(false);
+	});
+
+	test('Should return true when there is an admin team', () => {
+		const repo: github_repositories = {
+			...nullRepo,
+			full_name: 'guardian/service-catalogue',
+			id: 1234n,
+		};
+
+		const teams: github_team_repositories[] = [
+			{
+				...nullTeam,
+				role_name: 'read-only',
+				id: 1234n,
+			},
+			{
+				...nullTeam,
+				role_name: 'admin',
+				id: 1234n,
+			},
+		];
+
+		expect(repository04(repo, teams)).toEqual(true);
+	});
+
+	test(`Should not evaluate repository's with a 'hackday' topic`, () => {
+		const repo: github_repositories = {
+			...nullRepo,
+			full_name: 'guardian/service-catalogue',
+			id: 1234n,
+			topics: ['hackday'],
+		};
+
+		const teams: github_team_repositories[] = [
+			{
+				...nullTeam,
+				role_name: 'read-only',
+				id: 1234n,
+			},
+			{
+				...nullTeam,
+				role_name: 'admin',
+				id: 1234n,
+			},
+		];
+
+		expect(repository04(repo, teams)).toEqual(false);
+	});
+
+	test(`Should evaluate repository's with a 'production' topic`, () => {
+		const repo: github_repositories = {
+			...nullRepo,
+			full_name: 'guardian/service-catalogue',
+			id: 1234n,
+			topics: ['production'],
+		};
+
+		const teams: github_team_repositories[] = [
+			{
+				...nullTeam,
+				role_name: 'read-only',
+				id: 1234n,
+			},
+			{
+				...nullTeam,
+				role_name: 'admin',
+				id: 1234n,
+			},
+		];
+
+		expect(repository04(repo, teams)).toEqual(true);
 	});
 });

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -1,9 +1,9 @@
 import type {
 	github_repositories,
 	github_repository_branches,
-	github_team_repositories,
 	repocop_github_repository_rules,
 } from '@prisma/client';
+import type { RepositoryTeams } from '../query';
 
 /**
  * Apply the following rule to a GitHub repository:
@@ -39,7 +39,7 @@ export function repository02(
  */
 export function repository04(
 	repo: github_repositories,
-	teams: github_team_repositories[],
+	teams: RepositoryTeams[],
 ): boolean {
 	const adminTeams = teams.filter(
 		({ id, role_name }) => id === repo.id && role_name === 'admin',
@@ -61,7 +61,7 @@ export function repository04(
 export function repositoryRuleEvaluation(
 	repo: github_repositories,
 	allBranches: github_repository_branches[],
-	teams: github_team_repositories[],
+	teams: RepositoryTeams[],
 ): repocop_github_repository_rules {
 	return {
 		full_name: repo.full_name!,

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -1,6 +1,7 @@
 import type {
 	github_repositories,
 	github_repository_branches,
+	github_team_repositories,
 	repocop_github_repository_rules,
 } from '@prisma/client';
 
@@ -32,11 +33,35 @@ export function repository02(
 }
 
 /**
+ * Apply the following rule to a GitHub repository:
+ *   > Grant at least one GitHub team Admin access - typically, the dev team that own the project.
+ *   > Repositories without one of the following topics are exempt: production, testing, documentation.
+ */
+export function repository04(
+	repo: github_repositories,
+	teams: github_team_repositories[],
+): boolean {
+	const adminTeams = teams.filter(
+		({ id, role_name }) => id === repo.id && role_name === 'admin',
+	);
+	const hasAdminTeam = adminTeams.length > 0;
+
+	// only evaluate repositories with no topic or a relevant topic
+	const relevantTopics = ['production', 'testing', 'documentation'];
+	const hasRelevantTopic =
+		repo.topics.length === 0 ||
+		repo.topics.filter((topic) => relevantTopics.includes(topic)).length > 0;
+
+	return hasAdminTeam && hasRelevantTopic;
+}
+
+/**
  * Apply rules to a repository as defined in https://github.com/guardian/recommendations/blob/main/best-practices.md.
  */
 export function repositoryRuleEvaluation(
 	repo: github_repositories,
 	allBranches: github_repository_branches[],
+	teams: github_team_repositories[],
 ): repocop_github_repository_rules {
 	return {
 		full_name: repo.full_name!,
@@ -45,7 +70,7 @@ export function repositoryRuleEvaluation(
 
 		// TODO - implement these rules
 		repository_03: false,
-		repository_04: false,
+		repository_04: repository04(repo, teams),
 		repository_05: false,
 		repository_06: false,
 		repository_07: false,

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -3,7 +3,7 @@ import type {
 	github_repository_branches,
 	repocop_github_repository_rules,
 } from '@prisma/client';
-import type { RepositoryTeams } from '../query';
+import type { RepositoryTeam } from '../query';
 
 /**
  * Apply the following rule to a GitHub repository:
@@ -39,7 +39,7 @@ export function repository02(
  */
 export function repository04(
 	repo: github_repositories,
-	teams: RepositoryTeams[],
+	teams: RepositoryTeam[],
 ): boolean {
 	const adminTeams = teams.filter(
 		({ id, role_name }) => id === repo.id && role_name === 'admin',
@@ -61,7 +61,7 @@ export function repository04(
 export function repositoryRuleEvaluation(
 	repo: github_repositories,
 	allBranches: github_repository_branches[],
-	teams: RepositoryTeams[],
+	teams: RepositoryTeam[],
 ): repocop_github_repository_rules {
 	return {
 		full_name: repo.full_name!,


### PR DESCRIPTION
## What does this change?
Implements rule [repository_04](https://github.com/guardian/recommendations/blob/main/best-practices.md):

> Grant at least one GitHub team Admin access - typically, the dev team that own the project.
> Repositories without one of the following topics are exempt: production, testing, documentation.

## How has it been verified?
Run Repocop locally. I've also [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/c236cb9b-db4c-4e4c-9e35-c326ade5e6c0), and successfully executed the lambda.