### PR TITLE
feat(repocop): Implement rule repository_06

### DIFF
--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -3,7 +3,12 @@ import type {
 	github_repository_branches,
 } from '@prisma/client';
 import type { RepositoryTeam } from '../query';
-import { repository01, repository02, repository04 } from './repository';
+import {
+	repository01,
+	repository02,
+	repository04,
+	repository06,
+} from './repository';
 
 const nullRepo: github_repositories = {
 	cq_sync_time: null,
@@ -266,5 +271,52 @@ describe('Repository admin access', () => {
 		];
 
 		expect(repository04(repo, teams)).toEqual(true);
+	});
+});
+
+describe('Repository topics', () => {
+	test('Should return true when there is a single recognised topic', () => {
+		const repo: github_repositories = {
+			...nullRepo,
+			topics: ['production'],
+		};
+
+		expect(repository06(repo)).toEqual(true);
+	});
+
+	test('Should return true when there is are multiple recognised topics', () => {
+		const repo: github_repositories = {
+			...nullRepo,
+			topics: ['production', 'hackday'],
+		};
+
+		expect(repository06(repo)).toEqual(true);
+	});
+
+	test('Should return true when there is are multiple topics, not all are recognised', () => {
+		const repo: github_repositories = {
+			...nullRepo,
+			topics: ['production', 'android'],
+		};
+
+		expect(repository06(repo)).toEqual(true);
+	});
+
+	test('Should return false when there are no topics', () => {
+		const repo: github_repositories = {
+			...nullRepo,
+			topics: [],
+		};
+
+		expect(repository06(repo)).toEqual(false);
+	});
+
+	test('Should return false when there are no recognised topics', () => {
+		const repo: github_repositories = {
+			...nullRepo,
+			topics: ['android', 'mobile'],
+		};
+
+		expect(repository06(repo)).toEqual(false);
 	});
 });

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -56,6 +56,24 @@ export function repository04(
 }
 
 /**
+ * Apply the following rule to a GitHub repository:
+ *   > Repositories should have a topic to help understand what is in production.
+ *   > Repositories owned only by non-P&E teams are exempt.
+ */
+export function repository06(repo: github_repositories): boolean {
+	const validTopics = [
+		'prototype',
+		'learning',
+		'hackday',
+		'testing',
+		'documentation',
+		'production',
+	];
+
+	return repo.topics.filter((topic) => validTopics.includes(topic)).length > 0;
+}
+
+/**
  * Apply rules to a repository as defined in https://github.com/guardian/recommendations/blob/main/best-practices.md.
  */
 export function repositoryRuleEvaluation(
@@ -72,7 +90,7 @@ export function repositoryRuleEvaluation(
 		repository_03: false,
 		repository_04: repository04(repo, teams),
 		repository_05: false,
-		repository_06: false,
+		repository_06: repository06(repo),
 		repository_07: false,
 	};
 }


### PR DESCRIPTION
## What does this change?
Implements rule [repository_06](https://github.com/guardian/recommendations/blob/main/best-practices.md):

> Repositories should have a topic to help understand what is in production.
> Repositories owned only by non-P&E teams are exempt.

I'm not sure how best to apply the exemption. We're already filtering out repositories that start [interactive-](https://github.com/guardian?q=interactive-&type=all&language=&sort=) or [oz-](https://github.com/guardian?q=oz-&type=all&language=&sort=). However this doesn't catch all non-P&E repositories, such as https://github.com/guardian/dog-breeds or https://github.com/guardian/my-project. I don't think this is a blocker; we'll be over reporting a little, but all the P&E owned repositories will be included.

## How has it been verified?
Run Repocop locally. I've also [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/092d9085-ed15-41a4-87e5-1bbe65a5c597), and successfully executed the lambda.