### PR TITLE
fix(repocop): Do not evaluate ESD owned repositories

### DIFF
--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -77,7 +77,11 @@ export async function getConfig(): Promise<Config> {
 		stage: getEnvOrThrow('STAGE'),
 		databaseConnectionString: await getDatabaseConnectionString(databaseConfig),
 		withQueryLogging: queryLogging,
-		ignoredRepositoryPrefixes: ['guardian/interactive-', 'guardian/oz-'],
+		ignoredRepositoryPrefixes: [
+			'guardian/interactive-',
+			'guardian/oz-',
+			'guardian/esd-',
+		],
 	};
 }
 


### PR DESCRIPTION
## What does this change?
Filters out repositories starting with [esd-](https://github.com/orgs/guardian/repositories?language=&q=esd-&sort=&type=all), as they are owned by ESD.

## Why?
The initial audience for Repocop is the P&E department, so remove ESD owned repositories to reduce noise.

## How has it been verified?
N/A.