### PR TITLE
fix(repocop): Ignore more non P&E repositories

### DIFF
--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -78,9 +78,22 @@ export async function getConfig(): Promise<Config> {
 		databaseConnectionString: await getDatabaseConnectionString(databaseConfig),
 		withQueryLogging: queryLogging,
 		ignoredRepositoryPrefixes: [
+			// Visuals team
 			'guardian/interactive-',
+			'guardian/interactives-',
 			'guardian/oz-',
+			'guardian/aus-',
+			'guardian/australia-',
+			'guardian/australian-',
+			'guardian/visuals-',
+			'guardian/us-',
+			'guardian/main-media-',
+
+			// ESD team
 			'guardian/esd-',
+
+			// Multimedia team
+			'guardian/pluto-',
 		],
 	};
 }


### PR DESCRIPTION
Follows on from #309.

## What does this change?
RepoCop's initial audience is the P&E department. Add some more exclusions to reduce noise. Today, these repositories account for 1334 of the 3450 in the GitHub organisation.

| prefix | count |
| :--- | :--- |
| guardian/aus- | 15 |
| guardian/australia- | 4 |
| guardian/australian- | 55 |
| guardian/esd- | 45 |
| guardian/interactive- | 1011 |
| guardian/interactives- | 17 |
| guardian/main-media- | 18 |
| guardian/oz- | 136 |
| guardian/pluto- | 12 |
| guardian/us- | 16 |
| guardian/visuals- | 5 |

<details>
<summary>SQL query used</summary>

```sql
SELECT  'guardian/interactive-' AS "prefix"
        , COUNT(full_name)
FROM    github_repositories
WHERE   full_name LIKE 'guardian/interactive-%'

UNION ALL

SELECT  'guardian/interactives-' AS "prefix"
        , COUNT(full_name)
FROM    github_repositories
WHERE   full_name LIKE 'guardian/interactives-%'

UNION ALL

SELECT  'guardian/oz-' AS "prefix"
        , COUNT(full_name)
FROM    github_repositories
WHERE   full_name LIKE 'guardian/oz-%'

UNION ALL

SELECT  'guardian/aus-' AS "prefix"
        , COUNT(full_name)
FROM    github_repositories
WHERE   full_name LIKE 'guardian/aus-%'

UNION ALL

SELECT  'guardian/australia-' AS "prefix"
        , COUNT(full_name)
FROM    github_repositories
WHERE   full_name LIKE 'guardian/australia-%'

UNION ALL

SELECT  'guardian/australian-' AS "prefix"
        , COUNT(full_name)
FROM    github_repositories
WHERE   full_name LIKE 'guardian/australian-%'

UNION ALL

SELECT  'guardian/visuals-' AS "prefix"
        , COUNT(full_name)
FROM    github_repositories
WHERE   full_name LIKE 'guardian/visuals-%'

UNION ALL

SELECT  'guardian/us-' AS "prefix"
        , COUNT(full_name)
FROM    github_repositories
WHERE   full_name LIKE 'guardian/us-%'

UNION ALL

SELECT  'guardian/main-media-' AS "prefix"
        , COUNT(full_name)
FROM    github_repositories
WHERE   full_name LIKE 'guardian/main-media-%'

UNION ALL

SELECT  'guardian/esd-' AS "prefix"
        , COUNT(full_name)
FROM    github_repositories
WHERE   full_name LIKE 'guardian/esd-%'

UNION ALL

SELECT  'guardian/pluto-' AS "prefix"
         , COUNT(full_name)
FROM    github_repositories
WHERE   full_name LIKE 'guardian/pluto-%';
```
</details>