### PR TITLE
feat(repocop): Increase the timeout of the lambda

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -10937,7 +10937,7 @@ spec:
             "Value": "TEST",
           },
         ],
-        "Timeout": 30,
+        "Timeout": 900,
         "VpcConfig": {
           "SecurityGroupIds": [
             {

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -505,6 +505,7 @@ export class ServiceCatalogue extends GuStack {
 			},
 			vpc,
 			securityGroups: [applicationToPostgresSecurityGroup],
+			timeout: Duration.minutes(15),
 		};
 
 		const repocopLambda = new GuScheduledLambda(


### PR DESCRIPTION
## What does this change, and why?
Increase the timeout of the Repocop lambda to the maximum (15 minutes). Repocop is making an increasing amount of SQL requests. The performance on these requests is largely related to the indexing of the database. Using the maximum duration provides enough time for the queries to complete.

This will impact costs if the lambda runs for over 30 seconds:

> Duration is calculated from the time your code begins executing until it returns or otherwise terminates, rounded up to the nearest 1 ms*. The price depends on the amount of memory you allocate to your function. In the AWS Lambda resource model, you choose the amount of memory you want for your function, and are allocated proportional CPU power and other resources. An increase in memory size triggers an equivalent increase in CPU available to your function.
> – https://aws.amazon.com/lambda/pricing/

As we're not increasing the memory, the lambda will still be billed against execution time. However, allowing the lambda to run for longer is better than being force terminated!

## How has it been verified?
N/A