### PR TITLE
Get all unarchived branches up front

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -2,9 +2,9 @@ import { PrismaClient } from '@prisma/client';
 import type { repocop_github_repository_rules } from '@prisma/client';
 import { getConfig } from './config';
 import {
-	getUnarchivedRepositories,
-	getRepositoryTeams,
 	getRepositoryBranches,
+	getRepositoryTeams,
+	getUnarchivedRepositories,
 } from './query';
 import { repositoryRuleEvaluation } from './rules/repository';
 

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -1,10 +1,10 @@
-import type { repocop_github_repository_rules } from '@prisma/client';
 import { PrismaClient } from '@prisma/client';
+import type { repocop_github_repository_rules } from '@prisma/client';
 import { getConfig } from './config';
 import {
 	getRepositories,
-	getRepositoryBranches,
 	getRepositoryTeams,
+	getUnarchivedRepositoryBranches,
 } from './query';
 import { repositoryRuleEvaluation } from './rules/repository';
 
@@ -14,9 +14,16 @@ async function evaluateRepositories(
 ): Promise<repocop_github_repository_rules[]> {
 	const repositories = await getRepositories(client, ignoredRepositoryPrefixes);
 
+	const unarchivedBranches = await getUnarchivedRepositoryBranches(
+		client,
+		repositories,
+	);
+
 	return await Promise.all(
 		repositories.map(async (repo) => {
-			const branches = await getRepositoryBranches(client, repo);
+			const branches = unarchivedBranches.filter(
+				(branch) => branch.repository_id === repo.id,
+			);
 			const teams = await getRepositoryTeams(client, repo);
 			return repositoryRuleEvaluation(repo, branches, teams);
 		}),

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -6,7 +6,7 @@ import type {
 } from '@prisma/client';
 import type { GetFindResult } from '@prisma/client/runtime/library';
 
-export async function getRepositories(
+export async function getUnarchivedRepositories(
 	client: PrismaClient,
 	ignoredRepositoryPrefixes: string[],
 ): Promise<github_repositories[]> {
@@ -29,16 +29,14 @@ export async function getRepositories(
 	return repositories;
 }
 
-// We only care about branches from unarchived repos, so lets only pull those to save us some time/memory
-export async function getUnarchivedRepositoryBranches(
+// We only care about branches from repos we've selected, so lets only pull those to save us some time/memory
+export async function getRepositoryBranches(
 	client: PrismaClient,
 	repos: github_repositories[],
 ): Promise<github_repository_branches[]> {
-	const unarchivedRepos = repos.filter((repo) => !repo.archived);
-
 	const branches = await client.github_repository_branches.findMany({
 		where: {
-			repository_id: { in: unarchivedRepos.map((repo) => repo.id) },
+			repository_id: { in: repos.map((repo) => repo.id) },
 		},
 	});
 

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -29,22 +29,18 @@ export async function getRepositories(
 	return repositories;
 }
 
-export async function getRepositoryBranches(
+// We only care about branches from unarchived repos, so lets only pull those to save us some time/memory
+export async function getUnarchivedRepositoryBranches(
 	client: PrismaClient,
-	repository: github_repositories,
+	repos: github_repositories[],
 ): Promise<github_repository_branches[]> {
+	const unarchivedRepos = repos.filter((repo) => !repo.archived);
+
 	const branches = await client.github_repository_branches.findMany({
 		where: {
-			repository_id: repository.id,
+			repository_id: { in: unarchivedRepos.map((repo) => repo.id) },
 		},
 	});
-
-	// `full_name` is typed as nullable, in reality it is not, so the fallback to `id` shouldn't happen
-	const repoIdentifier = repository.full_name ?? repository.id;
-
-	console.log(
-		`Found ${branches.length} branches for repository ${repoIdentifier}`,
-	);
 
 	return branches;
 }


### PR DESCRIPTION
## What does this change?

Previously, we were getting branches for each repo by making a DB call for each one. Now, we are grabbing all the ones we need at the beginning

## Why?

Fewer requests mean fewer chances for requests to fail. Also places less strain on the DB

## How has it been verified?

~~Tested a before and after on CODE. Job ran successfully. We've gone from 7.5GB seconds to 9 GB seconds. Assuming one run a day for 30 days, this equates to an additional cost of $0.00075 per month (about 1/12th of a cent). Which seemed like an acceptable increase to me.~~

After following @akash1810 's advice on filtering archived repos, we've actually **dropped** from 7.5 GB seconds to 7.1.
