### PR TITLE
feat(repocop): Implement rule repository_05

### DIFF
--- a/packages/repocop/src/date.test.ts
+++ b/packages/repocop/src/date.test.ts
@@ -1,0 +1,26 @@
+import { daysDifference } from './date';
+
+describe('Date calculation', () => {
+	test('Calculating the difference between two dates, both at midnight, in the same month', () => {
+		const date1 = new Date(2023, 0, 20, 0, 0, 0);
+		const date2 = new Date(2023, 0, 0, 0, 0, 0);
+
+		expect(daysDifference(date1, date2)).toEqual(20);
+	});
+
+	test('Calculating the difference between two dates, both at midnight, across daylight saving time', () => {
+		const date1 = new Date(2023, 6, 0, 0, 0, 0);
+		const date2 = new Date(2022, 12, 0, 0, 0, 0);
+
+		const expected = 31 + 31 + 28 + 31 + 30 + 31 - 1; // All of (Dec + Jan + Feb + Mar + Apr + May) - 1st Dec;
+		expect(daysDifference(date1, date2)).toEqual(expected);
+	});
+
+	test('Calculating the difference between two dates, across daylight saving time', () => {
+		const date1 = new Date(2023, 6, 0, 8, 0, 8);
+		const date2 = new Date(2022, 12, 0, 12, 30, 45);
+
+		const expected = 31 + 31 + 28 + 31 + 30 + 31 - 1; // All of (Dec + Jan + Feb + Mar + Apr + May) - 1st Dec;
+		expect(daysDifference(date1, date2)).toEqual(expected);
+	});
+});

--- a/packages/repocop/src/date.ts
+++ b/packages/repocop/src/date.ts
@@ -1,0 +1,5 @@
+export function daysDifference(date1: Date, date2: Date): number {
+	const diff = date1.getTime() - date2.getTime();
+	const millisInADay = 1000 * 60 * 60 * 24;
+	return Math.round(diff / millisInADay);
+}

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -7,6 +7,7 @@ import {
 	repository01,
 	repository02,
 	repository04,
+	repository05,
 	repository06,
 } from './repository';
 
@@ -318,5 +319,40 @@ describe('Repository topics', () => {
 		};
 
 		expect(repository06(repo)).toEqual(false);
+	});
+});
+
+describe('Identification of an inactive repository', () => {
+	beforeAll(() => {
+		// Make the system time deterministic
+		jest.useFakeTimers().setSystemTime(new Date(2023, 9, 1, 12, 0, 0));
+	});
+
+	test('Should identify a repo last pushed to over 2 years ago, with a random topic, and no teams as inactive', () => {
+		const repo: github_repositories = {
+			...nullRepo,
+			id: 1234n,
+			archived: false,
+			pushed_at: new Date(2020, 1, 1),
+			topics: ['random'],
+		};
+
+		const teams: RepositoryTeam[] = [];
+
+		expect(repository05(repo, teams)).toEqual(false);
+	});
+
+	test(`Should identify a repo last pushed to over 2 years ago, with a 'production' topic, and no teams as active`, () => {
+		const repo: github_repositories = {
+			...nullRepo,
+			id: 1234n,
+			archived: false,
+			pushed_at: new Date(2020, 1, 1),
+			topics: ['production'],
+		};
+
+		const teams: RepositoryTeam[] = [];
+
+		expect(repository05(repo, teams)).toEqual(true);
 	});
 });

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -85,12 +85,12 @@ export function repositoryRuleEvaluation(
 		full_name: repo.full_name!,
 		repository_01: repository01(repo),
 		repository_02: repository02(repo, allBranches),
+		repository_04: repository04(repo, teams),
+		repository_06: repository06(repo),
 
 		// TODO - implement these rules
 		repository_03: false,
-		repository_04: repository04(repo, teams),
 		repository_05: false,
-		repository_06: repository06(repo),
 		repository_07: false,
 	};
 }


### PR DESCRIPTION
## What does this change?
Implements rule [repository_05](https://github.com/guardian/recommendations/blob/main/best-practices.md):

> Repositories that are no longer used should be archived.

Where "no longer used" is defined as:
- No commits added to repository in last year
- Repository topic is not `production`, `testing` or `documentation`
- Repository is not owned by a team (for a team to own a repository, they must be admins of that repository)
- TBD: Repository is not running in an AWS services

## Why?
Archiving unused repositories improves the overall health of our GitHub organisation. It allows us to be more focused in our efforts of, for example, updating dependencies.

## How has it been verified?
TBD.