### PR TITLE
Add evaluated_on migration for table repocop_github_repository_rules

### DIFF
--- a/packages/repocop/prisma/migrations/20230915132202_add_field_evaluated_on_to_repocop_github_repository_rules/migration.sql
+++ b/packages/repocop/prisma/migrations/20230915132202_add_field_evaluated_on_to_repocop_github_repository_rules/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `evaluated_on` to the `repocop_github_repository_rules` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "repocop_github_repository_rules" ADD COLUMN     "evaluated_on" TIMESTAMP(3) NOT NULL;

--- a/packages/repocop/prisma/schema.prisma
+++ b/packages/repocop/prisma/schema.prisma
@@ -17,6 +17,7 @@ model repocop_github_repository_rules {
   repository_05   Boolean
   repository_06   Boolean
   repository_07   Boolean
+  evaluated_on    DateTime
 }
 
 model aws_accessanalyzer_analyzer_archive_rules {

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -92,5 +92,6 @@ export function repositoryRuleEvaluation(
 		repository_05: false,
 		repository_06: repository06(repo),
 		repository_07: false,
+		evaluated_on: new Date()
 	};
 }


### PR DESCRIPTION
## What does this change?
Add a mandatory field evaluated_on to the table repocop_github_repository_rules 

## Why?
We want to have a timestamp when the entries were last generated

## How has it been verified?
Applied locally

## How to deploy to code
We do have a migration history for database changes but applying those changes is a manual process.
We need to apply 
```
npx prisma migrate deploy  
``` 