### PR TITLE
repository_05 and 07 optional

### DIFF
--- a/packages/repocop/README.md
+++ b/packages/repocop/README.md
@@ -15,8 +15,14 @@ We need to apply the inial schema to our migration history
 ```
 npx prisma migrate resolve --applied 0_init
 ```
+The prisma commands need to be run in the repocop directory.
 The migration history is in the prisma/migration directory in the repository and the table _prisma_migrations in 
 databases that use prisma to handle migrations.
+
+If you want to use your new table in typescript code you need to regenerate the prisma client
+```
+npx prisma generate
+```
 
 ## Adding new tables in dev
 

--- a/packages/repocop/prisma/migrations/20230915151426_repository_05_and_07_optional/migration.sql
+++ b/packages/repocop/prisma/migrations/20230915151426_repository_05_and_07_optional/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "repocop_github_repository_rules" ALTER COLUMN "repository_05" DROP NOT NULL,
+ALTER COLUMN "repository_07" DROP NOT NULL;

--- a/packages/repocop/prisma/schema.prisma
+++ b/packages/repocop/prisma/schema.prisma
@@ -14,9 +14,9 @@ model repocop_github_repository_rules {
   repository_02   Boolean
   repository_03   Boolean
   repository_04   Boolean
-  repository_05   Boolean
+  repository_05   Boolean?
   repository_06   Boolean
-  repository_07   Boolean
+  repository_07   Boolean?
   evaluated_on    DateTime
 }
 

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -89,9 +89,9 @@ export function repositoryRuleEvaluation(
 		// TODO - implement these rules
 		repository_03: false,
 		repository_04: repository04(repo, teams),
-		repository_05: false,
+		repository_05: null,
 		repository_06: repository06(repo),
-		repository_07: false,
+		repository_07: null,
 		evaluated_on: new Date(),
 	};
 }


### PR DESCRIPTION
## What does this change?
Make repository_05 and 07 in table repocop_github_repository_rules optional

## Why?
These will not be implemented in the first iteration of repocop and having the field populated with true or false is misleading

## How has it been verified?
Applied database migration to code with
```
npx prisma migrate deploy
```
Deployed to code and started lamda and verified that the fields repository_05 and repository_07 are now populated with null

## How to deploy
Before merging the database migration should be applied to prod
