### PR TITLE
Modify some repo rules

### DIFF
--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -229,7 +229,8 @@ describe('Repository admin access', () => {
 		expect(repository04(repo, teams)).toEqual(true);
 	});
 
-	test(`Should not evaluate repository's with a 'hackday' topic`, () => {
+	test(`Should validate repositories with a 'hackday' topic`, () => {
+		//We are not interested in making sure hackday projects are kept up to date
 		const repo: github_repositories = {
 			...nullRepo,
 			full_name: 'guardian/service-catalogue',
@@ -237,21 +238,12 @@ describe('Repository admin access', () => {
 			topics: ['hackday'],
 		};
 
-		const teams: RepositoryTeam[] = [
-			{
-				role_name: 'read-only',
-				id: 1234n,
-			},
-			{
-				role_name: 'admin',
-				id: 1234n,
-			},
-		];
+		const teams: RepositoryTeam[] = [];
 
-		expect(repository04(repo, teams)).toEqual(false);
+		expect(repository04(repo, teams)).toEqual(true);
 	});
 
-	test(`Should evaluate repository's with a 'production' topic`, () => {
+	test(`Should evaluate repositories with a 'production' topic`, () => {
 		const repo: github_repositories = {
 			...nullRepo,
 			full_name: 'guardian/service-catalogue',
@@ -272,6 +264,19 @@ describe('Repository admin access', () => {
 
 		expect(repository04(repo, teams)).toEqual(true);
 	});
+
+	test(`Should return false if all topics are unrecognised`, () => {
+		const repo: github_repositories = {
+			...nullRepo,
+			full_name: 'guardian/service-catalogue',
+			id: 1234n,
+			topics: ['avocado'],
+		};
+
+		const teams: RepositoryTeam[] = [];
+
+		expect(repository04(repo, teams)).toEqual(false);
+	});
 });
 
 describe('Repository topics', () => {
@@ -284,13 +289,15 @@ describe('Repository topics', () => {
 		expect(repository06(repo)).toEqual(true);
 	});
 
-	test('Should return true when there is are multiple recognised topics', () => {
+	test('Should return false when there are multiple recognised topics', () => {
+		// Having more than one recognised topic creates confusion about how the repo
+		// is being used, and could also confuse repocop.
 		const repo: github_repositories = {
 			...nullRepo,
 			topics: ['production', 'hackday'],
 		};
 
-		expect(repository06(repo)).toEqual(true);
+		expect(repository06(repo)).toEqual(false);
 	});
 
 	test('Should return true when there is are multiple topics, not all are recognised', () => {

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -56,7 +56,7 @@ export function repository04(
 }
 /**
  * Apply the following rule to a GitHub repository:
- *   > Repositories should have a topic to help understand what is in production.
+ *   > Repositories should have one and only one of the following topics to help understand what is in production.
  *   > Repositories owned only by non-P&E teams are exempt.
  */
 export function repository06(repo: github_repositories): boolean {
@@ -69,7 +69,9 @@ export function repository06(repo: github_repositories): boolean {
 		'production',
 	];
 
-	return repo.topics.filter((topic) => validTopics.includes(topic)).length > 0;
+	return (
+		repo.topics.filter((topic) => validTopics.includes(topic)).length === 1
+	);
 }
 
 /**

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -41,20 +41,19 @@ export function repository04(
 	repo: github_repositories,
 	teams: RepositoryTeam[],
 ): boolean {
+	// Repos that have explicitly been classified as these topics are exempt.
+	// Any other repos, regardless of topic, need to be owned by a team, or assigned one of these topics.
+	const exemptedTopics = ['prototype', 'learning', 'hackday'];
+	const isExempt =
+		repo.topics.filter((topic) => exemptedTopics.includes(topic)).length > 0;
+
 	const adminTeams = teams.filter(
 		({ id, role_name }) => id === repo.id && role_name === 'admin',
 	);
 	const hasAdminTeam = adminTeams.length > 0;
 
-	// only evaluate repositories with no topic or a relevant topic
-	const relevantTopics = ['production', 'testing', 'documentation'];
-	const hasRelevantTopic =
-		repo.topics.length === 0 ||
-		repo.topics.filter((topic) => relevantTopics.includes(topic)).length > 0;
-
-	return hasAdminTeam && hasRelevantTopic;
+	return isExempt || hasAdminTeam;
 }
-
 /**
  * Apply the following rule to a GitHub repository:
  *   > Repositories should have a topic to help understand what is in production.


### PR DESCRIPTION
## What does this change?

### Repository_04

We saw some repos with valid owners failing the repo_04 check, because of the way we were checking the topics. Some repos have topics that are not recognised by devX, so using `repo.topics.length === 0` as the first check for "might be in production" doesn't work, as a repo with topics such as `avocado` or `misc` would have counted as having a valid topic, then short circuited and never moved on to the second check.

The topic check has also been refactored slightly for improved readability, and we will update the recommendations repo to reflect this.

### Repository_06

Having multiple topics recognised by devx can cause confusion about what a repo is used for. It also potentially causes confusion for REPOSITORY_04, as something with both a `hackday` and `production` topic is not valid, and we don't have logic to support ranking the topics.

## How has it been verified?

Unit tests have been added and modified where relevant
