### PR TITLE
Use deployTools as dev account

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,9 +90,7 @@ final line: `repo_owners.repo_name=certs.tags ->>'gu:repo'` which joins the repo
 repository associated with a stack. It allows us to generate a table of domain owners like this:
 
 | domain_name     | team_name   |
-|-----------------|-------------|
+| --------------- | ----------- |
 | api.example.com | Team Edward |
 | example.com     | Team Jacob  |
 | example.net     | Team Rocket |
-
-

--- a/packages/cloudquery/README.md
+++ b/packages/cloudquery/README.md
@@ -19,7 +19,7 @@ It includes:
 
 ## Setup
 
-1. Get developer playground credentials from Janus
+1. Get deployTools credentials from Janus
 2. In the project root, run the following, and follow the resulting instructions:
 
 ```sh

--- a/packages/cloudquery/dev-config/cloudquery.yaml
+++ b/packages/cloudquery/dev-config/cloudquery.yaml
@@ -67,8 +67,8 @@ spec:
       - eu-west-1
       - us-east-1
     accounts:
-      - id: 'developerPlayground'
-        local_profile: 'developerPlayground'
+      - id: 'deployTools'
+        local_profile: 'deployTools'
 ---
 kind: source
 spec:

--- a/packages/cloudquery/script/start
+++ b/packages/cloudquery/script/start
@@ -9,12 +9,12 @@ MAIN_ENV_FILE=$ROOT_DIR/.env
 LOCAL_ENV_FILE=$HOME/.gu/service_catalogue/secrets/.env
 
 echo "Checking AWS credentials"
-STATUS=$(aws sts get-caller-identity --profile developerPlayground 2>&1 || true)
+STATUS=$(aws sts get-caller-identity --profile deployTools 2>&1 || true)
 if [[ ${STATUS} =~ (ExpiredToken) ]]; then
-  echo "Credentials for the developerPlayground profile have expired. Please fetch new credentials, and run this script again."
+  echo "Credentials for the deployTools profile have expired. Please fetch new credentials, and run this script again."
   exit 1
 elif [[ ${STATUS} =~ ("could not be found") ]]; then
-  echo "Credentials for the developerPlayground profile are missing. Please fetch some, and run this script again."
+  echo "Credentials for the deployTools profile are missing. Please fetch some, and run this script again."
   exit 1
 else
   echo "AWS credentials are valid"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+# Set up text colours
+red='\033[0;31m'
+clear='\033[0m'
+yellow='\033[1;33m'
+cyan='\033[0;36m'
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=${DIR}/..
 
@@ -44,10 +50,10 @@ check_credentials() {
   echo "Checking AWS credentials"
   STATUS=$(aws sts get-caller-identity --profile "$PROFILE" 2>&1 || true)
   if [[ ${STATUS} =~ (ExpiredToken) ]]; then
-    echo -e "${red}Credentials for the ${yellow}$PROFILE${red} profile have expired${clear}. Please fetch new credentials."
+    echo -e "${red}Credentials for the ${yellow}$PROFILE${red} profile have expired${clear}. Please fetch new credentials and rerun the script."
     exit 1
   elif [[ ${STATUS} =~ ("could not be found") ]]; then
-    echo -e "${red}Credentials for the ${yellow}$PROFILE${red} profile are missing${clear}. Please fetch some."
+    echo -e "${red}Credentials for the ${yellow}$PROFILE${red} profile are missing${clear}. Please fetch new credentials and rerun the script."
     exit 1
   else
     echo "AWS credentials for $PROFILE are valid"
@@ -55,13 +61,6 @@ check_credentials() {
 }
 
 setup_cloudquery() {
-  red='\033[0;31m'
-  clear='\033[0m'
-  yellow='\033[1;33m'
-  cyan='\033[0;36m'
-
-  check_credentials developerPlayground
-  check_credentials deployTools
 
   DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -118,7 +117,7 @@ Visit ${cyan}https://github.com/settings/tokens?type=beta${clear}, and add it to
   if [ -z "$SNYK_TOKEN" ]
   then
     echo -e "${yellow}Please create or retrieve a Snyk token${clear}.
-  Visit ${cyan}https://docs.snyk.io/snyk-api-info/authentication-for-api${clear}, and add it to ${cyan}$LOCAL_ENV_FILE${clear}"
+Visit ${cyan}https://docs.snyk.io/snyk-api-info/authentication-for-api${clear}, and add it to ${cyan}$LOCAL_ENV_FILE${clear}"
   fi
 
 
@@ -126,5 +125,5 @@ Visit ${cyan}https://github.com/settings/tokens?type=beta${clear}, and add it to
 
 check_node_version
 install_dependencies
+check_credentials deployTools
 setup_cloudquery
-


### PR DESCRIPTION
## What does this change?

Previously, we were using developerPlayground and deployTools resources to test Cloudquery. This required us to fetch two sets of credentials. We are now using only deployTools resources for local testing.

## Why?

To improve the developer experience, and make setup faster

## How has it been verified?

The correct error messages show up at the expected points, and we are able to gather AWS data locally for the relevant account
