### PR TITLE
Refactor: create local migrate script

### DIFF
--- a/.env
+++ b/.env
@@ -25,3 +25,9 @@ CQ_SNYK=3.1.5
 
 # See https://github.com/guardian/cq-source-snyk-full-project
 CQ_GUARDIAN_SNYK=0.1.1
+
+# For local development only
+LOCAL_DB_USER=postgres
+LOCAL_DB_PASSWORD=not_at_all_secret
+LOCAL_DB_HOSTNAME=localhost
+LOCAL_DB_PORT=5432

--- a/.env
+++ b/.env
@@ -27,6 +27,7 @@ CQ_SNYK=3.1.5
 CQ_GUARDIAN_SNYK=0.1.1
 
 # For local development only
+LOCAL_STAGE=DEV
 LOCAL_DB_USER=postgres
 LOCAL_DB_PASSWORD=not_at_all_secret
 LOCAL_DB_HOSTNAME=localhost

--- a/package-lock.json
+++ b/package-lock.json
@@ -9496,7 +9496,7 @@
         "@prisma/client": "^5.3.1"
       },
       "devDependencies": {
-        "@types/aws-lambda": "^8.10.122",
+        "@types/aws-lambda": "^8.10.119",
         "prisma": "^5.3.1"
       }
     }

--- a/packages/cloudquery/README.md
+++ b/packages/cloudquery/README.md
@@ -28,7 +28,7 @@ It includes:
 
 ## Running
 
-1. Put your GitHub PAT and Snyk token in the `.env` file at `~/.gu/service_catalogue/secrets/.env`(n.b. DO NOT put them in the repo `.env` file, as you will probably commit a secret by accident).
+1. Put your GitHub PAT and Snyk token in the `.env.local` file at `~/.gu/service_catalogue/`(n.b. DO NOT put them in the repo `.env` file, as you could commit a secret by accident).
 2. Start Docker
 3. Run:
 

--- a/packages/cloudquery/docker-compose.yaml
+++ b/packages/cloudquery/docker-compose.yaml
@@ -3,11 +3,11 @@ services:
   postgres:
     image: postgres:14.6
     ports:
-      - "5432:5432"
+      - "${LOCAL_DB_PORT}:${LOCAL_DB_PORT}"
     environment:
-      POSTGRES_DB: postgres
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: not_at_all_secret
+      POSTGRES_DB: ${LOCAL_DB_HOSTNAME}
+      POSTGRES_USER: ${LOCAL_DB_USER}
+      POSTGRES_PASSWORD: ${LOCAL_DB_PASSWORD}
   cloudquery:
     image: ghcr.io/cloudquery/cloudquery:${CQ_CLI}
     platform: linux/amd64

--- a/packages/cloudquery/script/start
+++ b/packages/cloudquery/script/start
@@ -6,7 +6,7 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ROOT_DIR=$DIR/../../..
 
 MAIN_ENV_FILE=$ROOT_DIR/.env
-LOCAL_ENV_FILE=$HOME/.gu/service_catalogue/secrets/.env
+LOCAL_ENV_FILE=$HOME/.gu/service_catalogue/.env.local
 
 echo "Checking AWS credentials"
 STATUS=$(aws sts get-caller-identity --profile deployTools 2>&1 || true)

--- a/packages/repocop/README.md
+++ b/packages/repocop/README.md
@@ -48,6 +48,5 @@ one scheme.prisma file.
 
 1. [Start Cloudquery](../../packages/cloudquery/README.md) to generate the database
 2. Put `DATABASE_URL="postgresql://postgres:not_at_all_secret@localhost:5432/postgres"` in a `.env` file in `packages/repocop`
-3. Apply the initial schema: `npx -w repocop prisma migrate resolve --applied 0_init`
-4. Run a migration: `npx -w repocop prisma migrate deploy`
-5. Start Repocop: `npm start -w repocop`
+3. Run `npm run migrate:dev -w repocop` to create the _prisma_migrations table in the database (n.b. this will replace any existing table)
+4. Start Repocop: `npm start -w repocop`

--- a/packages/repocop/README.md
+++ b/packages/repocop/README.md
@@ -47,6 +47,5 @@ one scheme.prisma file.
 ## Running Repocop locally
 
 1. [Start Cloudquery](../../packages/cloudquery/README.md) to generate the database
-2. Put `DATABASE_URL="postgresql://postgres:not_at_all_secret@localhost:5432/postgres"` in a `.env` file in `packages/repocop`
-3. Run `npm run migrate:dev -w repocop` to create the _prisma_migrations table in the database (n.b. this will replace any existing table)
-4. Start Repocop: `npm start -w repocop`
+2. Run `npm run migrate:dev -w repocop` to create the _prisma_migrations table in the database (n.b. this will replace any existing table locally)
+3. Start Repocop: `npm start -w repocop`

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -4,7 +4,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.122",
     "@types/aws-lambda": "^8.10.119",
-    "dotenv-cli": "^7.3.0",
     "prisma": "^5.3.1"
   },
   "scripts": {
@@ -12,7 +11,9 @@
     "start": "ts-node src/run-locally.ts",
     "postinstall": "prisma generate",
     "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects repocop",
-    "migrate:dev": "./script/migrate_dev"
+    "migrate:dev": "script/migrate.sh --dev",
+    "migrate:code": "script/migrate.sh --code",
+    "migrate:prod": "script/migrate.sh --prod"
   },
   "prisma": {
     "schema": "prisma/schema.prisma"

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -3,13 +3,16 @@
   "version": "1.0.0",
   "devDependencies": {
     "@types/aws-lambda": "^8.10.122",
+    "@types/aws-lambda": "^8.10.119",
+    "dotenv-cli": "^7.3.0",
     "prisma": "^5.3.1"
   },
   "scripts": {
     "build": "esbuild src/index.ts --bundle --platform=node --target=node18 --outdir=dist --external:@aws-sdk --external:@prisma/client --external:prisma",
     "start": "ts-node src/run-locally.ts",
     "postinstall": "prisma generate",
-    "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects repocop"
+    "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects repocop",
+    "migrate:dev": "./script/migrate_dev"
   },
   "prisma": {
     "schema": "prisma/schema.prisma"

--- a/packages/repocop/script/migrate.sh
+++ b/packages/repocop/script/migrate.sh
@@ -13,11 +13,11 @@ migrateDEV() {
 }
 
 migrateCODE() {
-  export DATABASE_URL="TODO"
+  echo "Migrating CODE"
 }
 
 migratePROD() {
-  export DATABASE_URL="TODO"
+  echo "Migrating PROD"
 }
 
 # Read in input flag

--- a/packages/repocop/script/migrate.sh
+++ b/packages/repocop/script/migrate.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -e
+
+migrateDEV() {
+  source ../../.env
+
+  export DATABASE_URL="postgresql://$LOCAL_DB_USER:$LOCAL_DB_PASSWORD@$LOCAL_DB_HOSTNAME:$LOCAL_DB_PORT/postgres"
+
+  # clear existing local migrations table (if applicable)
+  # and apply all migrations
+  npx prisma migrate reset --force --schema "prisma/schema.prisma"
+}
+
+migrateCODE() {
+  export DATABASE_URL="TODO"
+}
+
+migratePROD() {
+  export DATABASE_URL="TODO"
+}
+
+# Read in input flag
+stage=$1
+
+if [ "$stage" == "--dev" ]
+then
+  migrateDEV
+elif [ "$stage" == "--code" ]
+then
+  migrateCODE
+elif [ "$stage" == "--prod" ]
+then
+  migratePROD
+else
+  echo -e "Stage '$stage' not recognised, please try again with either '--dev', '--code' or '--prod' flags"
+fi

--- a/packages/repocop/script/migrate_dev
+++ b/packages/repocop/script/migrate_dev
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+# clear existing local migrations table (if applicable)
+# and apply all migrations
+dotenv -e ~/.gu/service_catalogue/.env.local -- npx prisma migrate reset --force

--- a/packages/repocop/script/migrate_dev
+++ b/packages/repocop/script/migrate_dev
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-# clear existing local migrations table (if applicable)
-# and apply all migrations
-dotenv -e ~/.gu/service_catalogue/.env.local -- npx prisma migrate reset --force

--- a/packages/repocop/src/run-locally.ts
+++ b/packages/repocop/src/run-locally.ts
@@ -2,7 +2,6 @@ import { main } from './index';
 
 if (require.main === module) {
 	// TODO set these values from a .env.local file.
-	//  The .env.local file should also be used within `docker-compose.yml` to stay DRY.
 	process.env.STAGE = 'DEV';
 	process.env.DATABASE_HOSTNAME = 'localhost';
 	process.env.DATABASE_PASSWORD = 'not_at_all_secret';

--- a/packages/repocop/src/run-locally.ts
+++ b/packages/repocop/src/run-locally.ts
@@ -1,8 +1,8 @@
 import { main } from './index';
 
 if (require.main === module) {
-	// TODO set these values from a .env file.
-	//  The .env file should also be used within `docker-compose.yml` to stay DRY.
+	// TODO set these values from a .env.local file.
+	//  The .env.local file should also be used within `docker-compose.yml` to stay DRY.
 	process.env.STAGE = 'DEV';
 	process.env.DATABASE_HOSTNAME = 'localhost';
 	process.env.DATABASE_PASSWORD = 'not_at_all_secret';

--- a/packages/repocop/src/run-locally.ts
+++ b/packages/repocop/src/run-locally.ts
@@ -1,11 +1,10 @@
 import { main } from './index';
 
 if (require.main === module) {
-	// TODO set these values from a .env.local file.
-	process.env.STAGE = 'DEV';
-	process.env.DATABASE_HOSTNAME = 'localhost';
-	process.env.DATABASE_PASSWORD = 'not_at_all_secret';
-	process.env.DATABASE_USER = 'postgres';
+	process.env.STAGE = process.env.LOCAL_STAGE;
+	process.env.DATABASE_HOSTNAME = process.env.LOCAL_DB_HOSTNAME;
+	process.env.DATABASE_PASSWORD = process.env.LOCAL_DB_PASSWORD;
+	process.env.DATABASE_USER = process.env.LOCAL_DB_USER;
 
 	// Set this to 'false' to disable SQL query logging
 	process.env.QUERY_LOGGING = 'true';

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -64,9 +64,9 @@ setup_cloudquery() {
 
   DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-  LOCAL_ENV_FILE_DIR=$HOME/.gu/service_catalogue/secrets
+  LOCAL_ENV_FILE_DIR=$HOME/.gu/service_catalogue
 
-  LOCAL_ENV_FILE=$LOCAL_ENV_FILE_DIR/.env
+  LOCAL_ENV_FILE=$LOCAL_ENV_FILE_DIR/.env.local
 
   SIZE_THRESHOLD=1
 
@@ -83,7 +83,8 @@ GALAXIES_BUCKET=${GALAXIES_BUCKET}
 
   echo "Running CloudQuery setup"
 
-  # Check if .env file exists in user's /service_catalogue/secrets/
+  # Check if .env.local file exists in ~/.gu/service_catalogue/
+  echo "Checking to see if you have a .env.local file in $LOCAL_ENV_FILE_DIR"
   if [ -e "$LOCAL_ENV_FILE" ]
   then
     # Get file size in bytes
@@ -92,15 +93,15 @@ GALAXIES_BUCKET=${GALAXIES_BUCKET}
     # Check if file is empty - don't want to overwrite any existing tokens
     if [ "$FILE_SIZE" -gt "$SIZE_THRESHOLD" ]
     then
-      echo "Local non-empty .env file found in $LOCAL_ENV_FILE_DIR. No changes made"
+      echo "Non-empty .env.local file found in $LOCAL_ENV_FILE_DIR. No changes made"
     else
-      echo "Empty local .env file found in $LOCAL_ENV_FILE_DIR, adding token names"
+      echo "Empty .env.local file found in $LOCAL_ENV_FILE_DIR, adding token names$"
       echo "$TOKEN_TEXT" >> "$LOCAL_ENV_FILE"
     fi
   else
-    echo "No local .env file found - creating it in $LOCAL_ENV_FILE_DIR and adding token names"
-    mkdir -p "$HOME"/.gu/service_catalogue/secrets
-    touch -a "$LOCAL_ENV_FILE_DIR"/.env
+    echo "No .env.local file found - creating it in $LOCAL_ENV_FILE_DIR and adding token names"
+    mkdir -p "$HOME"/.gu/service_catalogue
+    touch -a "$LOCAL_ENV_FILE_DIR"/.env.local
     echo "$TOKEN_TEXT" >> "$LOCAL_ENV_FILE"
   fi
 
@@ -119,8 +120,6 @@ Visit ${cyan}https://github.com/settings/tokens?type=beta${clear}, and add it to
     echo -e "${yellow}Please create or retrieve a Snyk token${clear}.
 Visit ${cyan}https://docs.snyk.io/snyk-api-info/authentication-for-api${clear}, and add it to ${cyan}$LOCAL_ENV_FILE${clear}"
   fi
-
-
 }
 
 check_node_version


### PR DESCRIPTION
## What does this change?
- Puts local env vars for Postgres DB into the root `.env` file so that they can be retrieved when running CloudQuery and Repocop locally
- Creates a migrate script which will eventually migrate for DEV, CODE and PROD, but this PR is concerned with DEV only. 
- Simplifies running Repocop locally as the `DATABASE_URL` env var is set in the migrate script.
- Updates the Repocop README to reflect the changes.
- Changes the name and path for the local .env file for simplification and clarity.

## Why?
This makes running locally simpler and now env vars are shared between scripts rather than being set manually. 

## How has it been verified?
Running `./scripts/setup.sh` followed by `npm start -w cloudquery`, `npm migrate:dev -w repocop` and `npm start -w repocop` all works.