### PR TITLE
fix(prisma): Bring some manually created tables into Prisma

### DIFF
--- a/packages/repocop/prisma/migrations/20230928080512_guardian_production_status/migration.sql
+++ b/packages/repocop/prisma/migrations/20230928080512_guardian_production_status/migration.sql
@@ -1,0 +1,16 @@
+-- The Guardian has six recognised production statuses for repositories.
+-- Here they are enumerated and prioritised
+create table guardian_production_status
+(
+    status   text PRIMARY KEY,
+    priority integer NOT NULL
+);
+
+insert into guardian_production_status (status, priority)
+values ('production', 0),
+       ('testing', 1),
+       ('documentation', 2), --no code, but still needs to be up to date
+       ('prototype', 3),
+       ('hackday', 4),
+       ('learning', 5)
+on conflict (status) do nothing;

--- a/packages/repocop/prisma/migrations/20230928080813_guardian_non_p_and_e_github_teams/migration.sql
+++ b/packages/repocop/prisma/migrations/20230928080813_guardian_non_p_and_e_github_teams/migration.sql
@@ -1,0 +1,29 @@
+/*
+ A lot of best practice recommendations and expectations only apply to repos
+ that are owned by P&E or are otherwise uncategorised. This is a list of github
+ team slugs for teams that sit outside of the P&E department for easy exclusion
+ of these teams in queries.
+ */
+create table guardian_non_p_and_e_github_teams
+(
+    team_name text PRIMARY KEY
+);
+insert into guardian_non_p_and_e_github_teams (team_name)
+values ('data-and-insight'),
+       ('data-design'),
+       ('data-science'),
+       ('d-i-data-science'),
+       ('enterprise-infrastructure'),
+       ('esd'),
+       ('esd-admin'),
+       ('guardian-design-team'),
+       ('guardian-us-design-team'),
+       ('glabs-au'),
+       ('it-australia'),
+       ('infosec'),
+       ('infosec-admin'),
+       ('interactive-team'),
+       ('interactives-owner-placeholder'),
+       ('interactives-admin'),
+       ('multimedia')
+on conflict (team_name) do nothing;

--- a/packages/repocop/prisma/schema.prisma
+++ b/packages/repocop/prisma/schema.prisma
@@ -15833,3 +15833,7 @@ model guardian_production_status {
   status   String @id
   priority Int
 }
+
+model guardian_non_p_and_e_github_teams {
+  team_name String @id
+}

--- a/packages/repocop/prisma/schema.prisma
+++ b/packages/repocop/prisma/schema.prisma
@@ -15828,3 +15828,8 @@ model galaxies_teams_table {
   team_google_chat_space_key String?
   team_primary_github_team   String?
 }
+
+model guardian_production_status {
+  status   String @id
+  priority Int
+}

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -1,22 +1,3 @@
--- The Guardian has six recognised production statuses for repositories.
--- Here they are enumerated and prioritised
-drop table if exists guardian_production_status;
-
-create table guardian_production_status
-(
-    status   text PRIMARY KEY,
-    priority integer NOT NULL
-);
-
-insert into guardian_production_status (status, priority)
-values ('production', 0),
-       ('testing', 1),
-       ('documentation', 2), --no code, but still needs to be up to date
-       ('prototype', 3),
-       ('hackday', 4),
-       ('learning', 5)
-on conflict (status) do nothing;
-
 /*
  A lot of best practice recommendations and expectations only apply to repos
  that are owned by P&E or are otherwise uncategorised. This is a list of github

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -1,35 +1,3 @@
-/*
- A lot of best practice recommendations and expectations only apply to repos
- that are owned by P&E or are otherwise uncategorised. This is a list of github
- team slugs for teams that sit outside of the P&E department for easy exclusion
- of these teams in queries.
- */
-drop table if exists guardian_non_p_and_e_github_teams;
-
-create table guardian_non_p_and_e_github_teams
-(
-    team_name text PRIMARY KEY
-);
-insert into guardian_non_p_and_e_github_teams (team_name)
-values ('data-and-insight'),
-       ('data-design'),
-       ('data-science'),
-       ('d-i-data-science'),
-       ('enterprise-infrastructure'),
-       ('esd'),
-       ('esd-admin'),
-       ('guardian-design-team'),
-       ('guardian-us-design-team'),
-       ('glabs-au'),
-       ('it-australia'),
-       ('infosec'),
-       ('infosec-admin'),
-       ('interactive-team'),
-       ('interactives-owner-placeholder'),
-       ('interactives-admin'),
-       ('multimedia')
-on conflict (team_name) do nothing;
-
 create or replace view view_repo_ownership as
 select ght.id        as "github_team_id"
      , ght.name      as "github_team_name"


### PR DESCRIPTION
## What does this change?
Adds a couple of manually created enumeration tables as Prisma migrations, to reduce the amount of manually invoked SQL.

## Why?
This is related to some work to bring our views into Prisma. Part of this involves [introspecting the views](https://www.prisma.io/docs/concepts/components/prisma-schema/views#use-introspection). I'm pulling this change out separately to keep the diff as small.