### PR TITLE
feat(repocop): Query the `view_repo_ownership` view

### DIFF
--- a/packages/repocop/prisma/migrations/20230928084104_view_repo_ownership/migration.sql
+++ b/packages/repocop/prisma/migrations/20230928084104_view_repo_ownership/migration.sql
@@ -1,0 +1,13 @@
+create or replace view view_repo_ownership as
+select ght.id        as "github_team_id"
+     , ght.name      as "github_team_name"
+     , tr.full_name  as "repo_name" --deprecated. use full_name below for consistency with other tables
+     , tr.full_name  as "full_name"
+     , tr.role_name
+     , tr.archived
+     , gtt.team_name as "galaxies_team"
+     , gtt.team_contact_email
+from github_team_repositories tr
+         join github_teams ght on tr.team_id = ght.id
+         left join galaxies_teams_table gtt on ght.slug = gtt.team_primary_github_team
+where tr.role_name = 'admin';

--- a/packages/repocop/prisma/schema.prisma
+++ b/packages/repocop/prisma/schema.prisma
@@ -1,6 +1,7 @@
 generator client {
-  provider      = "prisma-client-js"
-  binaryTargets = ["native", "rhel-openssl-1.0.x"]
+  provider        = "prisma-client-js"
+  previewFeatures = ["views"]
+  binaryTargets   = ["native", "rhel-openssl-1.0.x"]
 }
 
 datasource db {
@@ -15836,4 +15837,17 @@ model guardian_production_status {
 
 model guardian_non_p_and_e_github_teams {
   team_name String @id
+}
+
+view view_repo_ownership {
+  github_team_id     BigInt
+  github_team_name   String
+  repo_name          String
+  full_name          String
+  role_name          String
+  archived           Boolean
+  galaxies_team      String?
+  team_contact_email String?
+
+  @@unique([github_team_id, full_name])
 }

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -2,13 +2,14 @@ import { PrismaClient } from '@prisma/client';
 import type { repocop_github_repository_rules } from '@prisma/client';
 import { getConfig } from './config';
 import {
+	getRepoOwnership,
 	getRepositoryBranches,
 	getRepositoryTeams,
 	getUnarchivedRepositories,
 } from './query';
 import { repositoryRuleEvaluation } from './rules/repository';
 
-async function evaluateRepositories(
+export async function evaluateRepositories(
 	client: PrismaClient,
 	ignoredRepositoryPrefixes: string[],
 ): Promise<repocop_github_repository_rules[]> {
@@ -44,6 +45,9 @@ export async function main() {
 			],
 		}),
 	});
+
+	// We're not doing anything with this data, this is just to demonstrate we can interact with SQL views using Prisma.
+	await getRepoOwnership(prisma);
 
 	const data = await evaluateRepositories(
 		prisma,

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -3,6 +3,7 @@ import type {
 	github_repository_branches,
 	Prisma,
 	PrismaClient,
+	view_repo_ownership,
 } from '@prisma/client';
 import type { GetFindResult } from '@prisma/client/runtime/library';
 
@@ -73,6 +74,16 @@ export async function getRepositoryTeams(
 	console.log(
 		`Found ${data.length} teams with access to repository ${repoIdentifier}`,
 	);
+
+	return data;
+}
+
+export async function getRepoOwnership(
+	client: PrismaClient,
+): Promise<view_repo_ownership[]> {
+	const data = await client.view_repo_ownership.findMany();
+
+	console.log(`Found ${data.length} repo ownership records.`);
 
 	return data;
 }

--- a/sql/views.sql
+++ b/sql/views.sql
@@ -1,17 +1,3 @@
-create or replace view view_repo_ownership as
-select ght.id        as "github_team_id"
-     , ght.name      as "github_team_name"
-     , tr.full_name  as "repo_name" --deprecated. use full_name below for consistency with other tables
-     , tr.full_name  as "full_name"
-     , tr.role_name
-     , tr.archived
-     , gtt.team_name as "galaxies_team"
-     , gtt.team_contact_email
-from github_team_repositories tr
-         join github_teams ght on tr.team_id = ght.id
-         left join galaxies_teams_table gtt on ght.slug = gtt.team_primary_github_team
-where tr.role_name = 'admin';
-
 CREATE OR REPLACE VIEW aws_accounts AS
 SELECT DISTINCT acc.id,
                 acc.name,


### PR DESCRIPTION
## What does this change?
Following https://github.com/guardian/service-catalogue/pull/338, this change brings the SQL view `view_repo_ownership` into Prisma[^1] so that it can be used within RepoCop.

## Why?
In order for RepoCop to know who to notify about a repository, we need to know who owns it, this information is within the `view_repo_ownership` view.

## How has it been verified?
I've [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/6a5f63dc-32ea-46b7-8984-03867cc0b209), run the lambda, and observed [the logs](https://logs.gutools.co.uk/s/devx/app/discover#/doc/626e7830-dd3a-11ea-88b6-37713dba5739/logstash-dev-tools-2023.09.28?id=B38O24oB1GrvOkJ_ak7i) matching the view.

### Log message
<img width="835" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/c78c0c3f-4476-46f3-b137-34196ac7d7ee">

### SQL result
<img width="644" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/979ab3b3-662c-486f-a3a3-8c957333868d">

[^1]: SQL view support in Prisma is currently in "ver early Preview" - https://www.prisma.io/docs/concepts/components/prisma-schema/views