### PR TITLE
Use new github team mapping to send notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2200,9 +2200,9 @@
       }
     },
     "node_modules/@guardian/anghammarad": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@guardian/anghammarad/-/anghammarad-1.0.2.tgz",
-      "integrity": "sha512-BLmCBFrj0iSzAQdpr2Ha+T3j/RmO9vnAjUy6FlqYtQ1Y14TUmmxXJC5qT1Ao49lIcG8rLbkgg0LSA4Q17T3mPw=="
+      "version": "1.8.0-SNAPSHOT",
+      "resolved": "https://registry.npmjs.org/@guardian/anghammarad/-/anghammarad-1.8.0-SNAPSHOT.tgz",
+      "integrity": "sha512-i7CknYLzjfxst3r2efkxsPcgy2Ofvmj2bLhgaXVA2TH/NAJo9ILJVAaq/CoSad5ljjEtrmbjeSOjzskwBO8hGw=="
     },
     "node_modules/@guardian/cdk": {
       "version": "50.10.14",
@@ -9633,7 +9633,7 @@
       "dependencies": {
         "@aws-sdk/client-ssm": "^3.418.0",
         "@aws-sdk/types": "^3.418.0",
-        "@guardian/anghammarad": "^1.0.2",
+        "@guardian/anghammarad": "^1.8.0-SNAPSHOT",
         "@octokit/types": "^12.0.0",
         "octokit": "^3.1.1"
       }

--- a/packages/branch-protector/package.json
+++ b/packages/branch-protector/package.json
@@ -11,7 +11,7 @@
 	"dependencies": {
 		"@aws-sdk/client-ssm": "^3.418.0",
 		"@aws-sdk/types": "^3.418.0",
-		"@guardian/anghammarad": "^1.0.2",
+		"@guardian/anghammarad": "^1.8.0-SNAPSHOT",
 		"@octokit/types": "^12.0.0",
 		"octokit": "^3.1.1"
 	}

--- a/packages/branch-protector/src/index.ts
+++ b/packages/branch-protector/src/index.ts
@@ -111,7 +111,12 @@ async function notify(fullRepoName: string, topicArn: string, slug: string) {
 	await client.notify({
 		subject: 'Hello',
 		message: `Branch protection has been applied to ${fullRepoName}`,
-		actions: [], //TODO: add a link to the repo prompting users to check the branch protection
+		actions: [
+			{
+				cta: 'Check branch protections here',
+				url: `https://github.com/${fullRepoName}/settings/branches`,
+			},
+		],
 		target: { GithubTeamSlug: slug },
 		channel: RequestedChannel.PreferHangouts,
 		sourceSystem: 'branch-protector',
@@ -147,7 +152,7 @@ export async function main(event: UpdateBranchProtectionEvent) {
 		await updateBranchProtection(octokit, owner, repo, defaultBranchName);
 		console.log(`Update of ${repo} successful`);
 		for (const slug of event.teamNameSlugs) {
-			await notify(repo, config.anghammaradSnsTopic, slug);
+			await notify(event.fullName, config.anghammaradSnsTopic, slug);
 		}
 		console.log(`Notified teams`);
 	}


### PR DESCRIPTION
## What does this change?

- Uses repo owner to send notifications to the department
- Add a call to action so teams can check their branch protections themselves

## Why?

We don't want all these notifications to come to devx.
This is possible now that https://github.com/guardian/anghammarad-config/pull/18 has been merged. https://github.com/guardian/anghammarad-config/pull/19 will allow more departmental teams to be notified

## How has it been verified?

Ran locally, messages routed via github team are delivered.
