### PR TITLE
Prisma migrate scripts

### DIFF
--- a/packages/repocop/README.md
+++ b/packages/repocop/README.md
@@ -22,8 +22,8 @@ DATABASE_URL="postgresql://dbuser:dbpassword@hosturl:5432/postgres
 
 The `DATABASE_URL` is set by the npm migration scripts (see below).
 
-**Note**  
-At the moment it is not possible to have more than
+> [!NOTE]  
+> At the moment it is not possible to have more than
 one `schema.prisma` file.
 
 ## Adding new tables locally
@@ -36,8 +36,8 @@ To add a new table to the database you need to add a new model to the `schema.pr
 npm -w repocop run migrate:dev [migration-name]
 ```
 
-**Note**
-This will apply all migrations including any new ones, and replace the `_prisma_migrations` table and any existing tables locally.
+> [!NOTE]  
+> This will apply all migrations including any new ones, and replace the `_prisma_migrations` table and any existing tables and data locally.
 
 See [Prisma documentation on creating migrations](https://www.prisma.io/docs/guides/migrate/developing-with-prisma-migrate#create-migrations).
 
@@ -51,8 +51,9 @@ npx prisma generate
 
 1. Create the migration (see above) and make sure it works locally.
 2. Raise a PR and ensure to note that migration has to be deployed manually after the PR is merged.
-3. Connect to the VPN.
-4. To deploy the migration to code, run:
+3. Get deployTools credentials from Janus.
+4. Connect to the VPN.
+5. To deploy the migration to code, run:
 
 ```
 npm -w repocop run migrate:code 
@@ -71,5 +72,5 @@ See [Prisma documentation on migration](https://www.prisma.io/docs/concepts/comp
 ## Running Repocop locally
 
 1. [Start Cloudquery](../../packages/cloudquery/README.md) to generate the database.
-2. Run `npm -w repocop run migrate:setuplocal` to create the `_prisma_migrations table` in the database. Note: This will replace any existing tables locally.
+2. Run `npm -w repocop run migrate:setuplocal` to create the `_prisma_migrations table` in the database. Note: This will replace any existing tables and data locally.
 3. Start Repocop: `npm -w repocop start`.

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -11,7 +11,8 @@
     "start": "ts-node src/run-locally.ts",
     "postinstall": "prisma generate",
     "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects repocop",
-    "migrate:dev": "script/migrate.sh --dev",
+    "migrate:setuplocal": "script/migrate.sh --dev",
+    "migrate:dev": "script/migrate.sh --dev $NAME",
     "migrate:code": "script/migrate.sh --code",
     "migrate:prod": "script/migrate.sh --prod"
   },

--- a/packages/repocop/script/migrate.sh
+++ b/packages/repocop/script/migrate.sh
@@ -26,12 +26,12 @@ getDbUrl() {
   allSecrets=$(aws secretsmanager list-secrets --profile deployTools --region eu-west-1 | jq '.SecretList')
   secret_id=$(jq -r --arg stage "$stage" '.[] | select(.Tags[] as $t | any($t.Key=="Stack" and $t.Value=="deploy")) | select(.Tags[] as $t | any($t.Key=="Stage" and $t.Value==$stage)) | select(.Tags[] as $t | any($t.Key=="App" and $t.Value=="service-catalogue")) | select(.Name | test("PostgresInstance")) | .Name' <<< "$allSecrets")
   dbSecretJson=$(aws secretsmanager get-secret-value --secret-id "$secret_id" --profile deployTools --region eu-west-1 | jq -c '[.SecretString | fromjson]')
-  db_usermigration_name=$(jq -r '.[] | .usermigration_name' <<< "$dbSecretJson")
+  db_username=$(jq -r '.[] | .username' <<< "$dbSecretJson")
   db_password=$(jq -r '.[] | .password' <<< "$dbSecretJson")
   db_host=$(jq -r '.[] | .host' <<< "$dbSecretJson")
   db_port=$(jq -r '.[] | .port' <<< "$dbSecretJson")
 
-  export DATABASE_URL="postgresql://$db_usermigration_name:$db_password@$db_host:$db_port/postgres"
+  export DATABASE_URL="postgresql://$db_username:$db_password@$db_host:$db_port/postgres"
 }
 
 note="NOTE: You need to be on the VPN to migrate. \nMigration may fail if the table(s) already exist in the database.\nSee https://www.prisma.io/docs/guides/migrate/production-troubleshooting#failed-migration for how to fix."

--- a/packages/repocop/script/migrate.sh
+++ b/packages/repocop/script/migrate.sh
@@ -14,7 +14,6 @@ migrateDEV() {
 
 getDbUrl() {
   stage=$1
-  echo "stage: $stage"
   allSecrets=$(aws secretsmanager list-secrets --profile deployTools --region eu-west-1 | jq '.SecretList')
   secret_id=$(jq -r --arg stage "$stage" '.[] | select(.Tags[] as $t | any($t.Key=="Stack" and $t.Value=="deploy")) | select(.Tags[] as $t | any($t.Key=="Stage" and $t.Value==$stage)) | select(.Tags[] as $t | any($t.Key=="App" and $t.Value=="service-catalogue")) | select(.Name | test("PostgresInstance")) | .Name' <<< "$allSecrets")
   dbSecretJson=$(aws secretsmanager get-secret-value --secret-id "$secret_id" --profile deployTools --region eu-west-1 | jq -c '[.SecretString | fromjson]')
@@ -29,7 +28,7 @@ getDbUrl() {
 migrateCODE() {
   echo "Migrating CODE"
   getDbUrl 'CODE'
-  # TODO: migrate
+  npx prisma migrate deploy
 }
 
 migratePROD() {

--- a/packages/repocop/script/migrate.sh
+++ b/packages/repocop/script/migrate.sh
@@ -6,14 +6,19 @@ red='\x1B[0;31m'
 bold='\x1B[1m'
 plain='\x1B[0m'
 
-migrateDEV() {
+devSetup() {
+  echo -e "${bold}Setting up local DATABASE_URL and resetting migrations${plain}"
   source ../../.env
-
   export DATABASE_URL="postgresql://$LOCAL_DB_USER:$LOCAL_DB_PASSWORD@$LOCAL_DB_HOSTNAME:$LOCAL_DB_PORT/postgres"
-
   # clear existing local migrations table (if applicable)
   # and apply all migrations
   npx prisma migrate reset --force --schema "prisma/schema.prisma"
+}
+
+migrateDEV() {
+  migration_name=$1
+  echo -e "${bold}Creating migration $migration_name${plain}"
+  npx prisma migrate dev --name "$migration_name"
 }
 
 getDbUrl() {
@@ -21,12 +26,12 @@ getDbUrl() {
   allSecrets=$(aws secretsmanager list-secrets --profile deployTools --region eu-west-1 | jq '.SecretList')
   secret_id=$(jq -r --arg stage "$stage" '.[] | select(.Tags[] as $t | any($t.Key=="Stack" and $t.Value=="deploy")) | select(.Tags[] as $t | any($t.Key=="Stage" and $t.Value==$stage)) | select(.Tags[] as $t | any($t.Key=="App" and $t.Value=="service-catalogue")) | select(.Name | test("PostgresInstance")) | .Name' <<< "$allSecrets")
   dbSecretJson=$(aws secretsmanager get-secret-value --secret-id "$secret_id" --profile deployTools --region eu-west-1 | jq -c '[.SecretString | fromjson]')
-  db_username=$(jq -r '.[] | .username' <<< "$dbSecretJson")
+  db_usermigration_name=$(jq -r '.[] | .usermigration_name' <<< "$dbSecretJson")
   db_password=$(jq -r '.[] | .password' <<< "$dbSecretJson")
   db_host=$(jq -r '.[] | .host' <<< "$dbSecretJson")
   db_port=$(jq -r '.[] | .port' <<< "$dbSecretJson")
 
-  export DATABASE_URL="postgresql://$db_username:$db_password@$db_host:$db_port/postgres"
+  export DATABASE_URL="postgresql://$db_usermigration_name:$db_password@$db_host:$db_port/postgres"
 }
 
 note="NOTE: You need to be on the VPN to migrate. \nMigration may fail if the table(s) already exist in the database.\nSee https://www.prisma.io/docs/guides/migrate/production-troubleshooting#failed-migration for how to fix."
@@ -57,12 +62,19 @@ migratePROD() {
   continueQuery "PROD"
 }
 
-# Read in input flag
+# Read in input stage(s)
 stage=$1
+migration_name=$2
 
 if [ "$stage" == "--dev" ]
 then
-  migrateDEV
+  devSetup
+  if [ -n "$migration_name" ]
+  then
+    migrateDEV "$migration_name"
+  else
+    :
+  fi
 elif [ "$stage" == "--code" ]
 then
   migrateCODE
@@ -70,5 +82,5 @@ elif [ "$stage" == "--prod" ]
 then
   migratePROD
 else
-  echo -e "Stage '$stage' not recognised, please try again with either '--dev', '--code' or '--prod' flags"
+  echo -e "Stage '$stage' not recognised, please try again."
 fi

--- a/packages/repocop/script/migrate.sh
+++ b/packages/repocop/script/migrate.sh
@@ -12,10 +12,11 @@ migrateDEV() {
   npx prisma migrate reset --force --schema "prisma/schema.prisma"
 }
 
-migrateCODE() {
-
+getDbUrl() {
+  stage=$1
+  echo "stage: $stage"
   allSecrets=$(aws secretsmanager list-secrets --profile deployTools --region eu-west-1 | jq '.SecretList')
-  secret_id=$(jq -r '.[] | select(.Tags[] as $t | any($t.Key=="Stack" and $t.Value=="deploy")) | select(.Tags[] as $t | any($t.Key=="Stage" and $t.Value=="CODE")) | select(.Tags[] as $t | any($t.Key=="App" and $t.Value=="service-catalogue")) | select(.Name | test("PostgresInstance")) | .Name' <<< "$allSecrets")
+  secret_id=$(jq -r --arg stage "$stage" '.[] | select(.Tags[] as $t | any($t.Key=="Stack" and $t.Value=="deploy")) | select(.Tags[] as $t | any($t.Key=="Stage" and $t.Value==$stage)) | select(.Tags[] as $t | any($t.Key=="App" and $t.Value=="service-catalogue")) | select(.Name | test("PostgresInstance")) | .Name' <<< "$allSecrets")
   dbSecretJson=$(aws secretsmanager get-secret-value --secret-id "$secret_id" --profile deployTools --region eu-west-1 | jq -c '[.SecretString | fromjson]')
   db_username=$(jq -r '.[] | .username' <<< "$dbSecretJson")
   db_password=$(jq -r '.[] | .password' <<< "$dbSecretJson")
@@ -23,11 +24,18 @@ migrateCODE() {
   db_port=$(jq -r '.[] | .port' <<< "$dbSecretJson")
 
   export DATABASE_URL="postgresql://$db_username:$db_password@$db_host:$db_port/postgres"
+}
+
+migrateCODE() {
   echo "Migrating CODE"
+  getDbUrl 'CODE'
+  # TODO: migrate
 }
 
 migratePROD() {
   echo "Migrating PROD"
+  getDbUrl 'PROD'
+  # TODO: migrate
 }
 
 # Read in input flag

--- a/packages/repocop/script/migrate.sh
+++ b/packages/repocop/script/migrate.sh
@@ -36,9 +36,9 @@ getDbUrl() {
 
 note="NOTE: You need to be on the VPN to migrate. \nMigration may fail if the table(s) already exist in the database.\nSee https://www.prisma.io/docs/guides/migrate/production-troubleshooting#failed-migration for how to fix."
 
-continueQuery() {
+continueMigrate() {
   stage=$1
-  echo -e "${bold}Do you want to continue (y/n)?${plain}"
+  echo -e "${bold}Do you want to continue (y/n)? (No is default)${plain}"
     read -r answer
     if [ "$answer" != "${answer#[Yy]}" ] ;then
         echo "$stage migration in progress..."
@@ -50,16 +50,16 @@ continueQuery() {
     fi
 }
 
-migrateCODE() {
-  echo -e "$note"
-  echo -e "${red}WARNING: Changes made on your local machine will affect Service Catalogue CODE data.${plain}"
-  continueQuery "CODE"
+migrateWarning() {
+  stage=$1
+  echo -e "${red}WARNING: Changes made on your local machine will affect Service Catalogue $stage data as all pending migrations will be applied.${plain}"
 }
 
-migratePROD() {
+migrateDeploy() {
+  stage=$1
   echo -e "$note"
-  echo -e "${red}${bold}WARNING: You are in PROD mode! ${plain}${red}Changes made on your local machine will affect Service Catalogue PROD data.${plain}"
-  continueQuery "PROD"
+  migrateWarning "$stage"
+  continueMigrate "$stage"
 }
 
 # Read in input stage(s)
@@ -77,10 +77,10 @@ then
   fi
 elif [ "$stage" == "--code" ]
 then
-  migrateCODE
+  migrateDeploy "CODE"
 elif [ "$stage" == "--prod" ]
 then
-  migratePROD
+  migrateDeploy "PROD"
 else
   echo -e "Stage '$stage' not recognised, please try again."
 fi


### PR DESCRIPTION
## What does this change?
- Provides NPM scripts for Prisma migration to code and prod environments.
- The code and prod migration scripts require confirmation in order to continue, just to be extra safe.
- Provides an NPM script for local setup of Prisma.
- The scripts create the `DATABASE_URL` environment variable that Prisma requires. In the case of code and prod, these are created from secret retrieved from Secrets Manager.
- Updates the dev script for running locally, separating out the reset function from the adding a new migration function.
- Updates the README to reflect the changes.

## Why?
- Prisma migration requires the setting of the `DATABASE_URL` environment variable. This previously relied on users putting the correct values into their environment, which is far from ideal and risks committing secrets.
- This should make it easier for future travelers to get started with Repocop and Prisma.

## How has it been verified?
Tested locally and on code. I have run the scripts for prod without the VPN to ensure the scripts run correctly (but the migration was not attempted for real). The code and prod scripts are essentially the same and the migration completed successfully on code.