### PR TITLE
Set up branch protection app as a lambda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,5 +55,7 @@ jobs:
               - packages/cdk/cdk.out
             repocop:
               - packages/repocop/dist/repocop.zip
+            branch-protector:
+              - packages/branch-protector/dist/branch-protector.zip
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'

--- a/package-lock.json
+++ b/package-lock.json
@@ -842,6 +842,454 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.427.0.tgz",
+      "integrity": "sha512-oVgRdqdxugywhjAOzu+S5QqVF8BdaXF109VRb7rWtLU44Yd8yDDWJtbJAbTPF2N0M3VVdOhG0i6AsT7F44qXyA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.427.0",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-sdk-sqs": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/md5-js": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
+        "@smithy/util-utf8": "^2.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso": {
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.427.0.tgz",
+      "integrity": "sha512-sFVFEmsQ1rmgYO1SgrOTxE/MTKpeE4hpOkm1WqhLQK7Ij136vXpjCxjH1JYZiHiUzO1wr9t4ex4dlB5J3VS/Xg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sts": {
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.427.0.tgz",
+      "integrity": "sha512-le2wLJKILyWuRfPz2HbyaNtu5kEki+ojUkTqCU6FPDRrqUvEkaaCBH9Awo/2AtrCfRkiobop8RuTTj6cAnpiJg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/credential-provider-node": "3.427.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-sdk-sts": "3.425.0",
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/region-config-resolver": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
+        "@smithy/util-utf8": "^2.0.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.425.0.tgz",
+      "integrity": "sha512-J20etnLvMKXRVi5FK4F8yOCNm2RTaQn5psQTGdDEPWJNGxohcSpzzls8U2KcMyUJ+vItlrThr4qwgpHG3i/N0w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.3.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.427.0.tgz",
+      "integrity": "sha512-NmH1cO/w98CKMltYec3IrJIIco19wRjATFNiw83c+FGXZ+InJwReqBnruxIOmKTx2KDzd6fwU1HOewS7UjaaaQ==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.425.0",
+        "@aws-sdk/credential-provider-process": "3.425.0",
+        "@aws-sdk/credential-provider-sso": "3.427.0",
+        "@aws-sdk/credential-provider-web-identity": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.427.0.tgz",
+      "integrity": "sha512-wYYbQ57nKL8OfgRbl8k6uXcdnYml+p3LSSfDUAuUEp1HKlQ8lOXFJ3BdLr5qrk7LhpyppSRnWBmh2c3kWa7ANQ==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.425.0",
+        "@aws-sdk/credential-provider-ini": "3.427.0",
+        "@aws-sdk/credential-provider-process": "3.425.0",
+        "@aws-sdk/credential-provider-sso": "3.427.0",
+        "@aws-sdk/credential-provider-web-identity": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.425.0.tgz",
+      "integrity": "sha512-YY6tkLdvtb1Fgofp3b1UWO+5vwS14LJ/smGmuGpSba0V7gFJRdcrJ9bcb9vVgAGuMdjzRJ+bUKlLLtqXkaykEw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.427.0.tgz",
+      "integrity": "sha512-c+tXyS/i49erHs4bAp6vKNYeYlyQ0VNMBgoco0LCn1rL0REtHbfhWMnqDLF6c2n3yIWDOTrQu0D73Idnpy16eA==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.427.0",
+        "@aws-sdk/token-providers": "3.427.0",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.3.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.425.0.tgz",
+      "integrity": "sha512-/0R65TgRzL01JU3SzloivWNwdkbIhr06uY/F5pBHf/DynQqaspKNfdHn6AiozgSVDfwRHFjKBTUy6wvf3QFkuA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.3.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.425.0.tgz",
+      "integrity": "sha512-E5Gt41LObQ+cr8QnLthwsH3MtVSNXy1AKJMowDr85h0vzqA/FHUkgHyOGntgozzjXT5M0MaSRYxS0xwTR5D4Ew==",
+      "dependencies": {
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/types": "^2.3.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.425.0.tgz",
+      "integrity": "sha512-INE9XWRXx2f4a/r2vOU0tAmgctVp7nEaEasemNtVBYhqbKLZvr9ndLBSgKGgJ8LIcXAoISipaMuFiqIGkFsm7A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.425.0.tgz",
+      "integrity": "sha512-77gnzJ5b91bgD75L/ugpOyerx6lR3oyS4080X1YI58EzdyBMkDrHM4FbMcY2RynETi3lwXCFzLRyZjWXY1mRlw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/types": "^2.3.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.425.0.tgz",
+      "integrity": "sha512-JFojrg76oKAoBknnr9EL5N2aJ1mRCtBqXoZYST58GSx8uYdFQ89qS65VNQ8JviBXzsrCNAn4vDhZ5Ch5E6TxGQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.425.0",
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.425.0.tgz",
+      "integrity": "sha512-ZpOfgJHk7ovQ0sSwg3tU4NxFOnz53lJlkJRf7S+wxQALHM0P2MJ6LYBrZaFMVsKiJxNIdZBXD6jclgHg72ZW6Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.3.4",
+        "@smithy/util-middleware": "^2.0.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.427.0.tgz",
+      "integrity": "sha512-y9HxYsNvnA3KqDl8w1jHeCwz4P9CuBEtu/G+KYffLeAMBsMZmh4SIkFFCO9wE/dyYg6+yo07rYcnnIfy7WA0bw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/types": "^2.3.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.425.0.tgz",
+      "integrity": "sha512-u7uv/iUOapIJdRgRkO3wnpYsUgV6ponsZJQgVg/8L+n+Vo5PQL5gAcIuAOwcYSKQPFaeK+KbmByI4SyOK203Vw==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/types": "^2.3.4",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/token-providers": {
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.427.0.tgz",
+      "integrity": "sha512-4E5E+4p8lJ69PBY400dJXF06LUHYx5lkKzBEsYqWWhoZcoftrvi24ltIhUDoGVLkrLcTHZIWSdFAWSos4hXqeg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.425.0",
+        "@aws-sdk/middleware-logger": "3.425.0",
+        "@aws-sdk/middleware-recursion-detection": "3.425.0",
+        "@aws-sdk/middleware-user-agent": "3.427.0",
+        "@aws-sdk/types": "3.425.0",
+        "@aws-sdk/util-endpoints": "3.427.0",
+        "@aws-sdk/util-user-agent-browser": "3.425.0",
+        "@aws-sdk/util-user-agent-node": "3.425.0",
+        "@smithy/config-resolver": "^2.0.11",
+        "@smithy/fetch-http-handler": "^2.2.1",
+        "@smithy/hash-node": "^2.0.10",
+        "@smithy/invalid-dependency": "^2.0.10",
+        "@smithy/middleware-content-length": "^2.0.12",
+        "@smithy/middleware-endpoint": "^2.0.10",
+        "@smithy/middleware-retry": "^2.0.13",
+        "@smithy/middleware-serde": "^2.0.10",
+        "@smithy/middleware-stack": "^2.0.4",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/node-http-handler": "^2.1.6",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.6",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.1.9",
+        "@smithy/types": "^2.3.4",
+        "@smithy/url-parser": "^2.0.10",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.13",
+        "@smithy/util-defaults-mode-node": "^2.0.15",
+        "@smithy/util-retry": "^2.0.3",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/types": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.425.0.tgz",
+      "integrity": "sha512-6lqbmorwerN4v+J5dqbHPAsjynI0mkEF+blf+69QTaKKGaxBBVaXgqoqul9RXYcK5MMrrYRbQIMd0zYOoy90kA==",
+      "dependencies": {
+        "@smithy/types": "^2.3.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.427.0.tgz",
+      "integrity": "sha512-rSyiAIFF/EVvity/+LWUqoTMJ0a25RAc9iqx0WZ4tf1UjuEXRRXxZEb+jEZg1bk+pY84gdLdx9z5E+MSJCZxNQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/node-config-provider": "^2.0.13",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.425.0.tgz",
+      "integrity": "sha512-22Y9iMtjGcFjGILR6/xdp1qRezlHVLyXtnpEsbuPTiernRCPk6zfAnK/ATH77r02MUjU057tdxVkd5umUBTn9Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.425.0.tgz",
+      "integrity": "sha512-SIR4F5uQeeVAi8lv4OgRirtdtNi5zeyogTuQgGi9su8F/WP1N6JqxofcwpUY5f8/oJ2UlXr/tx1f09UHfJJzvA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/node-config-provider": "^2.0.13",
+        "@smithy/types": "^2.3.4",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@aws-sdk/client-ssm": {
       "version": "3.427.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.427.0.tgz",
@@ -1737,6 +2185,33 @@
         "@aws-sdk/types": "3.418.0",
         "@smithy/protocol-http": "^3.0.5",
         "@smithy/types": "^2.3.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.425.0.tgz",
+      "integrity": "sha512-c+8SQmxs9NMgaCea0o2RSsonYlDXbsYf7SODqiYKmPbHic7oa+rUmIWq7cLjxcMT8W2WKFkpvLHJZ8ex+BOHXQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.425.0",
+        "@smithy/types": "^2.3.4",
+        "@smithy/util-hex-encoding": "^2.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@aws-sdk/types": {
+      "version": "3.425.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.425.0.tgz",
+      "integrity": "sha512-6lqbmorwerN4v+J5dqbHPAsjynI0mkEF+blf+69QTaKKGaxBBVaXgqoqul9RXYcK5MMrrYRbQIMd0zYOoy90kA==",
+      "dependencies": {
+        "@smithy/types": "^2.3.4",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -4029,6 +4504,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.0.11.tgz",
+      "integrity": "sha512-YBIv+e95qeGvQA05ucwstmTeQ/bUzWgU+nO2Ffmif5awu6IzSR0Jfk3XLYh4mdy7f8DCgsn8qA63u7N9Lu0+5A==",
+      "dependencies": {
+        "@smithy/types": "^2.3.5",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@smithy/middleware-content-length": {
@@ -10327,6 +10812,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.418.0",
+        "@aws-sdk/client-sqs": "^3.418.0",
         "@aws-sdk/client-ssm": "^3.418.0",
         "@aws-sdk/types": "^3.418.0",
         "@guardian/anghammarad": "^1.8.0",

--- a/packages/branch-protector/package.json
+++ b/packages/branch-protector/package.json
@@ -4,6 +4,7 @@
 	"description": "A lambda which applies branch protection to repos that are passed to it via an SQS topic",
 	"main": "index.ts",
 	"scripts": {
+		"build": "esbuild src/index.ts --bundle --platform=node --target=node18 --outdir=dist --external:@aws-sdk",
 		"test": "echo \"No test specified\" && exit 0",
 		"start": "ts-node src/run-locally.ts"
 	},

--- a/packages/branch-protector/package.json
+++ b/packages/branch-protector/package.json
@@ -11,6 +11,7 @@
 	"author": "guardian",
 	"dependencies": {
 		"@aws-sdk/client-secrets-manager": "^3.418.0",
+		"@aws-sdk/client-sqs": "^3.418.0",
 		"@aws-sdk/client-ssm": "^3.418.0",
 		"@aws-sdk/types": "^3.418.0",
 		"@guardian/anghammarad": "^1.8.0",

--- a/packages/branch-protector/src/aws-requests.ts
+++ b/packages/branch-protector/src/aws-requests.ts
@@ -1,0 +1,50 @@
+import { ReceiveMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
+import { Anghammarad, RequestedChannel } from '@guardian/anghammarad';
+import type { Config } from './config';
+import type { UpdateBranchProtectionEvent } from './model';
+
+export async function getEvents(
+	msgCount: number,
+	config: Config,
+): Promise<UpdateBranchProtectionEvent[]> {
+	const command = new ReceiveMessageCommand({
+		QueueUrl: config.queueUrl,
+		MaxNumberOfMessages: msgCount,
+		WaitTimeSeconds: 20,
+	});
+
+	const sqsClient = new SQSClient({});
+
+	const result = await sqsClient.send(command);
+	if (result.Messages === undefined) {
+		console.log('No messages found');
+		return [];
+	} else {
+		const messages = result.Messages.map((msg) => msg.Body)
+			.filter((msg): msg is string => !!msg)
+			.map((msg) => JSON.parse(msg) as UpdateBranchProtectionEvent);
+		return messages;
+	}
+}
+
+export async function notify(
+	fullRepoName: string,
+	topicArn: string,
+	slug: string,
+) {
+	const client = new Anghammarad();
+	await client.notify({
+		subject: 'Hello',
+		message: `Branch protection has been applied to ${fullRepoName}`,
+		actions: [
+			{
+				cta: 'Check branch protections here',
+				url: `https://github.com/${fullRepoName}/settings/branches`,
+			},
+		],
+		target: { GithubTeamSlug: slug },
+		channel: RequestedChannel.PreferHangouts,
+		sourceSystem: 'branch-protector',
+		topicArn: topicArn,
+	});
+}

--- a/packages/branch-protector/src/config.ts
+++ b/packages/branch-protector/src/config.ts
@@ -28,6 +28,11 @@ export interface Config {
 	 * SNS topic to use for Anghammarad.
 	 */
 	anghammaradSnsTopic: string;
+
+	/**
+	 * SQS queue to read messages from.
+	 */
+	queueUrl: string;
 }
 
 interface GithubAppSecret {
@@ -61,6 +66,7 @@ export async function getConfig() {
 			installationId: secretJson.installationId,
 		},
 		anghammaradSnsTopic: getEnvOrThrow('ANGHAMMARAD'),
+		queueUrl: getEnvOrThrow('QUEUE_URL'),
 	};
 	return config;
 }

--- a/packages/branch-protector/src/config.ts
+++ b/packages/branch-protector/src/config.ts
@@ -47,8 +47,7 @@ async function getGithubAppSecretJson(): Promise<GithubAppSecret> {
 	const secretsManager = new SecretsManager();
 
 	const secret = await secretsManager.getSecretValue({
-		SecretId:
-			'/CODE/deploy/service-catalogue/branch-protector-github-app-secret',
+		SecretId: process.env['GITHUB_APP_SECRET'],
 	});
 
 	const secretJson = JSON.parse(secret.SecretString ?? '{}') as GithubAppSecret;

--- a/packages/branch-protector/src/config.ts
+++ b/packages/branch-protector/src/config.ts
@@ -65,7 +65,7 @@ export async function getConfig() {
 			},
 			installationId: secretJson.installationId,
 		},
-		anghammaradSnsTopic: getEnvOrThrow('ANGHAMMARAD'),
+		anghammaradSnsTopic: getEnvOrThrow('ANGHAMMARAD_SNS_ARN'),
 		queueUrl: getEnvOrThrow('QUEUE_URL'),
 	};
 	return config;

--- a/packages/branch-protector/src/config.ts
+++ b/packages/branch-protector/src/config.ts
@@ -1,6 +1,14 @@
 import { SecretsManager } from '@aws-sdk/client-secrets-manager';
-import { SSM, SSMClient } from '@aws-sdk/client-ssm';
 import { type StrategyOptions } from '@octokit/auth-app';
+
+//TODO: move to a common place
+export function getEnvOrThrow(key: string): string {
+	const value: string | undefined = process.env[key];
+	if (value === undefined) {
+		throw new Error(`Environment variable ${key} is not set.`);
+	}
+	return value;
+}
 
 export interface Config {
 	/**
@@ -20,19 +28,6 @@ export interface Config {
 	 * SNS topic to use for Anghammarad.
 	 */
 	anghammaradSnsTopic: string;
-}
-
-async function getAnghammaradTopic(region: string): Promise<string> {
-	const ssmClient = new SSMClient({ region: region });
-	const ssm = new SSM(ssmClient);
-	const topic = await ssm.getParameter({
-		Name: '/account/services/anghammarad.topic.arn',
-	});
-
-	if (topic.Parameter === undefined) {
-		throw new Error('Topic not found');
-	}
-	return topic.Parameter.Value!;
 }
 
 interface GithubAppSecret {
@@ -65,7 +60,7 @@ export async function getConfig() {
 			},
 			installationId: secretJson.installationId,
 		},
-		anghammaradSnsTopic: await getAnghammaradTopic('eu-west-1'),
+		anghammaradSnsTopic: getEnvOrThrow('ANGHAMMARAD'),
 	};
 	return config;
 }

--- a/packages/branch-protector/src/github-requests.ts
+++ b/packages/branch-protector/src/github-requests.ts
@@ -1,0 +1,70 @@
+import { createAppAuth } from '@octokit/auth-app';
+import { Octokit } from 'octokit';
+import type { Config } from './config';
+import type { UpdateBranchProtectionParams } from './model';
+
+export async function getGithubClient(config: Config) {
+	const auth = createAppAuth(config.githubAppConfig.strategyOptions);
+
+	const installationAuthentication = await auth({
+		type: 'installation',
+		installationId: config.githubAppConfig.installationId,
+	});
+
+	const octokit: Octokit = new Octokit({
+		auth: installationAuthentication.token,
+	});
+	return octokit;
+}
+
+export async function updateBranchProtection(
+	octokit: Octokit,
+	owner: string,
+	repo: string,
+	branch: string,
+) {
+	console.log(`Updating ${repo} branch protection`);
+	//https://github.com/guardian/recommendations/blob/main/github.md#branch-protection
+	const branchProtectionParams: UpdateBranchProtectionParams = {
+		owner: owner,
+		repo: repo,
+		branch: branch,
+		required_status_checks: {
+			strict: true,
+			contexts: [],
+		},
+		restrictions: null,
+		enforce_admins: true,
+		required_pull_request_reviews: {
+			require_code_owner_reviews: true,
+			required_approving_review_count: 1,
+		},
+		allow_force_pushes: false,
+		allow_deletions: false,
+	};
+	await octokit.rest.repos.updateBranchProtection(branchProtectionParams);
+	console.log(`Update of ${repo} successful`);
+}
+
+export async function getDefaultBranchName(
+	owner: string,
+	repo: string,
+	octokit: Octokit,
+) {
+	const data = await octokit.rest.repos.get({ owner: owner, repo: repo });
+	return data.data.default_branch;
+}
+
+export async function isBranchProtected(
+	octokit: Octokit,
+	owner: string,
+	repo: string,
+	branch: string,
+): Promise<boolean> {
+	const branchData = await octokit.rest.repos.getBranch({
+		owner,
+		repo,
+		branch,
+	});
+	return branchData.data.protected;
+}

--- a/packages/branch-protector/src/index.ts
+++ b/packages/branch-protector/src/index.ts
@@ -6,15 +6,6 @@ import { getConfig } from './config';
 import type { Config } from './config';
 import type { UpdateBranchProtectionEvent } from './model';
 
-//TODO: move to a common place
-export function getEnvOrThrow(key: string): string {
-	const value: string | undefined = process.env[key];
-	if (value === undefined) {
-		throw new Error(`Environment variable ${key} is not set`);
-	}
-	return value;
-}
-
 export type UpdateBranchProtectionParams =
 	Endpoints['PUT /repos/{owner}/{repo}/branches/{branch}/protection']['parameters'];
 

--- a/packages/branch-protector/src/model.ts
+++ b/packages/branch-protector/src/model.ts
@@ -1,4 +1,9 @@
+import type { Endpoints } from '@octokit/types';
+
 export interface UpdateBranchProtectionEvent {
 	fullName: string; // in the format of owner/repo-name
 	teamNameSlugs: string[];
 }
+
+export type UpdateBranchProtectionParams =
+	Endpoints['PUT /repos/{owner}/{repo}/branches/{branch}/protection']['parameters'];

--- a/packages/branch-protector/src/run-locally.ts
+++ b/packages/branch-protector/src/run-locally.ts
@@ -1,14 +1,8 @@
-import type { UpdateBranchProtectionEvent } from './model';
 import { main } from './index';
 
 if (require.main === module) {
 	process.env.AWS_PROFILE = 'deployTools';
 	process.env.AWS_REGION = 'eu-west-1';
 
-	const input: UpdateBranchProtectionEvent = {
-		fullName: 'guardian/service-catalogue',
-		teamNameSlugs: ['devx-operations', 'devx-security'],
-	};
-
-	void (async () => await main(input))();
+	void (async () => await main())();
 }

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -12,6 +12,8 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuLoggingStreamNameParameter",
       "GuDistributionBucketParameter",
       "GuScheduledLambda",
+      "GuScheduledLambda",
+      "GuLambdaErrorPercentageAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -11474,6 +11476,637 @@ spec:
         "ToPort": 5432,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "branchprotector2BAF8BEE": {
+      "DependsOn": [
+        "branchprotectorServiceRoleDefaultPolicyD589D260",
+        "branchprotectorServiceRole765F8899",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "deploy/TEST/branch-protector/branch-protector.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "branch-protector",
+            "GITHUB_APP_SECRET": {
+              "Fn::Join": [
+                "-",
+                [
+                  {
+                    "Fn::Select": [
+                      0,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "branchprotectorgithubappauth4E91892E",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      1,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "branchprotectorgithubappauth4E91892E",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      2,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "branchprotectorgithubappauth4E91892E",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      3,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "branchprotectorgithubappauth4E91892E",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      4,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "branchprotectorgithubappauth4E91892E",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      5,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "branchprotectorgithubappauth4E91892E",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+            "STACK": "deploy",
+            "STAGE": "TEST",
+          },
+        },
+        "Handler": "index.main",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "branchprotectorServiceRole765F8899",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "branch-protector",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 60,
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "branchprotectorSecurityGroupD3A8131B",
+                "GroupId",
+              ],
+            },
+          ],
+          "SubnetIds": {
+            "Ref": "PrivateSubnets",
+          },
+        },
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "branchprotectorErrorPercentageAlarmForLambda873E733D": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":devx-alerts",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "branchprotector2BAF8BEE",
+              },
+              " exceeded 50% error rate",
+            ],
+          ],
+        },
+        "AlarmName": {
+          "Fn::Join": [
+            "",
+            [
+              "High error % from ",
+              {
+                "Ref": "branchprotector2BAF8BEE",
+              },
+              " lambda in TEST",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "branchprotector2BAF8BEE",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "branchprotector2BAF8BEE",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "branchprotector2BAF8BEE",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 50,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "branchprotectorSecurityGroupD3A8131B": {
+      "Properties": {
+        "GroupDescription": "Automatic security group for Lambda Function ServiceCataloguebranchprotector0084E4FA",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "branch-protector",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "branchprotectorServiceRole765F8899": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "branch-protector",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "branchprotectorServiceRoleDefaultPolicyD589D260": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/deploy/TEST/branch-protector/branch-protector.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/branch-protector",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/branch-protector/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "branchprotectorqueueEF5856E4",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "branchprotectorServiceRoleDefaultPolicyD589D260",
+        "Roles": [
+          {
+            "Ref": "branchprotectorServiceRole765F8899",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "branchprotectorbranchprotectorrate7days0565AEC58": {
+      "Properties": {
+        "ScheduleExpression": "rate(7 days)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "branchprotector2BAF8BEE",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "branchprotectorbranchprotectorrate7days0AllowEventRuleServiceCataloguebranchprotector0084E4FA873714D6": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "branchprotector2BAF8BEE",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "branchprotectorbranchprotectorrate7days0565AEC58",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "branchprotectorgithubappauth4E91892E": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "GenerateSecretString": {},
+        "Name": "/TEST/deploy/service-catalogue/branch-protector-github-app-secret",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "branchprotectorqueueEF5856E4": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "ContentBasedDeduplication": true,
+        "FifoQueue": true,
+        "QueueName": "branch-protector-queue.fifo",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
     },
     "fastlycredentialsF42D3C80": {
       "DeletionPolicy": "Delete",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -13,7 +13,6 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuDistributionBucketParameter",
       "GuScheduledLambda",
       "GuScheduledLambda",
-      "GuLambdaErrorPercentageAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -11698,114 +11697,6 @@ spec:
         },
       },
       "Type": "AWS::Lambda::Function",
-    },
-    "branchprotectorErrorPercentageAlarmForLambda873E733D": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":devx-alerts",
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": {
-          "Fn::Join": [
-            "",
-            [
-              {
-                "Ref": "branchprotector2BAF8BEE",
-              },
-              " exceeded 50% error rate",
-            ],
-          ],
-        },
-        "AlarmName": {
-          "Fn::Join": [
-            "",
-            [
-              "High error % from ",
-              {
-                "Ref": "branchprotector2BAF8BEE",
-              },
-              " lambda in TEST",
-            ],
-          ],
-        },
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 1,
-        "Metrics": [
-          {
-            "Expression": "100*m1/m2",
-            "Id": "expr_1",
-            "Label": {
-              "Fn::Join": [
-                "",
-                [
-                  "Error % of ",
-                  {
-                    "Ref": "branchprotector2BAF8BEE",
-                  },
-                ],
-              ],
-            },
-          },
-          {
-            "Id": "m1",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "branchprotector2BAF8BEE",
-                    },
-                  },
-                ],
-                "MetricName": "Errors",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-          {
-            "Id": "m2",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "branchprotector2BAF8BEE",
-                    },
-                  },
-                ],
-                "MetricName": "Invocations",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "Threshold": 50,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
     },
     "branchprotectorSecurityGroupD3A8131B": {
       "Properties": {

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -12112,7 +12112,8 @@ spec:
       "Properties": {
         "ContentBasedDeduplication": true,
         "FifoQueue": true,
-        "QueueName": "branch-protector-queue.fifo",
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": "branch-protector-queue-TEST.fifo",
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -11495,6 +11495,9 @@ spec:
         },
         "Environment": {
           "Variables": {
+            "ANGHAMMARAD_TOPIC_ARN": {
+              "Ref": "anghammaradtopicParameter",
+            },
             "APP": "branch-protector",
             "GITHUB_APP_SECRET": {
               "Fn::Join": [
@@ -12045,6 +12048,13 @@ spec:
                     ":parameter/account/services/anghammarad.topic.arn",
                   ],
                 ],
+              },
+            },
+            {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "anghammaradtopicParameter",
               },
             },
           ],

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -42,6 +42,10 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
     },
+    "anghammaradtopicParameter": {
+      "Default": "/account/services/anghammarad.topic.arn",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
   },
   "Resources": {
     "CloudQueryAlertTopicBFD81410": {
@@ -12012,6 +12016,35 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "branchprotectorgithubappauth4E91892E",
+              },
+            },
+            {
+              "Action": [
+                "ssm:DescribeParameters",
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+                "ssm:GetParameterHistory",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/account/services/anghammarad.topic.arn",
+                  ],
+                ],
               },
             },
           ],

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -12,6 +12,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuLoggingStreamNameParameter",
       "GuDistributionBucketParameter",
       "GuScheduledLambda",
+      "GuAnghammaradTopicParameter",
       "GuScheduledLambda",
     ],
     "gu:cdk:version": "TEST",
@@ -19,6 +20,11 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
   "Parameters": {
     "ActionsStaticSiteBucketArnParam": {
       "Default": "/INFRA/deploy/cloudquery/actions-static-site-bucket-arn",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "AnghammaradSnsArn": {
+      "Default": "/account/services/anghammarad.topic.arn",
+      "Description": "SSM parameter containing the ARN of the Anghammarad SNS topic",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "DistributionBucketName": {
@@ -40,10 +46,6 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
-    },
-    "anghammaradtopicParameter": {
-      "Default": "/account/services/anghammarad.topic.arn",
-      "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
   "Resources": {
@@ -11494,8 +11496,8 @@ spec:
         },
         "Environment": {
           "Variables": {
-            "ANGHAMMARAD": {
-              "Ref": "anghammaradtopicParameter",
+            "ANGHAMMARAD_SNS_ARN": {
+              "Ref": "AnghammaradSnsArn",
             },
             "APP": "branch-protector",
             "GITHUB_APP_SECRET": {
@@ -11919,7 +11921,7 @@ spec:
               "Action": "sns:Publish",
               "Effect": "Allow",
               "Resource": {
-                "Ref": "anghammaradtopicParameter",
+                "Ref": "AnghammaradSnsArn",
               },
             },
           ],

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -12004,6 +12004,16 @@ spec:
                 ],
               },
             },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "branchprotectorgithubappauth4E91892E",
+              },
+            },
           ],
           "Version": "2012-10-17",
         },

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -11644,6 +11644,9 @@ spec:
                 ],
               ],
             },
+            "QUEUE_URL": {
+              "Ref": "branchprotectorqueueEF5856E4",
+            },
             "STACK": "deploy",
             "STAGE": "TEST",
           },

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -11495,7 +11495,7 @@ spec:
         },
         "Environment": {
           "Variables": {
-            "ANGHAMMARAD_TOPIC_ARN": {
+            "ANGHAMMARAD": {
               "Ref": "anghammaradtopicParameter",
             },
             "APP": "branch-protector",
@@ -12019,35 +12019,6 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "branchprotectorgithubappauth4E91892E",
-              },
-            },
-            {
-              "Action": [
-                "ssm:DescribeParameters",
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-                "ssm:GetParameterHistory",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/account/services/anghammarad.topic.arn",
-                  ],
-                ],
               },
             },
             {

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -566,7 +566,7 @@ export class ServiceCatalogue extends GuStack {
 			runtime: Runtime.NODEJS_18_X,
 			environment: {
 				GITHUB_APP_SECRET: branchProtectorGithubCredentials.secretName,
-				ANGHAMMARAD_TOPIC_ARN: anghammaradTopicParameter.stringValue,
+				ANGHAMMARAD: anghammaradTopicParameter.stringValue,
 			},
 			vpc,
 			timeout: Duration.minutes(1),
@@ -586,7 +586,6 @@ export class ServiceCatalogue extends GuStack {
 
 		branchProtectorQueue.grantConsumeMessages(branchProtectorLambda);
 		branchProtectorGithubCredentials.grantRead(branchProtectorLambda);
-		anghammaradTopicParameter.grantRead(branchProtectorLambda);
 		Topic.fromTopicArn(
 			this,
 			'anghammarad-arn',

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -541,6 +541,18 @@ export class ServiceCatalogue extends GuStack {
 				secretName: `/${stage}/${stack}/${app}/branch-protector-github-app-secret`,
 			},
 		);
+		
+		/*
+		 * We are not reading the topic ARN directly into the lambda currently as that is an
+		 * extra environment variable that needs to be set when running locally.
+		 *
+		 * TODO: Add a step to setup script that grabs the ARN and sets it as an env var
+		 */
+		const anghammaradTopic = StringParameter.fromStringParameterName(
+			this,
+			'anghammarad-topic',
+			'/account/services/anghammarad.topic.arn',
+		);
 
 		const branchProtectorLambdaProps: GuScheduledLambdaProps = {
 			app: 'branch-protector',
@@ -575,5 +587,6 @@ export class ServiceCatalogue extends GuStack {
 
 		branchProtectorQueue.grantConsumeMessages(branchProtectorLambda);
 		branchProtectorGithubCredentials.grantRead(branchProtectorLambda);
+		anghammaradTopic.grantRead(branchProtectorLambda);
 	}
 }

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -550,9 +550,9 @@ export class ServiceCatalogue extends GuStack {
 		);
 
 		const branchProtectorQueue = new Queue(this, 'branch-protector-queue', {
-			queueName: 'branch-protector-queue.fifo',
+			queueName: `branch-protector-queue-${stage}.fifo`,
 			contentBasedDeduplication: true,
-			fifo: true, //defaults to false for some reason
+			retentionPeriod: Duration.days(14),
 		});
 
 		const branchProtectorLambdaProps: GuScheduledLambdaProps = {

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -4,7 +4,11 @@ import type {
 	NoMonitoring,
 } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
-import { GuStack, GuStringParameter } from '@guardian/cdk/lib/constructs/core';
+import {
+	GuAnghammaradTopicParameter,
+	GuStack,
+	GuStringParameter,
+} from '@guardian/cdk/lib/constructs/core';
 import {
 	GuSecurityGroup,
 	GuVpc,
@@ -559,11 +563,8 @@ export class ServiceCatalogue extends GuStack {
 			},
 		);
 
-		const anghammaradTopicParameter = StringParameter.fromStringParameterName(
-			this,
-			'anghammarad-topic',
-			'/account/services/anghammarad.topic.arn',
-		);
+		const anghammaradTopicParameter =
+			GuAnghammaradTopicParameter.getInstance(this);
 
 		const branchProtectorQueue = new Queue(this, 'branch-protector-queue', {
 			queueName: `branch-protector-queue-${stage}.fifo`,
@@ -580,7 +581,7 @@ export class ServiceCatalogue extends GuStack {
 			runtime: Runtime.NODEJS_18_X,
 			environment: {
 				GITHUB_APP_SECRET: branchProtectorGithubCredentials.secretName,
-				ANGHAMMARAD: anghammaradTopicParameter.stringValue,
+				ANGHAMMARAD_SNS_ARN: anghammaradTopicParameter.valueAsString,
 				QUEUE_URL: branchProtectorQueue.queueUrl,
 			},
 			vpc,
@@ -598,7 +599,7 @@ export class ServiceCatalogue extends GuStack {
 		Topic.fromTopicArn(
 			this,
 			'anghammarad-arn',
-			anghammaradTopicParameter.stringValue,
+			anghammaradTopicParameter.valueAsString,
 		).grantPublish(branchProtectorLambda);
 	}
 }

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -12,6 +12,7 @@ npm run synth
 npm run build
 
 createRepocopZip() {
+  echo "Creating repocop package"
   # Copy the Prisma schema file to the dist directory
   cp -r "$ROOT_DIR/packages/repocop/prisma" "$ROOT_DIR/packages/repocop/dist"
 
@@ -24,8 +25,17 @@ createRepocopZip() {
   # Create a zip file of the dist directory
   (
     cd "$ROOT_DIR/packages/repocop/dist"
-    zip -r repocop.zip .
+    zip -qr repocop.zip .
+  )
+}
+
+createBranchProtectorZip() {
+  echo "Creating branch-protector package"
+  (
+    cd "$ROOT_DIR/packages/branch-protector/dist"
+    zip -qr branch-protector.zip .
   )
 }
 
 createRepocopZip
+createBranchProtectorZip

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -81,6 +81,10 @@ setup_cloudquery() {
 
   GALAXIES_BUCKET=$(aws ssm get-parameter --name /INFRA/deploy/services-api/galaxies-bucket-name --profile deployTools --region eu-west-1 | jq '.Parameter.Value' | tr -d '"')
 
+  ANGHAMMARAD=$(aws ssm get-parameter --name /account/services/anghammarad.topic.arn --profile deployTools --region eu-west-1 | jq '.Parameter.Value' | tr -d '"')
+
+  echo "$ANGHAMMARAD"
+
   TOKEN_TEXT="# See https://github.com/settings/tokens?type=beta
 GITHUB_ACCESS_TOKEN=
 
@@ -88,6 +92,8 @@ GITHUB_ACCESS_TOKEN=
 SNYK_TOKEN=
 
 GALAXIES_BUCKET=${GALAXIES_BUCKET}
+
+ANGHAMMARAD=${ANGHAMMARAD}
 "
 
   echo "Running CloudQuery setup"
@@ -96,15 +102,16 @@ GALAXIES_BUCKET=${GALAXIES_BUCKET}
   echo "Checking for .env.local file in $LOCAL_ENV_FILE_DIR"
   if [ -e "$LOCAL_ENV_FILE" ]
   then
+    echo "Found .env.local file in $LOCAL_ENV_FILE_DIR"
     # Get file size in bytes
     FILE_SIZE=$(wc -c < "$LOCAL_ENV_FILE")
 
     # Check if file is empty - don't want to overwrite any existing tokens
     if [ "$FILE_SIZE" -gt "$SIZE_THRESHOLD" ]
     then
-      echo "Detected non-empty env.local. No changes made."
+      echo "File is not empty. No changes made."
     else
-      echo "Empty .env.local file found in $LOCAL_ENV_FILE_DIR, adding token names$"
+      echo "File is empty, adding token names$"
       echo "$TOKEN_TEXT" >> "$LOCAL_ENV_FILE"
     fi
   else
@@ -119,7 +126,7 @@ source "$LOCAL_ENV_FILE"
   # Check if GitHub token is set
   if [ -z "$GITHUB_ACCESS_TOKEN" ]
   then
-    echo -e "${yellow}Please create a GitHub token${clear}.
+    echo -e "${yellow}Please create or retrieve a GitHub token${clear}.
 Visit ${cyan}https://github.com/settings/tokens?type=beta${clear}, and add it to ${cyan}$LOCAL_ENV_FILE${clear}"
   fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -81,9 +81,7 @@ setup_cloudquery() {
 
   GALAXIES_BUCKET=$(aws ssm get-parameter --name /INFRA/deploy/services-api/galaxies-bucket-name --profile deployTools --region eu-west-1 | jq '.Parameter.Value' | tr -d '"')
 
-  ANGHAMMARAD=$(aws ssm get-parameter --name /account/services/anghammarad.topic.arn --profile deployTools --region eu-west-1 | jq '.Parameter.Value' | tr -d '"')
-
-  echo "$ANGHAMMARAD"
+  ANGHAMMARAD_SNS_ARN=$(aws ssm get-parameter --name /account/services/anghammarad.topic.arn --profile deployTools --region eu-west-1 | jq '.Parameter.Value' | tr -d '"')
 
   TOKEN_TEXT="# See https://github.com/settings/tokens?type=beta
 GITHUB_ACCESS_TOKEN=
@@ -93,7 +91,7 @@ SNYK_TOKEN=
 
 GALAXIES_BUCKET=${GALAXIES_BUCKET}
 
-ANGHAMMARAD=${ANGHAMMARAD}
+ANGHAMMARAD_SNS_ARN=${ANGHAMMARAD_SNS_ARN}
 "
 
   echo "Running CloudQuery setup"


### PR DESCRIPTION
## What does this change?

- Branch protector now reads off an SQS topic.
- The schedule of this lambda has initially been set to weekly, while we are still testing  but this will change as we find the optimum cadence.
- Functions have been pulled out to separate files based on what APIs they are calling.

This looks like a much larger PR than it is, due to bits of code being moved about, and a large snapshot. The main functional change is the introduction of the `getEvents` method, to read items in the queue

We are also pulling the anghammarad ARN as part of the setup script

Local execution does still work, but the developer experience has been degraded slightly as some environment variables need to be manually retrieved and set. This will be addressed in a subsequent PR

TODO: 
- Set QUEUE_URL as part of local setup
- Set GITHUB_APP_SECRET (the ARN of the secret, not the credentials themselves) as part of local setup
- Create Github App to authenticate on `PROD`

## How has it been verified?

Deployed to `CODE`

Submitting a message such as
```json
{
"fullName": "X"
"teamNameSlugs": ["Y", "Z"]
}
```
to the queue, and triggering the lambda, works.
