### PR TITLE
chore(deps): Correct `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10861,7 +10861,7 @@
         "@prisma/client": "^5.3.1"
       },
       "devDependencies": {
-        "@types/aws-lambda": "^8.10.119",
+        "@types/aws-lambda": "^8.10.122",
         "prisma": "^5.4.2"
       }
     }

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "devDependencies": {
     "@types/aws-lambda": "^8.10.122",
-    "@types/aws-lambda": "^8.10.119",
     "prisma": "^5.4.2"
   },
   "scripts": {


### PR DESCRIPTION
## What does this change?
Removes a duplicated line from `package.json`, resolving this warning displayed during `npm i`:

```
Warning: G] Duplicate key "@types/aws-lambda" in object literal [duplicate-object-key]

    package.json:6:4:
      6 │     "@types/aws-lambda": "^8.10.119",
        ╵     ~~~~~~~~~~~~~~~~~~~

  The original key "@types/aws-lambda" is here:

    package.json:5:4:
      5 │     "@types/aws-lambda": "^8.10.122",
        ╵     ~~~~~~~~~~~~~~~~~~~

1 warning
```