### PR TITLE
Collect all CloudFormation data

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -629,7 +629,6 @@ spec:
             },
             {
               "Action": [
-                "cloudformation:GetTemplate",
                 "dynamodb:GetItem",
                 "dynamodb:BatchGetItem",
                 "dynamodb:Query",
@@ -1276,7 +1275,6 @@ spec:
             },
             {
               "Action": [
-                "cloudformation:GetTemplate",
                 "dynamodb:GetItem",
                 "dynamodb:BatchGetItem",
                 "dynamodb:Query",
@@ -5835,7 +5833,6 @@ spec:
             },
             {
               "Action": [
-                "cloudformation:GetTemplate",
                 "dynamodb:GetItem",
                 "dynamodb:BatchGetItem",
                 "dynamodb:Query",
@@ -6483,7 +6480,6 @@ spec:
             },
             {
               "Action": [
-                "cloudformation:GetTemplate",
                 "dynamodb:GetItem",
                 "dynamodb:BatchGetItem",
                 "dynamodb:Query",
@@ -6697,10 +6693,7 @@ spec:
   path: cloudquery/aws
   version: v22.6.0
   tables:
-    - aws_cloudformation_stacks
-    - aws_cloudformation_stack_resources
-    - aws_cloudformation_stack_templates
-    - aws_cloudformation_template_summaries
+    - aws_cloudformation_*
   destinations:
     - postgresql
   spec:
@@ -7134,7 +7127,6 @@ spec:
             },
             {
               "Action": [
-                "cloudformation:GetTemplate",
                 "dynamodb:GetItem",
                 "dynamodb:BatchGetItem",
                 "dynamodb:Query",
@@ -7740,7 +7732,6 @@ spec:
             },
             {
               "Action": [
-                "cloudformation:GetTemplate",
                 "dynamodb:GetItem",
                 "dynamodb:BatchGetItem",
                 "dynamodb:Query",
@@ -8431,7 +8422,6 @@ spec:
             },
             {
               "Action": [
-                "cloudformation:GetTemplate",
                 "dynamodb:GetItem",
                 "dynamodb:BatchGetItem",
                 "dynamodb:Query",
@@ -9080,7 +9070,6 @@ spec:
             },
             {
               "Action": [
-                "cloudformation:GetTemplate",
                 "dynamodb:GetItem",
                 "dynamodb:BatchGetItem",
                 "dynamodb:Query",
@@ -9728,7 +9717,6 @@ spec:
             },
             {
               "Action": [
-                "cloudformation:GetTemplate",
                 "dynamodb:GetItem",
                 "dynamodb:BatchGetItem",
                 "dynamodb:Query",
@@ -9951,10 +9939,7 @@ spec:
     - aws_organization*
     - aws_accessanalyzer_*
     - aws_securityhub_*
-    - aws_cloudformation_stacks
-    - aws_cloudformation_stack_resources
-    - aws_cloudformation_stack_templates
-    - aws_cloudformation_template_summaries
+    - aws_cloudformation_*
     - aws_elbv1_*
     - aws_elbv2_*
     - aws_autoscaling_groups
@@ -10422,7 +10407,6 @@ spec:
             },
             {
               "Action": [
-                "cloudformation:GetTemplate",
                 "dynamodb:GetItem",
                 "dynamodb:BatchGetItem",
                 "dynamodb:Query",

--- a/packages/cdk/lib/ecs/policies.ts
+++ b/packages/cdk/lib/ecs/policies.ts
@@ -19,7 +19,6 @@ export const standardDenyPolicy =
 		effect: Effect.DENY,
 		resources: ['*'],
 		actions: [
-			'cloudformation:GetTemplate',
 			'dynamodb:GetItem',
 			'dynamodb:BatchGetItem',
 			'dynamodb:Query',

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -211,12 +211,7 @@ export class ServiceCatalogue extends GuStack {
 					'Collecting CloudFormation data across the organisation. We use CloudFormation stacks as a proxy for a service, so collect the data multiple times a day',
 				schedule: nonProdSchedule ?? Schedule.rate(Duration.hours(3)),
 				config: awsSourceConfigForOrganisation({
-					tables: [
-						'aws_cloudformation_stacks',
-						'aws_cloudformation_stack_resources',
-						'aws_cloudformation_stack_templates',
-						'aws_cloudformation_template_summaries',
-					],
+					tables: ['aws_cloudformation_*'],
 				}),
 				managedPolicies: [readonlyPolicy],
 				policies: [listOrgsPolicy, standardDenyPolicy, cloudqueryAccess('*')],


### PR DESCRIPTION
## What does this change?
This will collect:
  - aws_cloudformation_stack_sets
  - aws_cloudformation_stack_instance_summaries
  - aws_cloudformation_stack_instance_resource_drifts
  - aws_cloudformation_stack_set_operations
  - aws_cloudformation_stack_set_operation_results
  - aws_cloudformation_stacks
  - aws_cloudformation_stack_resources
  - aws_cloudformation_stack_templates
  - aws_cloudformation_template_summaries

This change also allows the `cloudformation:GetTemplate` IAM policy, which is needed for the table `aws_cloudformation_stack_templates`.

## Why?
The `aws_cloudformation_stack_templates` table shows the template body.

## How has it been verified?
Ran locally.