### PR TITLE
Testing https://github.com/guardian/devx-logs/pull/32

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -321,7 +321,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -962,7 +962,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -1617,7 +1617,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -2234,7 +2234,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -3111,7 +3111,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -3570,7 +3570,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -4239,7 +4239,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -4896,7 +4896,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -5490,7 +5490,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -6137,7 +6137,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -6814,7 +6814,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -7631,7 +7631,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -8079,7 +8079,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -8927,7 +8927,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -9374,7 +9374,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -10069,7 +10069,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -10725,7 +10725,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:aa-ecs-parser",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {

--- a/packages/cdk/lib/ecs/task.ts
+++ b/packages/cdk/lib/ecs/task.ts
@@ -29,7 +29,7 @@ const cloudqueryImage = ContainerImage.fromRegistry(
 );
 
 const firelensImage = ContainerImage.fromRegistry(
-	'ghcr.io/guardian/devx-logs:main',
+	'ghcr.io/guardian/devx-logs:aa-ecs-parser',
 );
 
 export interface ScheduledCloudqueryTaskProps


### PR DESCRIPTION
## What does this change?
This is a test of https://github.com/guardian/devx-logs/pull/32. Once deployed, log lines in Central ELK should have the standard Stack, Stage, App markers.

Indeed, they do!

## Before
<img width="760" alt="image" src="https://github.com/guardian/devx-logs/assets/836140/d00017ec-dcd9-4bd4-ae10-f6409b0436bc">

## After
<img width="794" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/97663a07-b066-4e78-b131-d975d6f27e01">