### PR TITLE
Update Cloudquery AWS plugin to 22.15.0

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ CQ_CLI=3.14.4
 CQ_POSTGRES=5.0.6
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
-CQ_AWS=22.6.0
+CQ_AWS=22.15.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
 CQ_GITHUB=7.2.0

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -197,7 +197,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.6.0
+  version: v22.15.0
   tables:
     - aws_accessanalyzer_*
     - aws_securityhub_*
@@ -840,7 +840,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.6.0
+  version: v22.15.0
   tables:
     - aws_organization*
   destinations:
@@ -5367,7 +5367,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.6.0
+  version: v22.15.0
   tables:
     - aws_autoscaling_groups
   destinations:
@@ -6014,7 +6014,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.6.0
+  version: v22.15.0
   tables:
     - aws_acm*
   destinations:
@@ -6691,7 +6691,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.6.0
+  version: v22.15.0
   tables:
     - aws_cloudformation_*
   destinations:
@@ -7508,7 +7508,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.6.0
+  version: v22.15.0
   tables:
     - aws_cloudwatch_alarms
   destinations:
@@ -7955,7 +7955,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.6.0
+  version: v22.15.0
   tables:
     - aws_inspector_findings
     - aws_inspector2_findings
@@ -8803,7 +8803,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.6.0
+  version: v22.15.0
   tables:
     - aws_elbv1_*
     - aws_elbv2_*
@@ -9251,7 +9251,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.6.0
+  version: v22.15.0
   tables:
     - aws_s3*
   destinations:
@@ -9898,7 +9898,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.6.0
+  version: v22.15.0
   tables:
     - aws_*
   skip_tables:

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -38,7 +38,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v22.6.0
+		  version: v22.15.0
 		  tables:
 		    - aws_s3_buckets
 		  destinations:
@@ -70,7 +70,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v22.6.0
+		  version: v22.15.0
 		  tables:
 		    - '*'
 		  skip_tables:
@@ -107,7 +107,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: aws
 		  path: cloudquery/aws
-		  version: v22.6.0
+		  version: v22.15.0
 		  tables:
 		    - aws_accessanalyzer_analyzers
 		    - aws_accessanalyzer_analyzer_archive_rules


### PR DESCRIPTION
## What does this change?

Bumps the Cloudquery AWS plugin to 22.15.0

## Why?

We fixed the bug in this version of CQ AWS which was causing some old buckets to not appear in our S3 buckets table.

https://github.com/cloudquery/cloudquery/pull/14476
