### PR TITLE
Bump CQ Github plugin to v7.4.0

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ CQ_POSTGRES=5.0.6
 CQ_AWS=22.15.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
-CQ_GITHUB=7.2.0
+CQ_GITHUB=7.4.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-fastly
 CQ_FASTLY=2.1.5

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -2950,7 +2950,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v7.2.0
+  version: v7.4.0
   tables:
     - github_issues
   destinations:
@@ -3402,7 +3402,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v7.2.0
+  version: v7.4.0
   tables:
     - github_repositories
     - github_repository_branches
@@ -4071,7 +4071,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v7.2.0
+  version: v7.4.0
   tables:
     - github_organizations
     - github_organization_members

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -137,7 +137,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: github
 		  path: cloudquery/github
-		  version: v7.2.0
+		  version: v7.4.0
 		  tables:
 		    - github_repositories
 		  destinations:


### PR DESCRIPTION
## What does this change?

Bump the Cloudquery Github plugin to V7.4.0

## Why?

v7.4.0 introduces several new tables which contain information about Github action workflow runs. This'll allow us to know various bits of information such as "how long a workflow takes on average", "what runners are most actively used and how much does it cost us", and "how often does a workflow need to be retried"

Back when I was in WebX we had some workflows that would fail all the time. A dashboard that could quantify how much time is being spent on re-running workflows would have been quite useful for planning time to make improvements to GHA.

https://github.com/cloudquery/cloudquery/pull/14529
https://github.com/cloudquery/cloudquery/releases/tag/plugins-source-github-v7.4.0

<del>DNM - Need to check if our current Github token has access to this info.</del> it has access
