### PR TITLE
docs: update repocop README

### DIFF
--- a/packages/repocop/README.md
+++ b/packages/repocop/README.md
@@ -14,13 +14,9 @@ database.
 
 All migrations in the `prisma/migrations` subdirectories must be named `migration.sql`.
 
-Prisma will look for the `DATABASE_URL` environment variable in order to carry out migration. It takes the form:
+Prisma will look for the `DATABASE_URL` environment variable in order to carry out migration. 
 
-```
-DATABASE_URL="postgresql://dbuser:dbpassword@hosturl:5432/postgres
-```
-
-The `DATABASE_URL` is set by the npm migration scripts (see below).
+The `DATABASE_URL` is set automatically by the NPM migration scripts for each stage (see below). 
 
 > [!NOTE]  
 > At the moment it is not possible to have more than


### PR DESCRIPTION
## What does this change?
- Edits the repocop README to make information about the `DATABASE_URL` (hopefully!) clearer.

## Why?
- It was a little confusing mentioning the format of the url (implying that the user will have to set it) when it is set automatically by a script now.

## How has it been verified?
Is it easier to understand?