### PR TITLE
burn after reading

### DIFF
--- a/packages/branch-protector/src/index.ts
+++ b/packages/branch-protector/src/index.ts
@@ -50,10 +50,7 @@ async function protectBranch(
 	}
 }
 
-function createEvents(
-	config: Config,
-	messages: Message[],
-): UpdateBranchProtectionEvent[] {
+function createEvents(messages: Message[]): UpdateBranchProtectionEvent[] {
 	const res = messages
 		.map((msg) => msg.Body)
 		.filter((msg): msg is string => !!msg)
@@ -68,7 +65,7 @@ export async function main() {
 	const sqsClient = new SQSClient({});
 
 	const messages = await readFromQueue(config, 1, sqsClient);
-	const events = createEvents(config, messages);
+	const events = createEvents(messages);
 	await Promise.all(
 		events.map(async (event) => await protectBranch(octokit, config, event)),
 	);


### PR DESCRIPTION
## What does this change?

Previously, we were reading the messages off of SQS, and then letting them sit there. This meant that we were reading the same messages over and over again. Now we delete messages after branch protection has been successfully applied.

## Why?

This prevents a backlog accumulating, as we can now read new messages off of the queue.

## How has it been verified?

Tested on DEV. NB that even for local invocations, we are interacting with real AWS resources, namely reading/deleting messages from the CODE queue.
