### PR TITLE
Refactor: Change branch protector schedule

### DIFF
--- a/packages/branch-protector/src/config.ts
+++ b/packages/branch-protector/src/config.ts
@@ -47,7 +47,7 @@ async function getGithubAppSecretJson(): Promise<GithubAppSecret> {
 	const secretsManager = new SecretsManager();
 
 	const secret = await secretsManager.getSecretValue({
-		SecretId: process.env['GITHUB_APP_SECRET'],
+		SecretId: getEnvOrThrow('GITHUB_APP_SECRET'),
 	});
 
 	const secretJson = JSON.parse(secret.SecretString ?? '{}') as GithubAppSecret;

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -12601,28 +12601,9 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
-    "branchprotectorbranchprotectorcron090AllowEventRuleServiceCataloguebranchprotector0084E4FA7B7052EF": {
+    "branchprotectorbranchprotectorcron0925039E31676": {
       "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "branchprotector2BAF8BEE",
-            "Arn",
-          ],
-        },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "branchprotectorbranchprotectorcron090B7083EDC",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
-    },
-    "branchprotectorbranchprotectorcron090B7083EDC": {
-      "Properties": {
-        "ScheduleExpression": "cron(0 9 * * ? *)",
+        "ScheduleExpression": "cron(0 9 ? * 2-5 *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -12637,6 +12618,25 @@ spec:
         ],
       },
       "Type": "AWS::Events::Rule",
+    },
+    "branchprotectorbranchprotectorcron09250AllowEventRuleServiceCataloguebranchprotector0084E4FA1DFDAEC7": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "branchprotector2BAF8BEE",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "branchprotectorbranchprotectorcron0925039E31676",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "branchprotectorgithubappauth4E91892E": {
       "DeletionPolicy": "Delete",

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -568,7 +568,7 @@ export class ServiceCatalogue extends GuStack {
 			fileName: 'repocop.zip',
 			handler: 'index.main',
 			monitoringConfiguration: stageAwareMonitoringConfiguration,
-			//Messages will be picked up by branch protector at 9:00 the next day
+			// Messages will be picked up by branch protector at 9:00 the next working day (Tue-Fri)
 			rules: [
 				{
 					schedule:
@@ -615,7 +615,8 @@ export class ServiceCatalogue extends GuStack {
 			rules: [
 				{
 					schedule:
-						nonProdSchedule ?? Schedule.cron({ minute: '0', hour: '9' }),
+						nonProdSchedule ??
+						Schedule.cron({ minute: '0', hour: '9', weekDay: '2-5' }),
 				},
 			],
 			runtime: Runtime.NODEJS_18_X,


### PR DESCRIPTION
## What does this change?

- Updates the schedule for the `branch-protector` lambda to run every morning at 9am Tue-Fri only. 
- Makes a small change to the way the `GITHUB_APP_SECRET` env var is retrieved.

## Why?
- We don't want people being notified about their branch protection being enabled on a non-working day. Starting the lambda on a Tuesday allows for pre-messaging to go out on the Monday also. 

## How has it been verified?
