### PR TITLE
Bump Cloudquery AWS plugin to 22.15.2

### DIFF
--- a/.env
+++ b/.env
@@ -9,7 +9,7 @@ CQ_CLI=3.14.4
 CQ_POSTGRES=5.0.6
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
-CQ_AWS=22.15.0
+CQ_AWS=22.15.2
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
 CQ_GITHUB=7.4.0

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -197,7 +197,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.15.0
+  version: v22.15.2
   tables:
     - aws_accessanalyzer_*
     - aws_securityhub_*
@@ -840,7 +840,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.15.0
+  version: v22.15.2
   tables:
     - aws_organization*
   destinations:
@@ -5367,7 +5367,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.15.0
+  version: v22.15.2
   tables:
     - aws_autoscaling_groups
   destinations:
@@ -6014,7 +6014,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.15.0
+  version: v22.15.2
   tables:
     - aws_acm*
   destinations:
@@ -6691,7 +6691,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.15.0
+  version: v22.15.2
   tables:
     - aws_cloudformation_*
   destinations:
@@ -7508,7 +7508,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.15.0
+  version: v22.15.2
   tables:
     - aws_cloudwatch_alarms
   destinations:
@@ -7955,7 +7955,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.15.0
+  version: v22.15.2
   tables:
     - aws_inspector_findings
     - aws_inspector2_findings
@@ -8803,7 +8803,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.15.0
+  version: v22.15.2
   tables:
     - aws_elbv1_*
     - aws_elbv2_*
@@ -9251,7 +9251,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.15.0
+  version: v22.15.2
   tables:
     - aws_s3*
   destinations:
@@ -9898,7 +9898,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.15.0
+  version: v22.15.2
   tables:
     - aws_*
   skip_tables:

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -34,30 +34,30 @@ describe('Config generation, and converting to YAML', () => {
 			tables: ['aws_s3_buckets'],
 		});
 		expect(dump(config)).toMatchInlineSnapshot(`
-		"kind: source
-		spec:
-		  name: aws
-		  path: cloudquery/aws
-		  version: v22.15.0
-		  tables:
-		    - aws_s3_buckets
-		  destinations:
-		    - postgresql
-		  spec:
-		    regions:
-		      - eu-west-1
-		      - eu-west-2
-		      - us-east-1
-		      - us-east-2
-		      - us-west-1
-		      - ap-southeast-2
-		      - ca-central-1
-		    org:
-		      member_role_name: cloudquery-access
-		      organization_units:
-		        - ou-123
-		"
-	`);
+"kind: source
+spec:
+  name: aws
+  path: cloudquery/aws
+  version: v22.15.2
+  tables:
+    - aws_s3_buckets
+  destinations:
+    - postgresql
+  spec:
+    regions:
+      - eu-west-1
+      - eu-west-2
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - ap-southeast-2
+      - ca-central-1
+    org:
+      member_role_name: cloudquery-access
+      organization_units:
+        - ou-123
+"
+`);
 	});
 
 	it('Should create an AWS source configuration with skipped tables for the organisation', () => {
@@ -66,32 +66,32 @@ describe('Config generation, and converting to YAML', () => {
 			skipTables: ['aws_s3_buckets'],
 		});
 		expect(dump(config)).toMatchInlineSnapshot(`
-		"kind: source
-		spec:
-		  name: aws
-		  path: cloudquery/aws
-		  version: v22.15.0
-		  tables:
-		    - '*'
-		  skip_tables:
-		    - aws_s3_buckets
-		  destinations:
-		    - postgresql
-		  spec:
-		    regions:
-		      - eu-west-1
-		      - eu-west-2
-		      - us-east-1
-		      - us-east-2
-		      - us-west-1
-		      - ap-southeast-2
-		      - ca-central-1
-		    org:
-		      member_role_name: cloudquery-access
-		      organization_units:
-		        - ou-123
-		"
-	`);
+"kind: source
+spec:
+  name: aws
+  path: cloudquery/aws
+  version: v22.15.2
+  tables:
+    - '*'
+  skip_tables:
+    - aws_s3_buckets
+  destinations:
+    - postgresql
+  spec:
+    regions:
+      - eu-west-1
+      - eu-west-2
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - ap-southeast-2
+      - ca-central-1
+    org:
+      member_role_name: cloudquery-access
+      organization_units:
+        - ou-123
+"
+`);
 	});
 
 	it('Should create an AWS source configuration for a single account', () => {
@@ -103,31 +103,31 @@ describe('Config generation, and converting to YAML', () => {
 			],
 		});
 		expect(dump(config)).toMatchInlineSnapshot(`
-		"kind: source
-		spec:
-		  name: aws
-		  path: cloudquery/aws
-		  version: v22.15.0
-		  tables:
-		    - aws_accessanalyzer_analyzers
-		    - aws_accessanalyzer_analyzer_archive_rules
-		    - aws_accessanalyzer_analyzer_findings
-		  destinations:
-		    - postgresql
-		  spec:
-		    regions:
-		      - eu-west-1
-		      - eu-west-2
-		      - us-east-1
-		      - us-east-2
-		      - us-west-1
-		      - ap-southeast-2
-		      - ca-central-1
-		    accounts:
-		      - id: cq-for-000000000015
-		        role_arn: arn:aws:iam::000000000015:role/cloudquery-access
-		"
-	`);
+"kind: source
+spec:
+  name: aws
+  path: cloudquery/aws
+  version: v22.15.2
+  tables:
+    - aws_accessanalyzer_analyzers
+    - aws_accessanalyzer_analyzer_archive_rules
+    - aws_accessanalyzer_analyzer_findings
+  destinations:
+    - postgresql
+  spec:
+    regions:
+      - eu-west-1
+      - eu-west-2
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - ap-southeast-2
+      - ca-central-1
+    accounts:
+      - id: cq-for-000000000015
+        role_arn: arn:aws:iam::000000000015:role/cloudquery-access
+"
+`);
 	});
 
 	it('Should create a GitHub source configuration', () => {


### PR DESCRIPTION
## What does this change?

Theres been a couple of fixes to some of the tables that we're querying.

- Don't error on ECR repositories when they're missing Lifecycle policies (aws_ecr_repository_lifecycle_policies) ([#14730](https://github.com/cloudquery/cloudquery/issues/14730)) ([352d46d](https://github.com/cloudquery/cloudquery/commit/352d46d784326ecb5aecab7a18c9df3a463f8e63))
- Don't error on S3 buckets with Object Lock disabled (aws_s3_bucket_object_lock_configurations ) ([#14726](https://github.com/cloudquery/cloudquery/issues/14726)) ([3328007](https://github.com/cloudquery/cloudquery/commit/33280074c71e4db21049842710fb268b2ca5ba0b))
