### PR TITLE
Add `aws_stepfunctions_executions` to list of skipped AWS tables

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -9936,6 +9936,7 @@ spec:
     - aws_xray_groups
     - aws_stepfunctions_map_runs
     - aws_stepfunctions_map_run_executions
+    - aws_stepfunctions_executions
     - aws_organization*
     - aws_accessanalyzer_*
     - aws_securityhub_*

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -307,7 +307,7 @@ export const skipTablesAws = [
 	// Don't collect them to reduce execution time.
 	'aws_stepfunctions_map_runs',
 	'aws_stepfunctions_map_run_executions',
-	'aws_stepfunctions_executions'
+	'aws_stepfunctions_executions',
 ];
 
 export const skipTablesGithub = [

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -307,6 +307,7 @@ export const skipTablesAws = [
 	// Don't collect them to reduce execution time.
 	'aws_stepfunctions_map_runs',
 	'aws_stepfunctions_map_run_executions',
+	'aws_stepfunctions_executions'
 ];
 
 export const skipTablesGithub = [


### PR DESCRIPTION
## What does this change?

Add `aws_stepfunctions_executions` to list of skipped AWS tables

## Why?

Like `aws_stepfunctions_map_executions` this table is extremely verbose as it tracks every invocation of a `Step Function`. [AWS holds step function execution history for up to 90 days](https://docs.aws.amazon.com/step-functions/latest/dg/limits-overview.html), and atleast one of our accounts has a Step Function that is executed every couple of minutes.

I don't think this data is particularly useful to us, and maybe we can consider trying to make this table incremental if we ever do need this data. The API is also "eventually consistent" which causes a lot of errors in our syncs.