### PR TITLE
refactor(repocop): Read straight from `.env` file to reduce duplication

### DIFF
--- a/.env
+++ b/.env
@@ -26,14 +26,15 @@ CQ_SNYK=3.1.5
 # See https://github.com/guardian/cq-source-snyk-full-project
 CQ_GUARDIAN_SNYK=0.1.1
 
-
 # --- FOR LOCAL DEVELOPMENT ONLY ---
+STAGE=DEV
+DATABASE_USER=postgres
+DATABASE_PASSWORD=not_at_all_secret
+DATABASE_HOSTNAME=localhost
+DATABASE_PORT=5432
 
-LOCAL_STAGE=DEV
-LOCAL_DB_USER=postgres
-LOCAL_DB_PASSWORD=not_at_all_secret
-LOCAL_DB_HOSTNAME=localhost
-LOCAL_DB_PORT=5432
+# Set this to 'false' to disable SQL query logging
+QUERY_LOGGING=true
 
 # Enables messaging from Repocop to Anghammarad for local testing
 ENABLE_MESSAGING=false

--- a/packages/repocop/src/run-locally.ts
+++ b/packages/repocop/src/run-locally.ts
@@ -5,13 +5,5 @@ import { main } from './index';
 config({ path: `${process.env.HOME}/.gu/service_catalogue/.env.local` });
 
 if (require.main === module) {
-	process.env.STAGE = process.env.LOCAL_STAGE;
-	process.env.DATABASE_HOSTNAME = process.env.LOCAL_DB_HOSTNAME;
-	process.env.DATABASE_PASSWORD = process.env.LOCAL_DB_PASSWORD;
-	process.env.DATABASE_USER = process.env.LOCAL_DB_USER;
-
-	// Set this to 'false' to disable SQL query logging
-	process.env.QUERY_LOGGING = 'true';
-
 	void (async () => await main())();
 }


### PR DESCRIPTION
## What does this change?
Removes some env var aliasing when running RepoCop locally, in favour of reading values directly from the `.env` file.

## Why?
It's simpler.

## How has it been verified?
N/A.