### PR TITLE
refactor: Obtain home directory via `os`

### DIFF
--- a/packages/repocop/src/run-locally.ts
+++ b/packages/repocop/src/run-locally.ts
@@ -1,8 +1,8 @@
+import { homedir } from 'os';
 import { config } from 'dotenv';
 import { main } from './index';
 
-// eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- on a dev machine we can be pretty sure there is a home directory
-config({ path: `${process.env.HOME}/.gu/service_catalogue/.env.local` });
+config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
 if (require.main === module) {
 	void (async () => await main())();


### PR DESCRIPTION
## What does this change?
Obtain the home directory from the `os` package. This allows us to remove an `eslint` disablement.