### PR TITLE
fix: update env vars to enable running cloudquery and migrate locally

### DIFF
--- a/packages/cloudquery/docker-compose.yaml
+++ b/packages/cloudquery/docker-compose.yaml
@@ -3,11 +3,11 @@ services:
   postgres:
     image: postgres:14.6
     ports:
-      - "${LOCAL_DB_PORT}:${LOCAL_DB_PORT}"
+      - "${DATABASE_PORT}:${DATABASE_PORT}"
     environment:
-      POSTGRES_DB: ${LOCAL_DB_HOSTNAME}
-      POSTGRES_USER: ${LOCAL_DB_USER}
-      POSTGRES_PASSWORD: ${LOCAL_DB_PASSWORD}
+      POSTGRES_DB: ${DATABASE_HOSTNAME}
+      POSTGRES_USER: ${DATABASE_USER}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
   cloudquery:
     image: ghcr.io/cloudquery/cloudquery:${CQ_CLI}
     platform: linux/amd64

--- a/packages/repocop/script/migrate.sh
+++ b/packages/repocop/script/migrate.sh
@@ -9,7 +9,7 @@ plain='\x1B[0m'
 devSetup() {
   echo -e "${bold}Setting up local DATABASE_URL and resetting migrations${plain}"
   source ../../.env
-  export DATABASE_URL="postgresql://$LOCAL_DB_USER:$LOCAL_DB_PASSWORD@$LOCAL_DB_HOSTNAME:$LOCAL_DB_PORT/postgres"
+  export DATABASE_URL="postgresql://$DATABASE_USER:$DATABASE_PASSWORD@$DATABASE_HOSTNAME:$DATABASE_PORT/postgres"
   # clear existing local migrations table (if applicable)
   # and apply all migrations
   npx prisma migrate reset --force --schema "prisma/schema.prisma"


### PR DESCRIPTION
## What does this change?
Updates the local development environment variables in the scripts that use them, following changes in #398.

## Why?
Running Cloudquery locally and the local migrate script were broken.

## How has it been verified?
Tested locally.