### PR TITLE
refactor: temporarily restrict branch protector messaging to DevX teams

### DIFF
--- a/packages/repocop/src/remediations/repository-02.test.ts
+++ b/packages/repocop/src/remediations/repository-02.test.ts
@@ -61,13 +61,13 @@ describe('Team slugs should be findable for every team associated with a repo', 
 			...nullOwner,
 			full_name: repo,
 			github_team_id: BigInt(1),
-			github_team_name: 'Team One',
+			github_team_name: 'Developer Experience', // TODO: revert this back to 'Team One' once rolled out to entire dept
 		};
 
 		const githubTeam: github_teams = {
 			...nullTeam,
 			id: BigInt(1),
-			slug: 'team-one',
+			slug: 'devx-security', // TODO: revert this back to 'team-one' once rolled out to entire dept
 		};
 
 		const actual = createRepository02Messages(
@@ -77,7 +77,9 @@ describe('Team slugs should be findable for every team associated with a repo', 
 			5,
 		);
 
-		expect(actual).toEqual([{ fullName: repo, teamNameSlugs: ['team-one'] }]);
+		expect(actual).toEqual([
+			{ fullName: repo, teamNameSlugs: ['devx-security'] }, // TODO: revert this back to 'team-one' once rolled out to entire dept
+		]);
 	});
 
 	test('A repository that has no owner should not be in the list of messages', () => {

--- a/packages/repocop/src/remediations/repository-02.ts
+++ b/packages/repocop/src/remediations/repository-02.ts
@@ -37,7 +37,19 @@ function findContactableOwners(
 		.map((owner) => findTeamSlugFromId(owner.github_team_id, teams))
 		.filter((slug): slug is string => !!slug);
 
-	return teamSlugs;
+	//return teamSlugs;
+
+	// TODO: remove this when testing over (limits to DevX repos only)
+	const devxTeams = [
+		'developer-experience',
+		'devx-operations',
+		'devx-security',
+		'devx-reliability',
+	];
+	const devxSlugs = teamSlugs.filter((slug): slug is string =>
+		devxTeams.includes(slug),
+	);
+	return devxSlugs;
 }
 
 function shuffle<T>(array: T[]): T[] {


### PR DESCRIPTION
## What does this change?
Limits Repocop to only messaging DevX teams about branch-protector remediations.

## Why?
This is a temporary change to allow us to fully test and improve messaging from Anghammarad without bothering other teams.

## How has it been verified?
Tested on CODE. Ran the Repocop lambda twice and it added a total of 3 DevX-owned repos to the branch-protector queue, and none owned by other teams.