### PR TITLE
fix: correct schedule for branch protector lambda

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -12602,9 +12602,9 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
-    "branchprotectorbranchprotectorcron0925039E31676": {
+    "branchprotectorbranchprotectorcron09TUEFRI0887F261E": {
       "Properties": {
-        "ScheduleExpression": "cron(0 9 ? * 2-5 *)",
+        "ScheduleExpression": "cron(0 9 ? * TUE-FRI *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -12620,7 +12620,7 @@ spec:
       },
       "Type": "AWS::Events::Rule",
     },
-    "branchprotectorbranchprotectorcron09250AllowEventRuleServiceCataloguebranchprotector0084E4FA1DFDAEC7": {
+    "branchprotectorbranchprotectorcron09TUEFRI0AllowEventRuleServiceCataloguebranchprotector0084E4FAE0314C21": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -12632,7 +12632,7 @@ spec:
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "branchprotectorbranchprotectorcron0925039E31676",
+            "branchprotectorbranchprotectorcron09TUEFRI0887F261E",
             "Arn",
           ],
         },

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -616,7 +616,7 @@ export class ServiceCatalogue extends GuStack {
 				{
 					schedule:
 						nonProdSchedule ??
-						Schedule.cron({ minute: '0', hour: '9', weekDay: '2-5' }),
+						Schedule.cron({ minute: '0', hour: '9', weekDay: 'TUE-FRI' }),
 				},
 			],
 			runtime: Runtime.NODEJS_18_X,


### PR DESCRIPTION
## What does this change?
Corrects the schedule for the `branch-protector` lambda to run Tuesday-Friday. It was running Monday-Thursday which was an error.

## Why?
We want the branch protector to run on working days only, so that the messages are seen by teams when branch protection has been applied.  We don't run on a Monday to allow for all warning messages to be seen by teams that were sent from Saturday to Monday inclusive.

## How has it been verified?
Cannot test on CODE, will merge and check the schedule. If it's wrong, will revert. 