### PR TITLE
fix: Collect remaining AWS data once a week

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -9841,7 +9841,7 @@ spec:
     },
     "CloudquerySourceRemainingAwsDataScheduledEventRuleAE2A0ED1": {
       "Properties": {
-        "ScheduleExpression": "cron(0 21 * * ? *)",
+        "ScheduleExpression": "cron(* * ? * MON *)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -283,11 +283,17 @@ export class ServiceCatalogue extends GuStack {
 			},
 		];
 
+		/*
+		This is a catch-all task, collecting all other AWS data.
+		Although we're not using the data for any particular reason, it is still useful to have.
+
+		It runs once a week because there is a lot of data, and we need to avoid overlapping invocations.
+		If we identify a table that needs to be updated more often, we should create a dedicated task for it.
+		 */
 		const remainingAwsSources: CloudquerySource = {
 			name: 'RemainingAwsData',
 			description: 'Data fetched across all accounts in the organisation.',
-			//this job can take upwards of 7 hours to run, so start late at night
-			schedule: nonProdSchedule ?? Schedule.cron({ minute: '0', hour: '21' }),
+			schedule: nonProdSchedule ?? Schedule.cron({ weekDay: 'MON' }),
 			config: awsSourceConfigForOrganisation({
 				tables: ['aws_*'],
 				skipTables: [


### PR DESCRIPTION
## What does this change?
Sets the task to collect all other AWS data to run once a week, and documents the reasoning.

## Why?
We're seeing this task take a long time to complete (over 15 hours, and counting). We don't need this data to be super fresh as we're not using it.

## How has it been verified?
N/A.