### PR TITLE
refactor: remove rate limit on branch protector reading from the queue

### DIFF
--- a/packages/branch-protector/src/aws-requests.ts
+++ b/packages/branch-protector/src/aws-requests.ts
@@ -8,12 +8,10 @@ import type { Config } from './config';
 
 export async function readFromQueue(
 	config: Config,
-	msgCount: number,
 	sqs: SQSClient,
 ): Promise<Message[]> {
 	const getCommand = new ReceiveMessageCommand({
 		QueueUrl: config.queueUrl,
-		MaxNumberOfMessages: msgCount,
 		WaitTimeSeconds: 5,
 	});
 

--- a/packages/branch-protector/src/index.ts
+++ b/packages/branch-protector/src/index.ts
@@ -68,7 +68,7 @@ export async function main() {
 	const octokit: Octokit = await getGithubClient(config);
 	const sqsClient = new SQSClient({});
 
-	const messages: Message[] = await readFromQueue(config, 1, sqsClient);
+	const messages: Message[] = await readFromQueue(config, sqsClient);
 	await Promise.all(
 		messages.map((msg) => handleMessage(config, octokit, sqsClient, msg)),
 	);


### PR DESCRIPTION
## What does this change?
Currently, the branch protector lambda takes one message off the queue each time it runs (once per day Tue-Fri).  Currently Repocop adds up to two messages to the queue every day. This change means that branch protector will now take all the messages from the queue when it runs. N.B. Repocop has just been temporarily configured to add only DevX-owned repos to the queue, so we will be the only team affected going forward although there are other teams' repos on the existing queue which will hopefully be cleared down.

## Why?
We want the branch protector to clear down the queue every day it runs so that protections are applied in a timely manner. 

## How has it been verified?
It will be verified on PROD, which is why we're restricting it to DevX repos while testing.