### PR TITLE
Use a v1 of the devx-logs Image instead of latest

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -321,7 +321,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -962,7 +962,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -1617,7 +1617,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -2234,7 +2234,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -3111,7 +3111,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -3570,7 +3570,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -4239,7 +4239,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -4896,7 +4896,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -5490,7 +5490,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -6137,7 +6137,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -6814,7 +6814,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -7631,7 +7631,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -8079,7 +8079,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -8927,7 +8927,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -9374,7 +9374,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -10070,7 +10070,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {
@@ -10726,7 +10726,7 @@ spec:
               },
               "Type": "fluentbit",
             },
-            "Image": "ghcr.io/guardian/devx-logs:main",
+            "Image": "ghcr.io/guardian/devx-logs:1",
             "LogConfiguration": {
               "LogDriver": "awslogs",
               "Options": {

--- a/packages/cdk/lib/ecs/task.ts
+++ b/packages/cdk/lib/ecs/task.ts
@@ -29,7 +29,7 @@ const cloudqueryImage = ContainerImage.fromRegistry(
 );
 
 const firelensImage = ContainerImage.fromRegistry(
-	'ghcr.io/guardian/devx-logs:main',
+	'ghcr.io/guardian/devx-logs:1',
 );
 
 export interface ScheduledCloudqueryTaskProps


### PR DESCRIPTION
## What does this change?

Use v1 of devx-logs

## Why?

I will be making some breaking changes in https://github.com/guardian/devx-logs/pull/34 which will cause `main` to break logging for service-catalogue . Also good practice to not always use the latest version of a docker image.
