### PR TITLE
Revert "refactor: remove rate limit on branch protector reading from the queue"

### DIFF
--- a/packages/branch-protector/src/aws-requests.ts
+++ b/packages/branch-protector/src/aws-requests.ts
@@ -8,10 +8,12 @@ import type { Config } from './config';
 
 export async function readFromQueue(
 	config: Config,
+	msgCount: number,
 	sqs: SQSClient,
 ): Promise<Message[]> {
 	const getCommand = new ReceiveMessageCommand({
 		QueueUrl: config.queueUrl,
+		MaxNumberOfMessages: msgCount,
 		WaitTimeSeconds: 5,
 	});
 

--- a/packages/branch-protector/src/index.ts
+++ b/packages/branch-protector/src/index.ts
@@ -68,7 +68,7 @@ export async function main() {
 	const octokit: Octokit = await getGithubClient(config);
 	const sqsClient = new SQSClient({});
 
-	const messages: Message[] = await readFromQueue(config, 1, sqsClient);
+	const messages: Message[] = await readFromQueue(config, 10, sqsClient);
 	await Promise.all(
 		messages.map((msg) => handleMessage(config, octokit, sqsClient, msg)),
 	);

--- a/packages/branch-protector/src/index.ts
+++ b/packages/branch-protector/src/index.ts
@@ -68,7 +68,7 @@ export async function main() {
 	const octokit: Octokit = await getGithubClient(config);
 	const sqsClient = new SQSClient({});
 
-	const messages: Message[] = await readFromQueue(config, sqsClient);
+	const messages: Message[] = await readFromQueue(config, 1, sqsClient);
 	await Promise.all(
 		messages.map((msg) => handleMessage(config, octokit, sqsClient, msg)),
 	);


### PR DESCRIPTION
Testing PROD has revealed that removing the number of messages param from the `readFromQueue` function in `branch-protector` has not removed rate limiting, it has just defaulted to 1. The allowed maximum is 10, so this PR reverts the previous removal and sets the max to 10.

- Reverts guardian/service-catalogue#411
- Increases number of messages taken from queue from 1 to 10 (the max)

This is for the meantime, ahead of a further planned refactor of `branch-protector` to make it batch work more effectively.
