### PR TITLE
Revert "fix: Collect remaining AWS data once a week"

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -9766,7 +9766,7 @@ spec:
     },
     "CloudquerySourceRemainingAwsDataScheduledEventRuleAE2A0ED1": {
       "Properties": {
-        "ScheduleExpression": "cron(* * ? * MON *)",
+        "ScheduleExpression": "cron(0 21 * * ? *)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -283,17 +283,11 @@ export class ServiceCatalogue extends GuStack {
 			},
 		];
 
-		/*
-		This is a catch-all task, collecting all other AWS data.
-		Although we're not using the data for any particular reason, it is still useful to have.
-
-		It runs once a week because there is a lot of data, and we need to avoid overlapping invocations.
-		If we identify a table that needs to be updated more often, we should create a dedicated task for it.
-		 */
 		const remainingAwsSources: CloudquerySource = {
 			name: 'RemainingAwsData',
 			description: 'Data fetched across all accounts in the organisation.',
-			schedule: nonProdSchedule ?? Schedule.cron({ weekDay: 'MON' }),
+			//this job can take upwards of 7 hours to run, so start late at night
+			schedule: nonProdSchedule ?? Schedule.cron({ minute: '0', hour: '21' }),
 			config: awsSourceConfigForOrganisation({
 				tables: ['aws_*'],
 				skipTables: [


### PR DESCRIPTION
Reverts guardian/service-catalogue#410 as by 10:14AM on Monday 30th October 2023, we had ~187 instances of this task running. This is ~186 more than intended!