### PR TITLE
fix(cdk): Run the RemainingAwsData task each Monday at 10AM 

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -9766,7 +9766,7 @@ spec:
     },
     "CloudquerySourceRemainingAwsDataScheduledEventRuleAE2A0ED1": {
       "Properties": {
-        "ScheduleExpression": "cron(0 21 * * ? *)",
+        "ScheduleExpression": "cron(* * ? * MON *)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -9766,7 +9766,7 @@ spec:
     },
     "CloudquerySourceRemainingAwsDataScheduledEventRuleAE2A0ED1": {
       "Properties": {
-        "ScheduleExpression": "cron(* * ? * MON *)",
+        "ScheduleExpression": "cron(0 10 ? * MON *)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -283,11 +283,17 @@ export class ServiceCatalogue extends GuStack {
 			},
 		];
 
+		/*
+		This is a catch-all task, collecting all other AWS data.
+		Although we're not using the data for any particular reason, it is still useful to have.
+
+		It runs once a week because there is a lot of data, and we need to avoid overlapping invocations.
+		If we identify a table that needs to be updated more often, we should create a dedicated task for it.
+		 */
 		const remainingAwsSources: CloudquerySource = {
 			name: 'RemainingAwsData',
 			description: 'Data fetched across all accounts in the organisation.',
-			//this job can take upwards of 7 hours to run, so start late at night
-			schedule: nonProdSchedule ?? Schedule.cron({ minute: '0', hour: '21' }),
+			schedule: nonProdSchedule ?? Schedule.cron({ weekDay: 'MON' }),
 			config: awsSourceConfigForOrganisation({
 				tables: ['aws_*'],
 				skipTables: [

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -293,7 +293,9 @@ export class ServiceCatalogue extends GuStack {
 		const remainingAwsSources: CloudquerySource = {
 			name: 'RemainingAwsData',
 			description: 'Data fetched across all accounts in the organisation.',
-			schedule: nonProdSchedule ?? Schedule.cron({ weekDay: 'MON' }),
+			schedule:
+				nonProdSchedule ??
+				Schedule.cron({ minute: '0', hour: '10', weekDay: 'MON' }), // Every Monday, at 10AM UTC
 			config: awsSourceConfigForOrganisation({
 				tables: ['aws_*'],
 				skipTables: [


### PR DESCRIPTION
## What does this change?
Follows #416, and #410 to set the `RemainingAwsData` task to run at 10AM on Monday's. It was previously every minute, of every hour on Monday!

---

Co-authored-by: @tjsilver 