### PR TITLE
refactor: friendly names for repocop rules

### DIFF
--- a/packages/repocop/prisma/migrations/20231027112910_github_repository_rules_friendly_names/migration.sql
+++ b/packages/repocop/prisma/migrations/20231027112910_github_repository_rules_friendly_names/migration.sql
@@ -1,0 +1,33 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `repository_01` on the `repocop_github_repository_rules` table. All the data in the column will be lost.
+  - You are about to drop the column `repository_02` on the `repocop_github_repository_rules` table. All the data in the column will be lost.
+  - You are about to drop the column `repository_03` on the `repocop_github_repository_rules` table. All the data in the column will be lost.
+  - You are about to drop the column `repository_04` on the `repocop_github_repository_rules` table. All the data in the column will be lost.
+  - You are about to drop the column `repository_05` on the `repocop_github_repository_rules` table. All the data in the column will be lost.
+  - You are about to drop the column `repository_06` on the `repocop_github_repository_rules` table. All the data in the column will be lost.
+  - You are about to drop the column `repository_07` on the `repocop_github_repository_rules` table. All the data in the column will be lost.
+  - Added the required column `admin_access` to the `repocop_github_repository_rules` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `branch_protection` to the `repocop_github_repository_rules` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `default_branch_name` to the `repocop_github_repository_rules` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `team_based_access` to the `repocop_github_repository_rules` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `topics` to the `repocop_github_repository_rules` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "repocop_github_repository_rules" DROP COLUMN "repository_01",
+DROP COLUMN "repository_02",
+DROP COLUMN "repository_03",
+DROP COLUMN "repository_04",
+DROP COLUMN "repository_05",
+DROP COLUMN "repository_06",
+DROP COLUMN "repository_07",
+ADD COLUMN     "admin_access" BOOLEAN NOT NULL,
+ADD COLUMN     "archiving" BOOLEAN,
+ADD COLUMN     "branch_protection" BOOLEAN NOT NULL,
+ADD COLUMN     "contents" BOOLEAN,
+ADD COLUMN     "default_branch_name" BOOLEAN NOT NULL,
+ADD COLUMN     "team_based_access" BOOLEAN NOT NULL,
+ADD COLUMN     "topics" BOOLEAN NOT NULL;
+

--- a/packages/repocop/prisma/migrations/20231027112910_github_repository_rules_friendly_names/migration.sql
+++ b/packages/repocop/prisma/migrations/20231027112910_github_repository_rules_friendly_names/migration.sql
@@ -1,33 +1,8 @@
-/*
-  Warnings:
-
-  - You are about to drop the column `repository_01` on the `repocop_github_repository_rules` table. All the data in the column will be lost.
-  - You are about to drop the column `repository_02` on the `repocop_github_repository_rules` table. All the data in the column will be lost.
-  - You are about to drop the column `repository_03` on the `repocop_github_repository_rules` table. All the data in the column will be lost.
-  - You are about to drop the column `repository_04` on the `repocop_github_repository_rules` table. All the data in the column will be lost.
-  - You are about to drop the column `repository_05` on the `repocop_github_repository_rules` table. All the data in the column will be lost.
-  - You are about to drop the column `repository_06` on the `repocop_github_repository_rules` table. All the data in the column will be lost.
-  - You are about to drop the column `repository_07` on the `repocop_github_repository_rules` table. All the data in the column will be lost.
-  - Added the required column `admin_access` to the `repocop_github_repository_rules` table without a default value. This is not possible if the table is not empty.
-  - Added the required column `branch_protection` to the `repocop_github_repository_rules` table without a default value. This is not possible if the table is not empty.
-  - Added the required column `default_branch_name` to the `repocop_github_repository_rules` table without a default value. This is not possible if the table is not empty.
-  - Added the required column `team_based_access` to the `repocop_github_repository_rules` table without a default value. This is not possible if the table is not empty.
-  - Added the required column `topics` to the `repocop_github_repository_rules` table without a default value. This is not possible if the table is not empty.
-
-*/
 -- AlterTable
-ALTER TABLE "repocop_github_repository_rules" DROP COLUMN "repository_01",
-DROP COLUMN "repository_02",
-DROP COLUMN "repository_03",
-DROP COLUMN "repository_04",
-DROP COLUMN "repository_05",
-DROP COLUMN "repository_06",
-DROP COLUMN "repository_07",
-ADD COLUMN     "admin_access" BOOLEAN NOT NULL,
-ADD COLUMN     "archiving" BOOLEAN,
-ADD COLUMN     "branch_protection" BOOLEAN NOT NULL,
-ADD COLUMN     "contents" BOOLEAN,
-ADD COLUMN     "default_branch_name" BOOLEAN NOT NULL,
-ADD COLUMN     "team_based_access" BOOLEAN NOT NULL,
-ADD COLUMN     "topics" BOOLEAN NOT NULL;
-
+ALTER TABLE "repocop_github_repository_rules" RENAME COLUMN  "repository_01" TO "default_branch_name";
+ALTER TABLE "repocop_github_repository_rules" RENAME COLUMN  "repository_02" TO "branch_protection";
+ALTER TABLE "repocop_github_repository_rules" RENAME COLUMN  "repository_03" TO "team_based_access";
+ALTER TABLE "repocop_github_repository_rules" RENAME COLUMN  "repository_04" TO "admin_access";
+ALTER TABLE "repocop_github_repository_rules" RENAME COLUMN  "repository_05" TO "archiving";
+ALTER TABLE "repocop_github_repository_rules" RENAME COLUMN  "repository_06" TO "topics";
+ALTER TABLE "repocop_github_repository_rules" RENAME COLUMN  "repository_07" TO "contents";

--- a/packages/repocop/prisma/schema.prisma
+++ b/packages/repocop/prisma/schema.prisma
@@ -15770,15 +15770,15 @@ model snyk_reporting_latest_issues {
 }
 
 model repocop_github_repository_rules {
-  full_name     String   @unique
-  repository_01 Boolean
-  repository_02 Boolean
-  repository_03 Boolean
-  repository_04 Boolean
-  repository_05 Boolean?
-  repository_06 Boolean
-  repository_07 Boolean?
-  evaluated_on  DateTime
+  full_name           String   @unique
+  default_branch_name Boolean
+  branch_protection   Boolean
+  team_based_access   Boolean
+  admin_access        Boolean
+  archiving           Boolean?
+  topics              Boolean
+  contents            Boolean?
+  evaluated_on        DateTime
 }
 
 model galaxies_people_profile_info_table {

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -4,12 +4,12 @@ import { PrismaClient } from '@prisma/client';
 import type { Config } from './config';
 import { getConfig } from './config';
 import { getRepoOwnership, getTeams, getUnarchivedRepositories } from './query';
-import type { UpdateBranchProtectionEvent } from './remediations/repository-02';
+import type { UpdateBranchProtectionEvent } from './remediations/repository-02-branch_protection';
 import {
 	addMessagesToQueue,
 	createRepository02Messages,
 	sendNotifications,
-} from './remediations/repository-02';
+} from './remediations/repository-02-branch_protection';
 import { evaluateRepositories } from './rules/repository';
 
 async function writeEvaluationTable(

--- a/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
@@ -3,8 +3,11 @@ import type {
 	repocop_github_repository_rules,
 	view_repo_ownership,
 } from '@prisma/client';
-import type { UpdateBranchProtectionEvent } from './repository-02';
-import { createEntry, createRepository02Messages } from './repository-02';
+import type { UpdateBranchProtectionEvent } from './repository-02-branch_protection';
+import {
+	createEntry,
+	createRepository02Messages,
+} from './repository-02-branch_protection';
 
 const nullOwner: view_repo_ownership = {
 	full_name: '',
@@ -47,13 +50,13 @@ describe('Team slugs should be findable for every team associated with a repo', 
 		const repo = 'guardian/repo1';
 		const evaluatedRepo: repocop_github_repository_rules = {
 			full_name: repo,
-			repository_01: true,
-			repository_02: false,
-			repository_03: true,
-			repository_04: true,
-			repository_05: true,
-			repository_06: true,
-			repository_07: true,
+			default_branch_name: true,
+			branch_protection: false,
+			team_based_access: true,
+			admin_access: true,
+			archiving: true,
+			topics: true,
+			contents: true,
 			evaluated_on: new Date(),
 		};
 
@@ -86,13 +89,13 @@ describe('Team slugs should be findable for every team associated with a repo', 
 		const repo = 'guardian/repo1';
 		const evaluatedRepo: repocop_github_repository_rules = {
 			full_name: repo,
-			repository_01: true,
-			repository_02: false,
-			repository_03: true,
-			repository_04: true,
-			repository_05: true,
-			repository_06: true,
-			repository_07: true,
+			default_branch_name: true,
+			branch_protection: false,
+			team_based_access: true,
+			admin_access: true,
+			archiving: true,
+			topics: true,
+			contents: true,
 			evaluated_on: new Date(),
 		};
 

--- a/packages/repocop/src/remediations/repository-02-branch_protection.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.ts
@@ -63,7 +63,7 @@ export function createRepository02Messages(
 	msgCount: number,
 ): UpdateBranchProtectionEvent[] {
 	const reposWithoutBranchProtection = evaluatedRepos.filter(
-		(repo) => !repo.repository_02,
+		(repo) => !repo.branch_protection,
 	);
 	const repo02WithContactableOwners = reposWithoutBranchProtection
 		.map((repo) => {

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -138,7 +138,7 @@ const thePerfectRepo: github_repositories = {
 	id: BigInt(1),
 };
 
-describe('repository_01 should be false when the default branch is not main', () => {
+describe('default_branch_name should be false when the default branch is not main', () => {
 	test('branch is not main', () => {
 		const badRepo = { ...thePerfectRepo, default_branch: 'notMain' };
 		const repos: github_repositories[] = [thePerfectRepo, badRepo];
@@ -146,7 +146,10 @@ describe('repository_01 should be false when the default branch is not main', ()
 			repositoryRuleEvaluation(repo, [], []),
 		);
 
-		expect(evaluation.map((repo) => repo.repository_01)).toEqual([true, false]);
+		expect(evaluation.map((repo) => repo.default_branch_name)).toEqual([
+			true,
+			false,
+		]);
 	});
 });
 
@@ -170,7 +173,7 @@ describe('Repositories should have branch protection', () => {
 			[],
 		);
 
-		expect(actual.repository_02).toEqual(true);
+		expect(actual.branch_protection).toEqual(true);
 	});
 	test('We should get a negative result when the default branch is not protected', () => {
 		const repo: github_repositories = {
@@ -189,7 +192,7 @@ describe('Repositories should have branch protection', () => {
 		};
 
 		const actual = repositoryRuleEvaluation(repo, [unprotectedMainBranch], []);
-		expect(actual.repository_02).toEqual(false);
+		expect(actual.branch_protection).toEqual(false);
 	});
 });
 
@@ -209,7 +212,7 @@ describe('Repository admin access', () => {
 		];
 
 		const actual = repositoryRuleEvaluation(repo, [], teams);
-		expect(actual.repository_04).toEqual(false);
+		expect(actual.admin_access).toEqual(false);
 	});
 
 	test('Should return true when there is an admin team', () => {
@@ -231,7 +234,7 @@ describe('Repository admin access', () => {
 		];
 
 		const actual = repositoryRuleEvaluation(repo, [], teams);
-		expect(actual.repository_04).toEqual(true);
+		expect(actual.admin_access).toEqual(true);
 	});
 
 	test(`Should validate repositories with a 'hackday' topic`, () => {
@@ -244,7 +247,7 @@ describe('Repository admin access', () => {
 		};
 
 		const actual = repositoryRuleEvaluation(repo, [], []);
-		expect(actual.repository_04).toEqual(true);
+		expect(actual.admin_access).toEqual(true);
 	});
 
 	test(`Should evaluate repositories with a 'production' topic`, () => {
@@ -266,7 +269,7 @@ describe('Repository admin access', () => {
 			},
 		];
 		const actual = repositoryRuleEvaluation(repo, [], teams);
-		expect(actual.repository_04).toEqual(true);
+		expect(actual.admin_access).toEqual(true);
 	});
 
 	test(`Should return false if all topics are unrecognised`, () => {
@@ -278,7 +281,7 @@ describe('Repository admin access', () => {
 		};
 
 		const actual = repositoryRuleEvaluation(repo, [], []);
-		expect(actual.repository_04).toEqual(false);
+		expect(actual.admin_access).toEqual(false);
 	});
 });
 
@@ -290,7 +293,7 @@ describe('Repository topics', () => {
 		};
 
 		const actual = repositoryRuleEvaluation(repo, [], []);
-		expect(actual.repository_06).toEqual(true);
+		expect(actual.topics).toEqual(true);
 	});
 
 	test('Should return false when there are multiple recognised topics', () => {
@@ -302,7 +305,7 @@ describe('Repository topics', () => {
 		};
 
 		const actual = repositoryRuleEvaluation(repo, [], []);
-		expect(actual.repository_06).toEqual(false);
+		expect(actual.topics).toEqual(false);
 	});
 
 	test('Should return true when there is are multiple topics, not all are recognised', () => {
@@ -312,7 +315,7 @@ describe('Repository topics', () => {
 		};
 
 		const actual = repositoryRuleEvaluation(repo, [], []);
-		expect(actual.repository_06).toEqual(true);
+		expect(actual.topics).toEqual(true);
 	});
 
 	test('Should return false when there are no topics', () => {
@@ -322,7 +325,7 @@ describe('Repository topics', () => {
 		};
 
 		const actual = repositoryRuleEvaluation(repo, [], []);
-		expect(actual.repository_06).toEqual(false);
+		expect(actual.topics).toEqual(false);
 	});
 
 	test('Should return false when there are no recognised topics', () => {
@@ -332,6 +335,6 @@ describe('Repository topics', () => {
 		};
 
 		const actual = repositoryRuleEvaluation(repo, [], []);
-		expect(actual.repository_06).toEqual(false);
+		expect(actual.topics).toEqual(false);
 	});
 });

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -12,18 +12,18 @@ import {
 } from '../query';
 
 /**
- * Apply the following rule to a GitHub repository:
+ * Evaluate the following rule for a Github repository:
  *   > The default branch name should be "main".
  */
-function repository01(repo: github_repositories): boolean {
+function hasDefaultBranchNameMain(repo: github_repositories): boolean {
 	return repo.default_branch === 'main';
 }
 
 /**
- * Apply the following rule to a GitHub repository:
+ * Evaluate the following rule for a Github repository:
  *   > Enable branch protection for the default branch, ensuring changes are reviewed before being deployed.
  */
-function repository02(
+function hasBranchProtection(
 	repo: github_repositories,
 	branches: github_repository_branches[],
 ): boolean {
@@ -39,11 +39,11 @@ function repository02(
 }
 
 /**
- * Apply the following rule to a GitHub repository:
+ * Evaluate the following rule for a Github repository:
  *   > Grant at least one GitHub team Admin access - typically, the dev team that own the project.
  *   > Repositories without one of the following topics are exempt: production, testing, documentation.
  */
-function repository04(
+function hasAdminAccess(
 	repo: github_repositories,
 	teams: RepositoryTeam[],
 ): boolean {
@@ -61,11 +61,11 @@ function repository04(
 	return isExempt || hasAdminTeam;
 }
 /**
- * Apply the following rule to a GitHub repository:
+ * Evaluate the following rule for a Github repository:
  *   > Repositories should have one and only one of the following topics to help understand what is in production.
  *   > Repositories owned only by non-P&E teams are exempt.
  */
-function repository06(repo: github_repositories): boolean {
+function hasTopics(repo: github_repositories): boolean {
 	const validTopics = [
 		'prototype',
 		'learning',
@@ -96,13 +96,12 @@ export function repositoryRuleEvaluation(
 
 	return {
 		full_name: fullName,
-		default_branch_name: repository01(repo),
-		branch_protection: repository02(repo, allBranches),
-		// TODO - implement these rules
+		default_branch_name: hasDefaultBranchNameMain(repo),
+		branch_protection: hasBranchProtection(repo, allBranches),
 		team_based_access: false,
-		admin_access: repository04(repo, teams),
+		admin_access: hasAdminAccess(repo, teams),
 		archiving: null,
-		topics: repository06(repo),
+		topics: hasTopics(repo),
 		contents: null,
 		evaluated_on: new Date(),
 	};

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -96,15 +96,14 @@ export function repositoryRuleEvaluation(
 
 	return {
 		full_name: fullName,
-		repository_01: repository01(repo),
-		repository_02: repository02(repo, allBranches),
-
+		default_branch_name: repository01(repo),
+		branch_protection: repository02(repo, allBranches),
 		// TODO - implement these rules
-		repository_03: false,
-		repository_04: repository04(repo, teams),
-		repository_05: null,
-		repository_06: repository06(repo),
-		repository_07: null,
+		team_based_access: false,
+		admin_access: repository04(repo, teams),
+		archiving: null,
+		topics: repository06(repo),
+		contents: null,
 		evaluated_on: new Date(),
 	};
 }


### PR DESCRIPTION
## What does this change?

- Renames the Repocop best practice rules in the `repocop_github_repository_rules` from their IDs to their Names.
- Renames the rule evaluation functions to indicate what they do using the friendly names, and updates the function comments to be more accurate.

## Why?

It will be easier for users to visit the [Repocop Compliance](https://metrics.gutools.co.uk/d/EOPnljWIz/repocop-compliance?orgId=1) dashboard and understand which rules their team's repos are breaking, reducing the number of times they will have to access the [rule definitions](https://github.com/guardian/service-catalogue/blob/main/packages/best-practices/best-practices.md). This is supported by the results of the recent UX research.

## How has it been verified?
The migration has been applied on CODE and the renamed columns can be seen on this [CODE dashboard](https://metrics.code.dev-gutools.co.uk/d/CqXjemVSz/repocop-compliance-code?orgId=1).

*Note*
Once this PR is merged, the migration will need to be carried out manually on PROD.