### PR TITLE
Source deployment data from RiffRaff

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,10 @@
 CQ_CLI=3.14.4
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql
-CQ_POSTGRES=5.0.6
+CQ_POSTGRES_DESTINATION=5.0.6
+
+# See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-postgresql
+CQ_POSTGRES_SOURCE=3.0.7
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
 CQ_AWS=22.18.0

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -9,8 +9,6 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuSecurityGroup",
       "GuSecurityGroup",
       "GuStringParameter",
-      "GuStringParameter",
-      "GuStringParameter",
       "GuLoggingStreamNameParameter",
       "GuAnghammaradTopicParameter",
       "GuDistributionBucketParameter",
@@ -44,11 +42,11 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "Description": "A list of private subnets",
       "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
-    "RiffRaffDatabaseAccessAddressParam": {
+    "SsmParameterValueTESTdeployriffraffexternaldatabaseaccessaddressC96584B6F00A464EAD1953AFF4B05118Parameter": {
       "Default": "/TEST/deploy/riff-raff/external-database-access-address",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "RiffRaffDatabaseAccessPortParam": {
+    "SsmParameterValueTESTdeployriffraffexternaldatabaseaccessportC96584B6F00A464EAD1953AFF4B05118Parameter": {
       "Default": "/TEST/deploy/riff-raff/external-database-access-port",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
@@ -10750,14 +10748,14 @@ spec:
       user=\${RIFFRAFF_DB_USERNAME} password=\${RIFFRAFF_DB_PASSWORD}
       host=",
                     {
-                      "Ref": "RiffRaffDatabaseAccessAddressParam",
+                      "Ref": "SsmParameterValueTESTdeployriffraffexternaldatabaseaccessaddressC96584B6F00A464EAD1953AFF4B05118Parameter",
                     },
                     " port=",
                     {
-                      "Ref": "RiffRaffDatabaseAccessPortParam",
+                      "Ref": "SsmParameterValueTESTdeployriffraffexternaldatabaseaccessportC96584B6F00A464EAD1953AFF4B05118Parameter",
                     },
                     " dbname=riffraff
-      sslmode=verify-full
+      sslmode=verify-ca
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -9,6 +9,8 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuSecurityGroup",
       "GuSecurityGroup",
       "GuStringParameter",
+      "GuStringParameter",
+      "GuStringParameter",
       "GuLoggingStreamNameParameter",
       "GuAnghammaradTopicParameter",
       "GuDistributionBucketParameter",
@@ -41,6 +43,18 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "Default": "/account/vpc/primary/subnets/private",
       "Description": "A list of private subnets",
       "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "RiffRaffDatabaseAccessAddressParam": {
+      "Default": "/TEST/deploy/riff-raff/external-database-access-address",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "RiffRaffDatabaseAccessPortParam": {
+      "Default": "/TEST/deploy/riff-raff/external-database-access-port",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "SsmParameterValueTESTdeployriffraffexternaldatabaseaccesssecuritygroupC96584B6F00A464EAD1953AFF4B05118Parameter": {
+      "Default": "/TEST/deploy/riff-raff/external-database-access-security-group",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "VpcId": {
       "Default": "/account/vpc/primary/id",
@@ -10450,6 +10464,663 @@ spec:
       },
       "Type": "AWS::Events::Rule",
     },
+    "CloudquerySourceRiffRaffDataScheduledEventRuleDE690018": {
+      "Properties": {
+        "ScheduleExpression": "cron(0 0 * * ? *)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "servicecatalogueCluster5FC34DC5",
+                "Arn",
+              ],
+            },
+            "EcsParameters": {
+              "LaunchType": "FARGATE",
+              "NetworkConfiguration": {
+                "AwsVpcConfiguration": {
+                  "AssignPublicIp": "DISABLED",
+                  "SecurityGroups": [
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
+                        "GroupId",
+                      ],
+                    },
+                    {
+                      "Ref": "SsmParameterValueTESTdeployriffraffexternaldatabaseaccesssecuritygroupC96584B6F00A464EAD1953AFF4B05118Parameter",
+                    },
+                  ],
+                  "Subnets": {
+                    "Ref": "PrivateSubnets",
+                  },
+                },
+              },
+              "TaskCount": 1,
+              "TaskDefinitionArn": {
+                "Ref": "CloudquerySourceRiffRaffDataTaskDefinitionFF023225",
+              },
+            },
+            "Id": "Target0",
+            "Input": "{}",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CloudquerySourceRiffRaffDataTaskDefinitionEventsRole5EF6E214",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CloudquerySourceRiffRaffDataTaskDefinitionCloudquerySourceRiffRaffDataFirelensLogGroup55CB2F37": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "RiffRaffData",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudquerySourceRiffRaffDataTaskDefinitionEventsRole5EF6E214": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "RiffRaffData",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceRiffRaffDataTaskDefinitionEventsRoleDefaultPolicyAD8B28A1": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ecs:RunTask",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": {
+                    "Fn::GetAtt": [
+                      "servicecatalogueCluster5FC34DC5",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CloudquerySourceRiffRaffDataTaskDefinitionFF023225",
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceRiffRaffDataTaskDefinitionExecutionRole18EFA1E2",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceRiffRaffDataTaskDefinitionTaskRoleC8F8FCE3",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceRiffRaffDataTaskDefinitionEventsRoleDefaultPolicyAD8B28A1",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceRiffRaffDataTaskDefinitionEventsRole5EF6E214",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceRiffRaffDataTaskDefinitionExecutionRole18EFA1E2": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "RiffRaffData",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceRiffRaffDataTaskDefinitionExecutionRoleDefaultPolicyA6FD732F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "RiffRaffDatabaseCredentials2033FD7A",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceRiffRaffDataTaskDefinitionCloudquerySourceRiffRaffDataFirelensLogGroup55CB2F37",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceRiffRaffDataTaskDefinitionExecutionRoleDefaultPolicyA6FD732F",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceRiffRaffDataTaskDefinitionExecutionRole18EFA1E2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceRiffRaffDataTaskDefinitionFF023225": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/sh",
+              "-c",
+              {
+                "Fn::Join": [
+                  "",
+                  [
+                    "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+spec:
+  name: postgresql
+  path: cloudquery/postgresql
+  version: v3.0.7
+  destinations:
+    - postgresql
+  tables:
+    - riffraff_*
+  spec:
+    connection_string: >-
+      user=\${RIFFRAFF_DB_USERNAME} password=\${RIFFRAFF_DB_PASSWORD}
+      host=",
+                    {
+                      "Ref": "RiffRaffDatabaseAccessAddressParam",
+                    },
+                    " port=",
+                    {
+                      "Ref": "RiffRaffDatabaseAccessPortParam",
+                    },
+                    " dbname=riffraff
+      sslmode=verify-full
+' > /source.yaml;printf 'kind: destination
+spec:
+  name: postgresql
+  registry: github
+  path: cloudquery/postgresql
+  version: v5.0.6
+  migrate_mode: forced
+  spec:
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
+' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+                  ],
+                ],
+              },
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Essential": true,
+            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-RiffRaffDataContainer",
+            "Secrets": [
+              {
+                "Name": "RIFFRAFF_DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "RiffRaffDatabaseCredentials2033FD7A",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "RIFFRAFF_DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "RiffRaffDatabaseCredentials2033FD7A",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            "Environment": [
+              {
+                "Name": "STACK",
+                "Value": "deploy",
+              },
+              {
+                "Name": "STAGE",
+                "Value": "TEST",
+              },
+              {
+                "Name": "APP",
+                "Value": "service-catalogue",
+              },
+              {
+                "Name": "GU_REPO",
+                "Value": "guardian/service-catalogue",
+              },
+            ],
+            "Essential": true,
+            "FirelensConfiguration": {
+              "Type": "fluentbit",
+            },
+            "Image": "ghcr.io/guardian/devx-logs:2",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudquerySourceRiffRaffDataTaskDefinitionCloudquerySourceRiffRaffDataFirelensLogGroup55CB2F37",
+                },
+                "awslogs-region": {
+                  "Ref": "AWS::Region",
+                },
+                "awslogs-stream-prefix": "deploy/TEST/service-catalogue",
+              },
+            },
+            "Name": "CloudquerySource-RiffRaffDataFirelens",
+          },
+        ],
+        "Cpu": "256",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceRiffRaffDataTaskDefinitionExecutionRole18EFA1E2",
+            "Arn",
+          ],
+        },
+        "Family": "ServiceCatalogueCloudquerySourceRiffRaffDataTaskDefinitionD52C3076",
+        "Memory": "512",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "RiffRaffData",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceRiffRaffDataTaskDefinitionTaskRoleC8F8FCE3",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
+    "CloudquerySourceRiffRaffDataTaskDefinitionTaskRoleC8F8FCE3": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "RiffRaffData",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceRiffRaffDataTaskDefinitionTaskRoleDefaultPolicyA40520E9": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":kinesis:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceRiffRaffDataTaskDefinitionTaskRoleDefaultPolicyA40520E9",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceRiffRaffDataTaskDefinitionTaskRoleC8F8FCE3",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceRiffRaffDataTaskErrorRule9346BC72": {
+      "Properties": {
+        "Description": "Rule for events indicating an ECS task exited due to an error.",
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers": {
+              "exitCode": [
+                1,
+                137,
+                139,
+                255,
+              ],
+            },
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stoppedReason": [
+              "Task CloudquerySource-RiffRaffData exited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceRiffRaffDataTaskDefinitionFF023225",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "CloudQueryAlertTopicBFD81410",
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "CloudquerySourceSnykAllScheduledEventRule73601A00": {
       "Properties": {
         "ScheduleExpression": "cron(0 6 * * ? *)",
@@ -11381,6 +12052,33 @@ spec:
         "ToPort": 5432,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "RiffRaffDatabaseCredentials2033FD7A": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "GenerateSecretString": {},
+        "Name": "/TEST/deploy/service-catalogue/riffraff-database-credentials",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
     },
     "branchprotector2BAF8BEE": {
       "DependsOn": [

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -42,14 +42,6 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "Description": "A list of private subnets",
       "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
     },
-    "SsmParameterValueTESTdeployriffraffexternaldatabaseaccessaddressC96584B6F00A464EAD1953AFF4B05118Parameter": {
-      "Default": "/TEST/deploy/riff-raff/external-database-access-address",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "SsmParameterValueTESTdeployriffraffexternaldatabaseaccessportC96584B6F00A464EAD1953AFF4B05118Parameter": {
-      "Default": "/TEST/deploy/riff-raff/external-database-access-port",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
     "SsmParameterValueTESTdeployriffraffexternaldatabaseaccesssecuritygroupC96584B6F00A464EAD1953AFF4B05118Parameter": {
       "Default": "/TEST/deploy/riff-raff/external-database-access-security-group",
       "Type": "AWS::SSM::Parameter::Value<String>",
@@ -10730,11 +10722,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              {
-                "Fn::Join": [
-                  "",
-                  [
-                    "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
+              "wget -O /usr/local/share/ca-certificates/rds-ca-2019-root.crt -q https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem && update-ca-certificates;printf 'kind: source
 spec:
   name: postgresql
   path: cloudquery/postgresql
@@ -10746,16 +10734,7 @@ spec:
   spec:
     connection_string: >-
       user=\${RIFFRAFF_DB_USERNAME} password=\${RIFFRAFF_DB_PASSWORD}
-      host=",
-                    {
-                      "Ref": "SsmParameterValueTESTdeployriffraffexternaldatabaseaccessaddressC96584B6F00A464EAD1953AFF4B05118Parameter",
-                    },
-                    " port=",
-                    {
-                      "Ref": "SsmParameterValueTESTdeployriffraffexternaldatabaseaccessportC96584B6F00A464EAD1953AFF4B05118Parameter",
-                    },
-                    " dbname=riffraff
-      sslmode=verify-ca
+      host=\${RIFFRAFF_DB_HOST} port=5432 dbname=riffraff sslmode=verify-ca
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -10768,9 +10747,6 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
-                  ],
-                ],
-              },
             ],
             "EntryPoint": [
               "",
@@ -10816,6 +10792,20 @@ spec:
                         "Ref": "RiffRaffDatabaseCredentials2033FD7A",
                       },
                       ":password::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "RIFFRAFF_DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "RiffRaffDatabaseCredentials2033FD7A",
+                      },
+                      ":host::",
                     ],
                   ],
                 },

--- a/packages/cdk/lib/ecs/cluster.ts
+++ b/packages/cdk/lib/ecs/cluster.ts
@@ -1,7 +1,7 @@
 import { GuLoggingStreamNameParameter } from '@guardian/cdk/lib/constructs/core';
 import type { AppIdentity, GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
-import type { IVpc } from 'aws-cdk-lib/aws-ec2';
+import type { ISecurityGroup, IVpc } from 'aws-cdk-lib/aws-ec2';
 import { Cluster } from 'aws-cdk-lib/aws-ecs';
 import type { Secret } from 'aws-cdk-lib/aws-ecs/lib/container-definition';
 import type { Schedule } from 'aws-cdk-lib/aws-events';
@@ -69,6 +69,11 @@ export interface CloudquerySource {
 	 * The number of cpu units used by the task.
 	 */
 	cpu?: 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384;
+
+	/**
+	 * Extra security groups applied to the task for accessing resources such as RiffRaff
+	 */
+	extraSecurityGroups?: ISecurityGroup[];
 }
 
 interface CloudqueryClusterProps extends AppIdentity {
@@ -146,6 +151,7 @@ export class CloudqueryCluster extends Cluster {
 				additionalCommands,
 				memoryLimitMiB,
 				cpu,
+				extraSecurityGroups,
 			}) => {
 				new ScheduledCloudqueryTask(scope, `CloudquerySource-${name}`, {
 					...taskProps,
@@ -158,6 +164,7 @@ export class CloudqueryCluster extends Cluster {
 					additionalCommands,
 					memoryLimitMiB,
 					cpu,
+					extraSecurityGroups,
 				});
 			},
 		);

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -25,7 +25,7 @@ export function postgresDestinationConfig(): CloudqueryConfig {
 			name: 'postgresql',
 			registry: 'github',
 			path: 'cloudquery/postgresql',
-			version: `v${Versions.CloudqueryPostgres}`,
+			version: `v${Versions.CloudqueryPostgresDestination}`,
 			migrate_mode: 'forced',
 			spec: {
 				connection_string: [
@@ -221,7 +221,7 @@ export function riffraffSourcesConfig(
 		spec: {
 			name: 'postgresql',
 			path: 'cloudquery/postgresql',
-			version: `v3.0.7`,
+			version: `v${Versions.CloudqueryPostgresSource}`,
 			destinations: ['postgresql'],
 			tables: ['riffraff_*'],
 			spec: {
@@ -231,8 +231,8 @@ export function riffraffSourcesConfig(
 					`host=${riffRaffDBAddress}`,
 					`port=${riffRaffDBPort}`,
 					'dbname=riffraff',
-					// Our riff-raff DB instances use an old SSL certificate that don't work with the version of Go that we use for service-catalogue.
-					// We cannot enable sslmode until we switch to using a different CA authority for riff-raff.
+					// Ideally we'd use sslmode=verify-full however the certificates used by riff-raffs DB are quite old and don't have any SANs set.
+					// In order to upgrade to verify-full we need to change the CA used by the riff-raff DB.
 					// See https://github.com/golang/go/issues/39568
 					'sslmode=verify-ca',
 				].join(' '),

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -212,10 +212,7 @@ export function galaxiesSourceConfig(bucketName: string): CloudqueryConfig {
 	};
 }
 
-export function riffraffSourcesConfig(
-	riffRaffDBAddress: string,
-	riffRaffDBPort: string,
-): CloudqueryConfig {
+export function riffraffSourcesConfig(): CloudqueryConfig {
 	return {
 		kind: 'source',
 		spec: {
@@ -228,8 +225,8 @@ export function riffraffSourcesConfig(
 				connection_string: [
 					'user=${RIFFRAFF_DB_USERNAME}',
 					'password=${RIFFRAFF_DB_PASSWORD}',
-					`host=${riffRaffDBAddress}`,
-					`port=${riffRaffDBPort}`,
+					'host=${RIFFRAFF_DB_HOST}',
+					'port=5432',
 					'dbname=riffraff',
 					// Ideally we'd use sslmode=verify-full however the certificates used by riff-raffs DB are quite old and don't have any SANs set.
 					// In order to upgrade to verify-full we need to change the CA used by the riff-raff DB.

--- a/packages/cdk/lib/ecs/config.ts
+++ b/packages/cdk/lib/ecs/config.ts
@@ -212,6 +212,35 @@ export function galaxiesSourceConfig(bucketName: string): CloudqueryConfig {
 	};
 }
 
+export function riffraffSourcesConfig(
+	riffRaffDBAddress: string,
+	riffRaffDBPort: string,
+): CloudqueryConfig {
+	return {
+		kind: 'source',
+		spec: {
+			name: 'postgresql',
+			path: 'cloudquery/postgresql',
+			version: `v3.0.7`,
+			destinations: ['postgresql'],
+			tables: ['riffraff_*'],
+			spec: {
+				connection_string: [
+					'user=${RIFFRAFF_DB_USERNAME}',
+					'password=${RIFFRAFF_DB_PASSWORD}',
+					`host=${riffRaffDBAddress}`,
+					`port=${riffRaffDBPort}`,
+					'dbname=riffraff',
+					// Our riff-raff DB instances use an old SSL certificate that don't work with the version of Go that we use for service-catalogue.
+					// We cannot enable sslmode until we switch to using a different CA authority for riff-raff.
+					// See https://github.com/golang/go/issues/39568
+					'sslmode=verify-ca',
+				].join(' '),
+			},
+		},
+	};
+}
+
 export function snykSourceConfig(
 	tableConfig: CloudqueryTableConfig,
 ): CloudqueryConfig {

--- a/packages/cdk/lib/ecs/task.ts
+++ b/packages/cdk/lib/ecs/task.ts
@@ -1,6 +1,7 @@
 import type { AppIdentity, GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
 import { Tags } from 'aws-cdk-lib';
+import type { ISecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import type { Cluster } from 'aws-cdk-lib/aws-ecs';
 import {
 	ContainerImage,
@@ -92,6 +93,11 @@ export interface ScheduledCloudqueryTaskProps
 	 * Additional commands to run within the ServiceCatalogue container, executed first.
 	 */
 	additionalCommands?: string[];
+
+	/**
+	 * Extra security groups applied to the task for accessing resources such as RiffRaff
+	 */
+	extraSecurityGroups?: ISecurityGroup[];
 }
 
 export class ScheduledCloudqueryTask extends ScheduledFargateTask {
@@ -114,6 +120,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			additionalCommands = [],
 			memoryLimitMiB,
 			cpu,
+			extraSecurityGroups,
 		} = props;
 		const { region, stack, stage } = scope;
 		const thisRepo = 'guardian/service-catalogue'; // TODO get this from GuStack
@@ -225,7 +232,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			scheduledFargateTaskDefinitionOptions: {
 				taskDefinition: task,
 			},
-			securityGroups: [dbAccess],
+			securityGroups: [dbAccess, ...(extraSecurityGroups ?? [])],
 			enabled,
 		});
 

--- a/packages/cdk/lib/ecs/versions.ts
+++ b/packages/cdk/lib/ecs/versions.ts
@@ -12,7 +12,8 @@ const envOrError = (name: string): string => {
  */
 export const Versions = {
 	CloudqueryCli: envOrError('CQ_CLI'),
-	CloudqueryPostgres: envOrError('CQ_POSTGRES'),
+	CloudqueryPostgresDestination: envOrError('CQ_POSTGRES_DESTINATION'),
+	CloudqueryPostgresSource: envOrError('CQ_POSTGRES_SOURCE'),
 	CloudqueryAws: envOrError('CQ_AWS'),
 	CloudqueryGithub: envOrError('CQ_GITHUB'),
 	CloudqueryFastly: envOrError('CQ_FASTLY'),

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -534,24 +534,11 @@ export class ServiceCatalogue extends GuStack {
 			},
 		);
 
-		const riffRaffDatabaseAddress = StringParameter.valueForStringParameter(
-			this,
-			`/${stage}/deploy/riff-raff/external-database-access-address`,
-		);
-
-		const riffRaffDatabasePort = StringParameter.valueForStringParameter(
-			this,
-			`/${stage}/deploy/riff-raff/external-database-access-port`,
-		);
-
 		const riffRaffSources: CloudquerySource = {
 			name: 'RiffRaffData',
 			description: "Source deployment data directly from riff-raff's database",
 			schedule: nonProdSchedule ?? Schedule.cron({ minute: '0', hour: '0' }),
-			config: riffraffSourcesConfig(
-				riffRaffDatabaseAddress,
-				riffRaffDatabasePort,
-			),
+			config: riffraffSourcesConfig(),
 			extraSecurityGroups: [applicationToRiffRaffDatabaseSecurityGroup],
 			secrets: {
 				RIFFRAFF_DB_USERNAME: Secret.fromSecretsManager(
@@ -561,6 +548,11 @@ export class ServiceCatalogue extends GuStack {
 				RIFFRAFF_DB_PASSWORD: Secret.fromSecretsManager(
 					cloudqueryRiffRaffDatabaseCredentials,
 					'password',
+				),
+
+				RIFFRAFF_DB_HOST: Secret.fromSecretsManager(
+					cloudqueryRiffRaffDatabaseCredentials,
+					'host',
 				),
 			},
 		};

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -165,6 +165,8 @@ export class ServiceCatalogue extends GuStack {
 				`/${stage}/deploy/riff-raff/external-database-access-security-group`,
 			);
 
+		// Provisioned by RiffRaff to specifically allow applications other than RiffRaff to access its DB
+		// See https://github.com/guardian/deploy-tools-platform/pull/731
 		const applicationToRiffRaffDatabaseSecurityGroup =
 			GuSecurityGroup.fromSecurityGroupId(
 				this,

--- a/packages/cli/src/aws.ts
+++ b/packages/cli/src/aws.ts
@@ -163,13 +163,18 @@ const runTaskByArn = async (
 	privateSubnets: string[],
 	securityGroup: string,
 ): Promise<RunTaskCommandOutput> => {
+	const securityGroups = [
+		securityGroup,
+		...(taskArn.includes('RiffRaffData') ? [] : []),
+	];
+
 	const command = new RunTaskCommand({
 		cluster: clusterArn,
 		taskDefinition: taskArn,
 		networkConfiguration: {
 			awsvpcConfiguration: {
 				subnets: privateSubnets,
-				securityGroups: [securityGroup],
+				securityGroups: [securityGroups],
 			},
 		},
 		capacityProviderStrategy: [{ capacityProvider: 'FARGATE' }],

--- a/packages/cli/src/aws.ts
+++ b/packages/cli/src/aws.ts
@@ -263,16 +263,17 @@ export const runAllTasks = async (
 
 	const privateSubnets = await getPrivateSubnets(ssmClient);
 	const securityGroup = await getSecurityGroup(ssmClient, stack, stage, app);
+	const riffRaffDBSecurityGroup = await getRiffRaffDBSecurityGroup(
+		ssmClient,
+		stage,
+	);
 
 	return Promise.all(
 		tasks.map((task) =>
-			runTaskByArn(
-				ecsClient,
-				task.arn,
-				cluster.arn,
-				privateSubnets,
+			runTaskByArn(ecsClient, task.arn, cluster.arn, privateSubnets, [
 				securityGroup,
-			),
+				...(task.arn.includes('RiffRaffData') ? [riffRaffDBSecurityGroup] : []),
+			]),
 		),
 	);
 };

--- a/packages/cloudquery/docker-compose.yaml
+++ b/packages/cloudquery/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - ./dev-config/cloudquery.yaml:/dev-config.yaml
     environment:
       AWS_SHARED_CREDENTIALS_FILE: "/.aws/credentials"
-      CQ_POSTGRES: ${CQ_POSTGRES}
+      CQ_POSTGRES_DESTINATION: ${CQ_POSTGRES_DESTINATION}
       CQ_AWS: ${CQ_AWS}
       CQ_GITHUB: ${CQ_GITHUB}
       CQ_SNYK: ${CQ_SNYK}


### PR DESCRIPTION
## What does this change?

Source riff-raff data such as deployment history into Cloudquery by using the riff-raff. This is done using the [Postgresql source plugin](https://www.cloudquery.io/docs/plugins/sources/postgresql/overview) to pull data from some [custom views](https://github.com/guardian/riff-raff/pull/1273) created in the riff-raff DB.

New tables:

- `riffraff_deploys` - List of all deploys
- `riffraff_deploy_logs` - History of each deployment
- `riffraff_authorized_history` - Users with access to riff-raff

Requires https://github.com/guardian/riff-raff/pull/1273 & https://github.com/guardian/deploy-tools-platform/pull/731 to be merged first.

## Why?

This lets us answer questions such as "Whats the latest version of an application running in production?" or "Is an application being deployed everyday?" or "What users have access to riff-raff but aren't part of a P&E team?"

## How has it been verified?

 - Deployed to CODE along with https://github.com/guardian/riff-raff/pull/1273 & https://github.com/guardian/deploy-tools-platform/pull/731

<img width="285" alt="image" src="https://github.com/guardian/service-catalogue/assets/21217225/7f9d7220-7d75-4c3c-851c-a3ecf7a23564">

