### PR TITLE
feat(messaging): Send messages to a thread, rather than individually 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11326,6 +11326,7 @@
         "@aws-sdk/client-sqs": "^3.438.0",
         "@aws-sdk/credential-providers": "^3.429.0",
         "@aws-sdk/rds-signer": "^3.429.0",
+        "@guardian/anghammarad": "^1.8.0",
         "@prisma/client": "^5.5.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3810,9 +3810,9 @@
       }
     },
     "node_modules/@guardian/anghammarad": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@guardian/anghammarad/-/anghammarad-1.8.0.tgz",
-      "integrity": "sha512-9AIiRlCrsczo7qzjRQAVeD74OXMG+gmu4tBcrfJ9DsHVQMJ5oLtVJwLkm4qI8mx3kpVwMoscHo0IGfxNM/HGeQ=="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@guardian/anghammarad/-/anghammarad-1.8.1.tgz",
+      "integrity": "sha512-aKEgbdG4+LoQXcMbxf2AH6epRPefLl/k5JTHLNuUkgtyQTZB02LwQviGhOxDU5W4oPo0EHScBVw+cf7/PyLV7w=="
     },
     "node_modules/@guardian/eslint-config": {
       "version": "5.0.0",
@@ -10774,7 +10774,7 @@
         "@aws-sdk/client-sqs": "^3.438.0",
         "@aws-sdk/client-ssm": "^3.438.0",
         "@aws-sdk/types": "^3.433.0",
-        "@guardian/anghammarad": "^1.8.0",
+        "@guardian/anghammarad": "^1.8.1",
         "@octokit/auth-app": "^6.0.1",
         "@octokit/types": "^12.0.0",
         "octokit": "^3.1.1"
@@ -11326,7 +11326,7 @@
         "@aws-sdk/client-sqs": "^3.438.0",
         "@aws-sdk/credential-providers": "^3.429.0",
         "@aws-sdk/rds-signer": "^3.429.0",
-        "@guardian/anghammarad": "^1.8.0",
+        "@guardian/anghammarad": "^1.8.1",
         "@prisma/client": "^5.5.0"
       },
       "devDependencies": {

--- a/packages/branch-protector/package.json
+++ b/packages/branch-protector/package.json
@@ -14,7 +14,7 @@
 		"@aws-sdk/client-sqs": "^3.438.0",
 		"@aws-sdk/client-ssm": "^3.438.0",
 		"@aws-sdk/types": "^3.433.0",
-		"@guardian/anghammarad": "^1.8.0",
+		"@guardian/anghammarad": "^1.8.1",
 		"@octokit/auth-app": "^6.0.1",
 		"@octokit/types": "^12.0.0",
 		"octokit": "^3.1.1"

--- a/packages/branch-protector/src/aws-requests.ts
+++ b/packages/branch-protector/src/aws-requests.ts
@@ -69,5 +69,6 @@ export async function notify(
 		channel: RequestedChannel.PreferHangouts,
 		sourceSystem: 'branch-protector',
 		topicArn: topicArn,
+		threadKey: 'service-catalogue',
 	});
 }

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -23,6 +23,6 @@
 		"@aws-sdk/rds-signer": "^3.429.0",
 		"@aws-sdk/credential-providers": "^3.429.0",
 		"@prisma/client": "^5.5.0",
-		"@guardian/anghammarad": "^1.8.0"
+		"@guardian/anghammarad": "^1.8.1"
 	}
 }

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -22,6 +22,7 @@
 		"@aws-sdk/client-sqs": "^3.438.0",
 		"@aws-sdk/rds-signer": "^3.429.0",
 		"@aws-sdk/credential-providers": "^3.429.0",
-		"@prisma/client": "^5.5.0"
+		"@prisma/client": "^5.5.0",
+		"@guardian/anghammarad": "^1.8.0"
 	}
 }

--- a/packages/repocop/src/remediations/repository-02.ts
+++ b/packages/repocop/src/remediations/repository-02.ts
@@ -139,6 +139,7 @@ async function notifyOneTeam(
 		channel: RequestedChannel.PreferHangouts,
 		sourceSystem: 'branch-protector',
 		topicArn: config.anghammaradSnsTopic,
+		threadKey: 'service-catalogue',
 	});
 
 	console.log(`Notified ${teamSlug} about ${fullName}`);


### PR DESCRIPTION
## What does this change?
This change adopts the recently added message threading in Anghammarad (see https://github.com/guardian/anghammarad/pull/138) to group messages together.

Messages from RepoCop and Branch Protector will appear on the _same_ thread, for all time.

❓ Should there be a different thread per day?

## Why?
The intention here is to reduce noise in Chat. Grouping messages together also helps to keep a running narrative of events.

## How has it been verified?
I've run RepoCop and observed the messages in Chat appearing on a single thread:

<img width="623" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/1e8a2ae2-46d8-4707-a722-a32b40612155">
