### PR TITLE
refactor: Tweak the message metadata

### DIFF
--- a/packages/branch-protector/package.json
+++ b/packages/branch-protector/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "esbuild src/index.ts --bundle --platform=node --target=node18 --outdir=dist --external:@aws-sdk",
 		"test": "echo \"No test specified\" && exit 0",
-		"start": "ts-node src/run-locally.ts"
+		"start": "APP=branch-protector ts-node src/run-locally.ts"
 	},
 	"author": "guardian",
 	"dependencies": {

--- a/packages/branch-protector/src/aws-requests.ts
+++ b/packages/branch-protector/src/aws-requests.ts
@@ -47,11 +47,13 @@ export async function deleteFromQueue(
 
 export async function notify(
 	fullRepoName: string,
-	topicArn: string,
-	slug: string,
+	config: Config,
+	teamSlug: string,
 ) {
+	const { app, stage, anghammaradSnsTopic } = config;
+
 	const repoUrl = `https://github.com/${fullRepoName}`;
-	const grafanaUrl = `https://metrics.gutools.co.uk/d/EOPnljWIz/repocop-compliance?var-team=${slug}&var-rule=All&orgId=1`;
+	const grafanaUrl = `https://metrics.gutools.co.uk/d/EOPnljWIz/repocop-compliance?var-team=${teamSlug}&var-rule=All&orgId=1`;
 	const protectionUrl = `https://github.com/${fullRepoName}/settings/branches`;
 	const actions = [
 		//duplicated in repocop
@@ -68,13 +70,13 @@ export async function notify(
 
 	const client = new Anghammarad();
 	await client.notify({
-		subject: 'Repocop branch protection',
+		subject: `Repocop branch protection (for GitHub team ${teamSlug})`,
 		message: `Branch protection has been applied to ${fullRepoName}`,
 		actions,
-		target: { GithubTeamSlug: slug },
+		target: { GithubTeamSlug: teamSlug },
 		channel: RequestedChannel.PreferHangouts,
-		sourceSystem: 'branch-protector',
-		topicArn: topicArn,
+		sourceSystem: `${app} ${stage}`,
+		topicArn: anghammaradSnsTopic,
 		threadKey: `service-catalogue-${fullRepoName.replaceAll('/', '-')}`,
 	});
 }

--- a/packages/branch-protector/src/config.ts
+++ b/packages/branch-protector/src/config.ts
@@ -12,6 +12,11 @@ export function getEnvOrThrow(key: string): string {
 
 export interface Config {
 	/**
+	 * The name of this application.
+	 */
+	app: string;
+
+	/**
 	 * The stage of the application, e.g. DEV, CODE, PROD.
 	 */
 	stage: string;
@@ -57,6 +62,7 @@ async function getGithubAppSecretJson(): Promise<GithubAppSecret> {
 export async function getConfig() {
 	const secretJson = await getGithubAppSecretJson();
 	const config: Config = {
+		app: getEnvOrThrow('APP'),
 		stage: process.env['STAGE'] ?? 'DEV',
 		githubAppConfig: {
 			strategyOptions: {

--- a/packages/branch-protector/src/index.ts
+++ b/packages/branch-protector/src/index.ts
@@ -41,7 +41,7 @@ async function protectBranch(
 		await updateBranchProtection(octokit, owner, repo, defaultBranchName);
 		console.log(`Updated ${repo}'s default branch protection`);
 		for (const slug of event.teamNameSlugs) {
-			await notify(event.fullName, config.anghammaradSnsTopic, slug);
+			await notify(event.fullName, config, slug);
 		}
 		console.log(`Notified teams`);
 	} else {

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -7,7 +7,7 @@
 	},
 	"scripts": {
 		"build": "esbuild src/index.ts --bundle --platform=node --target=node18 --outdir=dist --external:@aws-sdk --external:@prisma/client --external:prisma",
-		"start": "ts-node src/run-locally.ts",
+		"start": "APP=repocop ts-node src/run-locally.ts",
 		"postinstall": "prisma generate",
 		"test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects repocop",
 		"migrate:setuplocal": "script/migrate.sh --dev",

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -3,6 +3,11 @@ import { Signer } from '@aws-sdk/rds-signer';
 
 export interface Config {
 	/**
+	 * The name of this application.
+	 */
+	app: string;
+
+	/**
 	 * The stage of the application, e.g. DEV, CODE, PROD.
 	 */
 	stage: string;
@@ -95,6 +100,7 @@ export async function getConfig(): Promise<Config> {
 	const queryLogging = (process.env['QUERY_LOGGING'] ?? 'false') === 'true';
 
 	return {
+		app: getEnvOrThrow('APP'),
 		stage: getEnvOrThrow('STAGE'),
 		region: 'eu-west-1',
 		anghammaradSnsTopic: getEnvOrThrow('ANGHAMMARAD_SNS_ARN'),

--- a/packages/repocop/src/remediations/repository-02-branch_protection.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.ts
@@ -106,6 +106,8 @@ async function notifyOneTeam(
 	teamSlug: string,
 	config: Config,
 ) {
+	const { app, stage, anghammaradSnsTopic } = config;
+
 	const githubUrl = `https://github.com/${fullName}`;
 	const grafanaUrl = `https://metrics.gutools.co.uk/d/EOPnljWIz/repocop-compliance?var-team=${teamSlug}&var-rule=All&orgId=1`;
 	const protectionUrl = `https://github.com/${fullName}/settings/branches`;
@@ -123,13 +125,13 @@ async function notifyOneTeam(
 	];
 
 	await anghammaradClient.notify({
-		subject: 'Repocop branch protection',
+		subject: `Repocop branch protection (for GitHub team ${teamSlug})`,
 		message: `Branch protections will be applied to ${fullName}. No action is required.`,
 		actions,
 		target: { GithubTeamSlug: teamSlug },
 		channel: RequestedChannel.PreferHangouts,
-		sourceSystem: 'branch-protector',
-		topicArn: config.anghammaradSnsTopic,
+		sourceSystem: `${app} ${stage}`,
+		topicArn: anghammaradSnsTopic,
 		threadKey: `service-catalogue-${fullName.replaceAll('/', '-')}`,
 	});
 


### PR DESCRIPTION
## What does this change?
We have two systems sending messages to teams via Anghammarad.

This change tweaks the sent message to allow one to better identify the origin of the message:
- The message's `sourceSystem` is unique, and is comprised of the app name and stage
- The message's `subject` includes the GitHub team slug

## Why?
We currently message every administering GitHub team of a repository. These GitHub teams may belong to the same P&E team, and therefore land in a single Chat thread.

For example:
<img width="511" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/42763b2b-69f0-4078-b1e9-7df2726705df">

These changes help to understand why the same message is appearing multiple times as the subjects will read:
- Repocop branch protection (for GitHub team A)
- Repocop branch protection (for GitHub team B)
- Repocop branch protection (for GitHub team C)

Rather than simply "Repocop branch protection" x3.

## How has it been verified?
N/A.