### PR TITLE
Fix Cloudquery dev-config using the old CQ_POSTGRES variable

### DIFF
--- a/packages/cloudquery/dev-config/cloudquery.yaml
+++ b/packages/cloudquery/dev-config/cloudquery.yaml
@@ -122,7 +122,7 @@ spec:
   name: 'postgresql'
   registry: 'github'
   path: 'cloudquery/postgresql'
-  version: v${CQ_POSTGRES}
+  version: v${CQ_POSTGRES_DESTINATION}
 
   # Automatically apply migrations whenever plugins are updated.
   # Note: This is not encouraged if risk averse, so we should consider removing this once fully in production.


### PR DESCRIPTION
## What does this change?

Use `CQ_POSTGRES_DESTINATION` instead of `CQ_POSTGRES`

## Why?

I renamed this variable in https://github.com/guardian/service-catalogue/pull/424 and its breaking our local cloudquery environment.
