### PR TITLE
Tweak logging

### DIFF
--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -75,7 +75,7 @@ export async function getRepositoryTeams(
 	// `full_name` is typed as nullable, in reality it is not, so the fallback to `id` shouldn't happen
 	const repoIdentifier = repository.full_name ?? repository.id;
 
-	console.log(
+	console.debug(
 		`Found ${data.length} teams with access to repository ${repoIdentifier}`,
 	);
 

--- a/packages/repocop/src/remediations/repository-02-branch_protection.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.ts
@@ -107,6 +107,9 @@ export async function addMessagesToQueue(
 		Entries: events.map((event) => createEntry(event)),
 	});
 	await sqsClient.send(command);
+
+	const repoListString = events.map((event) => event.fullName).join(', ');
+	console.log(`Repos added to branch protector queue: ${repoListString}`);
 }
 
 async function notifyOneTeam(


### PR DESCRIPTION
## What does this change?

The team repos logs are quite noisy. Made them debug statements so we can filter them out if needed.
Log which repos have been added to the queue

## Why?

Make debugging easier

## How has it been verified?

Deployed to code and verified the new message still shows up.

The debug statements also still show up, so no behaviour has changed there