### PR TITLE
feat: add some error messaging for branch protector functions

### DIFF
--- a/packages/branch-protector/src/aws-requests.ts
+++ b/packages/branch-protector/src/aws-requests.ts
@@ -29,14 +29,20 @@ export async function deleteFromQueue(
 	message: Message,
 	sqs: SQSClient,
 ) {
+	const messageId = message.MessageId ?? 'unknown';
+	console.log(`Attempting to delete ${messageId} from queue`);
 	const deleteCommand = new DeleteMessageCommand({
 		QueueUrl: config.queueUrl,
 		ReceiptHandle: message.ReceiptHandle,
 	});
 
-	await sqs.send(deleteCommand);
-
-	console.log(`Deleted message ${message.MessageId ?? 'unknown'}`);
+	try {
+		await sqs.send(deleteCommand);
+		console.log(`Deleted message ${messageId}`);
+	} catch (error) {
+		console.error(`Error: delete command failed for ${messageId}`);
+		console.error(error);
+	}
 }
 
 export async function notify(

--- a/packages/branch-protector/src/github-requests.ts
+++ b/packages/branch-protector/src/github-requests.ts
@@ -42,8 +42,13 @@ export async function updateBranchProtection(
 		allow_force_pushes: false,
 		allow_deletions: false,
 	};
-	await octokit.rest.repos.updateBranchProtection(branchProtectionParams);
-	console.log(`Update of ${repo} successful`);
+	try {
+		await octokit.rest.repos.updateBranchProtection(branchProtectionParams);
+		console.log(`Branch protection successfully applied to ${repo}`);
+	} catch (error) {
+		console.error(`Error: branch protection failed for ${repo}`);
+		console.error(error);
+	}
 }
 
 export async function getDefaultBranchName(


### PR DESCRIPTION
## What does this change?

Adds some error messaging to branch protector functions.

## Why?

Branch protector was only deleting one message off the queue rather than one after each application of branch protection (10 per day). Although this is now fixed, and probably due to an edge case, this will help to understand when we do have errors.

## How has it been verified?
Branch protector only applies branch protection on PROD so it is not possible to test all of this in CODE.