### PR TITLE
Change scheduling

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -11055,7 +11055,7 @@ spec:
     },
     "CloudquerySourceRemainingAwsDataScheduledEventRuleAE2A0ED1": {
       "Properties": {
-        "ScheduleExpression": "cron(0 10 ? * MON *)",
+        "ScheduleExpression": "cron(0 16 ? * SAT *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -14020,7 +14020,7 @@ spec:
             "Value": "TEST",
           },
         ],
-        "Timeout": 900,
+        "Timeout": 300,
         "VpcConfig": {
           "SecurityGroupIds": [
             {

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -333,7 +333,7 @@ export class ServiceCatalogue extends GuStack {
 			description: 'Data fetched across all accounts in the organisation.',
 			schedule:
 				nonProdSchedule ??
-				Schedule.cron({ minute: '0', hour: '10', weekDay: 'MON' }), // Every Monday, at 10AM UTC
+				Schedule.cron({ minute: '0', hour: '16', weekDay: 'SAT' }), // Every Saturday, at 4PM UTC
 			config: awsSourceConfigForOrganisation({
 				tables: ['aws_*'],
 				skipTables: [
@@ -641,7 +641,7 @@ export class ServiceCatalogue extends GuStack {
 			},
 			vpc,
 			securityGroups: [applicationToPostgresSecurityGroup],
-			timeout: Duration.minutes(15),
+			timeout: Duration.minutes(5),
 		};
 
 		const repocopLambda = new GuScheduledLambda(


### PR DESCRIPTION
## What does this change?

1. Changes schedule of remaining AWS tasks from 10am on Monday to 4pm on Saturday
2. Lower timeout of repocop

## Why?

1. The job running during the week means a lot of DB connections are used up when things like repocop are running, resulting in timeouts. Moving it to the weekend makes this issue less prelevant.
2. Repocop typically takes between 10 and 70 seconds to complete. A hanging DB request here means that the lambda will wait for 15 minutes before failing, accumulating cost, and wasting resources. Lowering the timeout to 5 minutes reduces that waste, while also giving us plenty of headroom.
