### PR TITLE
refactor: give branch protector queue url env var unique name

### DIFF
--- a/packages/branch-protector/src/config.ts
+++ b/packages/branch-protector/src/config.ts
@@ -72,7 +72,7 @@ export async function getConfig() {
 			installationId: secretJson.installationId,
 		},
 		anghammaradSnsTopic: getEnvOrThrow('ANGHAMMARAD_SNS_ARN'),
-		queueUrl: getEnvOrThrow('BRANCH_PROT_QUEUE_URL'),
+		queueUrl: getEnvOrThrow('BRANCH_PROTECTOR_QUEUE_URL'),
 	};
 	return config;
 }

--- a/packages/branch-protector/src/config.ts
+++ b/packages/branch-protector/src/config.ts
@@ -72,7 +72,7 @@ export async function getConfig() {
 			installationId: secretJson.installationId,
 		},
 		anghammaradSnsTopic: getEnvOrThrow('ANGHAMMARAD_SNS_ARN'),
-		queueUrl: getEnvOrThrow('QUEUE_URL'),
+		queueUrl: getEnvOrThrow('BRANCH_PROT_QUEUE_URL'),
 	};
 	return config;
 }

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -13377,7 +13377,7 @@ spec:
               "Ref": "AnghammaradSnsArn",
             },
             "APP": "branch-protector",
-            "BRANCH_PROT_QUEUE_URL": {
+            "BRANCH_PROTECTOR_QUEUE_URL": {
               "Ref": "branchprotectorqueueEF5856E4",
             },
             "GITHUB_APP_SECRET": {
@@ -13978,7 +13978,7 @@ spec:
               "Ref": "AnghammaradSnsArn",
             },
             "APP": "repocop",
-            "BRANCH_PROT_QUEUE_URL": {
+            "BRANCH_PROTECTOR_QUEUE_URL": {
               "Ref": "branchprotectorqueueEF5856E4",
             },
             "DATABASE_HOSTNAME": {

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -13377,6 +13377,9 @@ spec:
               "Ref": "AnghammaradSnsArn",
             },
             "APP": "branch-protector",
+            "BRANCH_PROT_QUEUE_URL": {
+              "Ref": "branchprotectorqueueEF5856E4",
+            },
             "GITHUB_APP_SECRET": {
               "Fn::Join": [
                 "-",
@@ -13521,9 +13524,6 @@ spec:
                   },
                 ],
               ],
-            },
-            "QUEUE_URL": {
-              "Ref": "branchprotectorqueueEF5856E4",
             },
             "STACK": "deploy",
             "STAGE": "TEST",
@@ -13978,6 +13978,9 @@ spec:
               "Ref": "AnghammaradSnsArn",
             },
             "APP": "repocop",
+            "BRANCH_PROT_QUEUE_URL": {
+              "Ref": "branchprotectorqueueEF5856E4",
+            },
             "DATABASE_HOSTNAME": {
               "Fn::GetAtt": [
                 "PostgresInstance16DE4286E",
@@ -13985,9 +13988,6 @@ spec:
               ],
             },
             "QUERY_LOGGING": "false",
-            "QUEUE_URL": {
-              "Ref": "branchprotectorqueueEF5856E4",
-            },
             "STACK": "deploy",
             "STAGE": "TEST",
           },

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -647,7 +647,7 @@ export class ServiceCatalogue extends GuStack {
 
 				// Set this to 'true' to enable SQL query logging
 				QUERY_LOGGING: 'false',
-				BRANCH_PROT_QUEUE_URL: branchProtectorQueue.queueUrl,
+				BRANCH_PROTECTOR_QUEUE_URL: branchProtectorQueue.queueUrl,
 			},
 			vpc,
 			securityGroups: [applicationToPostgresSecurityGroup],
@@ -688,7 +688,7 @@ export class ServiceCatalogue extends GuStack {
 			environment: {
 				GITHUB_APP_SECRET: branchProtectorGithubCredentials.secretName,
 				ANGHAMMARAD_SNS_ARN: anghammaradTopicParameter.valueAsString,
-				BRANCH_PROT_QUEUE_URL: branchProtectorQueue.queueUrl,
+				BRANCH_PROTECTOR_QUEUE_URL: branchProtectorQueue.queueUrl,
 			},
 			vpc,
 			timeout: Duration.minutes(1),

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -647,7 +647,7 @@ export class ServiceCatalogue extends GuStack {
 
 				// Set this to 'true' to enable SQL query logging
 				QUERY_LOGGING: 'false',
-				QUEUE_URL: branchProtectorQueue.queueUrl,
+				BRANCH_PROT_QUEUE_URL: branchProtectorQueue.queueUrl,
 			},
 			vpc,
 			securityGroups: [applicationToPostgresSecurityGroup],
@@ -688,7 +688,7 @@ export class ServiceCatalogue extends GuStack {
 			environment: {
 				GITHUB_APP_SECRET: branchProtectorGithubCredentials.secretName,
 				ANGHAMMARAD_SNS_ARN: anghammaradTopicParameter.valueAsString,
-				QUEUE_URL: branchProtectorQueue.queueUrl,
+				BRANCH_PROT_QUEUE_URL: branchProtectorQueue.queueUrl,
 			},
 			vpc,
 			timeout: Duration.minutes(1),

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -106,7 +106,7 @@ export async function getConfig(): Promise<Config> {
 		anghammaradSnsTopic: getEnvOrThrow('ANGHAMMARAD_SNS_ARN'),
 		databaseConnectionString: await getDatabaseConnectionString(databaseConfig),
 		withQueryLogging: queryLogging,
-		queueUrl: getEnvOrThrow('QUEUE_URL'),
+		queueUrl: getEnvOrThrow('BRANCH_PROT_QUEUE_URL'),
 		enableMessaging: process.env.ENABLE_MESSAGING === 'false' ? false : true,
 		ignoredRepositoryPrefixes: [
 			// Visuals team

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -106,7 +106,7 @@ export async function getConfig(): Promise<Config> {
 		anghammaradSnsTopic: getEnvOrThrow('ANGHAMMARAD_SNS_ARN'),
 		databaseConnectionString: await getDatabaseConnectionString(databaseConfig),
 		withQueryLogging: queryLogging,
-		queueUrl: getEnvOrThrow('BRANCH_PROT_QUEUE_URL'),
+		queueUrl: getEnvOrThrow('BRANCH_PROTECTOR_QUEUE_URL'),
 		enableMessaging: process.env.ENABLE_MESSAGING === 'false' ? false : true,
 		ignoredRepositoryPrefixes: [
 			// Visuals team

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -82,7 +82,7 @@ setup_environment() {
 
   ANGHAMMARAD_SNS_ARN=$(aws ssm get-parameter --name /account/services/anghammarad.topic.arn --profile deployTools --region eu-west-1 | jq '.Parameter.Value' | tr -d '"')
 
-  BRANCH_PROT_QUEUE_URL=$(aws sqs get-queue-url --queue-name branch-protector-queue-CODE.fifo --profile deployTools --region eu-west-1 | jq '.QueueUrl' | tr -d '"')
+  BRANCH_PROTECTOR_QUEUE_URL=$(aws sqs get-queue-url --queue-name branch-protector-queue-CODE.fifo --profile deployTools --region eu-west-1 | jq '.QueueUrl' | tr -d '"')
 
   github_info_url="https://github.com/settings/tokens?type=beta"
 
@@ -97,7 +97,7 @@ SNYK_TOKEN="
   env_var_text="
 GALAXIES_BUCKET=${GALAXIES_BUCKET}
 ANGHAMMARAD_SNS_ARN=${ANGHAMMARAD_SNS_ARN}
-BRANCH_PROT_QUEUE_URL=${BRANCH_PROT_QUEUE_URL}
+BRANCH_PROTECTOR_QUEUE_URL=${BRANCH_PROTECTOR_QUEUE_URL}
 "
 
   # Check if .env.local file exists in ~/.gu/service_catalogue/

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -82,7 +82,7 @@ setup_environment() {
 
   ANGHAMMARAD_SNS_ARN=$(aws ssm get-parameter --name /account/services/anghammarad.topic.arn --profile deployTools --region eu-west-1 | jq '.Parameter.Value' | tr -d '"')
 
-  QUEUE_URL=$(aws sqs get-queue-url --queue-name branch-protector-queue-CODE.fifo --profile deployTools --region eu-west-1 | jq '.QueueUrl' | tr -d '"')
+  BRANCH_PROT_QUEUE_URL=$(aws sqs get-queue-url --queue-name branch-protector-queue-CODE.fifo --profile deployTools --region eu-west-1 | jq '.QueueUrl' | tr -d '"')
 
   github_info_url="https://github.com/settings/tokens?type=beta"
 
@@ -97,7 +97,7 @@ SNYK_TOKEN="
   env_var_text="
 GALAXIES_BUCKET=${GALAXIES_BUCKET}
 ANGHAMMARAD_SNS_ARN=${ANGHAMMARAD_SNS_ARN}
-QUEUE_URL=${QUEUE_URL}
+BRANCH_PROT_QUEUE_URL=${BRANCH_PROT_QUEUE_URL}
 "
 
   # Check if .env.local file exists in ~/.gu/service_catalogue/


### PR DESCRIPTION
## What does this change?

Changes the name of the `QUEUE_URL` env var that is used by `branch-protector` to be specific to that app.

## Why?

This makes it clear that this is a branch protector and allows for another queue url to be added for other apps in future.

## How has it been verified?
Tested locally by running ./scripts/setup and then cloudquery and then repocop.