### PR TITLE
refactor: revert restriction on branch protector

### DIFF
--- a/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
@@ -64,13 +64,13 @@ describe('Team slugs should be findable for every team associated with a repo', 
 			...nullOwner,
 			full_name: repo,
 			github_team_id: BigInt(1),
-			github_team_name: 'Developer Experience', // TODO: revert this back to 'Team One' once rolled out to entire dept
+			github_team_name: 'Team One',
 		};
 
 		const githubTeam: github_teams = {
 			...nullTeam,
 			id: BigInt(1),
-			slug: 'devx-security', // TODO: revert this back to 'team-one' once rolled out to entire dept
+			slug: 'team-one',
 		};
 
 		const actual = createRepository02Messages(
@@ -80,9 +80,7 @@ describe('Team slugs should be findable for every team associated with a repo', 
 			5,
 		);
 
-		expect(actual).toEqual([
-			{ fullName: repo, teamNameSlugs: ['devx-security'] }, // TODO: revert this back to 'team-one' once rolled out to entire dept
-		]);
+		expect(actual).toEqual([{ fullName: repo, teamNameSlugs: ['team-one'] }]);
 	});
 
 	test('A repository that has no owner should not be in the list of messages', () => {

--- a/packages/repocop/src/remediations/repository-02-branch_protection.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.ts
@@ -37,19 +37,7 @@ function findContactableOwners(
 		.map((owner) => findTeamSlugFromId(owner.github_team_id, teams))
 		.filter((slug): slug is string => !!slug);
 
-	//return teamSlugs;
-
-	// TODO: remove this when testing over (limits to DevX repos only)
-	const devxTeams = [
-		'developer-experience',
-		'devx-operations',
-		'devx-security',
-		'devx-reliability',
-	];
-	const devxSlugs = teamSlugs.filter((slug): slug is string =>
-		devxTeams.includes(slug),
-	);
-	return devxSlugs;
+	return teamSlugs;
 }
 
 function shuffle<T>(array: T[]): T[] {


### PR DESCRIPTION
## What does this change?

Allows branch protector to be applied to all teams in the department, reverting the temporary restriction to DevX repos.

## Why?

The app is now in a place where we can roll it out more widely again and get teams' branches protected.

## How has it been verified?

Ran tests locally. 