### PR TITLE
collect dependabot alerts

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -3389,7 +3389,6 @@ spec:
   skip_tables:
     - github_releases
     - github_release_assets
-    - github_repository_dependabot_alerts
     - github_repository_dependabot_secrets
   destinations:
     - postgresql

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -4052,7 +4052,6 @@ spec:
     - github_team_members
     - github_team_repositories
   skip_tables:
-    - github_organization_dependabot_alerts
     - github_organization_dependabot_secrets
   destinations:
     - postgresql

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -443,7 +443,6 @@ export class ServiceCatalogue extends GuStack {
 						We don't use them as they take a long time to collect, so skip them.
 						See https://www.cloudquery.io/docs/advanced-topics/performance-tuning#improve-performance-by-skipping-relations
 						 */
-						'github_organization_dependabot_alerts',
 						'github_organization_dependabot_secrets',
 					],
 				}),

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -415,7 +415,6 @@ export class ServiceCatalogue extends GuStack {
 					skipTables: [
 						'github_releases',
 						'github_release_assets',
-						'github_repository_dependabot_alerts',
 						'github_repository_dependabot_secrets',
 					],
 				}),


### PR DESCRIPTION
## What does this change?

## Why?

In order for PNPM to become a recommended package manager across the department, we need to be able to track its vulnerabilities. Let's start gathering this information

## How has it been verified?

TODO: deploy to code
