### PR TITLE
fix: throw error if a repo doesn't have any branches

### DIFF
--- a/packages/branch-protector/src/index.ts
+++ b/packages/branch-protector/src/index.ts
@@ -69,8 +69,8 @@ async function handleMessage(
 		try {
 			await protectBranch(octokit, config, event);
 		} catch (error) {
-			console.error(`Error: branch protection failed for  ${event.fullName}`);
-			console.error(error);
+			console.warn(`Branch protection failed for ${event.fullName}`);
+			console.warn(error);
 		}
 	}
 	await deleteFromQueue(config, message, sqs);

--- a/packages/branch-protector/src/index.ts
+++ b/packages/branch-protector/src/index.ts
@@ -41,15 +41,17 @@ async function protectBranch(
 
 	const stageIsProd = config.stage === 'PROD';
 
-	if (branchIsProtected && stageIsProd) {
-		console.log(`No action required`);
-	} else if (!branchIsProtected && stageIsProd) {
-		await updateBranchProtection(octokit, owner, repo, defaultBranchName);
-		console.log(`Updated ${repo}'s default branch protection`);
-		for (const slug of event.teamNameSlugs) {
-			await notify(event.fullName, config, slug);
+	if (stageIsProd) {
+		if (branchIsProtected) {
+			console.log(`No action required`);
+		} else {
+			await updateBranchProtection(octokit, owner, repo, defaultBranchName);
+			console.log(`Updated ${repo}'s default branch protection`);
+			for (const slug of event.teamNameSlugs) {
+				await notify(event.fullName, config, slug);
+			}
+			console.log(`Notified teams`);
 		}
-		console.log(`Notified teams`);
 	} else {
 		// !stageIsProd
 		console.log(`Detected stage: ${config.stage}. No action taken`);


### PR DESCRIPTION
## What does this change?

Throws an error in `branch-protector` if the a repo doesn't have any branches. Also adds some console errors if branch protection fails, and slightly refactors the protect branch function to by DRYer.

## Why?

We recently had problems when `branch-protector` came across a repo that was empty and thus didn't have any branches to protect  (`guardian/braze-diff-publisher`).

## How has it been verified?
Tested on CODE with `braze-diff-publisher`. There were 5 other messages on the queue, and `branch-protector` ran successfully, didn't apply branch protections to the other repos (as it's CODE, expected), threw an error for `braze-diff-publisher`, and deleted all the messages off the queue including the failing one.