### PR TITLE
refactor: Share `UpdateBranchProtectionEvent` interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6906,6 +6906,10 @@
       "version": "1.1.4",
       "license": "MIT"
     },
+    "node_modules/common": {
+      "resolved": "packages/common",
+      "link": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
@@ -12296,6 +12300,9 @@
       }
     },
     "packages/cloudquery": {
+      "version": "0.0.0"
+    },
+    "packages/common": {
       "version": "0.0.0"
     },
     "packages/repocop": {

--- a/packages/best-practices/tsconfig.json
+++ b/packages/best-practices/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../../tsconfig.json",
+  "references": [{ "path": "../common" }],
   "compilerOptions": {
     "module": "es6",
     "allowImportingTsExtensions": true

--- a/packages/branch-protector/src/index.ts
+++ b/packages/branch-protector/src/index.ts
@@ -1,5 +1,6 @@
 import type { Message } from '@aws-sdk/client-sqs';
 import { SQSClient } from '@aws-sdk/client-sqs';
+import type { UpdateBranchProtectionEvent } from 'common/types';
 import type { Octokit } from 'octokit';
 import { deleteFromQueue, notify, readFromQueue } from './aws-requests';
 import { getConfig } from './config';
@@ -10,7 +11,6 @@ import {
 	isBranchProtected,
 	updateBranchProtection,
 } from './github-requests';
-import type { UpdateBranchProtectionEvent } from './model';
 
 async function protectBranch(
 	octokit: Octokit,

--- a/packages/branch-protector/src/model.ts
+++ b/packages/branch-protector/src/model.ts
@@ -1,9 +1,4 @@
 import type { Endpoints } from '@octokit/types';
 
-export interface UpdateBranchProtectionEvent {
-	fullName: string; // in the format of owner/repo-name
-	teamNameSlugs: string[];
-}
-
 export type UpdateBranchProtectionParams =
 	Endpoints['PUT /repos/{owner}/{repo}/branches/{branch}/protection']['parameters'];

--- a/packages/branch-protector/tsconfig.json
+++ b/packages/branch-protector/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [{ "path": "../common" }]
 }

--- a/packages/cdk/tsconfig.json
+++ b/packages/cdk/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["lib/**/*", "bin/**/*"],
-  "exclude": ["node_modules", "cdk.out", "dist"]
+  "exclude": ["node_modules", "cdk.out", "dist"],
+  "references": [{ "path": "../common" }]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [{ "path": "../common" }]
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "common",
+  "version": "0.0.0",
+  "scripts": {
+    "typecheck": "tsc"
+  }
+}

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,0 +1,4 @@
+export interface UpdateBranchProtectionEvent {
+	fullName: string; // in the format of owner/repo-name
+	teamNameSlugs: string[];
+}

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true
+  }
+}

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -1,10 +1,10 @@
 import { Anghammarad } from '@guardian/anghammarad';
 import type { repocop_github_repository_rules } from '@prisma/client';
 import { PrismaClient } from '@prisma/client';
+import type { UpdateBranchProtectionEvent } from 'common/types';
 import type { Config } from './config';
 import { getConfig } from './config';
 import { getRepoOwnership, getTeams, getUnarchivedRepositories } from './query';
-import type { UpdateBranchProtectionEvent } from './remediations/repository-02-branch_protection';
 import {
 	addMessagesToQueue,
 	createRepository02Messages,

--- a/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
@@ -3,7 +3,7 @@ import type {
 	repocop_github_repository_rules,
 	view_repo_ownership,
 } from '@prisma/client';
-import type { UpdateBranchProtectionEvent } from './repository-02-branch_protection';
+import type { UpdateBranchProtectionEvent } from 'common/types';
 import {
 	createEntry,
 	createRepository02Messages,

--- a/packages/repocop/src/remediations/repository-02-branch_protection.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.ts
@@ -8,16 +8,8 @@ import type {
 	repocop_github_repository_rules,
 	view_repo_ownership,
 } from '@prisma/client';
+import type { UpdateBranchProtectionEvent } from 'common/types';
 import type { Config } from '../config';
-
-/*
- * This interface has been copied from packages/branch-protector/src/model.ts
- * The two interfaces should be kept in sync until we can share the interface.
- */
-export interface UpdateBranchProtectionEvent {
-	fullName: string; // in the format of owner/repo-name
-	teamNameSlugs: string[];
-}
 
 function findTeamSlugFromId(
 	id: bigint,

--- a/packages/repocop/tsconfig.json
+++ b/packages/repocop/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../../tsconfig.json"
+  "extends": "../../tsconfig.json",
+  "references": [{ "path": "../common" }]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,10 @@
     "module": "commonjs",
     "esModuleInterop": true,
     "baseUrl": ".",
+    "paths": {
+      "common": ["packages/common/src"],
+      "common/*": ["packages/common/src/*"]
+    }
   },
   "ts-node": {
     "require": ["tsconfig-paths/register", "dotenv/config"]


### PR DESCRIPTION
## What does this change?
Introduces a `common` package where shared code can live.

## Why?
Having a place to share code:
- Allows for DRYness. For example the interactions with Anghammarad.
- Allows for better decoupling. For example, we can move database migrations out of RepoCop.

## How has it been verified?
In this change, the `UpdateBranchProtectionEvent` interface is moved to this `common` package addressing the comment:

> The two interfaces should be kept in sync until we can share the interface.

The change can be verified via the compiler. If the compiler (a.k.a the build) is green, then we're good.