### PR TITLE
refactor(cdk): Simplify IAM Policies

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -564,9 +564,6 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -625,26 +622,6 @@ spec:
                   ],
                 ],
               },
-            },
-            {
-              "Action": [
-                "dynamodb:GetItem",
-                "dynamodb:BatchGetItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "ec2:GetConsoleOutput",
-                "ec2:GetConsoleScreenshot",
-                "ecr:BatchGetImage",
-                "ecr:GetAuthorizationToken",
-                "ecr:GetDownloadUrlForLayer",
-                "kinesis:Get*",
-                "lambda:GetFunction",
-                "logs:GetLogEvents",
-                "sdb:Select*",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Deny",
-              "Resource": "*",
             },
             {
               "Action": "sts:AssumeRole",
@@ -1200,9 +1177,6 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -1265,26 +1239,6 @@ spec:
             {
               "Action": "organizations:List*",
               "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": [
-                "dynamodb:GetItem",
-                "dynamodb:BatchGetItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "ec2:GetConsoleOutput",
-                "ec2:GetConsoleScreenshot",
-                "ecr:BatchGetImage",
-                "ecr:GetAuthorizationToken",
-                "ecr:GetDownloadUrlForLayer",
-                "kinesis:Get*",
-                "lambda:GetFunction",
-                "logs:GetLogEvents",
-                "sdb:Select*",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Deny",
               "Resource": "*",
             },
             {
@@ -5723,9 +5677,6 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -5788,26 +5739,6 @@ spec:
             {
               "Action": "organizations:List*",
               "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": [
-                "dynamodb:GetItem",
-                "dynamodb:BatchGetItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "ec2:GetConsoleOutput",
-                "ec2:GetConsoleScreenshot",
-                "ecr:BatchGetImage",
-                "ecr:GetAuthorizationToken",
-                "ecr:GetDownloadUrlForLayer",
-                "kinesis:Get*",
-                "lambda:GetFunction",
-                "logs:GetLogEvents",
-                "sdb:Select*",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Deny",
               "Resource": "*",
             },
             {
@@ -6365,9 +6296,6 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -6430,26 +6358,6 @@ spec:
             {
               "Action": "organizations:List*",
               "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": [
-                "dynamodb:GetItem",
-                "dynamodb:BatchGetItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "ec2:GetConsoleOutput",
-                "ec2:GetConsoleScreenshot",
-                "ecr:BatchGetImage",
-                "ecr:GetAuthorizationToken",
-                "ecr:GetDownloadUrlForLayer",
-                "kinesis:Get*",
-                "lambda:GetFunction",
-                "logs:GetLogEvents",
-                "sdb:Select*",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Deny",
               "Resource": "*",
             },
             {
@@ -7007,9 +6915,6 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -7072,26 +6977,6 @@ spec:
             {
               "Action": "organizations:List*",
               "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": [
-                "dynamodb:GetItem",
-                "dynamodb:BatchGetItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "ec2:GetConsoleOutput",
-                "ec2:GetConsoleScreenshot",
-                "ecr:BatchGetImage",
-                "ecr:GetAuthorizationToken",
-                "ecr:GetDownloadUrlForLayer",
-                "kinesis:Get*",
-                "lambda:GetFunction",
-                "logs:GetLogEvents",
-                "sdb:Select*",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Deny",
               "Resource": "*",
             },
             {
@@ -7675,26 +7560,6 @@ spec:
               "Resource": "*",
             },
             {
-              "Action": [
-                "dynamodb:GetItem",
-                "dynamodb:BatchGetItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "ec2:GetConsoleOutput",
-                "ec2:GetConsoleScreenshot",
-                "ecr:BatchGetImage",
-                "ecr:GetAuthorizationToken",
-                "ecr:GetDownloadUrlForLayer",
-                "kinesis:Get*",
-                "lambda:GetFunction",
-                "logs:GetLogEvents",
-                "sdb:Select*",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Deny",
-              "Resource": "*",
-            },
-            {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Resource": "arn:aws:iam::*:role/cloudquery-access",
@@ -7760,9 +7625,6 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -8291,9 +8153,6 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -8356,26 +8215,6 @@ spec:
             {
               "Action": "organizations:List*",
               "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": [
-                "dynamodb:GetItem",
-                "dynamodb:BatchGetItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "ec2:GetConsoleOutput",
-                "ec2:GetConsoleScreenshot",
-                "ecr:BatchGetImage",
-                "ecr:GetAuthorizationToken",
-                "ecr:GetDownloadUrlForLayer",
-                "kinesis:Get*",
-                "lambda:GetFunction",
-                "logs:GetLogEvents",
-                "sdb:Select*",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Deny",
               "Resource": "*",
             },
             {
@@ -8935,9 +8774,6 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -9000,26 +8836,6 @@ spec:
             {
               "Action": "organizations:List*",
               "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": [
-                "dynamodb:GetItem",
-                "dynamodb:BatchGetItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "ec2:GetConsoleOutput",
-                "ec2:GetConsoleScreenshot",
-                "ecr:BatchGetImage",
-                "ecr:GetAuthorizationToken",
-                "ecr:GetDownloadUrlForLayer",
-                "kinesis:Get*",
-                "lambda:GetFunction",
-                "logs:GetLogEvents",
-                "sdb:Select*",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Deny",
               "Resource": "*",
             },
             {
@@ -9578,9 +9394,6 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -9643,26 +9456,6 @@ spec:
             {
               "Action": "organizations:List*",
               "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": [
-                "dynamodb:GetItem",
-                "dynamodb:BatchGetItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "ec2:GetConsoleOutput",
-                "ec2:GetConsoleScreenshot",
-                "ecr:BatchGetImage",
-                "ecr:GetAuthorizationToken",
-                "ecr:GetDownloadUrlForLayer",
-                "kinesis:Get*",
-                "lambda:GetFunction",
-                "logs:GetLogEvents",
-                "sdb:Select*",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Deny",
               "Resource": "*",
             },
             {
@@ -10221,9 +10014,6 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -10286,26 +10076,6 @@ spec:
             {
               "Action": "organizations:List*",
               "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": [
-                "dynamodb:GetItem",
-                "dynamodb:BatchGetItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "ec2:GetConsoleOutput",
-                "ec2:GetConsoleScreenshot",
-                "ecr:BatchGetImage",
-                "ecr:GetAuthorizationToken",
-                "ecr:GetDownloadUrlForLayer",
-                "kinesis:Get*",
-                "lambda:GetFunction",
-                "logs:GetLogEvents",
-                "sdb:Select*",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Deny",
               "Resource": "*",
             },
             {
@@ -10863,9 +10633,6 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -10928,26 +10695,6 @@ spec:
             {
               "Action": "organizations:List*",
               "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": [
-                "dynamodb:GetItem",
-                "dynamodb:BatchGetItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "ec2:GetConsoleOutput",
-                "ec2:GetConsoleScreenshot",
-                "ecr:BatchGetImage",
-                "ecr:GetAuthorizationToken",
-                "ecr:GetDownloadUrlForLayer",
-                "kinesis:Get*",
-                "lambda:GetFunction",
-                "logs:GetLogEvents",
-                "sdb:Select*",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Deny",
               "Resource": "*",
             },
             {
@@ -11558,9 +11305,6 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -11619,26 +11363,6 @@ spec:
                   ],
                 ],
               },
-            },
-            {
-              "Action": [
-                "dynamodb:GetItem",
-                "dynamodb:BatchGetItem",
-                "dynamodb:Query",
-                "dynamodb:Scan",
-                "ec2:GetConsoleOutput",
-                "ec2:GetConsoleScreenshot",
-                "ecr:BatchGetImage",
-                "ecr:GetAuthorizationToken",
-                "ecr:GetDownloadUrlForLayer",
-                "kinesis:Get*",
-                "lambda:GetFunction",
-                "logs:GetLogEvents",
-                "sdb:Select*",
-                "sqs:ReceiveMessage",
-              ],
-              "Effect": "Deny",
-              "Resource": "*",
             },
             {
               "Action": "sts:AssumeRole",

--- a/packages/cdk/lib/ecs/policies.ts
+++ b/packages/cdk/lib/ecs/policies.ts
@@ -1,40 +1,4 @@
-import type { IManagedPolicy } from 'aws-cdk-lib/aws-iam';
-import { Effect, ManagedPolicy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import type { Construct } from 'constructs';
-
-export const readonlyAccessManagedPolicy = (
-	scope: Construct,
-	id: string,
-): IManagedPolicy =>
-	ManagedPolicy.fromManagedPolicyArn(
-		scope,
-		`readonly-policy-${id}`,
-		'arn:aws:iam::aws:policy/ReadOnlyAccess',
-	);
-
-export const standardDenyPolicy =
-	// See https://github.com/cloudquery/iam-for-aws-orgs/ and
-	// https://github.com/cloudquery/iam-for-aws-orgs/blob/d44ffe5509ba8a6c84c31dcc1dac7f475a5099e3/template.yml#L95.
-	new PolicyStatement({
-		effect: Effect.DENY,
-		resources: ['*'],
-		actions: [
-			'dynamodb:GetItem',
-			'dynamodb:BatchGetItem',
-			'dynamodb:Query',
-			'dynamodb:Scan',
-			'ec2:GetConsoleOutput',
-			'ec2:GetConsoleScreenshot',
-			'ecr:BatchGetImage',
-			'ecr:GetAuthorizationToken',
-			'ecr:GetDownloadUrlForLayer',
-			'kinesis:Get*',
-			'lambda:GetFunction',
-			'logs:GetLogEvents',
-			'sdb:Select*',
-			'sqs:ReceiveMessage',
-		],
-	});
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 
 export const listOrgsPolicy = new PolicyStatement({
 	effect: Effect.ALLOW,
@@ -42,6 +6,11 @@ export const listOrgsPolicy = new PolicyStatement({
 	actions: ['organizations:List*'],
 });
 
+/**
+ * This role is provisioned in https://github.com/guardian/aws-account-setup.
+ *
+ * @see https://github.com/guardian/aws-account-setup/blob/main/packages/cdk/lib/constructs/cloudquery-role.ts
+ */
 export function cloudqueryAccess(accountId: string) {
 	return new PolicyStatement({
 		effect: Effect.ALLOW,

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -63,8 +63,6 @@ import {
 	cloudqueryAccess,
 	listOrgsPolicy,
 	readBucketPolicy,
-	readonlyAccessManagedPolicy,
-	standardDenyPolicy,
 } from './ecs/policies';
 
 interface ServiceCatalogueProps extends GuStackProps {
@@ -184,11 +182,6 @@ export class ServiceCatalogue extends GuStack {
 				riffRaffDatabaseAccessSecurityGroupParam,
 			);
 
-		const readonlyPolicy = readonlyAccessManagedPolicy(
-			this,
-			'readonly-managed-policy',
-		);
-
 		const individualAwsSources: CloudquerySource[] = [
 			{
 				name: 'DeployToolsListOrgs',
@@ -207,10 +200,8 @@ export class ServiceCatalogue extends GuStack {
 						'aws_organization*',
 					],
 				}),
-				managedPolicies: [readonlyPolicy],
 				policies: [
 					listOrgsPolicy,
-					standardDenyPolicy,
 					cloudqueryAccess(GuardianAwsAccounts.DeployTools),
 				],
 			},
@@ -223,11 +214,7 @@ export class ServiceCatalogue extends GuStack {
 					tables: ['aws_accessanalyzer_*', 'aws_securityhub_*'],
 					concurrency: 2000,
 				}),
-				managedPolicies: [readonlyPolicy],
-				policies: [
-					standardDenyPolicy,
-					cloudqueryAccess(GuardianAwsAccounts.Security),
-				],
+				policies: [cloudqueryAccess(GuardianAwsAccounts.Security)],
 				memoryLimitMiB: 2048,
 				cpu: 1024,
 			},
@@ -239,8 +226,7 @@ export class ServiceCatalogue extends GuStack {
 				config: awsSourceConfigForOrganisation({
 					tables: ['aws_cloudformation_*'],
 				}),
-				managedPolicies: [readonlyPolicy],
-				policies: [listOrgsPolicy, standardDenyPolicy, cloudqueryAccess('*')],
+				policies: [listOrgsPolicy, cloudqueryAccess('*')],
 			},
 			{
 				name: 'OrgWideLoadBalancers',
@@ -250,8 +236,7 @@ export class ServiceCatalogue extends GuStack {
 				config: awsSourceConfigForOrganisation({
 					tables: ['aws_elbv1_*', 'aws_elbv2_*'],
 				}),
-				managedPolicies: [readonlyPolicy],
-				policies: [listOrgsPolicy, standardDenyPolicy, cloudqueryAccess('*')],
+				policies: [listOrgsPolicy, cloudqueryAccess('*')],
 			},
 			{
 				name: 'OrgWideAutoScalingGroups',
@@ -261,8 +246,7 @@ export class ServiceCatalogue extends GuStack {
 				config: awsSourceConfigForOrganisation({
 					tables: ['aws_autoscaling_groups'],
 				}),
-				managedPolicies: [readonlyPolicy],
-				policies: [listOrgsPolicy, standardDenyPolicy, cloudqueryAccess('*')],
+				policies: [listOrgsPolicy, cloudqueryAccess('*')],
 			},
 			{
 				name: 'OrgWideCertificates',
@@ -272,8 +256,7 @@ export class ServiceCatalogue extends GuStack {
 				config: awsSourceConfigForOrganisation({
 					tables: ['aws_acm*'],
 				}),
-				managedPolicies: [readonlyPolicy],
-				policies: [listOrgsPolicy, standardDenyPolicy, cloudqueryAccess('*')],
+				policies: [listOrgsPolicy, cloudqueryAccess('*')],
 			},
 			{
 				name: 'OrgWideCloudwatchAlarms',
@@ -283,8 +266,7 @@ export class ServiceCatalogue extends GuStack {
 				config: awsSourceConfigForOrganisation({
 					tables: ['aws_cloudwatch_alarms'],
 				}),
-				managedPolicies: [readonlyPolicy],
-				policies: [listOrgsPolicy, standardDenyPolicy, cloudqueryAccess('*')],
+				policies: [listOrgsPolicy, cloudqueryAccess('*')],
 			},
 			{
 				name: 'OrgWideInspector',
@@ -293,8 +275,7 @@ export class ServiceCatalogue extends GuStack {
 				config: awsSourceConfigForOrganisation({
 					tables: ['aws_inspector_findings', 'aws_inspector2_findings'],
 				}),
-				managedPolicies: [readonlyPolicy],
-				policies: [listOrgsPolicy, standardDenyPolicy, cloudqueryAccess('*')],
+				policies: [listOrgsPolicy, cloudqueryAccess('*')],
 			},
 			{
 				name: 'OrgWideS3',
@@ -304,8 +285,7 @@ export class ServiceCatalogue extends GuStack {
 				config: awsSourceConfigForOrganisation({
 					tables: ['aws_s3*'],
 				}),
-				managedPolicies: [readonlyPolicy],
-				policies: [listOrgsPolicy, standardDenyPolicy, cloudqueryAccess('*')],
+				policies: [listOrgsPolicy, cloudqueryAccess('*')],
 			},
 			{
 				name: 'OrgWideDynamoDB',
@@ -315,8 +295,7 @@ export class ServiceCatalogue extends GuStack {
 				config: awsSourceConfigForOrganisation({
 					tables: ['aws_dynamodb*'],
 				}),
-				managedPolicies: [readonlyPolicy],
-				policies: [listOrgsPolicy, standardDenyPolicy, cloudqueryAccess('*')],
+				policies: [listOrgsPolicy, cloudqueryAccess('*')],
 			},
 			{
 				name: 'OrgWideEc2',
@@ -330,8 +309,7 @@ export class ServiceCatalogue extends GuStack {
 						'aws_ec2_images',
 					],
 				}),
-				managedPolicies: [readonlyPolicy],
-				policies: [listOrgsPolicy, standardDenyPolicy, cloudqueryAccess('*')],
+				policies: [listOrgsPolicy, cloudqueryAccess('*')],
 			},
 		];
 
@@ -364,8 +342,7 @@ export class ServiceCatalogue extends GuStack {
 				// See https://www.cloudquery.io/docs/reference/source-spec#concurrency.
 				concurrency: 2000,
 			}),
-			managedPolicies: [readonlyPolicy],
-			policies: [standardDenyPolicy, cloudqueryAccess('*')],
+			policies: [cloudqueryAccess('*')],
 
 			// This task is quite expensive, and requires more power than the default (500MB memory, 0.25 vCPU).
 			memoryLimitMiB: 2048,


### PR DESCRIPTION
## What does this change?
We have been doubling up the IAM Policies we provide the ECS tasks.

In this repo, we have been saying:
  - You can assume the role `arn:aws:iam::*:role/cloudquery-access`
  - You can't do `dynamodb:GetItem`, `dynamodb:BatchGetItem`, etc.

However, these deny policies are already attached to the [`arn:aws:iam::*:role/cloudquery-access` role](https://github.com/guardian/aws-account-setup/blob/main/packages/cdk/lib/constructs/cloudquery-role.ts)!

## Why?
Keeping IAM as simple as possible makes it easier to follow least privilege, IMO.

It confused me why the policy changes in https://github.com/guardian/service-catalogue/pull/364 wasn't enough, and why https://github.com/guardian/aws-account-setup/pull/118 was needed 😅.

## How has it been verified?
I've [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/ebcae6a9-6e51-456d-bd5b-9e5ec0c64207) and successfully ran some tasks without any new errors appearing in [the logs](https://logs.gutools.co.uk/s/devx/goto/2aa52bf0-8201-11ee-b899-87fdfb6dc5e2).

![image](https://github.com/guardian/service-catalogue/assets/836140/755f146e-8e3e-4e1a-902a-fce255655ca1)
