### PR TITLE
refactor: improve branch protector log messaging

### DIFF
--- a/packages/branch-protector/src/aws-requests.ts
+++ b/packages/branch-protector/src/aws-requests.ts
@@ -34,7 +34,6 @@ export async function deleteFromQueue(
 	sqs: SQSClient,
 ) {
 	const messageId = message.MessageId ?? 'unknown';
-	console.log(`Attempting to delete ${messageId} from queue`);
 	const deleteCommand = new DeleteMessageCommand({
 		QueueUrl: config.queueUrl,
 		ReceiptHandle: message.ReceiptHandle,
@@ -44,8 +43,8 @@ export async function deleteFromQueue(
 		await sqs.send(deleteCommand);
 		console.log(`Deleted message ${messageId}`);
 	} catch (error) {
-		console.error(`Error: delete command failed for ${messageId}`);
-		console.error(error);
+		console.warn(`Delete command failed for ${messageId}`);
+		console.warn(error);
 	}
 }
 

--- a/packages/branch-protector/src/github-requests.ts
+++ b/packages/branch-protector/src/github-requests.ts
@@ -23,7 +23,7 @@ export async function updateBranchProtection(
 	repo: string,
 	branch: string,
 ) {
-	console.log(`Updating ${repo} branch protection`);
+	console.log(`Attempting to apply branch protection to ${repo}`);
 	//https://github.com/guardian/recommendations/blob/main/github.md#branch-protection
 	const branchProtectionParams: UpdateBranchProtectionParams = {
 		owner: owner,

--- a/packages/branch-protector/src/index.ts
+++ b/packages/branch-protector/src/index.ts
@@ -46,7 +46,6 @@ async function protectBranch(
 			console.log(`No action required`);
 		} else {
 			await updateBranchProtection(octokit, owner, repo, defaultBranchName);
-			console.log(`Updated ${repo}'s default branch protection`);
 			for (const slug of event.teamNameSlugs) {
 				await notify(event.fullName, config, slug);
 			}


### PR DESCRIPTION
## What does this change?
- Changes the 'delete message' log lines from `error` to `warn`
- Deletes a log line that is more or less duplicated later
- Changes the messaging of the branch protector function to be more appropriate.

## Why?

Hopefully this will make understanding the logs a bit easier and make them less repetitive.


