### PR TITLE
feat: Enable backups in PROD

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3698,15 +3698,15 @@
       "integrity": "sha512-aKEgbdG4+LoQXcMbxf2AH6epRPefLl/k5JTHLNuUkgtyQTZB02LwQviGhOxDU5W4oPo0EHScBVw+cf7/PyLV7w=="
     },
     "node_modules/@guardian/cdk": {
-      "version": "52.1.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-52.1.0.tgz",
-      "integrity": "sha512-2Lzd+13n7F4/jmtGmklEeDVcl2A/UcdRvcIZ/OtopqJcBI6+igHOrn2OTBIGo72kSRFZSqhbJ1RomW1ZQzP1Sw==",
+      "version": "52.2.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-52.2.0.tgz",
+      "integrity": "sha512-KsvryvrKmt4lqfTJZNbI8HTrllN7BQpUzZJZbAsL1SJEpxOVJ2wwG/N3ELi/ZRrb0fY0v1fcb62dQ/eCmjqhOQ==",
       "dev": true,
       "dependencies": {
         "@changesets/cli": "^2.26.2",
         "@oclif/core": "2.15.0",
         "aws-cdk-lib": "2.100.0",
-        "aws-sdk": "^2.1485.0",
+        "aws-sdk": "^2.1490.0",
         "chalk": "^4.1.2",
         "codemaker": "^1.91.0",
         "constructs": "10.3.0",
@@ -6391,9 +6391,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1489.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1489.0.tgz",
-      "integrity": "sha512-DXps/qhDxnVMoQmMu+HIEd92IlCR5HLGGEMmivBaRkga1uyMBrI1D5glNYjyZMfZS1n7ECpiU6xXa/jyBKZ8Qg==",
+      "version": "2.1492.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1492.0.tgz",
+      "integrity": "sha512-3q17ruBkwb3pL87CHSbRlYiwx1LCq7D7hIjHgZ/5SPeKknkXgkHnD20SD2lC8Nj3xGbpIUhoKXcpDAGgIM5DBA==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -12270,7 +12270,7 @@
     "packages/cdk": {
       "version": "1.0.0",
       "devDependencies": {
-        "@guardian/cdk": "52.1.0",
+        "@guardian/cdk": "52.2.0",
         "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
         "@types/js-yaml": "^4.0.8",
         "aws-cdk": "2.100.0",

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -10,6 +10,7 @@ new ServiceCatalogue(app, 'ServiceCatalogue-PROD', {
 	stack: 'deploy',
 	stage: 'PROD',
 	env: { region: 'eu-west-1' },
+	withBackup: true,
 });
 
 new ServiceCatalogue(app, 'ServiceCatalogue-CODE', {

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -13134,6 +13134,10 @@ spec:
         "StorageType": "gp2",
         "Tags": [
           {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },

--- a/packages/cdk/lib/service-catalogue.test.ts
+++ b/packages/cdk/lib/service-catalogue.test.ts
@@ -8,6 +8,7 @@ describe('The ServiceCatalogue stack', () => {
 		const stack = new ServiceCatalogue(app, 'ServiceCatalogue', {
 			stack: 'deploy',
 			stage: 'TEST',
+			withBackup: true,
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -7,7 +7,7 @@
     "synth": "DOTENV_CONFIG_PATH=../../.env cdk synth --path-metadata false --version-reporting false"},
   "devDependencies": {
     "@types/js-yaml": "^4.0.8",
-    "@guardian/cdk": "52.1.0",
+    "@guardian/cdk": "52.2.0",
     "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
     "aws-cdk": "2.100.0",
     "aws-cdk-lib": "2.100.0",


### PR DESCRIPTION
## What does this change?
Uses a [recent change in GuCDK](https://github.com/guardian/cdk/releases/tag/v52.2.0) to enable backups of the RDS database in PROD (the test is updated so we can see the snapshot changes).

## Why?
Having database backups is good practice!

## How has it been verified?
Not sure how TBH, as true success is if the backup is made. @guardian/devx-reliability any advice?