### PR TITLE
don't bombard people with messages on a tuesday

### DIFF
--- a/packages/branch-protector/src/index.ts
+++ b/packages/branch-protector/src/index.ts
@@ -81,7 +81,7 @@ export async function main() {
 	const octokit: Octokit = await getGithubClient(config);
 	const sqsClient = new SQSClient({});
 
-	const messages: Message[] = await readFromQueue(config, 10, sqsClient);
+	const messages: Message[] = await readFromQueue(config, 5, sqsClient);
 	await Promise.all(
 		messages.map((msg) => handleMessage(config, octokit, sqsClient, msg)),
 	);

--- a/packages/branch-protector/src/index.ts
+++ b/packages/branch-protector/src/index.ts
@@ -81,7 +81,7 @@ export async function main() {
 	const octokit: Octokit = await getGithubClient(config);
 	const sqsClient = new SQSClient({});
 
-	const messages: Message[] = await readFromQueue(config, 5, sqsClient);
+	const messages: Message[] = await readFromQueue(config, 6, sqsClient);
 	await Promise.all(
 		messages.map((msg) => handleMessage(config, octokit, sqsClient, msg)),
 	);

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -51,7 +51,7 @@ async function notifyBranchProtector(
 		relevantRepos,
 		repoOwners,
 		teams,
-		2,
+		3,
 	);
 	await addMessagesToQueue(events, config);
 


### PR DESCRIPTION
## What does this change?

Bumping from 2 to 3 messages a day allows us to move through the backlog a little faster.
Repocop will add two messages to the backlog a day, but branch protector only runs four days a week. This means messages accumulate for three days over the weekend, and all get sent out at once. Let's work through the backlog at a more even pace

| Day of week | Messages Added | Messages read | Total in queue |
|-------------|----------------|---------------|----------------|
| Saturday  | 3 | 0 | 3 |
| Sunday    | 3 | 0 | 6 |
| Monday    | 3 | 0 | 9 |
| Tuesday   | 3 | 6 | 6 |
| Wednesday | 3 | 6 | 3 |
| Thursday  | 3 | 6 | 0 |
| Friday    | 3 | 3 | 0 |

