### PR TITLE
Interactive is a valid topic

### DIFF
--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -296,6 +296,18 @@ describe('Repository topics', () => {
 		expect(actual.topics).toEqual(true);
 	});
 
+	test(`Should validate repos with an interactive topic`, () => {
+		const repo: github_repositories = {
+			...nullRepo,
+			full_name: 'guardian/service-catalogue',
+			id: 1234n,
+			topics: ['interactive'],
+		};
+
+		const actual = repositoryRuleEvaluation(repo, [], []);
+		expect(actual.topics).toEqual(true);
+	});
+
 	test('Should return false when there are multiple recognised topics', () => {
 		// Having more than one recognised topic creates confusion about how the repo
 		// is being used, and could also confuse repocop.

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -73,6 +73,7 @@ function hasTopics(repo: github_repositories): boolean {
 		'testing',
 		'documentation',
 		'production',
+		'interactive',
 	];
 
 	return (


### PR DESCRIPTION
## What does this change?

Adds interactive as a valid status topic

## Why?

To reflect [best practices](https://github.com/guardian/service-catalogue/blob/main/packages/best-practices/best-practices.md) 


## How has it been verified?

tests pass
