### PR TITLE
Generate list of potential interactives

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -6,6 +6,7 @@ import {
 	notifyAnghammaradBranchProtection,
 	notifyBranchProtector,
 } from './remediations/repository-02-branch_protection';
+import { findPotentialInteractives } from './remediations/repository-06-topic-monitor-interactive';
 import { evaluateRepositories } from './rules/repository';
 
 async function writeEvaluationTable(
@@ -43,6 +44,11 @@ export async function main() {
 
 	const evaluatedRepos: repocop_github_repository_rules[] =
 		await evaluateRepositories(prisma, config.ignoredRepositoryPrefixes);
+
+	const potentialInteractives = findPotentialInteractives(evaluatedRepos);
+	console.log(
+		`Found ${potentialInteractives.length} potential interactives of ${evaluatedRepos.length} evaluated repositories`,
+	);
 
 	await writeEvaluationTable(evaluatedRepos, prisma);
 	if (config.enableMessaging) {

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.test.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.test.ts
@@ -1,0 +1,33 @@
+import type { repocop_github_repository_rules } from '@prisma/client';
+import { findPotentialInteractives } from './repository-06-topic-monitor-interactive';
+
+describe('findPotentialInteractives', () => {
+	it('should return an empty array when evaluatedRepos is empty', () => {
+		const evaluatedRepos: repocop_github_repository_rules[] = [];
+		const result = findPotentialInteractives(evaluatedRepos);
+		expect(result).toEqual([]);
+	});
+
+	it('should return an only repositories with no valid topics', () => {
+		const exampleRepo = {
+			full_name: 'org/repo1',
+			default_branch_name: true,
+			branch_protection: true,
+			team_based_access: true,
+			admin_access: true,
+			archiving: true,
+			topics: true,
+			contents: true,
+			evaluated_on: new Date(),
+		};
+
+		const evaluatedRepos: repocop_github_repository_rules[] = [
+			exampleRepo,
+			{ ...exampleRepo, full_name: 'org/repo2' },
+			{ ...exampleRepo, full_name: 'org/repo3', topics: false },
+		];
+
+		const result = findPotentialInteractives(evaluatedRepos);
+		expect(result).toEqual(['org/repo3']);
+	});
+});

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
@@ -1,0 +1,9 @@
+import type { repocop_github_repository_rules } from '@prisma/client';
+
+export function findPotentialInteractives(
+	evaluatedRepos: repocop_github_repository_rules[],
+): string[] {
+	return evaluatedRepos
+		.filter((repo) => !repo.topics)
+		.map((repo) => repo.full_name);
+}


### PR DESCRIPTION
## What does this change?

Creates a list of unlabelled repos that could be interactives.

## Why?

There are a few clues indicating that a repository might be an interactive

1. The repository was created from a list of template repositories the interactives team uses
2. We can detect artifacts from that repo in a particular bucket

Going through potentially hundreds of candidates and checking them all here would take too much time, so we're generating a list of repos to be submitted elsewhere for checks.

## How has it been verified?

Unit tests have been added.
