### PR TITLE
Add aws_ec2_images to 5 minutely ec2 cloudquery task

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -8545,6 +8545,7 @@ spec:
   tables:
     - aws_ec2_instances
     - aws_ec2_security_groups
+    - aws_ec2_images
   destinations:
     - postgresql
   spec:
@@ -11166,6 +11167,7 @@ spec:
     - aws_dynamodb*
     - aws_ec2_instances
     - aws_ec2_security_groups
+    - aws_ec2_images
   destinations:
     - postgresql
   concurrency: 2000

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -324,7 +324,11 @@ export class ServiceCatalogue extends GuStack {
 					'Collecting EC2 instance information, and their security groups. Uses include identifying instances failing the "30 day old" SLO, and (eventually) replacing Prism.',
 				schedule: nonProdSchedule ?? Schedule.rate(Duration.minutes(5)),
 				config: awsSourceConfigForOrganisation({
-					tables: ['aws_ec2_instances', 'aws_ec2_security_groups'],
+					tables: [
+						'aws_ec2_instances',
+						'aws_ec2_security_groups',
+						'aws_ec2_images',
+					],
 				}),
 				managedPolicies: [readonlyPolicy],
 				policies: [listOrgsPolicy, standardDenyPolicy, cloudqueryAccess('*')],


### PR DESCRIPTION
## What does this change?

This change adds the aws_ec2_images table to the task which syncs ec2 data every 5 minutes.

## Why?

AWS EC2 AMI data was fairly out of date, and caused some dashboards/queries to report misleading information.