### PR TITLE
bump versions

### DIFF
--- a/.env
+++ b/.env
@@ -3,10 +3,10 @@
 # Environment variables shared between ci and DEV.
 
 # See https://github.com/cloudquery/cloudquery/releases?q=cli
-CQ_CLI=3.14.4
+CQ_CLI=3.28.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql
-CQ_POSTGRES_DESTINATION=5.0.6
+CQ_POSTGRES_DESTINATION=7.0.1
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-postgresql
 CQ_POSTGRES_SOURCE=3.0.7
@@ -18,13 +18,13 @@ CQ_AWS=22.18.0
 CQ_GITHUB=7.4.2
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-fastly
-CQ_FASTLY=2.1.5
+CQ_FASTLY=2.1.12
 
 # See https://github.com/guardian/cq-source-galaxies
 CQ_GUARDIAN_GALAXIES=1.1.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-snyk
-CQ_SNYK=3.1.5
+CQ_SNYK=3.1.11
 
 # See https://github.com/guardian/cq-source-snyk-full-project
 CQ_GUARDIAN_SNYK=0.1.1

--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ CQ_POSTGRES_SOURCE=3.0.7
 CQ_AWS=22.18.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
-CQ_GITHUB=7.4.0
+CQ_GITHUB=7.4.2
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-fastly
 CQ_FASTLY=2.1.5

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -225,7 +225,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -237,7 +237,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -861,7 +861,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -873,7 +873,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -1480,7 +1480,7 @@ spec:
 spec:
   name: fastly
   path: cloudquery/fastly
-  version: v2.1.5
+  version: v2.1.12
   tables:
     - fastly_services
     - fastly_service_versions
@@ -1497,7 +1497,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -1509,7 +1509,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -2120,7 +2120,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -2135,7 +2135,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -2953,7 +2953,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -2965,7 +2965,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -3407,7 +3407,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -3419,7 +3419,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -4071,7 +4071,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -4083,7 +4083,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -4751,7 +4751,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -4763,7 +4763,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -5354,7 +5354,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -5366,7 +5366,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -5996,7 +5996,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -6008,7 +6008,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -6668,7 +6668,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -6680,7 +6680,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -7480,7 +7480,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -7492,7 +7492,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -7922,7 +7922,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -7934,7 +7934,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -8566,7 +8566,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -8578,7 +8578,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -9209,7 +9209,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -9221,7 +9221,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -10052,7 +10052,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -10064,7 +10064,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -10494,7 +10494,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -10506,7 +10506,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -11189,7 +11189,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -11201,7 +11201,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -12032,7 +12032,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -12044,7 +12044,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -12460,7 +12460,7 @@ spec:
 spec:
   name: snyk
   path: cloudquery/snyk
-  version: v3.1.5
+  version: v3.1.11
   tables:
     - snyk_dependencies
     - snyk_groups
@@ -12483,7 +12483,7 @@ spec:
   name: postgresql
   registry: github
   path: cloudquery/postgresql
-  version: v5.0.6
+  version: v7.0.1
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -12495,7 +12495,7 @@ spec:
               "",
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.14.4",
+            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -2934,7 +2934,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v7.4.0
+  version: v7.4.2
   tables:
     - github_issues
   destinations:
@@ -3381,7 +3381,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v7.4.0
+  version: v7.4.2
   tables:
     - github_repositories
     - github_repository_branches
@@ -4045,7 +4045,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v7.4.0
+  version: v7.4.2
   tables:
     - github_organizations
     - github_organization_members

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -3,11 +3,8 @@ import { dump } from 'js-yaml';
 import {
 	awsSourceConfigForAccount,
 	awsSourceConfigForOrganisation,
-	fastlySourceConfig,
-	galaxiesSourceConfig,
 	githubSourceConfig,
 	postgresDestinationConfig,
-	snykSourceConfig,
 } from './config';
 
 describe('Config generation, and converting to YAML', () => {
@@ -19,7 +16,7 @@ describe('Config generation, and converting to YAML', () => {
 		  name: postgresql
 		  registry: github
 		  path: cloudquery/postgresql
-		  version: v5.0.6
+		  version: v7.0.1
 		  migrate_mode: forced
 		  spec:
 		    connection_string: >-
@@ -151,67 +148,6 @@ spec:
 		        private_key_path: /github-private-key
 		        app_id: \${file:/github-app-id}
 		        installation_id: \${file:/github-installation-id}
-		"
-	`);
-	});
-
-	it('Should create a Fastly source configuration', () => {
-		const config = fastlySourceConfig({ tables: ['*'] });
-		expect(dump(config)).toMatchInlineSnapshot(`
-		"kind: source
-		spec:
-		  name: fastly
-		  path: cloudquery/fastly
-		  version: v2.1.5
-		  tables:
-		    - '*'
-		  destinations:
-		    - postgresql
-		  concurrency: 1000
-		  spec:
-		    fastly_api_key: \${FASTLY_API_KEY}
-		"
-	`);
-	});
-
-	it('Should create a Galaxies source configuration', () => {
-		const config = galaxiesSourceConfig('my-galaxies-bucket');
-		expect(dump(config)).toMatchInlineSnapshot(`
-		"kind: source
-		spec:
-		  name: galaxies
-		  path: guardian/galaxies
-		  version: v1.1.0
-		  destinations:
-		    - postgresql
-		  tables:
-		    - galaxies_people_table
-		    - galaxies_teams_table
-		    - galaxies_streams_table
-		    - galaxies_people_profile_info_table
-		  spec:
-		    bucket: my-galaxies-bucket
-		"
-	`);
-	});
-
-	it('Should create a Snyk source configuration', () => {
-		const config = snykSourceConfig({ tables: ['*'] });
-		expect(dump(config)).toMatchInlineSnapshot(`
-		"kind: source
-		spec:
-		  name: snyk
-		  path: cloudquery/snyk
-		  version: v3.1.5
-		  tables:
-		    - '*'
-		  destinations:
-		    - postgresql
-		  spec:
-		    api_key: \${SNYK_API_KEY}
-		    table_options:
-		      snyk_reporting_issues:
-		        period: 30d
 		"
 	`);
 	});

--- a/packages/cdk/lib/ecs/config.test.ts
+++ b/packages/cdk/lib/ecs/config.test.ts
@@ -137,7 +137,7 @@ spec:
 		spec:
 		  name: github
 		  path: cloudquery/github
-		  version: v7.4.0
+		  version: v7.4.2
 		  tables:
 		    - github_repositories
 		  destinations:


### PR DESCRIPTION
## What does this change?

- bumps versions
- deletes most snapshot tests

## Why?

- they need bumping
- inline snapshots are not automatically updated when using this version of jest. We've removed some of them for now as two is enough to verify that the functionality works, while being less annoying to developers

## How has it been verified?
TODO: test on code
