### PR TITLE
Create interactive monitor infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,7 @@ jobs:
               - packages/repocop/dist/repocop.zip
             branch-protector:
               - packages/branch-protector/dist/branch-protector.zip
+            interactive-monitor:
+              - packages/interactive-monitor/dist/interactive-monitor.zip
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'

--- a/package-lock.json
+++ b/package-lock.json
@@ -8529,6 +8529,10 @@
       "version": "2.0.4",
       "license": "ISC"
     },
+    "node_modules/interactive-monitor": {
+      "resolved": "packages/interactive-monitor",
+      "link": true
+    },
     "node_modules/internal-slot": {
       "version": "1.0.5",
       "dev": true,
@@ -12307,6 +12311,9 @@
       "dependencies": {
         "@guardian/anghammarad": "^1.8.1"
       }
+    },
+    "packages/interactive-monitor": {
+      "version": "1.0.0"
     },
     "packages/repocop": {
       "version": "1.0.0",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -11,7 +11,6 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuStringParameter",
       "GuLoggingStreamNameParameter",
       "GuAnghammaradTopicParameter",
-      "GuParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuScheduledLambda",
@@ -52,10 +51,6 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
-    },
-    "interactivebucket": {
-      "Description": "The name of the S3 bucket where the interactive content is stored",
-      "Type": "String",
     },
   },
   "Resources": {
@@ -13726,14 +13721,12 @@ spec:
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "deploy/TEST//index.js",
+          "S3Key": "deploy/TEST//interactive-monitor.zip",
         },
         "Environment": {
           "Variables": {
             "APP": "",
-            "BUCKET": {
-              "Ref": "interactivebucket",
-            },
+            "BUCKET": "???",
             "GITHUB_CREDENTIALS": "???",
             "STACK": "deploy",
             "STAGE": "TEST",
@@ -13885,7 +13878,7 @@ spec:
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/deploy/TEST//index.js",
+                      "/deploy/TEST//interactive-monitor.zip",
                     ],
                   ],
                 },

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -13721,18 +13721,15 @@ spec:
           "S3Bucket": {
             "Ref": "DistributionBucketName",
           },
-          "S3Key": "deploy/TEST//interactive-monitor.zip",
+          "S3Key": "deploy/TEST/interactive-monitor/interactive-monitor.zip",
         },
         "Environment": {
           "Variables": {
-            "APP": "",
+            "APP": "interactive-monitor",
             "BUCKET": "???",
             "GITHUB_CREDENTIALS": "???",
             "STACK": "deploy",
             "STAGE": "TEST",
-            "TOPIC_ARN": {
-              "Ref": "TopicBFC7AF6E",
-            },
           },
         },
         "Handler": "index.handler",
@@ -13747,7 +13744,7 @@ spec:
         "Tags": [
           {
             "Key": "App",
-            "Value": "",
+            "Value": "interactive-monitor",
           },
           {
             "Key": "gu:cdk:version",
@@ -13817,7 +13814,7 @@ spec:
         "Tags": [
           {
             "Key": "App",
-            "Value": "",
+            "Value": "interactive-monitor",
           },
           {
             "Key": "gu:cdk:version",
@@ -13878,7 +13875,7 @@ spec:
                       {
                         "Ref": "DistributionBucketName",
                       },
-                      "/deploy/TEST//interactive-monitor.zip",
+                      "/deploy/TEST/interactive-monitor/interactive-monitor.zip",
                     ],
                   ],
                 },
@@ -13899,7 +13896,7 @@ spec:
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/deploy/",
+                    ":parameter/TEST/deploy/interactive-monitor",
                   ],
                 ],
               },
@@ -13922,7 +13919,7 @@ spec:
                     {
                       "Ref": "AWS::AccountId",
                     },
-                    ":parameter/TEST/deploy//*",
+                    ":parameter/TEST/deploy/interactive-monitor/*",
                   ],
                 ],
               },

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -11,11 +11,11 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuStringParameter",
       "GuLoggingStreamNameParameter",
       "GuAnghammaradTopicParameter",
-      "GuDistributionBucketParameter",
-      "GuScheduledLambda",
-      "GuScheduledLambda",
       "GuParameter",
+      "GuDistributionBucketParameter",
       "GuLambdaFunction",
+      "GuScheduledLambda",
+      "GuScheduledLambda",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -13988,6 +13988,9 @@ spec:
                 "Endpoint.Address",
               ],
             },
+            "INTERACTIVE_MONITOR_TOPIC_ARN": {
+              "Ref": "TopicBFC7AF6E",
+            },
             "QUERY_LOGGING": "false",
             "STACK": "deploy",
             "STAGE": "TEST",
@@ -14244,6 +14247,13 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "AnghammaradSnsArn",
+              },
+            },
+            {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "TopicBFC7AF6E",
               },
             },
           ],

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -14,6 +14,8 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuDistributionBucketParameter",
       "GuScheduledLambda",
       "GuScheduledLambda",
+      "GuParameter",
+      "GuLambdaFunction",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -50,6 +52,10 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+    "interactivebucket": {
+      "Description": "The name of the S3 bucket where the interactive content is stored",
+      "Type": "String",
     },
   },
   "Resources": {
@@ -13085,6 +13091,30 @@ spec:
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
     },
+    "TopicBFC7AF6E": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "TopicName": "interactive-monitor-topic",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
     "branchprotector2BAF8BEE": {
       "DependsOn": [
         "branchprotectorServiceRoleDefaultPolicyD589D260",
@@ -13685,6 +13715,251 @@ spec:
       },
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
+    },
+    "interactivemonitor3435C6C2": {
+      "DependsOn": [
+        "interactivemonitorServiceRoleDefaultPolicy44B1B670",
+        "interactivemonitorServiceRoleC210EED3",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "deploy/TEST//index.js",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "",
+            "BUCKET": {
+              "Ref": "interactivebucket",
+            },
+            "GITHUB_CREDENTIALS": "???",
+            "STACK": "deploy",
+            "STAGE": "TEST",
+            "TOPIC_ARN": {
+              "Ref": "TopicBFC7AF6E",
+            },
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "interactivemonitorServiceRoleC210EED3",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "interactivemonitorAllowInvokeServiceCatalogueTopic0AC51635C623A304": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "interactivemonitor3435C6C2",
+            "Arn",
+          ],
+        },
+        "Principal": "sns.amazonaws.com",
+        "SourceArn": {
+          "Ref": "TopicBFC7AF6E",
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "interactivemonitorServiceRoleC210EED3": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "interactivemonitorServiceRoleDefaultPolicy44B1B670": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/deploy/TEST//index.js",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy//*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "interactivemonitorServiceRoleDefaultPolicy44B1B670",
+        "Roles": [
+          {
+            "Ref": "interactivemonitorServiceRoleC210EED3",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "interactivemonitorTopic5CA9BB6E": {
+      "Properties": {
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "interactivemonitor3435C6C2",
+            "Arn",
+          ],
+        },
+        "Protocol": "lambda",
+        "TopicArn": {
+          "Ref": "TopicBFC7AF6E",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
     },
     "repocop20553EB8": {
       "DependsOn": [

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -5,6 +5,7 @@ import { Topic } from 'aws-cdk-lib/aws-sns';
 import { LambdaSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 
 export class InteractiveMonitor {
+	public topic: Topic;
 	constructor(guStack: GuStack) {
 		// your class implementation here
 		const topic = new Topic(guStack, 'Topic', {
@@ -34,5 +35,7 @@ export class InteractiveMonitor {
 		});
 
 		topic.addSubscription(new LambdaSubscription(lambda, {}));
+
+		this.topic = topic;
 	}
 }

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -1,0 +1,38 @@
+import { GuParameter, type GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Topic } from 'aws-cdk-lib/aws-sns';
+import { LambdaSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
+
+export class InteractiveMonitor {
+	constructor(guStack: GuStack) {
+		// your class implementation here
+		const topic = new Topic(guStack, 'Topic', {
+			topicName: 'interactive-monitor-topic',
+		});
+
+		const interactiveBucketParameter = new GuParameter(
+			guStack,
+			'interactive-bucket',
+			{
+				type: 'String',
+				description:
+					'The name of the S3 bucket where the interactive content is stored',
+			},
+		);
+
+		const lambda = new GuLambdaFunction(guStack, 'interactive-monitor', {
+			app: guStack.app ?? '',
+			fileName: 'index.js',
+			handler: 'index.handler',
+			runtime: Runtime.NODEJS_18_X,
+			environment: {
+				TOPIC_ARN: topic.topicArn,
+				BUCKET: interactiveBucketParameter.valueAsString,
+				GITHUB_CREDENTIALS: '???',
+			},
+		});
+
+		topic.addSubscription(new LambdaSubscription(lambda, {}));
+	}
+}

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -4,20 +4,21 @@ import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { LambdaSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 
+const app = 'interactive-monitor';
+
 export class InteractiveMonitor {
 	public topic: Topic;
 	constructor(guStack: GuStack) {
 		const topic = new Topic(guStack, 'Topic', {
-			topicName: 'interactive-monitor-topic',
+			topicName: `${app}-topic`,
 		});
 
-		const lambda = new GuLambdaFunction(guStack, 'interactive-monitor', {
-			app: guStack.app ?? '',
-			fileName: 'interactive-monitor.zip',
+		const lambda = new GuLambdaFunction(guStack, app, {
+			app,
+			fileName: `${app}.zip`,
 			handler: 'index.handler',
 			runtime: Runtime.NODEJS_18_X,
 			environment: {
-				TOPIC_ARN: topic.topicArn,
 				BUCKET: '???',
 				GITHUB_CREDENTIALS: '???',
 			},

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -1,4 +1,4 @@
-import { GuParameter, type GuStack } from '@guardian/cdk/lib/constructs/core';
+import { type GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Topic } from 'aws-cdk-lib/aws-sns';
@@ -7,29 +7,18 @@ import { LambdaSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 export class InteractiveMonitor {
 	public topic: Topic;
 	constructor(guStack: GuStack) {
-		// your class implementation here
 		const topic = new Topic(guStack, 'Topic', {
 			topicName: 'interactive-monitor-topic',
 		});
 
-		const interactiveBucketParameter = new GuParameter(
-			guStack,
-			'interactive-bucket',
-			{
-				type: 'String',
-				description:
-					'The name of the S3 bucket where the interactive content is stored',
-			},
-		);
-
 		const lambda = new GuLambdaFunction(guStack, 'interactive-monitor', {
 			app: guStack.app ?? '',
-			fileName: 'index.js',
+			fileName: 'interactive-monitor.zip',
 			handler: 'index.handler',
 			runtime: Runtime.NODEJS_18_X,
 			environment: {
 				TOPIC_ARN: topic.topicArn,
-				BUCKET: interactiveBucketParameter.valueAsString,
+				BUCKET: '???',
 				GITHUB_CREDENTIALS: '???',
 			},
 		});

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -610,6 +610,8 @@ export class ServiceCatalogue extends GuStack {
 		const stageAwareMonitoringConfiguration =
 			stage === 'PROD' ? prodMonitoring : codeMonitoring;
 
+		const interactiveMonitor = new InteractiveMonitor(this);
+
 		const repocopLampdaProps: GuScheduledLambdaProps = {
 			app: 'repocop',
 			fileName: 'repocop.zip',
@@ -630,6 +632,7 @@ export class ServiceCatalogue extends GuStack {
 				// Set this to 'true' to enable SQL query logging
 				QUERY_LOGGING: 'false',
 				BRANCH_PROTECTOR_QUEUE_URL: branchProtectorQueue.queueUrl,
+				INTERACTIVE_MONITOR_TOPIC_ARN: interactiveMonitor.topic.topicArn,
 			},
 			vpc,
 			securityGroups: [applicationToPostgresSecurityGroup],
@@ -692,7 +695,6 @@ export class ServiceCatalogue extends GuStack {
 		branchProtectorGithubCredentials.grantRead(branchProtectorLambda);
 		anghammaradTopic.grantPublish(branchProtectorLambda);
 		anghammaradTopic.grantPublish(repocopLambda);
-
-		new InteractiveMonitor(this);
+		interactiveMonitor.topic.grantPublish(repocopLambda);
 	}
 }

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -64,6 +64,7 @@ import {
 	listOrgsPolicy,
 	readBucketPolicy,
 } from './ecs/policies';
+import { InteractiveMonitor } from './interactive-monitor';
 
 interface ServiceCatalogueProps extends GuStackProps {
 	//TODO add fields for every kind of job to make schedule explicit at a glance.
@@ -691,5 +692,7 @@ export class ServiceCatalogue extends GuStack {
 		branchProtectorGithubCredentials.grantRead(branchProtectorLambda);
 		anghammaradTopic.grantPublish(branchProtectorLambda);
 		anghammaradTopic.grantPublish(repocopLambda);
+
+		new InteractiveMonitor(this);
 	}
 }

--- a/packages/interactive-monitor/README.md
+++ b/packages/interactive-monitor/README.md
@@ -1,0 +1,1 @@
+## Interactive Monitor

--- a/packages/interactive-monitor/package.json
+++ b/packages/interactive-monitor/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "interactive-monitor",
+	"version": "1.0.0",
+	"description": "A lambda which applies branch protection to repos that are passed to it via an SQS topic",
+	"main": "index.ts",
+	"scripts": {
+		"build": "esbuild src/index.ts --bundle --platform=node --target=node18 --outdir=dist --external:@aws-sdk",
+		"test": "echo \"No test specified\" && exit 0"
+	},
+	"author": "guardian"
+}

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -1,0 +1,3 @@
+export function main() {
+	console.log('Hello, world!');
+}

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -1,3 +1,3 @@
-export function main() {
+export function handler() {
 	console.log('Hello, world!');
 }

--- a/packages/interactive-monitor/tsconfig.json
+++ b/packages/interactive-monitor/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "references": [{ "path": "../common" }]
+}

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -29,13 +29,14 @@ createRepocopZip() {
   )
 }
 
-createBranchProtectorZip() {
-  echo "Creating branch-protector package"
+createZip() {
+  echo "Creating $1 package"
   (
-    cd "$ROOT_DIR/packages/branch-protector/dist"
-    zip -qr branch-protector.zip .
+    cd "$ROOT_DIR/packages/$1/dist"
+    zip -qr "$1".zip .
   )
 }
 
 createRepocopZip
-createBranchProtectorZip
+createZip "branch-protector"
+createZip "interactive-monitor"


### PR DESCRIPTION
## What does this change?

Creates infrastructure for a lambda that will:

1. Listen to repocop for repositories that might be interactives
2. Run checks to verify whether or not a repository is an interactive
3. Apply the relevant label to the repository if required

For now though, it just says hello.

## Why?

We aim to have as many repos as possible labelled with a valid production status, so we can prioritise it appropriately. New interactives pop up all the time, so we need an ongoing way to detect them.

## How has it been verified?

Deployed to code.
