### PR TITLE
fix(OrgWideEc2): Skip `aws_ec2_images` dependent tables, and reduce frequency

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -8546,6 +8546,9 @@ spec:
     - aws_ec2_instances
     - aws_ec2_security_groups
     - aws_ec2_images
+  skip_tables:
+    - aws_ec2_image_launch_permissions
+    - aws_ec2_image_last_launched_times
   destinations:
     - postgresql
   spec:

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -8484,7 +8484,7 @@ spec:
     },
     "CloudquerySourceOrgWideEc2ScheduledEventRule3D54BEFB": {
       "Properties": {
-        "ScheduleExpression": "rate(5 minutes)",
+        "ScheduleExpression": "rate(20 minutes)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -322,7 +322,7 @@ export class ServiceCatalogue extends GuStack {
 				name: 'OrgWideEc2',
 				description:
 					'Collecting EC2 instance information, and their security groups. Uses include identifying instances failing the "30 day old" SLO, and (eventually) replacing Prism.',
-				schedule: nonProdSchedule ?? Schedule.rate(Duration.minutes(5)),
+				schedule: nonProdSchedule ?? Schedule.rate(Duration.minutes(20)),
 				config: awsSourceConfigForOrganisation({
 					tables: [
 						'aws_ec2_instances',

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -329,6 +329,15 @@ export class ServiceCatalogue extends GuStack {
 						'aws_ec2_security_groups',
 						'aws_ec2_images',
 					],
+					skipTables: [
+						/*
+						These are dependent tables of `aws_ec2_images` and are automatically collected.
+						They're not interesting, so skip them here.
+						They'll be collected in the `RemainingAwsData` job.
+						 */
+						'aws_ec2_image_launch_permissions',
+						'aws_ec2_image_last_launched_times',
+					],
 				}),
 				managedPolicies: [readonlyPolicy],
 				policies: [listOrgsPolicy, standardDenyPolicy, cloudqueryAccess('*')],


### PR DESCRIPTION
## What does this change?
In #456 we added a new table to the `OrgWideEc2` task. Skip some [dependent tables](https://www.cloudquery.io/docs/plugins/sources/aws/tables/aws_ec2_images) as we're not using them. This should reduce the execution time.

To provide a sense of scale:

```sql
select count(*) from aws_ec2_image_launch_permissions; -- 180127
select count(*) from aws_ec2_image_last_launched_times; -- 2674
```

## Why?
The `OrgWideEc2` task runs every 5 minutes, and we're seeing it exceed that duration, and backing up. PROD had multiple instances running at once. This is likely to begin a [thundering herd](https://en.wikipedia.org/wiki/Thundering_herd_problem) scenario, and impact billing.

<img width="1652" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/b77c23a9-5421-4aee-a2f2-fd7776548ea9">

## How has it been verified?
TBD.