### PR TITLE
Run `OrgWideEc2` task every 30 minutes

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -8323,7 +8323,7 @@ spec:
     },
     "CloudquerySourceOrgWideEc2ScheduledEventRule3D54BEFB": {
       "Properties": {
-        "ScheduleExpression": "rate(5 minutes)",
+        "ScheduleExpression": "rate(30 minutes)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -301,7 +301,7 @@ export class ServiceCatalogue extends GuStack {
 				name: 'OrgWideEc2',
 				description:
 					'Collecting EC2 instance information, and their security groups. Uses include identifying instances failing the "30 day old" SLO, and (eventually) replacing Prism.',
-				schedule: nonProdSchedule ?? Schedule.rate(Duration.minutes(5)),
+				schedule: nonProdSchedule ?? Schedule.rate(Duration.minutes(30)),
 				config: awsSourceConfigForOrganisation({
 					tables: [
 						'aws_ec2_instances',


### PR DESCRIPTION
## What does this change?
After https://github.com/guardian/service-catalogue/pull/456 this task is taking longer than 5 minutes to run, and therefore seeing overlapping runs. Run every 30 minutes instead in an attempt to avoid overlaps.

This is a regression. Once we enable singleton tasks, we can run at a more frequent schedule.