### PR TITLE
Skip `snyk_organization_provisions`

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -12193,9 +12193,10 @@ spec:
     - snyk_integrations
     - snyk_organizations
     - snyk_organization_members
-    - snyk_organization_provisions
     - snyk_reporting_issues
     - snyk_reporting_latest_issues
+  skip_tables:
+    - snyk_organization_provisions
   destinations:
     - postgresql
   spec:

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -519,10 +519,10 @@ export class ServiceCatalogue extends GuStack {
 						'snyk_integrations',
 						'snyk_organizations',
 						'snyk_organization_members',
-						'snyk_organization_provisions',
 						'snyk_reporting_issues',
 						'snyk_reporting_latest_issues',
 					],
+					skipTables: ['snyk_organization_provisions'],
 				}),
 				secrets: {
 					SNYK_API_KEY: Secret.fromSecretsManager(snykCredentials, 'api-key'),


### PR DESCRIPTION


## What does this change?

Skip `snyk_organization_provisions`

## Why?

The API this table depends on does not allow service users from accessing it https://snyk.docs.apiary.io/#reference/organizations/manage-organization/list-pending-user-provisions . This causes a lot of errors in our logs that can throw off our alerts.