### PR TITLE
Refactor: Move shareable functions into shared file

### DIFF
--- a/packages/branch-protector/src/index.ts
+++ b/packages/branch-protector/src/index.ts
@@ -1,7 +1,7 @@
 import type { Message } from '@aws-sdk/client-sqs';
 import { SQSClient } from '@aws-sdk/client-sqs';
 import { getGithubClient } from 'common/functions';
-import type { UpdateBranchProtectionEvent } from 'common/types';
+import type { UpdateMessageEvent } from 'common/types';
 import type { Octokit } from 'octokit';
 import { deleteFromQueue, notify, readFromQueue } from './aws-requests';
 import { getConfig } from './config';
@@ -15,7 +15,7 @@ import {
 async function protectBranch(
 	octokit: Octokit,
 	config: Config,
-	event: UpdateBranchProtectionEvent,
+	event: UpdateMessageEvent,
 ) {
 	const [owner, repo] = event.fullName.split('/');
 
@@ -64,7 +64,7 @@ async function handleMessage(
 	message: Message,
 ) {
 	if (message.Body !== undefined) {
-		const event = JSON.parse(message.Body) as UpdateBranchProtectionEvent;
+		const event = JSON.parse(message.Body) as UpdateMessageEvent;
 		try {
 			await protectBranch(octokit, config, event);
 		} catch (error) {

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -78,6 +78,27 @@ export function branchProtectionCtas(
 	];
 }
 
+export function topicProductionCtas(
+	fullRepoName: string,
+	teamSlug: string,
+): Action[] {
+	const githubUrl = `https://github.com/${fullRepoName}`;
+	const grafanaUrl = `https://metrics.gutools.co.uk/d/EOPnljWIz/repocop-compliance?var-team=${teamSlug}&var-rule=All&orgId=1`;
+	const topicsUrl = `https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics#adding-topics-to-your-repository`;
+
+	return [
+		{ cta: 'Repository', url: githubUrl },
+		{
+			cta: 'Compliance information for repos',
+			url: grafanaUrl,
+		},
+		{
+			cta: 'How to add a topic',
+			url: topicsUrl,
+		},
+	];
+}
+
 export function anghammaradThreadKey(fullRepoName: string) {
 	return `service-catalogue-${fullRepoName.replaceAll('/', '-')}`;
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -9,6 +9,7 @@ export type GithubAppSecret = {
 };
 
 export interface UpdateBranchProtectionEvent {
+export interface UpdateMessageEvent {
 	fullName: string; // in the format of owner/repo-name
 	teamNameSlugs: string[];
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -7,8 +7,6 @@ export type GithubAppSecret = {
 	clientSecret: string;
 	installationId: string;
 };
-
-export interface UpdateBranchProtectionEvent {
 export interface UpdateMessageEvent {
 	fullName: string; // in the format of owner/repo-name
 	teamNameSlugs: string[];

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -54,7 +54,7 @@ export interface Config {
 	/**
 	 * SQS queue to send topic 'production' messages to.
 	 */
-	topicProductionQueueUrl: string;
+	// topicProductionQueueUrl: string; //TODO
 
 	/**
 	 * Flag to enable messaging when running locally.
@@ -118,7 +118,7 @@ export async function getConfig(): Promise<Config> {
 		databaseConnectionString: await getDatabaseConnectionString(databaseConfig),
 		withQueryLogging: queryLogging,
 		branchProtectorQueueUrl: getEnvOrThrow('BRANCH_PROTECTOR_QUEUE_URL'),
-		topicProductionQueueUrl: getEnvOrThrow('TOPIC_PRODUCTION_QUEUE_URL'), // TODO: produce this
+		// topicProductionQueueUrl: getEnvOrThrow('TOPIC_PRODUCTION_QUEUE_URL'), // TODO: produce this
 		enableMessaging: process.env.ENABLE_MESSAGING === 'false' ? false : true,
 		ignoredRepositoryPrefixes: [
 			'guardian/esd-', // ESD team

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -47,9 +47,14 @@ export interface Config {
 	ignoredRepositoryPrefixes: string[];
 
 	/**
-	 * SQS queue to send messages to.
+	 * SQS queue to send branch protector messages to.
 	 */
-	queueUrl: string;
+	branchProtectorQueueUrl: string;
+
+	/**
+	 * SQS queue to send topic 'production' messages to.
+	 */
+	topicProductionQueueUrl: string;
 
 	/**
 	 * Flag to enable messaging when running locally.
@@ -112,7 +117,8 @@ export async function getConfig(): Promise<Config> {
 		interactiveMonitorSnsTopic: getEnvOrThrow('INTERACTIVE_MONITOR_TOPIC_ARN'),
 		databaseConnectionString: await getDatabaseConnectionString(databaseConfig),
 		withQueryLogging: queryLogging,
-		queueUrl: getEnvOrThrow('BRANCH_PROTECTOR_QUEUE_URL'),
+		branchProtectorQueueUrl: getEnvOrThrow('BRANCH_PROTECTOR_QUEUE_URL'),
+		topicProductionQueueUrl: getEnvOrThrow('TOPIC_PRODUCTION_QUEUE_URL'), // TODO: produce this
 		enableMessaging: process.env.ENABLE_MESSAGING === 'false' ? false : true,
 		ignoredRepositoryPrefixes: [
 			'guardian/esd-', // ESD team

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -54,7 +54,7 @@ export interface Config {
 	/**
 	 * SQS queue to send topic 'production' messages to.
 	 */
-	// topicProductionQueueUrl: string; //TODO
+	topicProductionQueueUrl: string;
 
 	/**
 	 * Flag to enable messaging when running locally.
@@ -118,6 +118,7 @@ export async function getConfig(): Promise<Config> {
 		databaseConnectionString: await getDatabaseConnectionString(databaseConfig),
 		withQueryLogging: queryLogging,
 		branchProtectorQueueUrl: getEnvOrThrow('BRANCH_PROTECTOR_QUEUE_URL'),
+		topicProductionQueueUrl: getEnvOrThrow('BRANCH_PROTECTOR_QUEUE_URL'), // TODO: remove this
 		// topicProductionQueueUrl: getEnvOrThrow('TOPIC_PRODUCTION_QUEUE_URL'), // TODO: produce this
 		enableMessaging: process.env.ENABLE_MESSAGING === 'false' ? false : true,
 		ignoredRepositoryPrefixes: [

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -8,8 +8,8 @@ import { Anghammarad } from '@guardian/anghammarad';
 import type { repocop_github_repository_rules } from '@prisma/client';
 import { PrismaClient } from '@prisma/client';
 import { getLocalProfile, shuffle } from 'common/src/functions';
-import type { Config } from './config';
 import type { UpdateMessageEvent } from 'common/types';
+import type { Config } from './config';
 import { getConfig } from './config';
 import {
 	notifyAnghammaradBranchProtection,

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -9,6 +9,7 @@ import type { repocop_github_repository_rules } from '@prisma/client';
 import { PrismaClient } from '@prisma/client';
 import { getLocalProfile, shuffle } from 'common/src/functions';
 import type { Config } from './config';
+import type { UpdateBranchProtectionEvent } from 'common/types';
 import { getConfig } from './config';
 import {
 	notifyAnghammaradBranchProtection,
@@ -89,7 +90,11 @@ export async function main() {
 	await writeEvaluationTable(evaluatedRepos, prisma);
 	if (config.enableMessaging) {
 		await sendPotentialInteractives(evaluatedRepos, config);
-		const msgs = await notifyBranchProtector(prisma, evaluatedRepos, config);
+		const msgs: UpdateBranchProtectionEvent[] = await notifyBranchProtector(
+			prisma,
+			evaluatedRepos,
+			config,
+		);
 		if (config.stage === 'PROD') {
 			const anghammaradClient = new Anghammarad();
 			await notifyAnghammaradBranchProtection(msgs, config, anghammaradClient);

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -48,7 +48,7 @@ async function sendPotentialInteractives(
 
 	const PublishBatchRequestEntries = potentialInteractives.map(
 		(repo): PublishBatchRequestEntry => ({
-			Id: repo,
+			Id: repo.replace(/\W/g, ''),
 			Message: repo,
 		}),
 	);

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -9,7 +9,7 @@ import type { repocop_github_repository_rules } from '@prisma/client';
 import { PrismaClient } from '@prisma/client';
 import { getLocalProfile, shuffle } from 'common/src/functions';
 import type { Config } from './config';
-import type { UpdateBranchProtectionEvent } from 'common/types';
+import type { UpdateMessageEvent } from 'common/types';
 import { getConfig } from './config';
 import {
 	notifyAnghammaradBranchProtection,
@@ -90,7 +90,7 @@ export async function main() {
 	await writeEvaluationTable(evaluatedRepos, prisma);
 	if (config.enableMessaging) {
 		await sendPotentialInteractives(evaluatedRepos, config);
-		const msgs: UpdateBranchProtectionEvent[] = await notifyBranchProtector(
+		const msgs: UpdateMessageEvent[] = await notifyBranchProtector(
 			prisma,
 			evaluatedRepos,
 			config,

--- a/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
@@ -3,7 +3,7 @@ import type {
 	repocop_github_repository_rules,
 	view_repo_ownership,
 } from '@prisma/client';
-import type { UpdateBranchProtectionEvent } from 'common/types';
+import type { UpdateMessageEvent } from 'common/types';
 import { createBranchProtectionWarningMessages } from './repository-02-branch_protection';
 import { createEntry } from './shared-utilities';
 
@@ -114,11 +114,11 @@ describe('Team slugs should be findable for every team associated with a repo', 
 
 describe('Batch entries should be created for each message', () => {
 	test('The batch ID of the message should contain no special characters', () => {
-		const event1: UpdateBranchProtectionEvent = {
+		const event1: UpdateMessageEvent = {
 			fullName: 'guardian/repo-1',
 			teamNameSlugs: ['team-one'],
 		};
-		const event2: UpdateBranchProtectionEvent = {
+		const event2: UpdateMessageEvent = {
 			fullName: '!@£$%^&*()l',
 			teamNameSlugs: ['team-two'],
 		};

--- a/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
@@ -3,9 +3,7 @@ import type {
 	repocop_github_repository_rules,
 	view_repo_ownership,
 } from '@prisma/client';
-import type { UpdateMessageEvent } from 'common/types';
-import { createBranchProtectionWarningMessages } from './repository-02-branch_protection';
-import { createSqsEntry } from './shared-utilities';
+import { createBranchProtectionWarningMessageEvents } from './repository-02-branch_protection';
 
 const nullOwner: view_repo_ownership = {
 	full_name: '',
@@ -71,7 +69,7 @@ describe('Team slugs should be findable for every team associated with a repo', 
 			slug: 'team-one',
 		};
 
-		const actual = createBranchProtectionWarningMessages(
+		const actual = createBranchProtectionWarningMessageEvents(
 			[evaluatedRepo],
 			[repoOwner],
 			[githubTeam],
@@ -101,7 +99,7 @@ describe('Team slugs should be findable for every team associated with a repo', 
 			slug: 'team-one',
 		};
 
-		const actual = createBranchProtectionWarningMessages(
+		const actual = createBranchProtectionWarningMessageEvents(
 			[evaluatedRepo],
 			[],
 			[githubTeam],
@@ -109,24 +107,5 @@ describe('Team slugs should be findable for every team associated with a repo', 
 		);
 
 		expect(actual.length).toEqual(0);
-	});
-});
-
-describe('Batch entries should be created for each message', () => {
-	test('The batch ID of the message should contain no special characters', () => {
-		const event1: UpdateMessageEvent = {
-			fullName: 'guardian/repo-1',
-			teamNameSlugs: ['team-one'],
-		};
-		const event2: UpdateMessageEvent = {
-			fullName: '!@£$%^&*()l',
-			teamNameSlugs: ['team-two'],
-		};
-
-		const actual1 = createSqsEntry(event1);
-		const actual2 = createSqsEntry(event2);
-
-		expect(actual1.Id).toEqual('guardianrepo1');
-		expect(actual2.Id).toEqual('l');
 	});
 });

--- a/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
@@ -5,7 +5,7 @@ import type {
 } from '@prisma/client';
 import type { UpdateBranchProtectionEvent } from 'common/types';
 import { createBranchProtectionWarningMessages } from './repository-02-branch_protection';
-import { createEntry } from './shared_functions';
+import { createEntry } from './shared-utilities';
 
 const nullOwner: view_repo_ownership = {
 	full_name: '',

--- a/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
@@ -4,10 +4,8 @@ import type {
 	view_repo_ownership,
 } from '@prisma/client';
 import type { UpdateBranchProtectionEvent } from 'common/types';
-import {
-	createBranchProtectionWarningMessages,
-	createEntry,
-} from './repository-02-branch_protection';
+import { createBranchProtectionWarningMessages } from './repository-02-branch_protection';
+import { createEntry } from './shared_functions';
 
 const nullOwner: view_repo_ownership = {
 	full_name: '',

--- a/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.test.ts
@@ -5,7 +5,7 @@ import type {
 } from '@prisma/client';
 import type { UpdateMessageEvent } from 'common/types';
 import { createBranchProtectionWarningMessages } from './repository-02-branch_protection';
-import { createEntry } from './shared-utilities';
+import { createSqsEntry } from './shared-utilities';
 
 const nullOwner: view_repo_ownership = {
 	full_name: '',
@@ -123,8 +123,8 @@ describe('Batch entries should be created for each message', () => {
 			teamNameSlugs: ['team-two'],
 		};
 
-		const actual1 = createEntry(event1);
-		const actual2 = createEntry(event2);
+		const actual1 = createSqsEntry(event1);
+		const actual2 = createSqsEntry(event2);
 
 		expect(actual1.Id).toEqual('guardianrepo1');
 		expect(actual2.Id).toEqual('l');

--- a/packages/repocop/src/remediations/repository-02-branch_protection.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.ts
@@ -28,7 +28,11 @@ import {
 	sendNotifications,
 } from './shared-utilities';
 
-export function createBranchProtectionWarningMessages(
+function shuffle<T>(array: T[]): T[] {
+	return array.sort(() => Math.random() - 0.5);
+}
+
+export function createBranchProtectionWarningMessageEvents(
 	evaluatedRepos: repocop_github_repository_rules[],
 	repoOwners: view_repo_ownership[],
 	teams: github_teams[],
@@ -74,12 +78,13 @@ export async function notifyBranchProtector(
 		productionOrDocs.includes(repo.full_name),
 	);
 
-	const events = createBranchProtectionWarningMessages(
-		relevantRepos,
-		repoOwners,
-		teams,
-		3,
-	);
+	const branchProtectionWarningMessages =
+		createBranchProtectionWarningMessageEvents(
+			relevantRepos,
+			repoOwners,
+			teams,
+			3,
+		);
 
 	const credentials =
 		config.stage === 'DEV' ? fromIni({ profile: 'deployTools' }) : undefined;
@@ -90,13 +95,13 @@ export async function notifyBranchProtector(
 	});
 
 	await addMessagesToQueue(
-		events,
+		branchProtectionWarningMessages,
 		sqsClient,
 		config.branchProtectorQueueUrl,
 		RemediationApp.BranchProtector,
 	);
 
-	return events;
+	return branchProtectionWarningMessages;
 }
 
 export async function notifyAnghammaradBranchProtection(

--- a/packages/repocop/src/remediations/repository-02-branch_protection.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.ts
@@ -25,7 +25,7 @@ import {
 	findContactableOwners,
 	RemediationApp,
 	sendNotifications,
-} from './shared_functions';
+} from './shared-utilities';
 
 export function createBranchProtectionWarningMessages(
 	evaluatedRepos: repocop_github_repository_rules[],
@@ -89,5 +89,10 @@ export async function notifyAnghammaradBranchProtection(
 	config: Config,
 	anghammaradClient: Anghammarad,
 ): Promise<void> {
-	await sendNotifications(anghammaradClient, events, config);
+	await sendNotifications(
+		anghammaradClient,
+		events,
+		config,
+		RemediationApp.BranchProtector,
+	);
 }

--- a/packages/repocop/src/remediations/repository-02-branch_protection.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.ts
@@ -1,4 +1,3 @@
-import type { SendMessageBatchRequestEntry } from '@aws-sdk/client-sqs/dist-types/models/models_0';
 import { SQSClient } from '@aws-sdk/client-sqs';
 import { fromIni } from '@aws-sdk/credential-providers';
 import type { Anghammarad } from '@guardian/anghammarad';
@@ -8,12 +7,7 @@ import type {
 	repocop_github_repository_rules,
 	view_repo_ownership,
 } from '@prisma/client';
-import {
-	anghammaradThreadKey,
-	branchProtectionCtas,
-	getLocalProfile,
-	shuffle,
-} from 'common/src/functions';
+import { shuffle } from 'common/src/functions';
 import type { UpdateMessageEvent } from 'common/types';
 import type { Config } from '../config';
 import {
@@ -27,10 +21,6 @@ import {
 	RemediationApp,
 	sendNotifications,
 } from './shared-utilities';
-
-function shuffle<T>(array: T[]): T[] {
-	return array.sort(() => Math.random() - 0.5);
-}
 
 export function createBranchProtectionWarningMessageEvents(
 	evaluatedRepos: repocop_github_repository_rules[],

--- a/packages/repocop/src/remediations/repository-02-branch_protection.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.ts
@@ -1,7 +1,6 @@
 import { SendMessageBatchCommand, SQSClient } from '@aws-sdk/client-sqs';
 import type { SendMessageBatchRequestEntry } from '@aws-sdk/client-sqs/dist-types/models/models_0';
 import type { Anghammarad } from '@guardian/anghammarad';
-import { RequestedChannel } from '@guardian/anghammarad';
 import type {
 	github_teams,
 	PrismaClient,
@@ -21,27 +20,12 @@ import {
 	getTeams,
 	getUnarchivedRepositories,
 } from '../query';
-
-function findTeamSlugFromId(
-	id: bigint,
-	teams: github_teams[],
-): string | undefined {
-	const match: github_teams | undefined = teams.find((team) => team.id === id);
-	return match?.slug ?? undefined;
-}
-
-function findContactableOwners(
-	repo: string,
-	allRepoOwners: view_repo_ownership[],
-	teams: github_teams[],
-): string[] {
-	const owners = allRepoOwners.filter((owner) => owner.full_name === repo);
-	const teamSlugs = owners
-		.map((owner) => findTeamSlugFromId(owner.github_team_id, teams))
-		.filter((slug): slug is string => !!slug);
-
-	return teamSlugs;
-}
+import {
+	addMessagesToQueue,
+	findContactableOwners,
+	RemediationApp,
+	sendNotifications,
+} from './shared_functions';
 
 export function createBranchProtectionWarningMessages(
 	evaluatedRepos: repocop_github_repository_rules[],
@@ -66,90 +50,6 @@ export function createBranchProtectionWarningMessages(
 	const sliceLength = Math.min(resultsCount, msgCount);
 
 	return shuffle(reposWithContactableOwners).slice(0, sliceLength);
-}
-
-export function createEntry(
-	message: UpdateBranchProtectionEvent,
-): SendMessageBatchRequestEntry {
-	const repoNoSpecialCharacters = message.fullName.replace(/\W/g, '');
-	return {
-		Id: repoNoSpecialCharacters,
-		MessageBody: JSON.stringify(message),
-		MessageGroupId: 'repocop',
-	};
-}
-
-export async function addMessagesToQueue(
-	events: UpdateBranchProtectionEvent[],
-	config: Config,
-): Promise<void> {
-	const sqsClient = new SQSClient({
-		region: config.region,
-		credentials: getLocalProfile(config.stage),
-	});
-	const command = new SendMessageBatchCommand({
-		QueueUrl: config.queueUrl,
-		Entries: events.map((event) => createEntry(event)),
-	});
-	await sqsClient.send(command);
-
-	const repoListString = events.map((event) => event.fullName).join(', ');
-	console.log(`Repos added to branch protector queue: ${repoListString}`);
-}
-
-async function notifyOneTeam(
-	anghammaradClient: Anghammarad,
-	fullName: string,
-	teamSlug: string,
-	config: Config,
-) {
-	const { app, stage, anghammaradSnsTopic } = config;
-
-	await anghammaradClient.notify({
-		subject: `Repocop branch protection (for GitHub team ${teamSlug})`,
-		message: `Branch protections will be applied to ${fullName}. No action is required.`,
-		actions: branchProtectionCtas(fullName, teamSlug),
-		target: { GithubTeamSlug: teamSlug },
-		channel: RequestedChannel.PreferHangouts,
-		sourceSystem: `${app} ${stage}`,
-		topicArn: anghammaradSnsTopic,
-		threadKey: anghammaradThreadKey(fullName),
-	});
-
-	console.log(`Notified ${teamSlug} about ${fullName}`);
-}
-
-async function notifyOneRepo(
-	anghammaradClient: Anghammarad,
-	event: UpdateBranchProtectionEvent,
-	config: Config,
-) {
-	try {
-		await Promise.all(
-			event.teamNameSlugs.map(async (slug) => {
-				await notifyOneTeam(anghammaradClient, event.fullName, slug, config);
-			}),
-		);
-		console.log(`Notified all teams about ${event.fullName}`);
-	} catch (error) {
-		console.error(error);
-	}
-}
-
-export async function sendNotifications(
-	anghammaradClient: Anghammarad,
-	events: UpdateBranchProtectionEvent[],
-	config: Config,
-): Promise<void> {
-	try {
-		await Promise.all(
-			events.map(async (event) => {
-				await notifyOneRepo(anghammaradClient, event, config);
-			}),
-		);
-	} catch (error) {
-		console.error(error);
-	}
 }
 
 export async function notifyBranchProtector(
@@ -179,7 +79,7 @@ export async function notifyBranchProtector(
 		teams,
 		3,
 	);
-	await addMessagesToQueue(events, config);
+	await addMessagesToQueue(events, config, RemediationApp.BranchProtector);
 
 	return events;
 }
@@ -188,6 +88,6 @@ export async function notifyAnghammaradBranchProtection(
 	events: UpdateBranchProtectionEvent[],
 	config: Config,
 	anghammaradClient: Anghammarad,
-) {
+): Promise<void> {
 	await sendNotifications(anghammaradClient, events, config);
 }

--- a/packages/repocop/src/remediations/repository-02-branch_protection.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.ts
@@ -13,7 +13,7 @@ import {
 	getLocalProfile,
 	shuffle,
 } from 'common/src/functions';
-import type { UpdateBranchProtectionEvent } from 'common/types';
+import type { UpdateMessageEvent } from 'common/types';
 import type { Config } from '../config';
 import {
 	getRepoOwnership,
@@ -32,7 +32,7 @@ export function createBranchProtectionWarningMessages(
 	repoOwners: view_repo_ownership[],
 	teams: github_teams[],
 	msgCount: number,
-): UpdateBranchProtectionEvent[] {
+): UpdateMessageEvent[] {
 	const reposWithoutBranchProtection = evaluatedRepos.filter(
 		(repo) => !repo.branch_protection,
 	);
@@ -85,7 +85,7 @@ export async function notifyBranchProtector(
 }
 
 export async function notifyAnghammaradBranchProtection(
-	events: UpdateBranchProtectionEvent[],
+	events: UpdateMessageEvent[],
 	config: Config,
 	anghammaradClient: Anghammarad,
 ): Promise<void> {

--- a/packages/repocop/src/remediations/shared-utilities.test.ts
+++ b/packages/repocop/src/remediations/shared-utilities.test.ts
@@ -1,0 +1,21 @@
+import type { UpdateMessageEvent } from 'common/types';
+import { createSqsEntry } from './shared-utilities';
+
+describe('Batch entries should be created for each message', () => {
+	test('The batch ID of the message should contain no special characters', () => {
+		const event1: UpdateMessageEvent = {
+			fullName: 'guardian/repo-1',
+			teamNameSlugs: ['team-one'],
+		};
+		const event2: UpdateMessageEvent = {
+			fullName: '!@£$%^&*()l',
+			teamNameSlugs: ['team-two'],
+		};
+
+		const actual1 = createSqsEntry(event1);
+		const actual2 = createSqsEntry(event2);
+
+		expect(actual1.Id).toEqual('guardianrepo1');
+		expect(actual2.Id).toEqual('l');
+	});
+});

--- a/packages/repocop/src/remediations/shared-utilities.ts
+++ b/packages/repocop/src/remediations/shared-utilities.ts
@@ -9,7 +9,7 @@ import {
 	branchProtectionCtas,
 	topicProductionCtas,
 } from 'common/src/functions';
-import type { UpdateBranchProtectionEvent } from 'common/types';
+import type { UpdateMessageEvent } from 'common/types';
 import type { Config } from '../config';
 
 function findTeamSlugFromId(
@@ -62,7 +62,7 @@ export function findContactableOwners(
 }
 
 export function createEntry(
-	message: UpdateBranchProtectionEvent,
+	message: UpdateMessageEvent,
 ): SendMessageBatchRequestEntry {
 	const repoNoSpecialCharacters = message.fullName.replace(/\W/g, '');
 	return {
@@ -73,7 +73,7 @@ export function createEntry(
 }
 
 export async function addMessagesToQueue(
-	events: UpdateBranchProtectionEvent[],
+	events: UpdateMessageEvent[],
 	config: Config,
 	app: RemediationApp,
 ): Promise<void> {
@@ -118,7 +118,7 @@ async function notifyOneTeam(
 
 async function notifyOneRepo(
 	anghammaradClient: Anghammarad,
-	event: UpdateBranchProtectionEvent,
+	event: UpdateMessageEvent,
 	config: Config,
 	remediationApp: RemediationApp,
 ) {
@@ -144,7 +144,7 @@ async function notifyOneRepo(
 
 export async function sendNotifications(
 	anghammaradClient: Anghammarad,
-	events: UpdateBranchProtectionEvent[],
+	events: UpdateMessageEvent[],
 	config: Config,
 	remediationApp: RemediationApp,
 ): Promise<void> {

--- a/packages/repocop/src/remediations/shared-utilities.ts
+++ b/packages/repocop/src/remediations/shared-utilities.ts
@@ -61,7 +61,7 @@ export function findContactableOwners(
 	return teamSlugs;
 }
 
-export function createEntry(
+export function createSqsEntry(
 	message: UpdateMessageEvent,
 ): SendMessageBatchRequestEntry {
 	const repoNoSpecialCharacters = message.fullName.replace(/\W/g, '');
@@ -85,7 +85,7 @@ export async function addMessagesToQueue(
 	});
 	const command = new SendMessageBatchCommand({
 		QueueUrl: config[`${app}QueueUrl`],
-		Entries: events.map((event) => createEntry(event)),
+		Entries: events.map((event) => createSqsEntry(event)),
 	});
 	await sqsClient.send(command);
 

--- a/packages/repocop/src/remediations/shared-utilities.ts
+++ b/packages/repocop/src/remediations/shared-utilities.ts
@@ -84,7 +84,7 @@ export async function addMessagesToQueue(
 		credentials,
 	});
 	const command = new SendMessageBatchCommand({
-		QueueUrl: `config.${app}queueUrl`,
+		QueueUrl: config[`${app}QueueUrl`],
 		Entries: events.map((event) => createEntry(event)),
 	});
 	await sqsClient.send(command);

--- a/packages/repocop/src/remediations/shared-utilities.ts
+++ b/packages/repocop/src/remediations/shared-utilities.ts
@@ -12,14 +12,6 @@ import {
 import type { UpdateMessageEvent } from 'common/types';
 import type { Config } from '../config';
 
-function findTeamSlugFromId(
-	id: bigint,
-	teams: github_teams[],
-): string | undefined {
-	const match: github_teams | undefined = teams.find((team) => team.id === id);
-	return match?.slug ?? undefined;
-}
-
 export enum RemediationApp {
 	BranchProtector = 'branchProtector',
 	TopicProduction = 'topicProduction',
@@ -47,6 +39,14 @@ const anghammaradMessages: AnghammaradMessages = {
 		actions: topicProductionCtas,
 	},
 };
+
+function findTeamSlugFromId(
+	id: bigint,
+	teams: github_teams[],
+): string | undefined {
+	const match: github_teams | undefined = teams.find((team) => team.id === id);
+	return match?.slug ?? undefined;
+}
 
 export function findContactableOwners(
 	repo: string,

--- a/packages/repocop/src/remediations/shared_functions.ts
+++ b/packages/repocop/src/remediations/shared_functions.ts
@@ -1,0 +1,125 @@
+import { SendMessageBatchCommand, SQSClient } from '@aws-sdk/client-sqs';
+import type { SendMessageBatchRequestEntry } from '@aws-sdk/client-sqs/dist-types/models/models_0';
+import { fromIni } from '@aws-sdk/credential-providers';
+import type { Anghammarad } from '@guardian/anghammarad';
+import { RequestedChannel } from '@guardian/anghammarad';
+import type { github_teams, view_repo_ownership } from '@prisma/client';
+import {
+	anghammaradThreadKey,
+	branchProtectionCtas,
+} from 'common/src/functions';
+import type { UpdateBranchProtectionEvent } from 'common/types';
+import type { Config } from '../config';
+
+function findTeamSlugFromId(
+	id: bigint,
+	teams: github_teams[],
+): string | undefined {
+	const match: github_teams | undefined = teams.find((team) => team.id === id);
+	return match?.slug ?? undefined;
+}
+
+export enum RemediationApp {
+	BranchProtector = 'branchProtector',
+	TopicProduction = 'topicProduction',
+}
+
+export function findContactableOwners(
+	repo: string,
+	allRepoOwners: view_repo_ownership[],
+	teams: github_teams[],
+): string[] {
+	const owners = allRepoOwners.filter((owner) => owner.full_name === repo);
+	const teamSlugs = owners
+		.map((owner) => findTeamSlugFromId(owner.github_team_id, teams))
+		.filter((slug): slug is string => !!slug);
+
+	return teamSlugs;
+}
+
+export function createEntry(
+	message: UpdateBranchProtectionEvent,
+): SendMessageBatchRequestEntry {
+	const repoNoSpecialCharacters = message.fullName.replace(/\W/g, '');
+	return {
+		Id: repoNoSpecialCharacters,
+		MessageBody: JSON.stringify(message),
+		MessageGroupId: 'repocop',
+	};
+}
+
+export async function addMessagesToQueue(
+	events: UpdateBranchProtectionEvent[],
+	config: Config,
+	app: RemediationApp,
+): Promise<void> {
+	const credentials =
+		config.stage === 'DEV' ? fromIni({ profile: 'deployTools' }) : undefined;
+	const sqsClient = new SQSClient({
+		region: config.region,
+		credentials,
+	});
+	const command = new SendMessageBatchCommand({
+		QueueUrl: `config.${app}queueUrl`,
+		Entries: events.map((event) => createEntry(event)),
+	});
+	await sqsClient.send(command);
+
+	const repoListString = events.map((event) => event.fullName).join(', ');
+	console.log(`Repos added to branch protector queue: ${repoListString}`);
+}
+
+async function notifyOneTeam(
+	anghammaradClient: Anghammarad,
+	fullName: string,
+	teamSlug: string,
+	config: Config,
+) {
+	const { app, stage, anghammaradSnsTopic } = config;
+
+	await anghammaradClient.notify({
+		subject: `Repocop branch protection (for GitHub team ${teamSlug})`,
+		message: `Branch protections will be applied to ${fullName}. No action is required.`,
+		actions: branchProtectionCtas(fullName, teamSlug),
+		target: { GithubTeamSlug: teamSlug },
+		channel: RequestedChannel.PreferHangouts,
+		sourceSystem: `${app} ${stage}`,
+		topicArn: anghammaradSnsTopic,
+		threadKey: anghammaradThreadKey(fullName),
+	});
+
+	console.log(`Notified ${teamSlug} about ${fullName}`);
+}
+
+async function notifyOneRepo(
+	anghammaradClient: Anghammarad,
+	event: UpdateBranchProtectionEvent,
+	config: Config,
+) {
+	try {
+		await Promise.all(
+			event.teamNameSlugs.map(async (slug) => {
+				await notifyOneTeam(anghammaradClient, event.fullName, slug, config);
+			}),
+		);
+		console.log(`Notified all teams about ${event.fullName}`);
+	} catch (error) {
+		console.error(error);
+	}
+}
+
+export async function sendNotifications(
+	anghammaradClient: Anghammarad,
+	events: UpdateBranchProtectionEvent[],
+	config: Config,
+): Promise<void> {
+	try {
+		await Promise.all(
+			events.map(async (event) => {
+				await notifyOneRepo(anghammaradClient, event, config);
+			}),
+		);
+	} catch (error) {
+		console.error(error);
+	}
+}


### PR DESCRIPTION
## What does this change?

- Moves various functions that are currently used by `branch-protector` into a shared file.
- Adds some types and objects to allow the right app and messaging to be passed into the shared messaging functions.
- Adds some scaffolding code so that the new topic monitor for 'production' tags is set up to message correctly.

## Why?

- The shared utitilies can be used by the forthcoming `topic-monitoring-production` lambda that will automate the application of the `production` topic to repos, as it will follow a very similar messaging pattern to `branch-protector`.

## How has it been verified?
Tested by running repocop locally using CODE database. Repocop ran successfully and added branch protection repos to the queue as before.