### PR TITLE
fix: Make SNS topic stage aware

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -13107,7 +13107,7 @@ spec:
             "Value": "TEST",
           },
         ],
-        "TopicName": "interactive-monitor-topic",
+        "TopicName": "interactive-monitor-topic-TEST",
       },
       "Type": "AWS::SNS::Topic",
     },

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -9,8 +9,9 @@ const app = 'interactive-monitor';
 export class InteractiveMonitor {
 	public topic: Topic;
 	constructor(guStack: GuStack) {
+		const { stage } = guStack;
 		const topic = new Topic(guStack, 'Topic', {
-			topicName: `${app}-topic`,
+			topicName: `${app}-topic-${stage}`,
 		});
 
 		const lambda = new GuLambdaFunction(guStack, app, {


### PR DESCRIPTION
## What does this change?
SNS topics must have a unique name, so add the stage to differentiate CODE from PROD.