### PR TITLE
Prevent lambda from timing out

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -13988,7 +13988,7 @@ spec:
           },
         },
         "Handler": "index.main",
-        "MemorySize": 512,
+        "MemorySize": 1024,
         "Role": {
           "Fn::GetAtt": [
             "repocopServiceRole757D74E8",

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -616,6 +616,7 @@ export class ServiceCatalogue extends GuStack {
 			app: 'repocop',
 			fileName: 'repocop.zip',
 			handler: 'index.main',
+			memorySize: 1024,
 			monitoringConfiguration: stageAwareMonitoringConfiguration,
 			// Messages will be picked up by branch protector at 9:00 the next working day (Tue-Fri)
 			rules: [

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -136,5 +136,5 @@ async function getDatabaseConnectionString(config: DatabaseConfig) {
 
 	return `postgres://${user}:${encodeURIComponent(
 		dbPassword,
-	)}@${hostname}:${port}/postgres?schema=public&sslmode=verify-full`;
+	)}@${hostname}:${port}/postgres?schema=public&sslmode=verify-full&connection_limit=20&pool_timeout=20`;
 }

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -72,13 +72,6 @@ export async function getRepositoryTeams(
 		},
 	);
 
-	// `full_name` is typed as nullable, in reality it is not, so the fallback to `id` shouldn't happen
-	const repoIdentifier = repository.full_name ?? repository.id;
-
-	console.debug(
-		`Found ${data.length} teams with access to repository ${repoIdentifier}`,
-	);
-
 	return data;
 }
 


### PR DESCRIPTION
## What does this change?

Allows more DB connections
Bumps the DB timeout
Provide additional memory to the repocop lambda

## Why?

The lambda has gotten busier, and more queries are being made. We should bump the number of connections to avoid timeouts

## How has it been verified?

Tested on PROD, repocop succeeds. Billed about the same number of GB seconds as before