### PR TITLE
create class for branch protector components

### DIFF
--- a/packages/cdk/lib/branch-protector.ts
+++ b/packages/cdk/lib/branch-protector.ts
@@ -1,0 +1,69 @@
+import type { GuScheduledLambdaProps } from '@guardian/cdk';
+import { GuScheduledLambda } from '@guardian/cdk';
+import type {
+	GuLambdaErrorPercentageMonitoringProps,
+	NoMonitoring,
+} from '@guardian/cdk/lib/constructs/cloudwatch';
+import type { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { Duration } from 'aws-cdk-lib';
+import type { IVpc } from 'aws-cdk-lib/aws-ec2';
+import { Schedule } from 'aws-cdk-lib/aws-events';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
+import type { ITopic } from 'aws-cdk-lib/aws-sns';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
+
+export class BranchProtector {
+	public readonly queue: Queue;
+	constructor(
+		guStack: GuStack,
+		monitoringConfiguration:
+			| NoMonitoring
+			| GuLambdaErrorPercentageMonitoringProps,
+		nonProdSchedule: Schedule | undefined,
+		vpc: IVpc,
+		anghammaradTopic: ITopic,
+	) {
+		const { stack, stage } = guStack;
+		const app = 'branch-protector';
+		const queue = new Queue(guStack, `${app}-queue`, {
+			queueName: `${app}-queue-${stage}.fifo`,
+			contentBasedDeduplication: true,
+			retentionPeriod: Duration.days(14),
+		});
+
+		const githubCredentials = new Secret(guStack, `${app}-github-app-auth`, {
+			secretName: `/${stage}/${stack}/service-catalogue/${app}-github-app-secret`,
+		});
+
+		const lambdaProps: GuScheduledLambdaProps = {
+			app,
+			fileName: `${app}.zip`,
+			handler: 'index.main',
+			monitoringConfiguration,
+			rules: [
+				{
+					schedule:
+						nonProdSchedule ??
+						Schedule.cron({ minute: '0', hour: '9', weekDay: 'TUE-FRI' }),
+				},
+			],
+			runtime: Runtime.NODEJS_18_X,
+			environment: {
+				GITHUB_APP_SECRET: githubCredentials.secretName,
+				ANGHAMMARAD_SNS_ARN: anghammaradTopic.topicArn,
+				BRANCH_PROTECTOR_QUEUE_URL: queue.queueUrl,
+			},
+			vpc,
+			timeout: Duration.minutes(1),
+		};
+
+		const lambda = new GuScheduledLambda(guStack, app, lambdaProps);
+
+		queue.grantConsumeMessages(lambda);
+		githubCredentials.grantRead(lambda);
+		anghammaradTopic.grantPublish(lambda);
+
+		this.queue = queue;
+	}
+}

--- a/packages/cdk/lib/branch-protector.ts
+++ b/packages/cdk/lib/branch-protector.ts
@@ -7,7 +7,7 @@ import type {
 import type { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { Duration } from 'aws-cdk-lib';
 import type { IVpc } from 'aws-cdk-lib/aws-ec2';
-import { Schedule } from 'aws-cdk-lib/aws-events';
+import type { Schedule } from 'aws-cdk-lib/aws-events';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import type { ITopic } from 'aws-cdk-lib/aws-sns';
@@ -20,7 +20,7 @@ export class BranchProtector {
 		monitoringConfiguration:
 			| NoMonitoring
 			| GuLambdaErrorPercentageMonitoringProps,
-		nonProdSchedule: Schedule | undefined,
+		schedule: Schedule,
 		vpc: IVpc,
 		anghammaradTopic: ITopic,
 	) {
@@ -43,9 +43,7 @@ export class BranchProtector {
 			monitoringConfiguration,
 			rules: [
 				{
-					schedule:
-						nonProdSchedule ??
-						Schedule.cron({ minute: '0', hour: '9', weekDay: 'TUE-FRI' }),
+					schedule,
 				},
 			],
 			runtime: Runtime.NODEJS_18_X,

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -40,12 +40,12 @@ import {
 } from 'aws-cdk-lib/aws-rds';
 import { Secret as SecretsManager } from 'aws-cdk-lib/aws-secretsmanager';
 import { Topic } from 'aws-cdk-lib/aws-sns';
-import { Queue } from 'aws-cdk-lib/aws-sqs';
 import {
 	ParameterDataType,
 	ParameterTier,
 	StringParameter,
 } from 'aws-cdk-lib/aws-ssm';
+import { BranchProtector } from './branch-protector';
 import type { CloudquerySource } from './ecs/cluster';
 import { CloudqueryCluster } from './ecs/cluster';
 import {
@@ -592,12 +592,6 @@ export class ServiceCatalogue extends GuStack {
 		const anghammaradTopicParameter =
 			GuAnghammaradTopicParameter.getInstance(this);
 
-		const branchProtectorQueue = new Queue(this, 'branch-protector-queue', {
-			queueName: `branch-protector-queue-${stage}.fifo`,
-			contentBasedDeduplication: true,
-			retentionPeriod: Duration.days(14),
-		});
-
 		const prodMonitoring: GuLambdaErrorPercentageMonitoringProps = {
 			toleratedErrorPercentage: 50,
 			lengthOfEvaluationPeriod: Duration.minutes(1),
@@ -611,6 +605,20 @@ export class ServiceCatalogue extends GuStack {
 			stage === 'PROD' ? prodMonitoring : codeMonitoring;
 
 		const interactiveMonitor = new InteractiveMonitor(this);
+
+		const anghammaradTopic = Topic.fromTopicArn(
+			this,
+			'anghammarad-arn',
+			anghammaradTopicParameter.valueAsString,
+		);
+
+		const branchProtector = new BranchProtector(
+			this,
+			stageAwareMonitoringConfiguration,
+			nonProdSchedule,
+			vpc,
+			anghammaradTopic,
+		);
 
 		const repocopLampdaProps: GuScheduledLambdaProps = {
 			app: 'repocop',
@@ -632,7 +640,7 @@ export class ServiceCatalogue extends GuStack {
 
 				// Set this to 'true' to enable SQL query logging
 				QUERY_LOGGING: 'false',
-				BRANCH_PROTECTOR_QUEUE_URL: branchProtectorQueue.queueUrl,
+				BRANCH_PROTECTOR_QUEUE_URL: branchProtector.queue.queueUrl,
 				INTERACTIVE_MONITOR_TOPIC_ARN: interactiveMonitor.topic.topicArn,
 			},
 			vpc,
@@ -648,53 +656,8 @@ export class ServiceCatalogue extends GuStack {
 
 		db.grantConnect(repocopLambda, 'repocop');
 
-		branchProtectorQueue.grantSendMessages(repocopLambda);
+		branchProtector.queue.grantSendMessages(repocopLambda);
 
-		const branchProtectorGithubCredentials = new SecretsManager(
-			this,
-			'branch-protector-github-app-auth',
-			{
-				secretName: `/${stage}/${stack}/${app}/branch-protector-github-app-secret`,
-			},
-		);
-
-		const branchProtectorLambdaProps: GuScheduledLambdaProps = {
-			app: 'branch-protector',
-			fileName: 'branch-protector.zip',
-			handler: 'index.main',
-			monitoringConfiguration: stageAwareMonitoringConfiguration,
-			rules: [
-				{
-					schedule:
-						nonProdSchedule ??
-						Schedule.cron({ minute: '0', hour: '9', weekDay: 'TUE-FRI' }),
-				},
-			],
-			runtime: Runtime.NODEJS_18_X,
-			environment: {
-				GITHUB_APP_SECRET: branchProtectorGithubCredentials.secretName,
-				ANGHAMMARAD_SNS_ARN: anghammaradTopicParameter.valueAsString,
-				BRANCH_PROTECTOR_QUEUE_URL: branchProtectorQueue.queueUrl,
-			},
-			vpc,
-			timeout: Duration.minutes(1),
-		};
-
-		const branchProtectorLambda = new GuScheduledLambda(
-			this,
-			'branch-protector',
-			branchProtectorLambdaProps,
-		);
-
-		const anghammaradTopic = Topic.fromTopicArn(
-			this,
-			'anghammarad-arn',
-			anghammaradTopicParameter.valueAsString,
-		);
-
-		branchProtectorQueue.grantConsumeMessages(branchProtectorLambda);
-		branchProtectorGithubCredentials.grantRead(branchProtectorLambda);
-		anghammaradTopic.grantPublish(branchProtectorLambda);
 		anghammaradTopic.grantPublish(repocopLambda);
 		interactiveMonitor.topic.grantPublish(repocopLambda);
 	}

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -615,7 +615,8 @@ export class ServiceCatalogue extends GuStack {
 		const branchProtector = new BranchProtector(
 			this,
 			stageAwareMonitoringConfiguration,
-			nonProdSchedule,
+			nonProdSchedule ??
+				Schedule.cron({ minute: '0', hour: '9', weekDay: 'TUE-FRI' }),
 			vpc,
 			anghammaradTopic,
 		);


### PR DESCRIPTION
## What does this change?

Pulls out branch protector infrastructure into its own class

## Why?

Declutter the main stack file
More of these classes will be created over the coming days

## How has it been verified?

No difference in snapshots
