### PR TITLE
refactor: rename production topic things for clarity

### DIFF
--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -78,7 +78,7 @@ export function branchProtectionCtas(
 	];
 }
 
-export function topicProductionCtas(
+export function topicMonitoringProductionTagCtas(
 	fullRepoName: string,
 	teamSlug: string,
 ): Action[] {

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -54,7 +54,7 @@ export interface Config {
 	/**
 	 * SQS queue to send topic 'production' messages to.
 	 */
-	topicProductionQueueUrl: string;
+	topicMonitoringProductionTagQueueUrl: string;
 
 	/**
 	 * Flag to enable messaging when running locally.
@@ -118,8 +118,10 @@ export async function getConfig(): Promise<Config> {
 		databaseConnectionString: await getDatabaseConnectionString(databaseConfig),
 		withQueryLogging: queryLogging,
 		branchProtectorQueueUrl: getEnvOrThrow('BRANCH_PROTECTOR_QUEUE_URL'),
-		topicProductionQueueUrl: getEnvOrThrow('BRANCH_PROTECTOR_QUEUE_URL'), // TODO: remove this
-		// topicProductionQueueUrl: getEnvOrThrow('TOPIC_PRODUCTION_QUEUE_URL'), // TODO: produce this
+		topicMonitoringProductionTagQueueUrl: getEnvOrThrow(
+			'BRANCH_PROTECTOR_QUEUE_URL',
+		), // TODO: remove this
+		// topicMonitoringProductionTagQueueUrl: getEnvOrThrow('TOPIC_MONITORING_PRODUCTION_TAG_QUEUE_URL'), // TODO: produce this
 		enableMessaging: process.env.ENABLE_MESSAGING === 'false' ? false : true,
 		ignoredRepositoryPrefixes: [
 			'guardian/esd-', // ESD team

--- a/packages/repocop/src/remediations/shared-utilities.ts
+++ b/packages/repocop/src/remediations/shared-utilities.ts
@@ -7,14 +7,14 @@ import type { github_teams, view_repo_ownership } from '@prisma/client';
 import {
 	anghammaradThreadKey,
 	branchProtectionCtas,
-	topicProductionCtas,
+	topicMonitoringProductionTagCtas,
 } from 'common/src/functions';
 import type { UpdateMessageEvent } from 'common/types';
 import type { Config } from '../config';
 
 export enum RemediationApp {
 	BranchProtector = 'branchProtector',
-	TopicProduction = 'topicProduction',
+	TopicMonitoringProductionTag = 'topicMonitoringProductionTag',
 }
 
 export interface AnghammaradMessage {
@@ -33,10 +33,10 @@ const anghammaradMessages: AnghammaradMessages = {
 		message: 'Branch protections',
 		actions: branchProtectionCtas,
 	},
-	topicProduction: {
+	topicMonitoringProductionTag: {
 		subject: 'Repocop topic monitoring',
 		message: "The 'production' topic",
-		actions: topicProductionCtas,
+		actions: topicMonitoringProductionTagCtas,
 	},
 };
 


### PR DESCRIPTION
## What does this change?

Changes the name of the scaffolding variables that refer to the upcoming implementation of the 'production' topic monitoring remediation in repocop.

## Why?

Feedback on PR #466  indicated that it was not clear, due to the confusion over the multiple meanings of the word 'production' in this context.

## How has it been verified?
Is it clearer?
