### PR TITLE
make repocop infrastructure its own class

### DIFF
--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -1,0 +1,63 @@
+import { GuScheduledLambda, type GuScheduledLambdaProps } from '@guardian/cdk';
+import type {
+	GuLambdaErrorPercentageMonitoringProps,
+	NoMonitoring,
+} from '@guardian/cdk/lib/constructs/cloudwatch';
+import type { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { Duration } from 'aws-cdk-lib';
+import type { IVpc, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
+import type { Schedule } from 'aws-cdk-lib/aws-events';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
+import type { ITopic, Topic } from 'aws-cdk-lib/aws-sns';
+import type { Queue } from 'aws-cdk-lib/aws-sqs';
+
+export class Repocop {
+	constructor(
+		guStack: GuStack,
+		schedule: Schedule,
+		anghammaradTopic: ITopic,
+		cloudqueryDB: DatabaseInstance,
+		monitoringConfiguration:
+			| NoMonitoring
+			| GuLambdaErrorPercentageMonitoringProps,
+		vpc: IVpc,
+		branchProtectorQueue: Queue,
+		interactiveMonitorTopic: Topic,
+		dbSecurityGroup: SecurityGroup,
+	) {
+		const repocopLampdaProps: GuScheduledLambdaProps = {
+			app: 'repocop',
+			fileName: 'repocop.zip',
+			handler: 'index.main',
+			memorySize: 1024,
+			monitoringConfiguration,
+			rules: [{ schedule }],
+			runtime: Runtime.NODEJS_18_X,
+			environment: {
+				ANGHAMMARAD_SNS_ARN: anghammaradTopic.topicArn,
+				DATABASE_HOSTNAME: cloudqueryDB.dbInstanceEndpointAddress,
+				QUERY_LOGGING: 'false', // Set this to 'true' to enable SQL query logging
+				// Messages sent to branch protector will be picked up at 9:00 the next working day (Tue-Fri)
+				BRANCH_PROTECTOR_QUEUE_URL: branchProtectorQueue.queueUrl,
+				INTERACTIVE_MONITOR_TOPIC_ARN: interactiveMonitorTopic.topicArn,
+			},
+			vpc,
+			securityGroups: [dbSecurityGroup],
+			timeout: Duration.minutes(5),
+		};
+
+		const repocopLambda = new GuScheduledLambda(
+			guStack,
+			'repocop',
+			repocopLampdaProps,
+		);
+
+		cloudqueryDB.grantConnect(repocopLambda, 'repocop');
+
+		branchProtectorQueue.grantSendMessages(repocopLambda);
+
+		anghammaradTopic.grantPublish(repocopLambda);
+		interactiveMonitorTopic.grantPublish(repocopLambda);
+	}
+}


### PR DESCRIPTION
## What does this change?

Similar to #477 , this PR puts all repocop infrastructure into its own class

## Why?

Better readability. This makes the separation between different parts of the service catalogue, and their interfaces (mostly SNS topics/SQS queues) clearer

## How has it been verified?

Snapshots are identical
