### PR TITLE
make logs more useful, fix octokit request

### DIFF
--- a/packages/interactive-monitor/src/config.ts
+++ b/packages/interactive-monitor/src/config.ts
@@ -1,4 +1,4 @@
-interface Config {
+export interface Config {
 	/**
 	 * The stage to run in.
 	 */

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -21,9 +21,12 @@ async function isFromInteractiveTemplate(
 
 export const handler: SNSHandler = async (event) => {
 	const config = getConfig();
-	if (event.Records.length !== 1) {
+	if (
+		event.Records.length !== 1 ||
+		!event.Records[0]!.Sns.Message.split('/')[1]
+	) {
 		throw new Error(
-			`Expected exactly one record, but got ${event.Records.length}`,
+			`Failed to process SNS message: ${JSON.stringify(event, null, 2)}`,
 		);
 	} else {
 		const repo = event.Records[0]!.Sns.Message.split('/')[1]!;

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -26,7 +26,7 @@ export const handler: SNSHandler = async (event) => {
 			`Expected exactly one record, but got ${event.Records.length}`,
 		);
 	} else {
-		const repo = event.Records[0]!.Sns.Message;
+		const repo = event.Records[0]!.Sns.Message.split('/')[1]!;
 		const owner = 'guardian';
 		console.log('received repo', repo);
 		const githubAppConfig: GitHubAppConfig = await getGitHubAppConfig();

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -2,15 +2,17 @@ import type { SNSHandler } from 'aws-lambda';
 import { getGitHubAppConfig, getGithubClient } from 'common/functions';
 import type { GitHubAppConfig } from 'common/types';
 import type { Octokit } from 'octokit';
+import type { Config } from './config';
 import { getConfig } from './config';
 
 async function isFromInteractiveTemplate(
 	repo: string,
+	owner: string,
 	octokit: Octokit,
 ): Promise<boolean> {
 	console.log('retrieving repo data');
 	const repoData = await octokit.rest.repos.get({
-		owner: 'guardian',
+		owner,
 		repo,
 	});
 
@@ -19,33 +21,34 @@ async function isFromInteractiveTemplate(
 	return repoData.data.template_repository?.name.includes(prefix) ?? false;
 }
 
+async function applyTopics(repo: string, owner: string, octokit: Octokit) {
+	const topics = (await octokit.rest.repos.getAllTopics({ owner, repo })).data
+		.names;
+	console.log(`${repo}is from interactive template`);
+	const names = topics.concat(['interactive']);
+	await octokit.rest.repos.replaceAllTopics({ owner, repo, names });
+	console.log(`added interactive topic to ${repo}`);
+}
+
+async function assessRepo(repo: string, owner: string, config: Config) {
+	console.log('received repo', repo);
+	const githubAppConfig: GitHubAppConfig = await getGitHubAppConfig();
+	const octokit: Octokit = await getGithubClient(githubAppConfig);
+
+	const isInteractive = await isFromInteractiveTemplate(repo, owner, octokit);
+
+	if (isInteractive && config.stage === 'PROD') {
+		await applyTopics(repo, owner, octokit);
+	} else {
+		console.log('No action taken');
+	}
+}
+
 export const handler: SNSHandler = async (event) => {
 	const config = getConfig();
-	if (
-		event.Records.length !== 1 ||
-		!event.Records[0]!.Sns.Message.split('/')[1]
-	) {
-		throw new Error(
-			`Failed to process SNS message: ${JSON.stringify(event, null, 2)}`,
-		);
-	} else {
-		const repo = event.Records[0]!.Sns.Message.split('/')[1]!;
-		const owner = 'guardian';
-		console.log('received repo', repo);
-		const githubAppConfig: GitHubAppConfig = await getGitHubAppConfig();
-		const octokit: Octokit = await getGithubClient(githubAppConfig);
-
-		const isInteractive = await isFromInteractiveTemplate(repo, octokit);
-		const topics = (await octokit.rest.repos.getAllTopics({ owner, repo })).data
-			.names;
-
-		if (isInteractive && config.stage === 'PROD') {
-			console.log(`${repo}is from interactive template`);
-			const names = topics.concat(['interactive']);
-			await octokit.rest.repos.replaceAllTopics({ owner, repo, names });
-			console.log(`added interactive topic to ${repo}`);
-		} else {
-			console.log('No action taken');
-		}
-	}
+	const owner = 'guardian';
+	const events = event.Records.map(
+		async (record) => await assessRepo(record.Sns.Message, owner, config),
+	);
+	await Promise.all(events);
 };

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -24,7 +24,7 @@ async function isFromInteractiveTemplate(
 async function applyTopics(repo: string, owner: string, octokit: Octokit) {
 	const topics = (await octokit.rest.repos.getAllTopics({ owner, repo })).data
 		.names;
-	console.log(`${repo}is from interactive template`);
+	console.log(`${repo} is from interactive template`);
 	const names = topics.concat(['interactive']);
 	await octokit.rest.repos.replaceAllTopics({ owner, repo, names });
 	console.log(`added interactive topic to ${repo}`);

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -19,7 +19,10 @@ import {
 	notifyAnghammaradBranchProtection,
 	notifyBranchProtector,
 } from './remediations/repository-02-branch_protection';
-import { findPotentialInteractives } from './remediations/repository-06-topic-monitor-interactive';
+import {
+	createBatchEntry,
+	findPotentialInteractives,
+} from './remediations/repository-06-topic-monitor-interactive';
 import { evaluateRepositories } from './rules/repository';
 
 async function writeEvaluationTable(
@@ -55,10 +58,7 @@ async function sendPotentialInteractives(
 	);
 
 	const PublishBatchRequestEntries = somePotentialInteractives.map(
-		(repo): PublishBatchRequestEntry => ({
-			Id: repo.replace(/\W/g, ''),
-			Message: repo,
-		}),
+		(repo): PublishBatchRequestEntry => createBatchEntry(repo),
 	);
 
 	const batchCommandInput: PublishBatchCommandInput = {

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -41,16 +41,20 @@ async function sendPotentialInteractives(
 	evaluatedRepos: repocop_github_repository_rules[],
 	config: Config,
 ) {
-	const snsBatchMaximum = 10;
 	const potentialInteractives = shuffle(
 		findPotentialInteractives(evaluatedRepos),
-	).slice(0, snsBatchMaximum);
+	);
+	const snsBatchMaximum = Math.min(potentialInteractives.length, 10);
+	const somePotentialInteractives = potentialInteractives.slice(
+		0,
+		snsBatchMaximum,
+	);
 
 	console.log(
 		`Found ${potentialInteractives.length} potential interactives of ${evaluatedRepos.length} evaluated repositories`,
 	);
 
-	const PublishBatchRequestEntries = potentialInteractives.map(
+	const PublishBatchRequestEntries = somePotentialInteractives.map(
 		(repo): PublishBatchRequestEntry => ({
 			Id: repo.replace(/\W/g, ''),
 			Message: repo,
@@ -62,7 +66,10 @@ async function sendPotentialInteractives(
 		PublishBatchRequestEntries,
 	};
 
-	console.log('Sending SNS batch');
+	const strList = somePotentialInteractives.join(', ');
+	console.log(
+		`Sending ${snsBatchMaximum} potential interactives to SNS. ${strList}}`,
+	);
 	const cmd = new PublishBatchCommand(batchCommandInput);
 	await new SNSClient({
 		region: config.region,

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -68,7 +68,7 @@ async function sendPotentialInteractives(
 
 	const strList = somePotentialInteractives.join(', ');
 	console.log(
-		`Sending ${snsBatchMaximum} potential interactives to SNS. ${strList}}`,
+		`Sending ${snsBatchMaximum} potential interactives to SNS. ${strList}`,
 	);
 	const cmd = new PublishBatchCommand(batchCommandInput);
 	await new SNSClient({

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.test.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.test.ts
@@ -1,5 +1,8 @@
 import type { repocop_github_repository_rules } from '@prisma/client';
-import { findPotentialInteractives } from './repository-06-topic-monitor-interactive';
+import {
+	createBatchEntry,
+	findPotentialInteractives,
+} from './repository-06-topic-monitor-interactive';
 
 describe('findPotentialInteractives', () => {
 	it('should return an empty array when evaluatedRepos is empty', () => {
@@ -29,5 +32,20 @@ describe('findPotentialInteractives', () => {
 
 		const result = findPotentialInteractives(evaluatedRepos);
 		expect(result).toEqual(['org/repo3']);
+	});
+});
+
+describe('createBatchEntry', () => {
+	it('should return a valid PublishBatchRequestEntry for a full repo name', () => {
+		const message = 'guardian/my-repo';
+		const result = createBatchEntry(message);
+		expect(result.Message).toEqual('my-repo');
+		expect(result.Id).toEqual('myrepo');
+	});
+	it('should throw an error for a short repo name', () => {
+		const message = 'my-repo';
+		expect(() => createBatchEntry(message)).toThrowError(
+			'Invalid repo name: my-repo',
+		);
 	});
 });

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
@@ -16,14 +16,16 @@ export function findPotentialInteractives(
 		.map((repo) => repo.full_name);
 }
 
-export function createBatchEntry(string: string): PublishBatchRequestEntry {
-	const shortString = string.split('/')[1];
-	if (!shortString) {
-		throw new Error(`Invalid repo name: ${string}`);
+export function createBatchEntry(
+	fullRepoName: string,
+): PublishBatchRequestEntry {
+	const shortName = fullRepoName.split('/')[1];
+	if (!shortName) {
+		throw new Error(`Invalid repo name: ${fullRepoName}`);
 	}
 	return {
-		Id: shortString.replace(/\W/g, ''),
-		Message: shortString,
+		Id: shortName.replace(/\W/g, ''),
+		Message: shortName,
 	};
 }
 

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
@@ -1,5 +1,12 @@
-import type { PublishBatchRequestEntry } from '@aws-sdk/client-sns';
+import {
+	PublishBatchCommand,
+	SNSClient,
+	type PublishBatchCommandInput,
+	type PublishBatchRequestEntry,
+} from '@aws-sdk/client-sns';
 import type { repocop_github_repository_rules } from '@prisma/client';
+import { getLocalProfile, shuffle } from 'common/functions';
+import type { Config } from '../config';
 
 export function findPotentialInteractives(
 	evaluatedRepos: repocop_github_repository_rules[],
@@ -18,4 +25,41 @@ export function createBatchEntry(string: string): PublishBatchRequestEntry {
 		Id: shortString.replace(/\W/g, ''),
 		Message: shortString,
 	};
+}
+
+export async function sendPotentialInteractives(
+	evaluatedRepos: repocop_github_repository_rules[],
+	config: Config,
+) {
+	const potentialInteractives = shuffle(
+		findPotentialInteractives(evaluatedRepos),
+	);
+	const snsBatchMaximum = Math.min(potentialInteractives.length, 10);
+	const somePotentialInteractives = potentialInteractives.slice(
+		0,
+		snsBatchMaximum,
+	);
+
+	console.log(
+		`Found ${potentialInteractives.length} potential interactives of ${evaluatedRepos.length} evaluated repositories`,
+	);
+
+	const PublishBatchRequestEntries = somePotentialInteractives.map(
+		(repo): PublishBatchRequestEntry => createBatchEntry(repo),
+	);
+
+	const batchCommandInput: PublishBatchCommandInput = {
+		TopicArn: config.interactiveMonitorSnsTopic,
+		PublishBatchRequestEntries,
+	};
+
+	const strList = somePotentialInteractives.join(', ');
+	console.log(
+		`Sending ${snsBatchMaximum} potential interactives to SNS. ${strList}`,
+	);
+	const cmd = new PublishBatchCommand(batchCommandInput);
+	await new SNSClient({
+		region: config.region,
+		credentials: getLocalProfile(config.stage),
+	}).send(cmd);
 }

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
@@ -5,7 +5,7 @@ import {
 	SNSClient,
 } from '@aws-sdk/client-sns';
 import type { repocop_github_repository_rules } from '@prisma/client';
-import { getLocalProfile, shuffle } from 'common/functions';
+import { getLocalProfile, shuffle } from 'common/src/functions';
 import type { Config } from '../config';
 
 export function findPotentialInteractives(

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
@@ -1,8 +1,8 @@
 import {
 	PublishBatchCommand,
-	SNSClient,
 	type PublishBatchCommandInput,
 	type PublishBatchRequestEntry,
+	SNSClient,
 } from '@aws-sdk/client-sns';
 import type { repocop_github_repository_rules } from '@prisma/client';
 import { getLocalProfile, shuffle } from 'common/functions';

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
@@ -1,3 +1,4 @@
+import type { PublishBatchRequestEntry } from '@aws-sdk/client-sns';
 import type { repocop_github_repository_rules } from '@prisma/client';
 
 export function findPotentialInteractives(
@@ -6,4 +7,15 @@ export function findPotentialInteractives(
 	return evaluatedRepos
 		.filter((repo) => !repo.topics)
 		.map((repo) => repo.full_name);
+}
+
+export function createBatchEntry(string: string): PublishBatchRequestEntry {
+	const shortString = string.split('/')[1];
+	if (!shortString) {
+		throw new Error(`Invalid repo name: ${string}`);
+	}
+	return {
+		Id: shortString.replace(/\W/g, ''),
+		Message: shortString,
+	};
 }


### PR DESCRIPTION
## What does this change?

We are submitting the full repo name to github. We shouldn't be doing this
Also make repocop logging more useful

## Why?

Passing in the full name into the name field means we are searching for the wrong repo and return a 404. ie `guardian/guardian%2Fcapi` rather than `guardian/capi`

## How has it been verified?

Deployed to code, octokit is able to find the correct repo