### PR TITLE
fix branch protection rule

### DIFF
--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -26,12 +26,16 @@ function hasBranchProtection(
 	repo: github_repositories,
 	branches: github_repository_branches[],
 ): boolean {
+	const exempt = !(
+		repo.topics.includes('production') || repo.topics.includes('documentation')
+	);
+
 	const branch = branches.find(
 		(branch) =>
 			branch.repository_id === repo.id && branch.name === repo.default_branch,
 	);
-	if (branch === undefined) {
-		return false;
+	if (exempt || branch === undefined) {
+		return true;
 	} else {
 		return branch.protected ?? false;
 	}


### PR DESCRIPTION
## What does this change?

- Exclude non production/documentation repos from requiring branch protection.
- Repos with no branches do not need protection
- Test the above changes

## Why?

It's unreasonable to expect every hackday project, for example, to have branch protection, and previously our code did not line up with our [exemptions](https://github.com/guardian/service-catalogue/blob/main/packages/best-practices/best-practices.md)

## How has it been verified?

Tests pass.
Branch protection increases from 14% to 98%
