### PR TITLE
refactor: call getUnarchivedRepositories only once 

### DIFF
--- a/packages/repocop/src/remediations/repository-02-branch_protection.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.ts
@@ -2,6 +2,7 @@ import { SQSClient } from '@aws-sdk/client-sqs';
 import { fromIni } from '@aws-sdk/credential-providers';
 import type { Anghammarad } from '@guardian/anghammarad';
 import type {
+	github_repositories,
 	github_teams,
 	PrismaClient,
 	repocop_github_repository_rules,
@@ -10,11 +11,7 @@ import type {
 import { shuffle } from 'common/src/functions';
 import type { UpdateMessageEvent } from 'common/types';
 import type { Config } from '../config';
-import {
-	getRepoOwnership,
-	getTeams,
-	getUnarchivedRepositories,
-} from '../query';
+import { getRepoOwnership, getTeams } from '../query';
 import {
 	addMessagesToQueue,
 	findContactableOwners,
@@ -51,12 +48,13 @@ export async function notifyBranchProtector(
 	prisma: PrismaClient,
 	evaluatedRepos: repocop_github_repository_rules[],
 	config: Config,
+	unarchivedRepositories: github_repositories[],
 ) {
 	const repoOwners = await getRepoOwnership(prisma);
 	const teams = await getTeams(prisma);
 
 	//repos with a 'production' or 'documentation' topic
-	const productionOrDocs = (await getUnarchivedRepositories(prisma, []))
+	const productionOrDocs = unarchivedRepositories
 		.filter(
 			(repo) =>
 				repo.topics.includes('production') ||

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -7,7 +7,6 @@ import type {
 import {
 	getRepositoryBranches,
 	getRepositoryTeams,
-	getUnarchivedRepositories,
 	type RepositoryTeam,
 } from '../query';
 
@@ -110,15 +109,9 @@ export function repositoryRuleEvaluation(
 
 export async function evaluateRepositories(
 	client: PrismaClient,
-	ignoredRepositoryPrefixes: string[],
+	repositories: github_repositories[],
 ): Promise<repocop_github_repository_rules[]> {
-	const repositories = await getUnarchivedRepositories(
-		client,
-		ignoredRepositoryPrefixes,
-	);
-
 	const branches = await getRepositoryBranches(client, repositories);
-
 	return await Promise.all(
 		repositories.map(async (repo) => {
 			const teams = await getRepositoryTeams(client, repo);


### PR DESCRIPTION
## What does this change?

Currently, the function `getUnarchivedRepositories` is called twice, in the main repocop function and the remediation for branch protection. Soon, it would have been called 3 times with the addition of the production topic remediation.

With this PR, the function is called once and then passed into the functions that need it. 

## Why?

This will hopefully save memory and time (and therefore money), and make things DRYer and more future-proof.

## How has it been verified?
Tested locally using the CODE database with messaging on, and all worked as expected.