### PR TITLE
refactor(repocop): Use shared `getEnvOrThrow`

### DIFF
--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -1,5 +1,6 @@
 import * as process from 'process';
 import { Signer } from '@aws-sdk/rds-signer';
+import { getEnvOrThrow } from 'common/functions';
 
 export interface Config {
 	/**
@@ -90,13 +91,6 @@ interface DatabaseConfig {
 	password?: string;
 }
 
-function getEnvOrThrow(key: string): string {
-	const value = process.env[key];
-	if (value === undefined) {
-		throw new Error(`Environment variable ${key} is not set`);
-	}
-	return value;
-}
 export async function getConfig(): Promise<Config> {
 	const databaseConfig: DatabaseConfig = {
 		hostname: getEnvOrThrow('DATABASE_HOSTNAME'),


### PR DESCRIPTION
## What does this change?
The [shared `getEnvOrThrow` function](https://github.com/guardian/service-catalogue/blob/235ad1bdab2a61e15f02503afb86ab6aafacab24/packages/common/src/functions.ts#L22-L28) has the same implementation, so no need to redefine it.

## How has it been verified?
N/A.