### PR TITLE
feat(data-audit): Initialise data-audit lambda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,5 +59,7 @@ jobs:
               - packages/branch-protector/dist/branch-protector.zip
             interactive-monitor:
               - packages/interactive-monitor/dist/interactive-monitor.zip
+            data-audit:
+              - packages/data-audit/dist/data-audit.zip
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'

--- a/package-lock.json
+++ b/package-lock.json
@@ -7983,6 +7983,10 @@
       "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==",
       "dev": true
     },
+    "node_modules/data-audit": {
+      "resolved": "packages/data-audit",
+      "link": true
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "license": "MIT",
@@ -13303,6 +13307,9 @@
       "devDependencies": {
         "@octokit/types": "^12.0.0"
       }
+    },
+    "packages/data-audit": {
+      "version": "0.0.0"
     },
     "packages/interactive-monitor": {
       "version": "1.0.0"

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -15,6 +15,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuScheduledLambda",
       "GuScheduledLambda",
+      "GuScheduledLambda",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -12879,6 +12880,250 @@ spec:
         ],
       },
       "Type": "AWS::Events::Rule",
+    },
+    "DataAudit2FEB3068": {
+      "DependsOn": [
+        "DataAuditServiceRoleDefaultPolicyB6C67E52",
+        "DataAuditServiceRole35A15887",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "deploy/TEST/data-audit/data-audit.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "data-audit",
+            "STACK": "deploy",
+            "STAGE": "TEST",
+          },
+        },
+        "Handler": "index.main",
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "DataAuditServiceRole35A15887",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs18.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "data-audit",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "DataAuditDataAuditrate1day015E5BEEB": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 day)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "DataAudit2FEB3068",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "DataAuditDataAuditrate1day0AllowEventRuleServiceCatalogueDataAudit9CC2131ED1368FFF": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "DataAudit2FEB3068",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "DataAuditDataAuditrate1day015E5BEEB",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "DataAuditServiceRole35A15887": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "data-audit",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "DataAuditServiceRoleDefaultPolicyB6C67E52": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/deploy/TEST/data-audit/data-audit.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/data-audit",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/data-audit/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DataAuditServiceRoleDefaultPolicyB6C67E52",
+        "Roles": [
+          {
+            "Ref": "DataAuditServiceRole35A15887",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "PostgresAccessSecurityGroupParam38DFE001": {
       "Properties": {

--- a/packages/cdk/lib/data-audit.ts
+++ b/packages/cdk/lib/data-audit.ts
@@ -1,0 +1,21 @@
+import { GuScheduledLambda } from '@guardian/cdk';
+import type { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { Duration } from 'aws-cdk-lib';
+import { Schedule } from 'aws-cdk-lib/aws-events';
+import { Runtime } from 'aws-cdk-lib/aws-lambda';
+
+export function addDataAuditLambda(scope: GuStack) {
+	const app = 'data-audit';
+	new GuScheduledLambda(scope, 'DataAudit', {
+		app,
+		fileName: `${app}.zip`,
+		handler: 'index.main',
+		monitoringConfiguration: { noMonitoring: true },
+		rules: [
+			{
+				schedule: Schedule.rate(Duration.days(1)),
+			},
+		],
+		runtime: Runtime.NODEJS_18_X,
+	});
+}

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -43,6 +43,7 @@ import {
 	StringParameter,
 } from 'aws-cdk-lib/aws-ssm';
 import { BranchProtector } from './branch-protector';
+import { addDataAuditLambda } from './data-audit';
 import type { CloudquerySource } from './ecs/cluster';
 import { CloudqueryCluster } from './ecs/cluster';
 import {
@@ -630,5 +631,7 @@ export class ServiceCatalogue extends GuStack {
 			interactiveMonitor.topic,
 			applicationToPostgresSecurityGroup,
 		);
+
+		addDataAuditLambda(this);
 	}
 }

--- a/packages/data-audit/package.json
+++ b/packages/data-audit/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "data-audit",
+  "version": "0.0.0",
+  "description": "Checking data accuracy",
+  "scripts": {
+    "test": "echo \"Error: no test specified\"",
+    "start": "APP=data-audit ts-node src/run-locally.ts",
+    "prebuild": "rm -rf dist",
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node18 --outdir=dist --external:@aws-sdk",
+    "postbuild": "cd dist && zip -r data-audit.zip ."
+  }
+}

--- a/packages/data-audit/src/config.ts
+++ b/packages/data-audit/src/config.ts
@@ -1,0 +1,20 @@
+import { getEnvOrThrow } from 'common/functions';
+
+export interface Config {
+	/**
+	 * The name of this application.
+	 */
+	app: string;
+
+	/**
+	 * The stage of the application, e.g. DEV, CODE, PROD.
+	 */
+	stage: string;
+}
+
+export function getConfig(): Config {
+	return {
+		app: getEnvOrThrow('APP'),
+		stage: getEnvOrThrow('STAGE'),
+	};
+}

--- a/packages/data-audit/src/index.ts
+++ b/packages/data-audit/src/index.ts
@@ -1,0 +1,8 @@
+import { getConfig } from './config';
+
+export async function main() {
+	const { app, stage } = getConfig();
+	const message = `Hello from ${app} (${stage}). The time is ${new Date().toString()}.`;
+	console.log(message);
+	return Promise.resolve(message);
+}

--- a/packages/data-audit/src/run-locally.ts
+++ b/packages/data-audit/src/run-locally.ts
@@ -1,0 +1,9 @@
+import { config } from 'dotenv';
+import { main } from './index';
+
+// Read the .env file from the repository root
+config({ path: `../../.env` });
+
+if (require.main === module) {
+	void (async () => await main())();
+}

--- a/packages/data-audit/tsconfig.json
+++ b/packages/data-audit/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "references": [{ "path": "../common" }]
+}


### PR DESCRIPTION
## What does this change?
Add the infrastructure for the data-audit lambda. The lambda currently prints the time, and will be later updated to track the accuracy of our data.

In this initial step, we're testing:
- Can we build the lambda?
- Can we deploy the lambda?
- Can we see the lambda's logs in Central ELK?

## Why?
See https://github.com/guardian/service-catalogue/blob/main/ADR/03-data-accuracy.md.

## How has it been verified?
- The lambda built and [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/a3789524-fe0d-4256-9b85-d18f9073eb65) successfully
- The logs appear in [Central ELK](https://logs.gutools.co.uk/s/devx/goto/98a08e80-8795-11ee-a34c-11e7b53d0c58)