### PR TITLE
feat(data-audit): Query the database

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2900,8 +2900,7 @@
     },
     "node_modules/@octokit/app": {
       "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.0.2.tgz",
-      "integrity": "sha512-NCSCktSx+XmjuSUVn2dLfqQ9WIYePGP95SDJs4I9cn/0ZkeXcPkaoCLl64Us3dRKL2ozC7hArwze5Eu+/qt1tg==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/auth-app": "^6.0.0",
         "@octokit/auth-unauthenticated": "^5.0.0",
@@ -2993,8 +2992,7 @@
     },
     "node_modules/@octokit/auth-unauthenticated": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-5.0.1.tgz",
-      "integrity": "sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/request-error": "^5.0.0",
         "@octokit/types": "^12.0.0"
@@ -3045,8 +3043,7 @@
     },
     "node_modules/@octokit/oauth-app": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-6.0.0.tgz",
-      "integrity": "sha512-bNMkS+vJ6oz2hCyraT9ZfTpAQ8dZNqJJQVNaKjPLx4ue5RZiFdU1YWXguOPR8AaSHS+lKe+lR3abn2siGd+zow==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/auth-oauth-app": "^7.0.0",
         "@octokit/auth-oauth-user": "^4.0.0",
@@ -3109,8 +3106,7 @@
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.1.4.tgz",
-      "integrity": "sha512-MvZx4WvfhBnt7PtH5XE7HORsO7bBk4er1FgRIUr1qJ89NR2I6bWjGyKsxk8z42FPQ34hFQm0Baanh4gzdZR4gQ==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^12.3.0"
       },
@@ -3198,8 +3194,7 @@
     },
     "node_modules/@octokit/webhooks": {
       "version": "12.0.7",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.0.7.tgz",
-      "integrity": "sha512-g9HKed5x+72yBZcTRAYNiR7Ane/iOwNEjd9sdu+Jvrcc/Z0FdkjYBMfBmQdowbOhHM4Nek9zpGC5u3C3Wxfhsg==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/request-error": "^5.0.0",
         "@octokit/webhooks-methods": "^4.0.0",
@@ -3212,16 +3207,14 @@
     },
     "node_modules/@octokit/webhooks-methods": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-4.0.0.tgz",
-      "integrity": "sha512-M8mwmTXp+VeolOS/kfRvsDdW+IO0qJ8kYodM/sAysk093q6ApgmBXwK1ZlUvAwXVrp/YVHp6aArj4auAxUAOFw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@octokit/webhooks-types": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.1.0.tgz",
-      "integrity": "sha512-y92CpG4kFFtBBjni8LHoV12IegJ+KFxLgKRengrVjKmGE5XMeCuGvlfRe75lTRrgXaG6XIWJlFpIDTlkoJsU8w=="
+      "license": "MIT"
     },
     "node_modules/@pkgr/utils": {
       "version": "2.3.1",
@@ -4152,8 +4145,7 @@
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "license": "MIT",
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -4164,8 +4156,7 @@
     },
     "node_modules/aggregate-error/node_modules/clean-stack": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -8361,8 +8352,7 @@
     },
     "node_modules/octokit": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/octokit/-/octokit-3.1.2.tgz",
-      "integrity": "sha512-MG5qmrTL5y8KYwFgE1A4JWmgfQBaIETE/lOlfwNYx1QOtCQHGVxkRJmdUJltFc1HVn73d61TlMhMyNTOtMl+ng==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/app": "^14.0.2",
         "@octokit/core": "^5.0.0",
@@ -10449,6 +10439,7 @@
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.441.0",
         "@aws-sdk/credential-providers": "^3.444.0",
+        "@aws-sdk/rds-signer": "^3.450.0",
         "@guardian/anghammarad": "^1.8.1",
         "@octokit/auth-app": "^6.0.1",
         "@prisma/client": "^5.5.2",
@@ -10477,8 +10468,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-sns": "^3.438.0",
-        "@aws-sdk/client-sqs": "^3.450.0",
-        "@aws-sdk/rds-signer": "^3.450.0"
+        "@aws-sdk/client-sqs": "^3.450.0"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.126"

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -12957,6 +12957,13 @@ spec:
         "Environment": {
           "Variables": {
             "APP": "data-audit",
+            "DATABASE_HOSTNAME": {
+              "Fn::GetAtt": [
+                "PostgresInstance16DE4286E",
+                "Endpoint.Address",
+              ],
+            },
+            "QUERY_LOGGING": "false",
             "STACK": "deploy",
             "STAGE": "TEST",
           },
@@ -12993,6 +13000,19 @@ spec:
           },
         ],
         "Timeout": 30,
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "PostgresAccessSecurityGroupServicecatalogue03C78F14",
+                "GroupId",
+              ],
+            },
+          ],
+          "SubnetIds": {
+            "Ref": "PrivateSubnets",
+          },
+        },
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -13057,6 +13077,18 @@ spec:
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
               ],
             ],
           },
@@ -13170,6 +13202,37 @@ spec:
                       "Ref": "AWS::AccountId",
                     },
                     ":parameter/TEST/deploy/data-audit/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/dataaudit",
                   ],
                 ],
               },

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -194,6 +194,10 @@ export class ServiceCatalogue extends GuStack {
 			applicationToPostgresSecurityGroup,
 		);
 
-		addDataAuditLambda(this);
+		addDataAuditLambda(this, {
+			vpc,
+			db,
+			dbAccess: applicationToPostgresSecurityGroup,
+		});
 	}
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -10,6 +10,7 @@
 		"@aws-sdk/client-secrets-manager": "^3.441.0",
 		"@guardian/anghammarad": "^1.8.1",
 		"@aws-sdk/credential-providers": "^3.444.0",
+		"@aws-sdk/rds-signer": "^3.450.0",
 		"@octokit/auth-app": "^6.0.1",
 		"octokit": "^3.1.2",
 		"@prisma/client": "^5.5.2"

--- a/packages/common/src/database.ts
+++ b/packages/common/src/database.ts
@@ -1,0 +1,75 @@
+import { Signer } from '@aws-sdk/rds-signer';
+import { awsClientConfig } from 'common/aws';
+import { getEnvOrThrow } from 'common/functions';
+
+export interface DatabaseConfig {
+	/**
+	 * The hostname of the database.
+	 */
+	hostname: string;
+
+	/**
+	 * The database user.
+	 */
+	user: string;
+
+	/**
+	 * The database password.
+	 *
+	 * When not defined, a token (temporary password) will be generated for IAM authentication for RDS.
+	 */
+	password?: string;
+}
+
+const databasePort = 5432;
+
+async function getRdsToken(stage: string, config: DatabaseConfig) {
+	console.log('Generating RDS token');
+
+	const { hostname, user } = config;
+
+	const signer = new Signer({
+		hostname,
+		port: databasePort,
+		username: user,
+		...awsClientConfig(stage),
+	});
+
+	return await signer.getAuthToken();
+}
+
+export function getDevDatabaseConfig(): Promise<DatabaseConfig> {
+	return Promise.resolve({
+		hostname: getEnvOrThrow('DATABASE_HOSTNAME'),
+		user: getEnvOrThrow('DATABASE_USER'),
+		password: getEnvOrThrow('DATABASE_PASSWORD'),
+	});
+}
+
+export async function getDatabaseConfig(
+	stage: string,
+	user: string,
+): Promise<DatabaseConfig> {
+	const hostname = getEnvOrThrow('DATABASE_HOSTNAME');
+	const password = await getRdsToken(stage, { hostname, user });
+
+	return {
+		hostname,
+		user,
+		password,
+	};
+}
+
+export function getDatabaseConnectionString(config: DatabaseConfig) {
+	const { user, password, hostname } = config;
+
+	if (!password) {
+		throw new Error(
+			'Unable to create a database connection string without password',
+		);
+	}
+
+	return `postgres://${user}:${encodeURIComponent(
+		password,
+	)}@${hostname}:${databasePort}/postgres?schema=public&sslmode=verify-full&connection_limit=20&pool_timeout=20`;
+}

--- a/packages/data-audit/package.json
+++ b/packages/data-audit/package.json
@@ -6,7 +6,6 @@
     "test": "echo \"Error: no test specified\"",
     "start": "APP=data-audit ts-node src/run-locally.ts",
     "prebuild": "rm -rf dist",
-    "build": "esbuild src/index.ts --bundle --platform=node --target=node18 --outdir=dist --external:@aws-sdk",
-    "postbuild": "cd dist && zip -r data-audit.zip ."
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node18 --outdir=dist --external:@aws-sdk --external:@prisma/client --external:prisma"
   }
 }

--- a/packages/data-audit/src/config.ts
+++ b/packages/data-audit/src/config.ts
@@ -1,3 +1,10 @@
+import process from 'process';
+import type { DatabaseConfig } from 'common/database';
+import {
+	getDatabaseConfig,
+	getDatabaseConnectionString,
+	getDevDatabaseConfig,
+} from 'common/database';
 import { getEnvOrThrow } from 'common/functions';
 
 export interface Config {
@@ -10,11 +17,34 @@ export interface Config {
 	 * The stage of the application, e.g. DEV, CODE, PROD.
 	 */
 	stage: string;
+
+	/**
+	 * The database connection string.
+	 */
+	databaseConnectionString: string;
+
+	/**
+	 * Whether to configure Prisma to log the SQL queries being executed.
+	 *
+	 * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/logging
+	 */
+	withQueryLogging: boolean;
 }
 
-export function getConfig(): Config {
+export async function getConfig(): Promise<Config> {
+	const stage = getEnvOrThrow('STAGE');
+
+	const databaseConfig: DatabaseConfig =
+		stage === 'DEV'
+			? await getDevDatabaseConfig()
+			: await getDatabaseConfig(stage, 'data-audit');
+
+	const queryLogging = (process.env['QUERY_LOGGING'] ?? 'false') === 'true';
+
 	return {
 		app: getEnvOrThrow('APP'),
-		stage: getEnvOrThrow('STAGE'),
+		stage,
+		databaseConnectionString: getDatabaseConnectionString(databaseConfig),
+		withQueryLogging: queryLogging,
 	};
 }

--- a/packages/data-audit/src/config.ts
+++ b/packages/data-audit/src/config.ts
@@ -37,7 +37,7 @@ export async function getConfig(): Promise<Config> {
 	const databaseConfig: DatabaseConfig =
 		stage === 'DEV'
 			? await getDevDatabaseConfig()
-			: await getDatabaseConfig(stage, 'data-audit');
+			: await getDatabaseConfig(stage, 'dataaudit');
 
 	const queryLogging = (process.env['QUERY_LOGGING'] ?? 'false') === 'true';
 

--- a/packages/data-audit/src/index.ts
+++ b/packages/data-audit/src/index.ts
@@ -1,8 +1,25 @@
+import { PrismaClient } from '@prisma/client';
 import { getConfig } from './config';
 
 export async function main() {
-	const { app, stage } = getConfig();
-	const message = `Hello from ${app} (${stage}). The time is ${new Date().toString()}.`;
-	console.log(message);
-	return Promise.resolve(message);
+	const config = await getConfig();
+
+	const prisma = new PrismaClient({
+		datasources: {
+			db: {
+				url: config.databaseConnectionString,
+			},
+		},
+		...(config.withQueryLogging && {
+			log: [
+				{
+					emit: 'stdout',
+					level: 'query',
+				},
+			],
+		}),
+	});
+
+	const awsAccounts = await prisma.aws_accounts.findMany();
+	console.log(`There are ${awsAccounts.length} AWS accounts in the database`);
 }

--- a/packages/data-audit/src/index.ts
+++ b/packages/data-audit/src/index.ts
@@ -20,6 +20,6 @@ export async function main() {
 		}),
 	});
 
-	const awsAccounts = await prisma.aws_accounts.findMany();
-	console.log(`There are ${awsAccounts.length} AWS accounts in the database`);
+	const awsAccounts = await prisma.aws_accounts.count();
+	console.log(`There are ${awsAccounts} AWS accounts in the database`);
 }

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -16,7 +16,6 @@
 	},
 	"dependencies": {
 		"@aws-sdk/client-sns": "^3.438.0",
-		"@aws-sdk/client-sqs": "^3.450.0",
-		"@aws-sdk/rds-signer": "^3.450.0"
+		"@aws-sdk/client-sqs": "^3.450.0"
 	}
 }

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -4,21 +4,24 @@ set -e
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ROOT_DIR=$(realpath "${DIR}/..")
 
-createRepocopZip() {
-  echo "Creating repocop package"
+createLambdaWithPrisma() {
+  name=$1
+
+  echo "Creating $name package"
+
   # Copy the Prisma schema file to the dist directory
-  cp -r "$ROOT_DIR/packages/common/prisma" "$ROOT_DIR/packages/repocop/dist"
+  cp -r "$ROOT_DIR/packages/common/prisma" "$ROOT_DIR/packages/$name/dist"
 
   # Copy the generated Prisma client
-  mkdir -p "$ROOT_DIR/packages/repocop/dist/node_modules"
-  cp -r "$ROOT_DIR/node_modules/@prisma" "$ROOT_DIR/packages/repocop/dist/node_modules/@prisma"
-  cp -r "$ROOT_DIR/node_modules/prisma" "$ROOT_DIR/packages/repocop/dist/node_modules/prisma"
-  cp -r "$ROOT_DIR/node_modules/.prisma" "$ROOT_DIR/packages/repocop/dist/node_modules/.prisma"
+  mkdir -p "$ROOT_DIR/packages/$name/dist/node_modules"
+  cp -r "$ROOT_DIR/node_modules/@prisma" "$ROOT_DIR/packages/$name/dist/node_modules/@prisma"
+  cp -r "$ROOT_DIR/node_modules/prisma" "$ROOT_DIR/packages/$name/dist/node_modules/prisma"
+  cp -r "$ROOT_DIR/node_modules/.prisma" "$ROOT_DIR/packages/$name/dist/node_modules/.prisma"
 
   # Create a zip file of the dist directory
   (
-    cd "$ROOT_DIR/packages/repocop/dist"
-    zip -qr repocop.zip .
+    cd "$ROOT_DIR/packages/$name/dist"
+    zip -qr $name.zip .
   )
 }
 
@@ -34,4 +37,8 @@ npm ci
 npm run typecheck & npm run lint
 npm run test
 npm run synth & npm run build
-createZip "branch-protector" & createZip "interactive-monitor" & createRepocopZip
+
+createZip "branch-protector" & \
+  createZip "interactive-monitor" & \
+  createLambdaWithPrisma "repocop" & \
+  createLambdaWithPrisma "data-audit"

--- a/sql/dbuser.sql
+++ b/sql/dbuser.sql
@@ -8,3 +8,8 @@ GRANT rds_iam TO repocop;
 
 -- This table is created via a Prisma migration
 GRANT ALL ON public.repocop_github_repository_rules TO repocop;
+
+CREATE USER dataaudit WITH LOGIN;
+GRANT USAGE ON SCHEMA public to dataaudit;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO dataaudit;
+GRANT rds_iam TO dataaudit;


### PR DESCRIPTION
## What does this change?
Updates the data-audit lambda to perform a basic query against the database. There's a bit of wiring involved:
- Moving the database connection string logic into the `common` package
- Placing the lambda in the VPC, and adjust it's security groups to allow database connection
- Creation of a database user[^1]
- Include prisma in the lambda artifact

As such, it'll be easier to review this change [commit by commit](https://github.com/guardian/service-catalogue/pull/504/commits).

## Why?
The data-audit lambda will compare what is in the database to what AWS thinks, e.g. number of S3 buckets. This change begins that process.

## How has it been verified?
- Ran data-audit locally and observed the log line "There are X AWS accounts in the database"
- [Deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/e4be404c-fa2d-4969-b102-040899c3cb2a) and manually invoked the lambda, and [observed the log line "There are X AWS accounts in the database"](https://logs.gutools.co.uk/s/devx/app/discover#/doc/626e7830-dd3a-11ea-88b6-37713dba5739/logstash-dev-tools-2023.11.22?id=LBWV94sBym0G9ucgjC-3)


[^1]: This user was created manually