### PR TITLE
Allow CI to run on merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
 
   # Manual invocation.
   workflow_dispatch:


### PR DESCRIPTION
## What does this change?

Grants permission for CI to run as part of a merge queue

## Why?

Without this, PRs will hang forever

## How has it been verified?

The only way to test this PR is to merge it
