### PR TITLE
feat(data-audit): Check the number of accounts we have data for

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -248,6 +248,55 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/@aws-sdk/client-organizations": {
+      "version": "3.454.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-organizations/-/client-organizations-3.454.0.tgz",
+      "integrity": "sha512-VTV7E1wf7DVGdecUlb7udpg7HfuyDyMdgjgAiMdyE8WTIcPyP7rHZfBfuwqh/Yjrglp5jv3chd2SQmb3vQNsFw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.454.0",
+        "@aws-sdk/core": "3.451.0",
+        "@aws-sdk/credential-provider-node": "3.451.0",
+        "@aws-sdk/middleware-host-header": "3.451.0",
+        "@aws-sdk/middleware-logger": "3.451.0",
+        "@aws-sdk/middleware-recursion-detection": "3.451.0",
+        "@aws-sdk/middleware-signing": "3.451.0",
+        "@aws-sdk/middleware-user-agent": "3.451.0",
+        "@aws-sdk/region-config-resolver": "3.451.0",
+        "@aws-sdk/types": "3.451.0",
+        "@aws-sdk/util-endpoints": "3.451.0",
+        "@aws-sdk/util-user-agent-browser": "3.451.0",
+        "@aws-sdk/util-user-agent-node": "3.451.0",
+        "@smithy/config-resolver": "^2.0.18",
+        "@smithy/fetch-http-handler": "^2.2.6",
+        "@smithy/hash-node": "^2.0.15",
+        "@smithy/invalid-dependency": "^2.0.13",
+        "@smithy/middleware-content-length": "^2.0.15",
+        "@smithy/middleware-endpoint": "^2.2.0",
+        "@smithy/middleware-retry": "^2.0.20",
+        "@smithy/middleware-serde": "^2.0.13",
+        "@smithy/middleware-stack": "^2.0.7",
+        "@smithy/node-config-provider": "^2.1.5",
+        "@smithy/node-http-handler": "^2.1.9",
+        "@smithy/protocol-http": "^3.0.9",
+        "@smithy/smithy-client": "^2.1.15",
+        "@smithy/types": "^2.5.0",
+        "@smithy/url-parser": "^2.0.13",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.19",
+        "@smithy/util-defaults-mode-node": "^2.0.25",
+        "@smithy/util-endpoints": "^1.0.4",
+        "@smithy/util-retry": "^2.0.6",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-secrets-manager": {
       "version": "3.454.0",
       "license": "Apache-2.0",
@@ -10451,7 +10500,10 @@
       }
     },
     "packages/data-audit": {
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dependencies": {
+        "@aws-sdk/client-organizations": "^3.454.0"
+      }
     },
     "packages/interactive-monitor": {
       "version": "1.0.0",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -13237,6 +13237,11 @@ spec:
                 ],
               },
             },
+            {
+              "Action": "organizations:List*",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
           ],
           "Version": "2012-10-17",
         },

--- a/packages/cdk/lib/data-audit.ts
+++ b/packages/cdk/lib/data-audit.ts
@@ -6,6 +6,7 @@ import type { IVpc } from 'aws-cdk-lib/aws-ec2';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
+import { listOrgsPolicy } from './cloudquery/ecs/policies';
 
 interface DataAuditProps {
 	vpc: IVpc;
@@ -38,4 +39,5 @@ export function addDataAuditLambda(scope: GuStack, props: DataAuditProps) {
 	});
 
 	db.grantConnect(lambda, 'dataaudit');
+	lambda.addToRolePolicy(listOrgsPolicy);
 }

--- a/packages/data-audit/package.json
+++ b/packages/data-audit/package.json
@@ -7,5 +7,8 @@
     "start": "APP=data-audit ts-node src/run-locally.ts",
     "prebuild": "rm -rf dist",
     "build": "esbuild src/index.ts --bundle --platform=node --target=node18 --outdir=dist --external:@aws-sdk --external:@prisma/client --external:prisma"
+  },
+  "dependencies": {
+    "@aws-sdk/client-organizations": "^3.454.0"
   }
 }

--- a/packages/data-audit/src/index.ts
+++ b/packages/data-audit/src/index.ts
@@ -1,10 +1,14 @@
+import {
+	OrganizationsClient,
+	paginateListAccounts,
+} from '@aws-sdk/client-organizations';
 import { PrismaClient } from '@prisma/client';
+import { awsClientConfig } from 'common/aws';
+import type { Config } from './config';
 import { getConfig } from './config';
 
-export async function main() {
-	const config = await getConfig();
-
-	const prisma = new PrismaClient({
+function numberOfAwsAccountsFromDatabase(config: Config): Promise<number> {
+	const client = new PrismaClient({
 		datasources: {
 			db: {
 				url: config.databaseConnectionString,
@@ -19,7 +23,33 @@ export async function main() {
 			],
 		}),
 	});
+	return client.aws_accounts.count();
+}
 
-	const awsAccounts = await prisma.aws_accounts.count();
-	console.log(`There are ${awsAccounts} AWS accounts in the database`);
+async function numberOfAwsAccountsFromAws(config: Config): Promise<number> {
+	const client = new OrganizationsClient(awsClientConfig(config.stage));
+
+	let total = 0;
+	for await (const page of paginateListAccounts(
+		{
+			client,
+			pageSize: 10,
+		},
+		{},
+	)) {
+		total += page.Accounts?.length ?? 0;
+	}
+	return total;
+}
+
+export async function main() {
+	const config = await getConfig();
+
+	const totalFromDb = await numberOfAwsAccountsFromDatabase(config);
+	const totalFromAws = await numberOfAwsAccountsFromAws(config);
+
+	const status = totalFromDb === totalFromAws ? 'PASS' : 'FAIL';
+	console.log(
+		`${status} AWS accounts check. DB: ${totalFromDb} AWS: ${totalFromAws}`,
+	);
 }

--- a/packages/data-audit/src/index.ts
+++ b/packages/data-audit/src/index.ts
@@ -33,7 +33,7 @@ async function numberOfAwsAccountsFromAws(config: Config): Promise<number> {
 	for await (const page of paginateListAccounts(
 		{
 			client,
-			pageSize: 10,
+			pageSize: 20,
 		},
 		{},
 	)) {


### PR DESCRIPTION
Requires #504.

## What does this change?
Check that the number of accounts in the database is the same as the number of accounts in the AWS Organisation. At the moment we're just logging the result. We'll alarm/alert in the near future.

## Why?
We want Service Catalogue to collect information for all our AWS accounts.

## How has it been verified?
- Ran locally
- [Deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/c6b3495a-2b40-45e8-8c16-413de5d13115), manually invoked the lambda, and observed the [logs](https://logs.gutools.co.uk/s/devx/goto/d1e852f0-8965-11ee-9308-f99e8aa2f574)

<img width="546" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/8b2aad64-ab65-43c7-ad3b-8f17b96625b9">
