### PR TITLE
Simplify branch protector notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10478,8 +10478,7 @@
       "dependencies": {
         "@aws-sdk/client-sns": "^3.438.0",
         "@aws-sdk/client-sqs": "^3.450.0",
-        "@aws-sdk/rds-signer": "^3.450.0",
-        "@guardian/anghammarad": "^1.8.1"
+        "@aws-sdk/rds-signer": "^3.450.0"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.126"

--- a/packages/branch-protector/src/aws-requests.ts
+++ b/packages/branch-protector/src/aws-requests.ts
@@ -58,7 +58,9 @@ export async function notify(
 	const client = new Anghammarad();
 	await client.notify({
 		subject: `RepoCop branch protections (for GitHub team ${teamSlug})`,
-		message: `Branch protections have been applied to ${fullRepoName}`,
+		message:
+			`Branch protections have been applied to ${fullRepoName}. ` +
+			`CI checks and at least one approval will now be required before merging to the default branch.`,
 		actions: branchProtectionCtas(fullRepoName, teamSlug),
 		target: { GithubTeamSlug: teamSlug },
 		channel: RequestedChannel.PreferHangouts,

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -76,13 +76,13 @@ export function branchProtectionCtas(
 	const protectionUrl = `https://github.com/${fullRepoName}/settings/branches`;
 
 	return [
-		{ cta: 'Repository', url: githubUrl },
+		{ cta: `View ${fullRepoName} on GitHub`, url: githubUrl },
 		{
-			cta: 'Compliance information for repos',
+			cta: `View compliance data for repositories owned by ${teamSlug}`,
 			url: grafanaUrl,
 		},
 		{
-			cta: 'Branch protections',
+			cta: `View branch protection settings for ${fullRepoName}`,
 			url: protectionUrl,
 		},
 	];

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -17,7 +17,6 @@
 	"dependencies": {
 		"@aws-sdk/client-sns": "^3.438.0",
 		"@aws-sdk/client-sqs": "^3.450.0",
-		"@aws-sdk/rds-signer": "^3.450.0",
-		"@guardian/anghammarad": "^1.8.1"
+		"@aws-sdk/rds-signer": "^3.450.0"
 	}
 }

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -1,16 +1,11 @@
-import { Anghammarad } from '@guardian/anghammarad';
 import type {
 	github_repositories,
 	repocop_github_repository_rules,
 } from '@prisma/client';
 import { PrismaClient } from '@prisma/client';
-import type { UpdateMessageEvent } from 'common/types';
 import { getConfig } from './config';
 import { getUnarchivedRepositories } from './query';
-import {
-	notifyAnghammaradBranchProtection,
-	notifyBranchProtector,
-} from './remediations/repository-02-branch_protection';
+import { notifyBranchProtector } from './remediations/repository-02-branch_protection';
 import { sendPotentialInteractives } from './remediations/repository-06-topic-monitor-interactive';
 import { evaluateRepositories } from './rules/repository';
 
@@ -56,16 +51,12 @@ export async function main() {
 	await writeEvaluationTable(evaluatedRepos, prisma);
 	if (config.enableMessaging) {
 		await sendPotentialInteractives(evaluatedRepos, config);
-		const msgs: UpdateMessageEvent[] = await notifyBranchProtector(
+		await notifyBranchProtector(
 			prisma,
 			evaluatedRepos,
 			config,
 			unarchivedRepositories,
 		);
-		if (config.stage === 'PROD') {
-			const anghammaradClient = new Anghammarad();
-			await notifyAnghammaradBranchProtection(msgs, config, anghammaradClient);
-		}
 	} else {
 		console.log(
 			'Messaging is not enabled. Set ENABLE_MESSAGING flag to enable.',

--- a/packages/repocop/src/remediations/repository-02-branch_protection.ts
+++ b/packages/repocop/src/remediations/repository-02-branch_protection.ts
@@ -1,5 +1,4 @@
 import { SQSClient } from '@aws-sdk/client-sqs';
-import type { Anghammarad } from '@guardian/anghammarad';
 import type {
 	github_repositories,
 	github_teams,
@@ -16,7 +15,6 @@ import {
 	addMessagesToQueue,
 	findContactableOwners,
 	RemediationApp,
-	sendNotifications,
 } from './shared-utilities';
 
 export function createBranchProtectionWarningMessageEvents(
@@ -84,17 +82,4 @@ export async function notifyBranchProtector(
 	);
 
 	return branchProtectionWarningMessages;
-}
-
-export async function notifyAnghammaradBranchProtection(
-	events: UpdateMessageEvent[],
-	config: Config,
-	anghammaradClient: Anghammarad,
-): Promise<void> {
-	await sendNotifications(
-		anghammaradClient,
-		events,
-		config,
-		RemediationApp.BranchProtector,
-	);
 }


### PR DESCRIPTION
## What does this change?

Makes the CTA for branch protector messages clearer.

Only send one message per repo per team

## Why?

Feedback gathered from recipients was that the messages from branch protector are too noisy, and that people don't understand what is happening to their repos, or that the CTAs were clickable

## How has it been verified?

CI passing should be sufficient
