### PR TITLE
downgrade snyk version

### DIFF
--- a/.env
+++ b/.env
@@ -24,7 +24,8 @@ CQ_FASTLY=2.1.12
 CQ_GUARDIAN_GALAXIES=1.1.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-snyk
-CQ_SNYK=3.1.11
+# Do not advance this plugin past 3.1.10, as more recent versions are paywalled, and will fail to run.
+CQ_SNYK=3.1.10
 
 # See https://github.com/guardian/cq-source-snyk-full-project
 CQ_GUARDIAN_SNYK=0.1.1

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -12361,7 +12361,7 @@ spec:
 spec:
   name: snyk
   path: cloudquery/snyk
-  version: v3.1.11
+  version: v3.1.10
   tables:
     - snyk_dependencies
     - snyk_groups


### PR DESCRIPTION
## What does this change?

Downgrades snyk from 3.1.11 to 3.1.10

## Why?

All versions of the Snyk plugin > 3.1.10 are a cloudquery premium feature. While we work out what to do about this, let's stick to a free version

## How has it been verified?

Able to gather snyk data locally again
