### PR TITLE
Fix migration script

### DIFF
--- a/packages/repocop/script/migrate.sh
+++ b/packages/repocop/script/migrate.sh
@@ -62,25 +62,30 @@ migrateDeploy() {
   continueMigrate "$stage"
 }
 
-# Read in input stage(s)
+stageAwareMigration() {
+  if [ "$stage" == "--dev" ]
+  then
+    devSetup
+    if [ -n "$migration_name" ]
+    then
+      migrateDEV "$migration_name"
+    else
+      :
+    fi
+  elif [ "$stage" == "--code" ]
+  then
+    migrateDeploy "CODE"
+  elif [ "$stage" == "--prod" ]
+  then
+    migrateDeploy "PROD"
+  else
+    echo -e "Stage '$stage' not recognised, please try again."
+  fi
+}
+
+(
 stage=$1
 migration_name=$2
-
-if [ "$stage" == "--dev" ]
-then
-  devSetup
-  if [ -n "$migration_name" ]
-  then
-    migrateDEV "$migration_name"
-  else
-    :
-  fi
-elif [ "$stage" == "--code" ]
-then
-  migrateDeploy "CODE"
-elif [ "$stage" == "--prod" ]
-then
-  migrateDeploy "PROD"
-else
-  echo -e "Stage '$stage' not recognised, please try again."
-fi
+  cd ../common
+  stageAwareMigration "$stage" "$migration_name"
+)


### PR DESCRIPTION
## What does this change?

Prisma code has been moved to common, this PR updates the migration script to reflect this.

I haven't moved it to the common folder as repocop populates basically all the non cloudquery tables created by the migration, so I think it makes sense to keep it here for the time being

## Why?

The script was failing due to the prisma package having been moved

## How has it been verified?

DEV migrations succeed.
TODO: test CODE migration
