### PR TITLE
refactor: Share function to create a prisma client

### DIFF
--- a/packages/data-audit/src/config.ts
+++ b/packages/data-audit/src/config.ts
@@ -1,5 +1,5 @@
 import process from 'process';
-import type { DatabaseConfig } from 'common/database';
+import type { DatabaseConfig, PrismaConfig } from 'common/database';
 import {
 	getDatabaseConfig,
 	getDatabaseConnectionString,
@@ -7,7 +7,7 @@ import {
 } from 'common/database';
 import { getEnvOrThrow } from 'common/functions';
 
-export interface Config {
+export interface Config extends PrismaConfig {
 	/**
 	 * The name of this application.
 	 */
@@ -17,18 +17,6 @@ export interface Config {
 	 * The stage of the application, e.g. DEV, CODE, PROD.
 	 */
 	stage: string;
-
-	/**
-	 * The database connection string.
-	 */
-	databaseConnectionString: string;
-
-	/**
-	 * Whether to configure Prisma to log the SQL queries being executed.
-	 *
-	 * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/logging
-	 */
-	withQueryLogging: boolean;
 }
 
 export async function getConfig(): Promise<Config> {

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -4,10 +4,10 @@ import {
 	getDatabaseConnectionString,
 	getDevDatabaseConfig,
 } from 'common/database';
-import type { DatabaseConfig } from 'common/database';
+import type { DatabaseConfig, PrismaConfig } from 'common/database';
 import { getEnvOrThrow } from 'common/functions';
 
-export interface Config {
+export interface Config extends PrismaConfig {
 	/**
 	 * The name of this application.
 	 */
@@ -27,20 +27,6 @@ export interface Config {
 	 * The ARN of the interactive-monitor topic.
 	 */
 	interactiveMonitorSnsTopic: string;
-
-	/**
-	 * The database connection string.
-	 *
-	 * If the `DATABASE_PASSWORD` environment variable is not set, a token (temporary password) will be generated for IAM authentication for RDS.
-	 */
-	databaseConnectionString: string;
-
-	/**
-	 * Whether to configure Prisma to log the SQL queries being executed.
-	 *
-	 * @see https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/logging
-	 */
-	withQueryLogging: boolean;
 
 	/**
 	 * Repositories that should not be processed, for example, because they are not owned by a team in Product and Engineering.

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -1,8 +1,9 @@
 import type {
 	github_repositories,
+	PrismaClient,
 	repocop_github_repository_rules,
 } from '@prisma/client';
-import { PrismaClient } from '@prisma/client';
+import { getPrismaClient } from 'common/database';
 import { getConfig } from './config';
 import { getUnarchivedRepositories } from './query';
 import { notifyBranchProtector } from './remediations/repository-02-branch_protection';
@@ -27,21 +28,7 @@ async function writeEvaluationTable(
 
 export async function main() {
 	const config = await getConfig();
-	const prisma = new PrismaClient({
-		datasources: {
-			db: {
-				url: config.databaseConnectionString,
-			},
-		},
-		...(config.withQueryLogging && {
-			log: [
-				{
-					emit: 'stdout',
-					level: 'query',
-				},
-			],
-		}),
-	});
+	const prisma = getPrismaClient(config);
 
 	const unarchivedRepositories: github_repositories[] =
 		await getUnarchivedRepositories(prisma, config.ignoredRepositoryPrefixes);


### PR DESCRIPTION
## What does this change?
Reduce code repetition by instantiating a prisma client in a shared way. This is a no-op change.