### PR TITLE
Use a function instead of a view for collecting last sync times

### DIFF
--- a/packages/common/prisma/migrations/20231124095700_cq_last_synced/migration.sql
+++ b/packages/common/prisma/migrations/20231124095700_cq_last_synced/migration.sql
@@ -1,0 +1,21 @@
+-- This view was created using a function which essentially hardcoded the tables the view references.
+-- This lead to issues with Cloudquery not being able to update the schema of tables due to cascading issues in the view
+DROP VIEW IF EXISTS cq_last_synced;
+
+-- Instead of hardcoding a view with a list of tables, fetch the tables needed on the fly, avoiding cascade issues.
+CREATE OR REPLACE FUNCTION cq_last_synced()
+    RETURNS TABLE (table_name text, _cq_sync_time timestamp) AS
+$$
+DECLARE
+    selected_table_names record;
+    selected_sync_times record;
+BEGIN
+    FOR selected_table_names IN SELECT DISTINCT table_name FROM information_schema.columns WHERE COLUMN_NAME IN ('_cq_sync_time')
+        LOOP
+            EXECUTE format('SELECT _cq_sync_time FROM %I LIMIT 1', tbl.table_name) INTO selected_sync_times;
+            table_name := selected_table_names.table_name;
+            _cq_sync_time := selected_sync_times._cq_sync_time;
+            RETURN NEXT;
+        END LOOP;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## What does this change?

Replace our cq_last_synced view with a cq_last_synced() function. This function does much the same thing but figures out which tables it needs to query at runtime, instead of it being hardcoded at creation.

## Why?

Because the old `cq_last_synced` view had hardcoded references to all Cloudquery tables in its DDL it caused Cloudquery to not be able to update table schemas due to Cascade issues. Since this new function doesn't directly reference any Cloudquery tables it hopefully shouldn't impact anything.

## How has it been verified?

Deployed this function and ran `SELECT * FROM cq_last_synced()`

<img width="842" alt="image" src="https://github.com/guardian/service-catalogue/assets/21217225/88df1cab-1043-41fb-9e56-7994f6a297b4">

Also verified that we're now able to drop Cloudquery tables again without having cascade issues
<img width="353" alt="image" src="https://github.com/guardian/service-catalogue/assets/21217225/b3c40ba3-8838-423b-b724-f1ec70533254">
