### PR TITLE
ci: Avoid race condition across builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ on:
   push:
     branches:
       - main
+
+# Ensure we only ever have one build running at a time.
+# If we push twice in quick succession, the first build will be stopped once the second starts.
+# This avoids any race conditions.
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CI:
     timeout-minutes: 15


### PR DESCRIPTION
## What does this change?
Configure GHA to have exactly one build per branch at a time. If a new one appears, all others are cancelled.

## Why?
Now that we're using merge queues, we want to be sure the build from the last item in the queue is also the last one to be deployed via CD.

## How has it been verified?
This PR triggered two builds in quick succession:
1. The change
2. The change, plus a rebase against `main`

<img width="1310" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/e89ce66b-bcde-4f96-9803-eb06e5b01f55">

The build from the [first](https://github.com/guardian/service-catalogue/actions/runs/6980653518) was cancelled:

<img width="666" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/6d304a15-8e97-4bcc-b1bf-09020c901397">
