### PR TITLE
Match repos to deployed interactives in S3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10833,6 +10833,7 @@
     "packages/interactive-monitor": {
       "version": "1.0.0",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.456.0",
         "@types/aws-lambda": "^8.10.126",
         "octokit": "^3.1.1"
       },

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -11,7 +11,6 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuStringParameter",
       "GuLoggingStreamNameParameter",
       "GuAnghammaradTopicParameter",
-      "GuParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuScheduledLambda",
@@ -47,10 +46,6 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
     "SsmParameterValueTESTdeployriffraffexternaldatabaseaccesssecuritygroupC96584B6F00A464EAD1953AFF4B05118Parameter": {
       "Default": "/TEST/deploy/riff-raff/external-database-access-security-group",
       "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "TESTdeployservicecatalogueinteractivebucket": {
-      "Description": "The bucket to check for interactive artifacts",
-      "Type": "String",
     },
     "VpcId": {
       "Default": "/account/vpc/primary/id",
@@ -14336,9 +14331,6 @@ spec:
         "Environment": {
           "Variables": {
             "APP": "interactive-monitor",
-            "BUCKET": {
-              "Ref": "TESTdeployservicecatalogueinteractivebucket",
-            },
             "GITHUB_APP_SECRET": {
               "Fn::Join": [
                 "-",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -11,6 +11,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuStringParameter",
       "GuLoggingStreamNameParameter",
       "GuAnghammaradTopicParameter",
+      "GuParameter",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuScheduledLambda",
@@ -46,6 +47,10 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
     "SsmParameterValueTESTdeployriffraffexternaldatabaseaccesssecuritygroupC96584B6F00A464EAD1953AFF4B05118Parameter": {
       "Default": "/TEST/deploy/riff-raff/external-database-access-security-group",
       "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "TESTdeployservicecatalogueinteractivebucket": {
+      "Description": "The bucket to check for interactive artifacts",
+      "Type": "String",
     },
     "VpcId": {
       "Default": "/account/vpc/primary/id",
@@ -14331,7 +14336,9 @@ spec:
         "Environment": {
           "Variables": {
             "APP": "interactive-monitor",
-            "BUCKET": "???",
+            "BUCKET": {
+              "Ref": "TESTdeployservicecatalogueinteractivebucket",
+            },
             "GITHUB_APP_SECRET": {
               "Fn::Join": [
                 "-",

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -1,4 +1,4 @@
-import { GuParameter, type GuStack } from '@guardian/cdk/lib/constructs/core';
+import { type GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
@@ -19,22 +19,12 @@ export class InteractiveMonitor {
 			secretName: `/${stage}/${stack}/${app}/${service}-github-app`,
 		});
 
-		const bucketParameter = new GuParameter(
-			guStack,
-			`${stage}/${stack}/${app}/interactive-bucket`,
-			{
-				description: 'The bucket to check for interactive artifacts',
-				type: 'String',
-			},
-		);
-
 		const lambda = new GuLambdaFunction(guStack, service, {
 			app: service,
 			fileName: `${service}.zip`,
 			handler: 'index.handler',
 			runtime: Runtime.NODEJS_18_X,
 			environment: {
-				BUCKET: bucketParameter.valueAsString,
 				GITHUB_APP_SECRET: githubCredentials.secretName,
 			},
 			reservedConcurrentExecutions: 1,

--- a/packages/interactive-monitor/package.json
+++ b/packages/interactive-monitor/package.json
@@ -10,8 +10,9 @@
 	},
 	"author": "guardian",
 	"dependencies": {
-		"octokit": "^3.1.1",
-		"@types/aws-lambda": "^8.10.126"
+		"@aws-sdk/client-s3": "^3.456.0",
+		"@types/aws-lambda": "^8.10.126",
+		"octokit": "^3.1.1"
 	},
 	"devDependencies": {
 		"@octokit/types": "^12.0.0"

--- a/packages/interactive-monitor/src/config.ts
+++ b/packages/interactive-monitor/src/config.ts
@@ -1,20 +1,12 @@
-import { getEnvOrThrow } from 'common/functions';
-
 export interface Config {
 	/**
 	 * The stage to run in.
 	 */
 	stage: string;
-
-	/**
-	 * The name of the bucket to use.
-	 */
-	bucket: string;
 }
 
 export function getConfig(): Config {
 	return {
 		stage: process.env['STAGE'] ?? 'DEV',
-		bucket: getEnvOrThrow('BUCKET'),
 	};
 }

--- a/packages/interactive-monitor/src/config.ts
+++ b/packages/interactive-monitor/src/config.ts
@@ -1,12 +1,20 @@
+import { getEnvOrThrow } from 'common/functions';
+
 export interface Config {
 	/**
 	 * The stage to run in.
 	 */
 	stage: string;
+
+	/**
+	 * The name of the bucket to use.
+	 */
+	bucket: string;
 }
 
 export function getConfig(): Config {
 	return {
 		stage: process.env['STAGE'] ?? 'DEV',
+		bucket: getEnvOrThrow('BUCKET'),
 	};
 }

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -102,6 +102,8 @@ export async function assessRepo(repo: string, owner: string, config: Config) {
 	const s3 = new S3Client({ region: 'us-east-1' });
 	const { stage, bucket } = config;
 
+	console.log(`Bucket: ${bucket}`);
+
 	const isFromTemplate = await isFromInteractiveTemplate(repo, owner, octokit);
 	const foundInS3 = await isLiveInteractive(octokit, s3, owner, repo, bucket);
 	const onProd = stage === 'PROD';

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -1,3 +1,4 @@
+import type { RestEndpointMethodTypes } from '@octokit/plugin-rest-endpoint-methods';
 import type { SNSHandler } from 'aws-lambda';
 import { stageAwareOctokit } from 'common/functions';
 import type { Octokit } from 'octokit';
@@ -16,6 +17,44 @@ async function isFromInteractiveTemplate(
 	return repoData.data.template_repository?.name.includes(prefix) ?? false;
 }
 
+type ContentResponse =
+	RestEndpointMethodTypes['repos']['getContent']['response'];
+
+interface FileMetadata {
+	name: string;
+	content: string;
+}
+
+interface ConfigJsonFile {
+	path: string;
+}
+
+function decodeFile(response: ContentResponse): ConfigJsonFile {
+	const deserialisedResponse = response.data as FileMetadata;
+	const fileContents = JSON.parse(
+		atob(deserialisedResponse.content),
+	) as ConfigJsonFile;
+
+	return fileContents;
+}
+async function getConfigJsonFromGithub(
+	octokit: Octokit,
+	repo: string,
+	owner: string,
+): Promise<ConfigJsonFile | undefined> {
+	try {
+		const configFile: ContentResponse = await octokit.rest.repos.getContent({
+			owner,
+			repo,
+			path: 'config.json',
+		});
+		return decodeFile(configFile);
+	} catch (e) {
+		console.log(`No config.json found for ${repo}`);
+		return undefined;
+	}
+}
+
 async function applyTopics(repo: string, owner: string, octokit: Octokit) {
 	console.log(`Applying interactive topic to ${repo}`);
 	const topics = (await octokit.rest.repos.getAllTopics({ owner, repo })).data
@@ -27,10 +66,16 @@ async function applyTopics(repo: string, owner: string, octokit: Octokit) {
 export async function assessRepo(repo: string, owner: string, stage: string) {
 	const octokit = await stageAwareOctokit(stage);
 
+	const file = await getConfigJsonFromGithub(octokit, repo, owner);
+	const configJsonExists = file !== undefined;
+
 	const isInteractive = await isFromInteractiveTemplate(repo, owner, octokit);
 	const onProd = stage === 'PROD';
 	if (isInteractive && onProd) {
 		await applyTopics(repo, owner, octokit);
+	} else if (configJsonExists && onProd) {
+		console.log(`Found potential s3 path for ${repo}`);
+		console.log('TODO: search s3 for path');
 	} else {
 		const reason =
 			(!isInteractive ? ' Repo not from interactive template.' : '') +

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -7,6 +7,18 @@ import type { Octokit } from 'octokit';
 import type { Config } from './config';
 import { getConfig } from './config';
 
+type ContentResponse =
+	RestEndpointMethodTypes['repos']['getContent']['response'];
+
+interface FileMetadata {
+	name: string;
+	content: string;
+}
+
+interface ConfigJsonFile {
+	path: string;
+}
+
 async function isFromInteractiveTemplate(
 	repo: string,
 	owner: string,
@@ -18,18 +30,6 @@ async function isFromInteractiveTemplate(
 	});
 	const prefix = 'interactive-atom-template';
 	return repoData.data.template_repository?.name.includes(prefix) ?? false;
-}
-
-type ContentResponse =
-	RestEndpointMethodTypes['repos']['getContent']['response'];
-
-interface FileMetadata {
-	name: string;
-	content: string;
-}
-
-interface ConfigJsonFile {
-	path: string;
 }
 
 function decodeFile(response: ContentResponse): ConfigJsonFile {

--- a/packages/interactive-monitor/src/run-locally.ts
+++ b/packages/interactive-monitor/src/run-locally.ts
@@ -1,7 +1,9 @@
 import { homedir } from 'os';
 import { config } from 'dotenv';
+import { getConfig } from './config';
 import { assessRepo } from './index';
 
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
-const testRepo = 'interactive-atom-template-2019'; //'service-catalogue';
-void (async () => await assessRepo(testRepo, 'guardian', 'DEV'))();
+const testRepo = 'interactive-house-affordability-nov-2023'; //'service-catalogue';
+const devConfig = getConfig();
+void (async () => await assessRepo(testRepo, 'guardian', devConfig))();

--- a/packages/interactive-monitor/src/run-locally.ts
+++ b/packages/interactive-monitor/src/run-locally.ts
@@ -3,5 +3,5 @@ import { config } from 'dotenv';
 import { assessRepo } from './index';
 
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
-const testRepo = 'service-catalogue';
+const testRepo = 'interactive-atom-template-2019'; //'service-catalogue';
 void (async () => await assessRepo(testRepo, 'guardian', 'DEV'))();

--- a/packages/interactive-monitor/src/run-locally.ts
+++ b/packages/interactive-monitor/src/run-locally.ts
@@ -4,6 +4,6 @@ import { getConfig } from './config';
 import { assessRepo } from './index';
 
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
-const testRepo = 'interactive-house-affordability-nov-2023'; //'service-catalogue';
+const testRepo = 'interactive-house-affordability-nov-2023';
 const devConfig = getConfig();
 void (async () => await assessRepo(testRepo, 'guardian', devConfig))();


### PR DESCRIPTION
## What does this change?

All interactives are deployed to an S3 bucket. Some of them have a config.json file with a `path` field. Those paths correspond to s3 prefixes. By searching the s3 bucket for those prefixes, we can tell if a repository corresponds to a deployed interactive, and label it accordingly

## Why?

To reduce the number of unlabelled repositories across the department

## How has it been verified?

Local testing against known interactives and non-interactives
Runs on CODE and produces the expected output
