### PR TITLE
fix: Resolve compilation errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "npm run test --workspaces --if-present",
     "test-update": "jest -u",
     "synth": "npm run synth --workspace=cdk",
-    "typecheck": "npm run typecheck --workspaces --if-present",
+    "typecheck": "tsc --noEmit",
     "build": "npm run build --workspaces --if-present",
     "lint": "eslint packages/** --ext .ts --no-error-on-unmatched-pattern"
   },

--- a/packages/best-practices/src/definitions.ts
+++ b/packages/best-practices/src/definitions.ts
@@ -1,4 +1,4 @@
-import type { IAllBestPractice, IBestPractice } from './types.ts';
+import type { IAllBestPractice, IBestPractice } from './types';
 
 const repository: readonly IBestPractice[] = [
 	{

--- a/packages/best-practices/src/index.ts
+++ b/packages/best-practices/src/index.ts
@@ -5,7 +5,7 @@
  */
 import * as fs from 'fs';
 import { markdownTable } from 'markdown-table';
-import { AllBestPractices } from './definitions.ts';
+import { AllBestPractices } from './definitions';
 
 const markdownFilepath = './best-practices.md';
 

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "scripts": {
     "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects cdk",
-    "typecheck": "tsc -noEmit",
     "synth": "DOTENV_CONFIG_PATH=../../.env cdk synth --path-metadata false --version-reporting false"},
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -2,7 +2,6 @@
 	"name": "common",
 	"version": "0.0.0",
 	"scripts": {
-		"typecheck": "tsc",
 		"postinstall": "prisma generate",
 		"test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects common"
 	},

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -1,7 +1,6 @@
 import type {
 	github_repositories,
 	PrismaClient,
-	PrismaClient,
 	repocop_github_repository_rules,
 } from '@prisma/client';
 import { getPrismaClient } from 'common/database';


### PR DESCRIPTION
## What does this change?
RepoCop isn't compiling due to a duplicate import. This wasn't caught in CI as we were only running `tsc` in a workspace if they defined a `typecheck` script (`npm run typecheck --workspaces --if-present`).

When you try to run RepoCop locally on `main` we get:

```console
➜ npm -w repocop start

> repocop@1.0.0 start
> APP=repocop ts-node src/run-locally.ts

/Users/akash_askoolum/code/service-catalogue/node_modules/ts-node/src/index.ts:859
    return new TSError(diagnosticText, diagnosticCodes, diagnostics);
           ^
TSError: ⨯ Unable to compile TypeScript:
src/index.ts:3:2 - error TS2300: Duplicate identifier 'PrismaClient'.

3  PrismaClient,
   ~~~~~~~~~~~~
src/index.ts:4:2 - error TS2300: Duplicate identifier 'PrismaClient'.

4  PrismaClient,
   ~~~~~~~~~~~~

    at createTSError (/Users/akash_askoolum/code/service-catalogue/node_modules/ts-node/src/index.ts:859:12)
    at reportTSError (/Users/akash_askoolum/code/service-catalogue/node_modules/ts-node/src/index.ts:863:19)
    at getOutput (/Users/akash_askoolum/code/service-catalogue/node_modules/ts-node/src/index.ts:1077:36)
    at Object.compile (/Users/akash_askoolum/code/service-catalogue/node_modules/ts-node/src/index.ts:1433:41)
    at Module.m._compile (/Users/akash_askoolum/code/service-catalogue/node_modules/ts-node/src/index.ts:1617:30)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Object.require.extensions.<computed> [as .ts] (/Users/akash_askoolum/code/service-catalogue/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Function.Module._load (node:internal/modules/cjs/loader:960:12)
    at Module.require (node:internal/modules/cjs/loader:1143:19) {
  diagnosticCodes: [ 2300, 2300 ]
}
npm ERR! Lifecycle script `start` failed with error: 
npm ERR! Error: command failed 
npm ERR!   in workspace: repocop@1.0.0 
npm ERR!   at location: /Users/akash_askoolum/code/service-catalogue/packages/repocop 
```

This change does two things:
1. Perform a compile at the root, compiling all projects, all the time.
2. Resolves the flagged compilation errors.

## Why?
The first change will catch errors at CI time, meaning the second change wouldn't be needed as `main` would always compile.

## How has it been verified?
- Run `npm run typecheck` on the first commit of this branch, and observe compilation errors. Then run again on the second commit, and observe no errors.
- Run RepoCop locally on `main` and observe the above error
- Run RepoCop on this branch, and it works as expected

To demonstrate that running `tsc --noEmit` at the root will compile all files, we can use `npx tsc --showConfig`.

<details>
<summary>npx tsc --showConfig</summary>
<p>

```console
➜ npx tsc --showConfig
{
    "compilerOptions": {
        "allowSyntheticDefaultImports": true,
        "esModuleInterop": true,
        "incremental": true,
        "module": "commonjs",
        "moduleResolution": "node10",
        "noImplicitReturns": true,
        "noUncheckedIndexedAccess": true,
        "noUnusedLocals": true,
        "resolveJsonModule": true,
        "strict": true,
        "target": "esnext",
        "baseUrl": "./",
        "paths": {
            "common": [
                "packages/common/src"
            ],
            "common/*": [
                "packages/common/src/*"
            ]
        }
    },
    "files": [
        "./packages/best-practices/src/definitions.ts",
        "./packages/best-practices/src/index.ts",
        "./packages/best-practices/src/types.ts",
        "./packages/cdk/bin/cdk.ts",
        "./packages/cdk/lib/data-audit.ts",
        "./packages/cdk/lib/interactive-monitor.ts",
        "./packages/cdk/lib/repocop.ts",
        "./packages/cdk/lib/service-catalogue.test.ts",
        "./packages/cdk/lib/service-catalogue.ts",
        "./packages/cdk/lib/cloudquery/index.ts",
        "./packages/cdk/lib/cloudquery/ecs/cluster.ts",
        "./packages/cdk/lib/cloudquery/ecs/config.test.ts",
        "./packages/cdk/lib/cloudquery/ecs/config.ts",
        "./packages/cdk/lib/cloudquery/ecs/policies.ts",
        "./packages/cdk/lib/cloudquery/ecs/task.ts",
        "./packages/cdk/lib/cloudquery/ecs/versions.ts",
        "./packages/cli/src/aws.ts",
        "./packages/cli/src/index.ts",
        "./packages/common/src/aws.ts",
        "./packages/common/src/database.ts",
        "./packages/common/src/functions.test.ts",
        "./packages/common/src/functions.ts",
        "./packages/common/src/types.ts",
        "./packages/data-audit/src/config.ts",
        "./packages/data-audit/src/index.ts",
        "./packages/data-audit/src/run-locally.ts",
        "./packages/data-audit/src/audit/aws-accounts.ts",
        "./packages/data-audit/src/audit/aws-s3-buckets.ts",
        "./packages/data-audit/src/audit/types.ts",
        "./packages/interactive-monitor/src/config.ts",
        "./packages/interactive-monitor/src/index.ts",
        "./packages/interactive-monitor/src/run-locally.ts",
        "./packages/repocop/src/config.ts",
        "./packages/repocop/src/index.ts",
        "./packages/repocop/src/query.ts",
        "./packages/repocop/src/run-locally.ts",
        "./packages/repocop/src/remediations/repository-06-topic-monitor-interactive.test.ts",
        "./packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts",
        "./packages/repocop/src/remediations/repository-06-topic-monitor-production.ts",
        "./packages/repocop/src/remediations/shared-utilities.test.ts",
        "./packages/repocop/src/remediations/shared-utilities.ts",
        "./packages/repocop/src/remediations/branch-protector/aws-requests.ts",
        "./packages/repocop/src/remediations/branch-protector/branch-protection.test.ts",
        "./packages/repocop/src/remediations/branch-protector/branch-protection.ts",
        "./packages/repocop/src/remediations/branch-protector/github-requests.ts",
        "./packages/repocop/src/remediations/branch-protector/model.ts",
        "./packages/repocop/src/rules/repository.test.ts",
        "./packages/repocop/src/rules/repository.ts"
    ]
}
```

</p>
</details> 