### PR TITLE
fix(cloudquery): Allow `RemainingAwsData` task to list orgs

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -12161,6 +12161,11 @@ spec:
               },
             },
             {
+              "Action": "organizations:List*",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Resource": "arn:aws:iam::*:role/cloudquery-access",

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -228,7 +228,7 @@ export function addCloudqueryEcsCluster(
 			// See https://www.cloudquery.io/docs/reference/source-spec#concurrency.
 			concurrency: 2000,
 		}),
-		policies: [cloudqueryAccess('*')],
+		policies: [listOrgsPolicy, cloudqueryAccess('*')],
 
 		// This task is quite expensive, and requires more power than the default (500MB memory, 0.25 vCPU).
 		memoryLimitMiB: 2048,


### PR DESCRIPTION
## What does this change, and why?
Every AWS task that runs in multiple accounts needs to be able to list the accounts. This permission is provided via the IAM Policy `organizations:List*`.

Add this permission to the `RemainingAwsData` task.

This fixes a regression from #447. In #447 this task lost the [ReadOnlyAccess managed policy](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/ReadOnlyAccess.html) which was providing `organizations:List*` permissions.

## How has it been verified?
[Deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/fb19d1e1-ff83-4e87-a173-efb5f5787c85), manually ran the `RemainingAwsData` task[^1], and observed data coming in ([logs](https://logs.gutools.co.uk/s/devx/goto/51393c50-8d11-11ee-9ace-b9608309e74f))!

[^1]: `npm -w cli start run-task -- --stage CODE --name RemainingAwsData`