### PR TITLE
send fewer messages on non-prod stages

### DIFF
--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
@@ -37,7 +37,10 @@ export async function sendPotentialInteractives(
 	const potentialInteractives = shuffle(
 		findPotentialInteractives(evaluatedRepos),
 	);
-	const snsBatchMaximum = Math.min(potentialInteractives.length, 10);
+	const snsBatchMaximum = Math.min(
+		potentialInteractives.length,
+		config.stage === 'PROD' ? 10 : 1,
+	);
 	const somePotentialInteractives = potentialInteractives.slice(
 		0,
 		snsBatchMaximum,

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
@@ -39,7 +39,7 @@ export async function sendPotentialInteractives(
 	);
 	const snsBatchMaximum = Math.min(
 		potentialInteractives.length,
-		config.stage === 'PROD' ? 10 : 1,
+		config.stage === 'PROD' ? 5 : 1,
 	);
 	const somePotentialInteractives = potentialInteractives.slice(
 		0,


### PR DESCRIPTION
## What does this change?

Only send one message if we are not running on prod

## Why?

We don't need to run the lambda 10 times to verify it works. Also, if we want to test the interactive monitor, the easiest thing to do would be to submit the name of the repo directly to SNS.

We're also getting rate limited by AWS on prod so let's lower the number of repos we send for now