### PR TITLE
Bunch potential interactives into one lambda invocation

### DIFF
--- a/packages/interactive-monitor/package.json
+++ b/packages/interactive-monitor/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@aws-sdk",
 		"test": "echo \"No test specified\" && exit 0",
-		"start": "AWS_PROFILE=deployTools ts-node src/run-locally.ts"
+		"start": "ts-node src/run-locally.ts"
 	},
 	"author": "guardian",
 	"dependencies": {

--- a/packages/interactive-monitor/package.json
+++ b/packages/interactive-monitor/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@aws-sdk",
 		"test": "echo \"No test specified\" && exit 0",
-		"start": "APP=interactive-monitor ts-node src/run-locally.ts"
+		"start": "AWS_PROFILE=deployTools ts-node src/run-locally.ts"
 	},
 	"author": "guardian",
 	"dependencies": {

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -136,7 +136,6 @@ export async function assessRepo(repo: string, owner: string, config: Config) {
 export const handler: SNSHandler = async (event) => {
 	const config = getConfig();
 	const owner = 'guardian';
-	console.log(JSON.stringify(event.Records));
 	const events = event.Records.map(async (record) =>
 		Promise.all(
 			(JSON.parse(record.Sns.Message) as string[]).map(

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -2,6 +2,7 @@ import type { _Object, ListObjectsCommandInput } from '@aws-sdk/client-s3';
 import { ListObjectsCommand, S3Client } from '@aws-sdk/client-s3';
 import type { RestEndpointMethodTypes } from '@octokit/plugin-rest-endpoint-methods';
 import type { SNSHandler } from 'aws-lambda';
+import { awsClientConfig } from 'common/aws';
 import { stageAwareOctokit } from 'common/functions';
 import type { Octokit } from 'octokit';
 import type { Config } from './config';
@@ -100,7 +101,8 @@ async function applyTopics(repo: string, owner: string, octokit: Octokit) {
 
 export async function assessRepo(repo: string, owner: string, config: Config) {
 	const octokit = await stageAwareOctokit(config.stage);
-	const s3 = new S3Client({ region: 'us-east-1' });
+	const awsConfig = awsClientConfig(config.stage);
+	const s3 = new S3Client({ ...awsConfig, region: 'us-east-1' });
 	const { stage } = config;
 
 	const isFromTemplate = await isFromInteractiveTemplate(repo, owner, octokit);

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -117,8 +117,13 @@ export async function assessRepo(repo: string, owner: string, config: Config) {
 export const handler: SNSHandler = async (event) => {
 	const config = getConfig();
 	const owner = 'guardian';
-	const events = event.Records.map(
-		async (record) => await assessRepo(record.Sns.Message, owner, config),
+	console.log(JSON.stringify(event.Records));
+	const events = event.Records.map(async (record) =>
+		Promise.all(
+			(JSON.parse(record.Sns.Message) as string[]).map(
+				async (repo) => await assessRepo(repo, owner, config),
+			),
+		),
 	);
 	await Promise.all(events);
 };

--- a/packages/interactive-monitor/src/run-locally.ts
+++ b/packages/interactive-monitor/src/run-locally.ts
@@ -4,6 +4,6 @@ import { getConfig } from './config';
 import { assessRepo } from './index';
 
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
-const testRepo = 'interactive-house-affordability-nov-2023';
+const testRepo = 'ofm-awards-label-2019-atom';
 const devConfig = getConfig();
 void (async () => await assessRepo(testRepo, 'guardian', devConfig))();

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.test.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.test.ts
@@ -1,8 +1,5 @@
 import type { repocop_github_repository_rules } from '@prisma/client';
-import {
-	createBatchEntry,
-	findPotentialInteractives,
-} from './repository-06-topic-monitor-interactive';
+import { findPotentialInteractives } from './repository-06-topic-monitor-interactive';
 
 describe('findPotentialInteractives', () => {
 	it('should return an empty array when evaluatedRepos is empty', () => {
@@ -32,20 +29,5 @@ describe('findPotentialInteractives', () => {
 
 		const result = findPotentialInteractives(evaluatedRepos);
 		expect(result).toEqual(['org/repo3']);
-	});
-});
-
-describe('createBatchEntry', () => {
-	it('should return a valid PublishBatchRequestEntry for a full repo name', () => {
-		const message = 'guardian/my-repo';
-		const result = createBatchEntry(message);
-		expect(result.Message).toEqual('my-repo');
-		expect(result.Id).toEqual('myrepo');
-	});
-	it('should throw an error for a short repo name', () => {
-		const message = 'my-repo';
-		expect(() => createBatchEntry(message)).toThrowError(
-			'Invalid repo name: my-repo',
-		);
 	});
 });

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
@@ -16,9 +16,12 @@ export async function sendPotentialInteractives(
 	evaluatedRepos: repocop_github_repository_rules[],
 	config: Config,
 ) {
-	const potentialInteractives = shuffle(
+	const potentialInteractives: string[] = shuffle(
 		findPotentialInteractives(evaluatedRepos),
-	);
+	)
+		.map((repo) => repo.split('/')[1])
+		.filter((repo) => repo !== undefined) as string[];
+
 	const snsBatchMaximum = Math.min(potentialInteractives.length, 10);
 	const somePotentialInteractives = potentialInteractives.slice(
 		0,

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
@@ -21,7 +21,7 @@ export async function sendPotentialInteractives(
 	)
 		.map((repo) => repo.split('/')[1])
 		.filter((repo) => repo !== undefined) as string[];
-	);
+
 	const snsBatchMaximum = Math.min(
 		potentialInteractives.length,
 		config.stage === 'PROD' ? 5 : 1,

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
@@ -1,10 +1,4 @@
-import {
-	PublishBatchCommand,
-	type PublishBatchCommandInput,
-	type PublishBatchRequestEntry,
-	PublishCommand,
-	SNSClient,
-} from '@aws-sdk/client-sns';
+import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
 import type { repocop_github_repository_rules } from '@prisma/client';
 import { awsClientConfig } from 'common/src/aws';
 import { shuffle } from 'common/src/functions';


### PR DESCRIPTION
## What does this change?

Previously, we were sending 10 individual messages to SNS at once. Now, we are creating a JSON list of x repositories, and submitting it in one invocation.

## Why?

Fewer lambda invocations means better performance overall. Theoretically we could send more in one go, but leaving it at 10 for now to keep us under AWS API's abuse limits, which seem to be triggered after about 10 repos have been checked. We can make the interactive monitor a bit smarter about which checks it runs in a later PR.

## How has it been verified?

Deployed to CODE and verified the messages are processed correctly
