### PR TITLE
Apply production topic and message teams

### DIFF
--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -101,9 +101,9 @@ export function topicMonitoringProductionTagCtas(
 
 	return [
 		{ cta: 'Repository', url: githubUrl },
-		{ cta: 'Best practices', url: bestPracticesUrl },
+		{ cta: 'Best practice rules', url: bestPracticesUrl },
 		{
-			cta: 'Repocop compliance dashboard',
+			cta: `View compliance data for repositories owned by ${teamSlug}`,
 			url: grafanaUrl,
 		},
 		{

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -93,13 +93,17 @@ export function topicMonitoringProductionTagCtas(
 	teamSlug: string,
 ): Action[] {
 	const githubUrl = `https://github.com/${fullRepoName}`;
+	const bestPracticesUrl =
+		'https://github.com/guardian/service-catalogue/blob/main/packages/best-practices/best-practices.md';
 	const grafanaUrl = `https://metrics.gutools.co.uk/d/EOPnljWIz/repocop-compliance?var-team=${teamSlug}&var-rule=All&orgId=1`;
-	const topicsUrl = `https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics#adding-topics-to-your-repository`;
+	const topicsUrl =
+		'https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/classifying-your-repository-with-topics#adding-topics-to-your-repository';
 
 	return [
 		{ cta: 'Repository', url: githubUrl },
+		{ cta: 'Best practices', url: bestPracticesUrl },
 		{
-			cta: 'Compliance information for repos',
+			cta: 'Repocop compliance dashboard',
 			url: grafanaUrl,
 		},
 		{

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -116,3 +116,16 @@ export function anghammaradThreadKey(fullRepoName: string) {
 export function shuffle<T>(array: T[]): T[] {
 	return array.sort(() => Math.random() - 0.5);
 }
+
+export async function applyTopics(
+	repo: string,
+	owner: string,
+	octokit: Octokit,
+	topic: string,
+) {
+	console.log(`Applying ${topic} topic to ${repo}`);
+	const topics = (await octokit.rest.repos.getAllTopics({ owner, repo })).data
+		.names;
+	const names = topics.concat([topic]);
+	await octokit.rest.repos.replaceAllTopics({ owner, repo, names });
+}

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -18,3 +18,13 @@ export type GitHubAppConfig = {
 };
 
 export type AWSCloudformationTag = Record<string, string>;
+
+export interface AWSCloudformationStack {
+	stackName: string | null;
+	tags: AWSCloudformationTag;
+	creationTime: Date | null;
+}
+
+export interface GuRepoStack extends AWSCloudformationStack {
+	guRepoName: string;
+}

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -2,7 +2,7 @@ import type { _Object, ListObjectsCommandInput } from '@aws-sdk/client-s3';
 import { ListObjectsCommand, S3Client } from '@aws-sdk/client-s3';
 import type { SNSHandler } from 'aws-lambda';
 import { awsClientConfig } from 'common/aws';
-import { stageAwareOctokit } from 'common/functions';
+import { applyTopics, stageAwareOctokit } from 'common/functions';
 import type { Octokit } from 'octokit';
 import type { Config } from './config';
 import { getConfig } from './config';
@@ -82,14 +82,6 @@ async function s3PathIsInConfig(
 	} else {
 		return !!(await findInS3(s3, `${s3Prefix ?? ''}/${parsedConfig.path}`));
 	}
-}
-
-async function applyTopics(repo: string, owner: string, octokit: Octokit) {
-	console.log(`Applying interactive topic to ${repo}`);
-	const topics = (await octokit.rest.repos.getAllTopics({ owner, repo })).data
-		.names;
-	const names = topics.concat(['interactive']);
-	await octokit.rest.repos.replaceAllTopics({ owner, repo, names });
 }
 
 export async function assessRepo(repo: string, owner: string, config: Config) {

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -128,7 +128,7 @@ export async function assessRepo(repo: string, owner: string, config: Config) {
 	}
 
 	if ((isFromTemplate || (await foundInS3())) && onProd) {
-		await applyTopics(repo, owner, octokit);
+		await applyTopics(repo, owner, octokit, 'interactive');
 	} else {
 		console.log(`No action taken for ${repo}.`);
 	}

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -34,11 +34,6 @@ export interface Config extends PrismaConfig {
 	ignoredRepositoryPrefixes: string[];
 
 	/**
-	 * SQS queue to send topic 'production' messages to.
-	 */
-	topicMonitoringProductionTagQueueUrl: string;
-
-	/**
 	 * Flag to enable messaging when running locally.
 	 */
 	enableMessaging: boolean;
@@ -66,8 +61,6 @@ export async function getConfig(): Promise<Config> {
 		interactiveMonitorSnsTopic: getEnvOrThrow('INTERACTIVE_MONITOR_TOPIC_ARN'),
 		databaseConnectionString: getDatabaseConnectionString(databaseConfig),
 		withQueryLogging: queryLogging,
-		topicMonitoringProductionTagQueueUrl: '???', // TODO: remove this
-		// topicMonitoringProductionTagQueueUrl: getEnvOrThrow('TOPIC_MONITORING_PRODUCTION_TAG_QUEUE_URL'), // TODO: produce this
 		enableMessaging: process.env.ENABLE_MESSAGING === 'false' ? false : true,
 		ignoredRepositoryPrefixes: [
 			'guardian/esd-', // ESD team

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -9,7 +9,7 @@ import { getConfig } from './config';
 import { getUnarchivedRepositories } from './query';
 import { protectBranches } from './remediations/branch-protector/branch-protection';
 import { sendPotentialInteractives } from './remediations/repository-06-topic-monitor-interactive';
-import { findReposInProdWithoutProductionTopic } from './remediations/repository-06-topic-monitor-production';
+import { applyProductionTopic } from './remediations/repository-06-topic-monitor-production';
 import { evaluateRepositories } from './rules/repository';
 
 async function writeEvaluationTable(
@@ -48,13 +48,12 @@ export async function main() {
 			unarchivedRepositories,
 			octokit,
 		);
+		await applyProductionTopic(prisma, unarchivedRepositories, octokit);
 	} else {
 		console.log(
 			'Messaging is not enabled. Set ENABLE_MESSAGING flag to enable.',
 		);
 	}
-
-	await findReposInProdWithoutProductionTopic(prisma, unarchivedRepositories);
 
 	console.log('Done');
 }

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -9,7 +9,7 @@ import { getConfig } from './config';
 import { getUnarchivedRepositories } from './query';
 import { protectBranches } from './remediations/branch-protector/branch-protection';
 import { sendPotentialInteractives } from './remediations/repository-06-topic-monitor-interactive';
-import { applyProductionTopic } from './remediations/repository-06-topic-monitor-production';
+import { applyProductionTopicAndMessageTeams } from './remediations/repository-06-topic-monitor-production';
 import { evaluateRepositories } from './rules/repository';
 
 async function writeEvaluationTable(
@@ -48,7 +48,12 @@ export async function main() {
 			unarchivedRepositories,
 			octokit,
 		);
-		await applyProductionTopic(prisma, unarchivedRepositories, octokit);
+		await applyProductionTopicAndMessageTeams(
+			prisma,
+			unarchivedRepositories,
+			octokit,
+			config,
+		);
 	} else {
 		console.log(
 			'Messaging is not enabled. Set ENABLE_MESSAGING flag to enable.',

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -7,7 +7,10 @@ import type {
 	view_repo_ownership,
 } from '@prisma/client';
 import type { GetFindResult } from '@prisma/client/runtime/library';
-import type { AWSCloudformationTag } from 'common/types';
+import type {
+	AWSCloudformationStack,
+	AWSCloudformationTag,
+} from 'common/types';
 
 export async function getUnarchivedRepositories(
 	client: PrismaClient,
@@ -86,8 +89,10 @@ export async function getRepoOwnership(
 	return data;
 }
 
-export async function findProdCfnStackTags(client: PrismaClient) {
-	const cfnStackTags = await client.aws_cloudformation_stacks.findMany({
+export async function findProdCfnStacks(
+	client: PrismaClient,
+): Promise<AWSCloudformationStack[]> {
+	const cfnStacks = await client.aws_cloudformation_stacks.findMany({
 		where: {
 			OR: [
 				{
@@ -122,10 +127,16 @@ export async function findProdCfnStackTags(client: PrismaClient) {
 		},
 		select: {
 			tags: true,
+			stack_name: true,
+			creation_time: true,
 		},
 	});
 
-	const tags = cfnStackTags.map((tag) => tag.tags as AWSCloudformationTag);
+	const stacks = cfnStacks.map((stack) => ({
+		stackName: stack.stack_name,
+		tags: stack.tags as AWSCloudformationTag,
+		creationTime: stack.creation_time,
+	}));
 
-	return tags;
+	return stacks;
 }

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-production.test.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-production.test.ts
@@ -4,6 +4,7 @@ import { nullRepo } from '../rules/repository.test';
 import {
 	getGuRepoNames,
 	getReposWithoutProductionTopic,
+	removeGuardian,
 } from './repository-06-topic-monitor-production';
 
 describe('getReposWithoutProductionTopic', () => {
@@ -65,5 +66,13 @@ describe('getGuRepoNames', () => {
 
 		const result: string[] = getGuRepoNames(cfnTags);
 		expect(result).toEqual(['guardian/repo-1']);
+	});
+});
+
+describe('removeGuardian', () => {
+	it('should strip "guardian/" from the full repo name', () => {
+		const fullRepoName = 'guardian/repo-1';
+		const result: string = removeGuardian(fullRepoName);
+		expect(result).toEqual('repo-1');
 	});
 });

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-production.test.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-production.test.ts
@@ -2,15 +2,16 @@ import type { github_repositories } from '@prisma/client';
 import type { AWSCloudformationTag } from 'common/types';
 import { nullRepo } from '../rules/repository.test';
 import {
-	getGuRepoNames,
-	getReposWithoutProductionTopic,
+	getGuRepoName,
+	getRepoNamesWithoutProductionTopic,
 	removeGuardian,
 } from './repository-06-topic-monitor-production';
 
 describe('getReposWithoutProductionTopic', () => {
 	it('should return an empty array when unarchivedRepos array is empty', () => {
 		const unarchivedRepos: github_repositories[] = [];
-		const result: string[] = getReposWithoutProductionTopic(unarchivedRepos);
+		const result: string[] =
+			getRepoNamesWithoutProductionTopic(unarchivedRepos);
 		expect(result).toEqual([]);
 	});
 
@@ -41,31 +42,34 @@ describe('getReposWithoutProductionTopic', () => {
 			},
 		];
 
-		const result: string[] = getReposWithoutProductionTopic(unarchivedRepos);
+		const result: string[] =
+			getRepoNamesWithoutProductionTopic(unarchivedRepos);
 		expect(result).toEqual(['guardian/repo-good-1', 'guardian/repo-good-2']);
 	});
 });
 
 describe('getGuRepoNames', () => {
-	it('should return an empty array when tags array is empty', () => {
-		const cfnTags: AWSCloudformationTag[] = [];
-		const result: string[] = getGuRepoNames(cfnTags);
-		expect(result).toEqual([]);
+	it('should return undefined if the "gu:repo" tag value is not present', () => {
+		const cfnTag: AWSCloudformationTag = {
+			App: 'app-1',
+			Stack: 'stack1',
+			Stage: 'PROD',
+			'gu:build-tool': 'guardian/some-build-tool',
+		};
+		const result: string | undefined = getGuRepoName(cfnTag);
+		expect(result).toEqual(undefined);
 	});
 
 	it('should return only the "gu:repo" tag value', () => {
-		const cfnTags: AWSCloudformationTag[] = [
-			{
-				App: 'app-1',
-				Stack: 'stack1',
-				Stage: 'PROD',
-				'gu:repo': 'guardian/repo-1',
-				'gu:build-tool': 'guardian/some-build-tool',
-			},
-		];
-
-		const result: string[] = getGuRepoNames(cfnTags);
-		expect(result).toEqual(['guardian/repo-1']);
+		const cfnTag: AWSCloudformationTag = {
+			App: 'app-1',
+			Stack: 'stack1',
+			Stage: 'PROD',
+			'gu:repo': 'guardian/repo-1',
+			'gu:build-tool': 'guardian/some-build-tool',
+		};
+		const result: string | undefined = getGuRepoName(cfnTag);
+		expect(result).toEqual('guardian/repo-1');
 	});
 });
 

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-production.test.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-production.test.ts
@@ -48,7 +48,7 @@ describe('getReposWithoutProductionTopic', () => {
 	});
 });
 
-describe('getGuRepoNames', () => {
+describe('getGuRepoName', () => {
 	it('should return undefined if the "gu:repo" tag value is not present', () => {
 		const cfnTag: AWSCloudformationTag = {
 			App: 'app-1',

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-production.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-production.ts
@@ -1,10 +1,10 @@
-// import { Anghammarad, RequestedChannel } from '@guardian/anghammarad';
+import { Anghammarad, RequestedChannel } from '@guardian/anghammarad';
 import type { github_repositories, PrismaClient } from '@prisma/client';
-// import {
-// 	anghammaradThreadKey,
-// 	applyTopics,
-// 	topicMonitoringProductionTagCtas,
-// } from 'common/src/functions';
+import {
+	anghammaradThreadKey,
+	applyTopics,
+	topicMonitoringProductionTagCtas,
+} from 'common/src/functions';
 import type {
 	AWSCloudformationStack,
 	AWSCloudformationTag,
@@ -15,26 +15,27 @@ import type { Config } from '../config';
 import { findProdCfnStacks, getRepoOwnership, getTeams } from '../query';
 import { findContactableOwners } from './shared-utilities';
 
-// async function notifyOneTeam(
-// 	fullRepoName: string,
-// 	config: Config,
-// 	teamSlug: string,
-// ) {
-// 	const { app, stage, anghammaradSnsTopic } = config;
-// 	const client = new Anghammarad();
-// 	await client.notify({
-// 		subject: `Production topic monitoring (for GitHub team ${teamSlug})`,
-// 		message:
-// 			`The production topic has applied to ${fullRepoName} as it appears to have a PROD or INFRA stack in AWS.` +
-// 			`Repositories should have one of the following topics, to help understand what is in production: production, testing, documentation, hackday, prototype, learning, interactive`,
-// 		actions: topicMonitoringProductionTagCtas(fullRepoName, teamSlug),
-// 		target: { GithubTeamSlug: teamSlug },
-// 		channel: RequestedChannel.PreferHangouts,
-// 		sourceSystem: `${app} ${stage}`,
-// 		topicArn: anghammaradSnsTopic,
-// 		threadKey: anghammaradThreadKey(fullRepoName),
-// 	});
-// }
+async function notifyOneTeam(
+	fullRepoName: string,
+	config: Config,
+	teamSlug: string,
+) {
+	const { app, stage, anghammaradSnsTopic } = config;
+	const client = new Anghammarad();
+	await client.notify({
+		subject: `Production topic monitoring (for GitHub team ${teamSlug})`,
+		message:
+			`The production topic has applied to ${fullRepoName} as it appears to have a PROD or INFRA stack in AWS.` +
+			`Repositories should have one of the following topics, to help understand what is in production: production, testing, documentation, hackday, prototype, learning, interactive` +
+			`Visit the links below to learn more.`,
+		actions: topicMonitoringProductionTagCtas(fullRepoName, teamSlug),
+		target: { GithubTeamSlug: teamSlug },
+		channel: RequestedChannel.PreferHangouts,
+		sourceSystem: `${app} ${stage}`,
+		topicArn: anghammaradSnsTopic,
+		threadKey: anghammaradThreadKey(fullRepoName),
+	});
+}
 
 export function getRepoNamesWithoutProductionTopic(
 	unarchivedRepos: github_repositories[],
@@ -68,12 +69,12 @@ async function findReposInProdWithoutProductionTopic(
 	prisma: PrismaClient,
 	unarchivedRepos: github_repositories[],
 ) {
-	console.log('Discovering Cloudformation stacks with PROD or INFRA tags');
+	console.log('Discovering Cloudformation stacks with PROD or INFRA tags.');
 
 	const repoNamesWithoutProductionTopic: string[] =
 		getRepoNamesWithoutProductionTopic(unarchivedRepos);
 	console.log(
-		`Found ${repoNamesWithoutProductionTopic.length} repositories without a production or interactive topic`,
+		`Found ${repoNamesWithoutProductionTopic.length} repositories without a production or interactive topic.`,
 	);
 
 	const cfnStacksWithProdInfraTags: AWSCloudformationStack[] =
@@ -93,7 +94,7 @@ async function findReposInProdWithoutProductionTopic(
 		});
 
 	console.log(
-		`Found ${guRepoStacks.length} repos with a PROD or INFRA Cloudformation stack`,
+		`Found ${guRepoStacks.length} Cloudformation stacks with a Stage tag of PROD or INFRA.`,
 	);
 
 	const reposInProdWithoutProductionTopic: GuRepoStack[] =
@@ -103,7 +104,7 @@ async function findReposInProdWithoutProductionTopic(
 		);
 
 	console.log(
-		`Found ${reposInProdWithoutProductionTopic.length} repos without a production/interactive topic that have a PROD/ INFRA Cloudformation Stage tag`,
+		`Found ${reposInProdWithoutProductionTopic.length} repos without a production/interactive topic that have a PROD/ INFRA Cloudformation Stage tag.`,
 	);
 
 	reposInProdWithoutProductionTopic.map((stack) =>
@@ -125,19 +126,19 @@ export function removeGuardian(fullRepoName: string): string {
 	return reponame ?? '';
 }
 
-// async function applyProductionTopicToOneRepoAndMessageTeams(
-// 	repoName: string,
-// 	teamNameSlugs: string[],
-// 	octokit: Octokit,
-// 	config: Config,
-// ) {
-// 	const owner = 'guardian';
-// 	const topic = 'production';
-// 	await applyTopics(repoName, owner, octokit, topic);
-// 	for (const teamNameSlug of teamNameSlugs) {
-// 		await notifyOneTeam(`${owner}/repoName`, config, teamNameSlug);
-// 	}
-// }
+async function applyProductionTopicToOneRepoAndMessageTeams(
+	repoName: string,
+	teamNameSlugs: string[],
+	octokit: Octokit,
+	config: Config,
+) {
+	const owner = 'guardian';
+	const topic = 'production';
+	await applyTopics(repoName, owner, octokit, topic);
+	for (const teamNameSlug of teamNameSlugs) {
+		await notifyOneTeam(`${owner}/repoName`, config, teamNameSlug);
+	}
+}
 
 export async function applyProductionTopicAndMessageTeams(
 	prisma: PrismaClient,
@@ -164,23 +165,24 @@ export async function applyProductionTopicAndMessageTeams(
 		})
 		.filter((contactableRepo) => contactableRepo.teamNameSlugs.length > 0);
 
-	console.log(`stage is ${config.stage}`);
 	console.log(
-		`Found ${reposWithContactableOwners.length} repos with contactable owners`,
+		`Found ${reposWithContactableOwners.length} repos with contactable owners.`,
 	);
 	reposWithContactableOwners.map((repo) => console.log(repo));
 
 	if (config.stage === 'PROD') {
-		console.log('In PROD');
-		// await Promise.all(
-		// 	reposWithContactableOwners.map((repo) =>
-		// 		applyProductionTopicToOneRepoAndMessageTeams(
-		// 			repo.fullName,
-		// 			repo.teamNameSlugs,
-		// 			octokit,
-		// 			config,
-		// 		),
-		// 	),
-		// );
+		console.log(
+			`Applying production topic to ${reposWithContactableOwners.length} repos and messaging their teams.`,
+		);
+		await Promise.all(
+			reposWithContactableOwners.map((repo) =>
+				applyProductionTopicToOneRepoAndMessageTeams(
+					repo.fullName,
+					repo.teamNameSlugs,
+					octokit,
+					config,
+				),
+			),
+		);
 	}
 }

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-production.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-production.ts
@@ -4,7 +4,7 @@ import {
 	anghammaradThreadKey,
 	applyTopics,
 	topicMonitoringProductionTagCtas,
-} from 'common/functions';
+} from 'common/src/functions';
 import type { AWSCloudformationTag } from 'common/types';
 import type { Octokit } from 'octokit';
 import type { Config } from '../config';

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-production.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-production.ts
@@ -1,38 +1,42 @@
-import { Anghammarad, RequestedChannel } from '@guardian/anghammarad';
+// import { Anghammarad, RequestedChannel } from '@guardian/anghammarad';
 import type { github_repositories, PrismaClient } from '@prisma/client';
-import {
-	anghammaradThreadKey,
-	applyTopics,
-	topicMonitoringProductionTagCtas,
-} from 'common/src/functions';
-import type { AWSCloudformationTag } from 'common/types';
+// import {
+// 	anghammaradThreadKey,
+// 	applyTopics,
+// 	topicMonitoringProductionTagCtas,
+// } from 'common/src/functions';
+import type {
+	AWSCloudformationStack,
+	AWSCloudformationTag,
+	GuRepoStack,
+} from 'common/types';
 import type { Octokit } from 'octokit';
 import type { Config } from '../config';
-import { findProdCfnStackTags, getRepoOwnership, getTeams } from '../query';
+import { findProdCfnStacks, getRepoOwnership, getTeams } from '../query';
 import { findContactableOwners } from './shared-utilities';
 
-async function notifyOneTeam(
-	fullRepoName: string,
-	config: Config,
-	teamSlug: string,
-) {
-	const { app, stage, anghammaradSnsTopic } = config;
-	const client = new Anghammarad();
-	await client.notify({
-		subject: `Production topic monitoring (for GitHub team ${teamSlug})`,
-		message:
-			`The production topic has applied to ${fullRepoName} as it appears to have a PROD or INFRA stack in AWS.` +
-			`Repositories should have one of the following topics, to help understand what is in production: production, testing, documentation, hackday, prototype, learning, interactive`,
-		actions: topicMonitoringProductionTagCtas(fullRepoName, teamSlug),
-		target: { GithubTeamSlug: teamSlug },
-		channel: RequestedChannel.PreferHangouts,
-		sourceSystem: `${app} ${stage}`,
-		topicArn: anghammaradSnsTopic,
-		threadKey: anghammaradThreadKey(fullRepoName),
-	});
-}
+// async function notifyOneTeam(
+// 	fullRepoName: string,
+// 	config: Config,
+// 	teamSlug: string,
+// ) {
+// 	const { app, stage, anghammaradSnsTopic } = config;
+// 	const client = new Anghammarad();
+// 	await client.notify({
+// 		subject: `Production topic monitoring (for GitHub team ${teamSlug})`,
+// 		message:
+// 			`The production topic has applied to ${fullRepoName} as it appears to have a PROD or INFRA stack in AWS.` +
+// 			`Repositories should have one of the following topics, to help understand what is in production: production, testing, documentation, hackday, prototype, learning, interactive`,
+// 		actions: topicMonitoringProductionTagCtas(fullRepoName, teamSlug),
+// 		target: { GithubTeamSlug: teamSlug },
+// 		channel: RequestedChannel.PreferHangouts,
+// 		sourceSystem: `${app} ${stage}`,
+// 		topicArn: anghammaradSnsTopic,
+// 		threadKey: anghammaradThreadKey(fullRepoName),
+// 	});
+// }
 
-export function getReposWithoutProductionTopic(
+export function getRepoNamesWithoutProductionTopic(
 	unarchivedRepos: github_repositories[],
 ): string[] {
 	return unarchivedRepos
@@ -46,17 +50,18 @@ export function getReposWithoutProductionTopic(
 		.filter((name) => !!name) as string[];
 }
 
-export function getGuRepoNames(tags: AWSCloudformationTag[]): string[] {
-	return tags.map((tag) => tag['gu:repo']).filter((r) => !!r) as string[];
+export function getGuRepoName(tag: AWSCloudformationTag): string | undefined {
+	return tag['gu:repo'];
 }
 
 export function getReposInProdWithoutProductionTopic(
 	reposWithoutProductionTopic: string[],
-	guReposWithProdCfnStacks: string[],
-) {
-	return reposWithoutProductionTopic.filter((repoName) =>
-		guReposWithProdCfnStacks.includes(repoName),
-	);
+	guRepoStacks: GuRepoStack[],
+): GuRepoStack[] {
+	return guRepoStacks.filter((stack) => {
+		const guRepoName: string = stack.guRepoName;
+		return reposWithoutProductionTopic.includes(guRepoName);
+	});
 }
 
 async function findReposInProdWithoutProductionTopic(
@@ -64,30 +69,52 @@ async function findReposInProdWithoutProductionTopic(
 	unarchivedRepos: github_repositories[],
 ) {
 	console.log('Discovering Cloudformation stacks with PROD or INFRA tags');
-	const reposWithoutProductionTopic: string[] =
-		getReposWithoutProductionTopic(unarchivedRepos);
+
+	const repoNamesWithoutProductionTopic: string[] =
+		getRepoNamesWithoutProductionTopic(unarchivedRepos);
 	console.log(
-		`Found ${reposWithoutProductionTopic.length} repositories without a production or interactive topic`,
+		`Found ${repoNamesWithoutProductionTopic.length} repositories without a production or interactive topic`,
 	);
 
-	const repoTagsWithProdCfnStacks = await findProdCfnStackTags(prisma);
+	const cfnStacksWithProdInfraTags: AWSCloudformationStack[] =
+		await findProdCfnStacks(prisma);
 
-	const guReposWithProdCfnStacks: string[] = getGuRepoNames(
-		repoTagsWithProdCfnStacks,
-	);
+	const guRepoStacks: GuRepoStack[] = cfnStacksWithProdInfraTags
+		.filter(
+			(stack: AWSCloudformationStack) =>
+				getGuRepoName(stack.tags) !== undefined,
+		)
+		.map((stack: AWSCloudformationStack) => {
+			const guRepoName = getGuRepoName(stack.tags) as string;
+			return {
+				...stack,
+				guRepoName,
+			};
+		});
 
 	console.log(
-		`Found ${guReposWithProdCfnStacks.length} repos with a PROD or INFRA Cloudformation stack`,
+		`Found ${guRepoStacks.length} repos with a PROD or INFRA Cloudformation stack`,
 	);
 
-	const reposInProdWithoutProductionTopic =
+	const reposInProdWithoutProductionTopic: GuRepoStack[] =
 		getReposInProdWithoutProductionTopic(
-			reposWithoutProductionTopic,
-			guReposWithProdCfnStacks,
+			repoNamesWithoutProductionTopic,
+			guRepoStacks,
 		);
 
 	console.log(
-		`Found ${reposInProdWithoutProductionTopic.length} repos without a production tag that have a PROD or INFRA Cloudformation Stage tag`,
+		`Found ${reposInProdWithoutProductionTopic.length} repos without a production/interactive topic that have a PROD/ INFRA Cloudformation Stage tag`,
+	);
+
+	reposInProdWithoutProductionTopic.map((stack) =>
+		console.log(
+			'repo:',
+			stack.guRepoName,
+			'stack:',
+			stack.stackName,
+			'stack created on:',
+			stack.creationTime,
+		),
 	);
 
 	return reposInProdWithoutProductionTopic;
@@ -98,19 +125,19 @@ export function removeGuardian(fullRepoName: string): string {
 	return reponame ?? '';
 }
 
-async function applyProductionTopicToOneRepoAndMessageTeams(
-	repoName: string,
-	teamNameSlugs: string[],
-	octokit: Octokit,
-	config: Config,
-) {
-	const owner = 'guardian';
-	const topic = 'production';
-	await applyTopics(repoName, owner, octokit, topic);
-	for (const teamNameSlug of teamNameSlugs) {
-		await notifyOneTeam(`${owner}/repoName`, config, teamNameSlug);
-	}
-}
+// async function applyProductionTopicToOneRepoAndMessageTeams(
+// 	repoName: string,
+// 	teamNameSlugs: string[],
+// 	octokit: Octokit,
+// 	config: Config,
+// ) {
+// 	const owner = 'guardian';
+// 	const topic = 'production';
+// 	await applyTopics(repoName, owner, octokit, topic);
+// 	for (const teamNameSlug of teamNameSlugs) {
+// 		await notifyOneTeam(`${owner}/repoName`, config, teamNameSlug);
+// 	}
+// }
 
 export async function applyProductionTopicAndMessageTeams(
 	prisma: PrismaClient,
@@ -118,10 +145,12 @@ export async function applyProductionTopicAndMessageTeams(
 	octokit: Octokit,
 	config: Config,
 ): Promise<void> {
-	const fullRepoNames: string[] = await findReposInProdWithoutProductionTopic(
+	const repos: GuRepoStack[] = await findReposInProdWithoutProductionTopic(
 		prisma,
 		unarchivedRepos,
 	);
+
+	const fullRepoNames = repos.map((repo) => repo.guRepoName);
 
 	const repoOwners = await getRepoOwnership(prisma);
 	const teams = await getTeams(prisma);
@@ -135,14 +164,23 @@ export async function applyProductionTopicAndMessageTeams(
 		})
 		.filter((contactableRepo) => contactableRepo.teamNameSlugs.length > 0);
 
-	await Promise.all(
-		reposWithContactableOwners.map((repo) =>
-			applyProductionTopicToOneRepoAndMessageTeams(
-				repo.fullName,
-				repo.teamNameSlugs,
-				octokit,
-				config,
-			),
-		),
+	console.log(`stage is ${config.stage}`);
+	console.log(
+		`Found ${reposWithContactableOwners.length} repos with contactable owners`,
 	);
+	reposWithContactableOwners.map((repo) => console.log(repo));
+
+	if (config.stage === 'PROD') {
+		console.log('In PROD');
+		// await Promise.all(
+		// 	reposWithContactableOwners.map((repo) =>
+		// 		applyProductionTopicToOneRepoAndMessageTeams(
+		// 			repo.fullName,
+		// 			repo.teamNameSlugs,
+		// 			octokit,
+		// 			config,
+		// 		),
+		// 	),
+		// );
+	}
 }


### PR DESCRIPTION
## What does this change?

Adds the functionality to apply the `production` topic to unarchived repos that
- have a `PROD` or `INFRA` stack in AWS (excluding Developer Playground)
- don't have a `production` or `interactive` topic
- have a 'contactable owner' - ie whether we can message the teams who the repos belong to. 

Once the topic has been applied, the repo owners will be notified via Anghammarad.

## Why?

This will help us to ensure that we know about all repos in production for security reasons.

## How has it been verified?

Tested the functions locally where posible, but will need to test in PROD to see if the topics are successfully applied and messaging is sent out.