### PR TITLE
interactive-monitor: Make fewer requests to S3 per repo

### DIFF
--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -78,15 +78,13 @@ async function s3PathIsInConfig(
 	owner: string,
 	repo: string,
 	path: string,
+	prefix?: string,
 ): Promise<boolean> {
 	const configJson = await getConfigJsonFromGithub(octokit, repo, owner, path);
 	if (configJson === undefined) {
 		return false;
 	} else {
-		const s3Response1 = !!(await findInS3(s3, `atoms/${configJson.path}`));
-		const s3Response2 = !!(await findInS3(s3, configJson.path));
-
-		return s3Response1 || s3Response2;
+		return !!(await findInS3(s3, `${prefix ?? ''}/${configJson.path}`));
 	}
 }
 
@@ -112,6 +110,7 @@ export async function assessRepo(repo: string, owner: string, config: Config) {
 		owner,
 		repo,
 		'config.json',
+		'atoms',
 	);
 	const foundInS3Json = await s3PathIsInConfig(
 		octokit,

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -83,41 +83,6 @@ async function s3PathIsInConfig(
 	}
 }
 
-// Using early returns to minimise the number of calls to S3 so we can avoid rate limiting
-async function pathHasBeenFoundInS3(
-	octokit: Octokit,
-	s3: S3Client,
-	repo: string,
-	owner: string,
-): Promise<boolean> {
-	const foundInConfigJson = await s3PathIsInConfig(
-		octokit,
-		s3,
-		owner,
-		repo,
-		'config.json',
-		'atoms',
-	);
-
-	if (foundInConfigJson) {
-		return true;
-	}
-
-	const foundInS3Json = await s3PathIsInConfig(
-		octokit,
-		s3,
-		owner,
-		repo,
-		'cfg/s3.json',
-	);
-
-	if (foundInS3Json) {
-		return true;
-	}
-
-	return false;
-}
-
 async function applyTopics(repo: string, owner: string, octokit: Octokit) {
 	console.log(`Applying interactive topic to ${repo}`);
 	const topics = (await octokit.rest.repos.getAllTopics({ owner, repo })).data

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -77,14 +77,19 @@ async function s3PathIsInConfig(
 	s3: S3Client,
 	owner: string,
 	repo: string,
-	path: string,
-	prefix?: string,
+	gitHubFile: string,
+	s3Prefix?: string,
 ): Promise<boolean> {
-	const configJson = await getConfigJsonFromGithub(octokit, repo, owner, path);
-	if (configJson === undefined) {
+	const parsedConfig = await getConfigJsonFromGithub(
+		octokit,
+		repo,
+		owner,
+		gitHubFile,
+	);
+	if (parsedConfig === undefined) {
 		return false;
 	} else {
-		return !!(await findInS3(s3, `${prefix ?? ''}/${configJson.path}`));
+		return !!(await findInS3(s3, `${s3Prefix ?? ''}/${parsedConfig.path}`));
 	}
 }
 

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -42,6 +42,11 @@ export interface Config extends PrismaConfig {
 	 * Flag to enable messaging when running locally.
 	 */
 	enableMessaging: boolean;
+
+	/**
+	 * The number of repositories to send to the interactive monitor for evaluation.
+	 */
+	interactivesCount: number;
 }
 
 export async function getConfig(): Promise<Config> {
@@ -68,5 +73,6 @@ export async function getConfig(): Promise<Config> {
 			'guardian/esd-', // ESD team
 			'guardian/pluto-', // Multimedia team
 		],
+		interactivesCount: stage === 'PROD' ? 8 : 1,
 	};
 }

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
@@ -39,7 +39,7 @@ export async function sendPotentialInteractives(
 	);
 	const snsBatchMaximum = Math.min(
 		potentialInteractives.length,
-		config.stage === 'PROD' ? 5 : 1,
+		config.interactivesCount,
 	);
 	const somePotentialInteractives = potentialInteractives.slice(
 		0,


### PR DESCRIPTION
## What does this change?

interactives with a `config.json` deploy into a different prefix than those with a `cfg/s3.json`. We know what these prefixes are so can search only in the correct parts of the bucket for artifacts.

## Why?

Halving the number of requests we are making to S3 means we can look at more of them at one time

## How has it been verified?

Local execution still works
