### PR TITLE
Add final interactive check.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -36,5 +36,12 @@ module.exports = {
 			],
 			testMatch: ['<rootDir>/packages/repocop/**/*.test.ts'],
 		},
+		{
+			displayName: 'interactive-monitor',
+			transform: {
+				'^.+\\.tsx?$': 'ts-jest',
+			},
+			testMatch: ['<rootDir>/packages/interactive-monitor/**/*.test.ts'],
+		},
 	],
 };

--- a/packages/interactive-monitor/package.json
+++ b/packages/interactive-monitor/package.json
@@ -5,7 +5,7 @@
 	"main": "index.ts",
 	"scripts": {
 		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@aws-sdk",
-		"test": "echo \"No test specified\" && exit 0",
+		"test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects interactive-monitor",
 		"start": "APP=interactive-monitor ts-node src/run-locally.ts"
 	},
 	"author": "guardian",

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -4,6 +4,8 @@ import type { RestEndpointMethodTypes } from '@octokit/plugin-rest-endpoint-meth
 import type { SNSHandler } from 'aws-lambda';
 import { stageAwareOctokit } from 'common/functions';
 import type { Octokit } from 'octokit';
+import type { SourceFile } from 'typescript';
+import { createSourceFile, ScriptKind, ScriptTarget } from 'typescript';
 import type { Config } from './config';
 import { getConfig } from './config';
 
@@ -102,10 +104,10 @@ export async function assessRepo(repo: string, owner: string, config: Config) {
 	const octokit = await stageAwareOctokit(config.stage);
 	const s3 = new S3Client({ region: 'us-east-1' });
 	const { stage } = config;
-
-	const isFromTemplate = await isFromInteractiveTemplate(repo, owner, octokit);
 	const onProd = stage === 'PROD';
 	console.log(`Detected stage: ${stage}`);
+
+	const isFromTemplate = await isFromInteractiveTemplate(repo, owner, octokit);
 	const foundInConfigJson = await s3PathIsInConfig(
 		octokit,
 		s3,

--- a/packages/interactive-monitor/src/js-parser.test.ts
+++ b/packages/interactive-monitor/src/js-parser.test.ts
@@ -1,0 +1,37 @@
+import { getPathFromConfigFile, parseFileToJS } from './js-parser';
+
+describe('getPathFromConfigFile', () => {
+	it('should return a valid path from a valid js file', () => {
+		const rawFile1 = String.raw`export default {
+            title: "Iran protests",
+            path: "2022/10/iran-protests"}`;
+		const file1 = parseFileToJS(rawFile1);
+		//get the path from the source file
+		expect(getPathFromConfigFile(file1!)).toEqual('2022/10/iran-protests');
+
+		const rawFile2 = String.raw`export default {
+            title: "Some Title",
+            html: '<div id="gv-atom"></div>',
+            placeholders: {
+                headline: "How the Svelte atom template works",
+                standfirst: "This is a description of how the Svelte atom template works",
+                paragraphBefore: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam laoreet, enim id consectetur vestibulum, odio nibh efficitur urna, non ornare massa eros vel ante. Suspendisse aliquet rutrum massa quis ornare. Sed elementum vitae mi ac ultricies. Vestibulum tempus pulvinar neque et suscipit. Nulla condimentum ut est in convallis. Ut eleifend ac elit non eleifend. Aenean egestas, velit ac pharetra imperdiet, velit lectus aliquet ligula, ut tristique tellus lectus vel ex. Phasellus eget mi eu ligula elementum venenatis. Quisque viverra ex quis tristique pharetra. Nam vehicula nibh vel tellus pellentesque suscipit. Nunc posuere enim elit, in sagittis velit laoreet consectetur. Integer eget lorem at lacus convallis mattis. Cras ultricies rhoncus vestibulum.",
+            },
+            path: "2022/10/some-title",
+        };`;
+		const file2 = parseFileToJS(rawFile2);
+		const result = getPathFromConfigFile(file2!);
+		expect(result).toEqual('2022/10/some-title');
+	});
+	it('should return undefined if the JS file is invalid', () => {
+		const rawFile = String.raw`export default {
+		    title: "Iran protests",
+		    asdf: "2022/10/iran-protests"}`;
+		const file = parseFileToJS(rawFile);
+		expect(getPathFromConfigFile(file!)).toBeUndefined();
+	});
+	it('should return undefined if the JS file is empty', () => {
+		const file = parseFileToJS('');
+		expect(getPathFromConfigFile(file!)).toBeUndefined();
+	});
+});

--- a/packages/interactive-monitor/src/js-parser.ts
+++ b/packages/interactive-monitor/src/js-parser.ts
@@ -1,0 +1,37 @@
+import {
+	createSourceFile,
+	ScriptKind,
+	ScriptTarget,
+	type SourceFile,
+} from 'typescript';
+
+export function parseFileToJS(input: string): SourceFile | undefined {
+	try {
+		const sourceFile: SourceFile = createSourceFile(
+			'config.json',
+			input,
+			ScriptTarget.Latest,
+			true,
+			ScriptKind.JS,
+		);
+		return sourceFile;
+	} catch (e) {
+		console.log(e);
+		return;
+	}
+}
+
+export function getPathFromConfigFile(
+	sourceFile: SourceFile,
+): string | undefined {
+	const lines = sourceFile.statements[0]?.getText().split('"'); //[3];
+	if (!lines) {
+		return;
+	}
+	const pathIndex = lines.findIndex((line) => line.includes('path'));
+	if (pathIndex < 1) {
+		return;
+	}
+	const path = lines[pathIndex + 1];
+	return path;
+}

--- a/packages/interactive-monitor/src/types.ts
+++ b/packages/interactive-monitor/src/types.ts
@@ -1,0 +1,13 @@
+import type { RestEndpointMethodTypes } from '@octokit/plugin-rest-endpoint-methods';
+
+export type ContentResponse =
+	RestEndpointMethodTypes['repos']['getContent']['response'];
+
+export interface FileMetadata {
+	name: string;
+	content: string;
+}
+
+export interface ConfigJsonFile {
+	path: string;
+}


### PR DESCRIPTION
## What does this change?

This adds a third way of checking if a repo is an interactive, by checking the contents of `project.config.js`. This is a little more complicated as it's a javascript file, not JSON.

The evaluation of these checks has also been delegated to a series of functions, rather than variables, so that they evaluate lazily, improving performance and reducing the number of GitHub/S3 calls (The S3 API has a particularly low abuse limit, so we want to avoid making calls unless absolutely neccessary)

## Why?

New interactives generally contain this `project.config.js`, and use it for deployment. We should check for them in case someone has created a repo in a way other than template generation.

## How has it been verified?

New unit tests pass, and expected behaviour is observed in repositories with and without the file.
