### PR TITLE
chore: Reduce build time noise from linter

### DIFF
--- a/packages/interactive-monitor/src/js-parser.test.ts
+++ b/packages/interactive-monitor/src/js-parser.test.ts
@@ -5,8 +5,11 @@ describe('getPathFromConfigFile', () => {
 		const rawFile1 = String.raw`export default {
             title: "Iran protests",
             path: "2022/10/iran-protests"}`;
-		const file1 = parseFileToJS(rawFile1);
-		expect(getPathFromConfigFile(file1!)).toEqual('2022/10/iran-protests');
+
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- content provided above, so can be sure this is never `undefined`
+		const file1 = parseFileToJS(rawFile1)!;
+
+		expect(getPathFromConfigFile(file1)).toEqual('2022/10/iran-protests');
 
 		const rawFile2 = String.raw`export default {
             title: "Some Title",
@@ -18,19 +21,29 @@ describe('getPathFromConfigFile', () => {
             },
             path: "2022/10/some-title",
         };`;
-		const file2 = parseFileToJS(rawFile2);
-		const result = getPathFromConfigFile(file2!);
+
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- content provided above, so can be sure this is never `undefined`
+		const file2 = parseFileToJS(rawFile2)!;
+
+		const result = getPathFromConfigFile(file2);
 		expect(result).toEqual('2022/10/some-title');
 	});
 	it('should return undefined if the JS file is invalid', () => {
 		const rawFile = String.raw`export default {
 		    title: "Iran protests",
 		    asdf: "2022/10/iran-protests"}`;
-		const file = parseFileToJS(rawFile);
-		expect(getPathFromConfigFile(file!)).toBeUndefined();
+
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- content provided above, so can be sure this is never `undefined`
+		const file = parseFileToJS(rawFile)!;
+
+		expect(getPathFromConfigFile(file)).toBeUndefined();
 	});
 	it('should return undefined if the JS file is empty', () => {
-		const file = parseFileToJS('');
-		expect(getPathFromConfigFile(file!)).toBeUndefined();
+		const rawFile = '';
+
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- content provided above, so can be sure this is never `undefined`
+		const file = parseFileToJS(rawFile)!;
+
+		expect(getPathFromConfigFile(file)).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## What does this change, and why?
Add some annotations to help the linter understand we know what we're doing, and therefore reduce noise in the build.

## How has it been verified?
Observe CI - the annotations appearing on `main` have been removed on this branch.

<details><summary>Annotations on main</summary>
<p>

<img width="666" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/7579baa1-f3cc-4e7e-aa49-3631a3278a7d">

</p>
</details>

<details><summary>Annotations on this branch</summary>
<p>

<img width="594" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/6b57cceb-7a9d-45a6-a687-63b394b64082">

</p>
</details>