### PR TITLE
Increase resources for `GithubTeams` task 

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -4846,7 +4846,7 @@ spec:
             "Name": "CloudquerySource-GitHubTeamsFirelens",
           },
         ],
-        "Cpu": "256",
+        "Cpu": "8192",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "CloudquerySourceGitHubTeamsTaskDefinitionExecutionRole9DEDACFD",
@@ -4854,7 +4854,7 @@ spec:
           ],
         },
         "Family": "ServiceCatalogueCloudquerySourceGitHubTeamsTaskDefinition5CFD9707",
-        "Memory": "512",
+        "Memory": "16384",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -317,6 +317,8 @@ export function addCloudqueryEcsCluster(
 			}),
 			secrets: githubSecrets,
 			additionalCommands: additionalGithubCommands,
+			memoryLimitMiB: 16384,
+			cpu: 8192,
 		},
 		{
 			name: 'GitHubIssues',


### PR DESCRIPTION
## What does this change, and why?
This task is being killed by AWS with the reason:

```
OurOFMemoryError: Container killed due to memory usage
```

Increase the resources, to resolve. From 500MB RAM, to 16GB. From 0.25 vCPU, to 8 vCPU.

Note, the new values were selected somewhat arbitrarily!

## How has it been verified?
We deployed to PROD, and ran the task successfully.