### PR TITLE
fix: pass reponame correctly to applyTopics function

### DIFF
--- a/packages/repocop/src/remediations/repository-06-topic-monitor-production.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-production.ts
@@ -127,16 +127,17 @@ export function removeGuardian(fullRepoName: string): string {
 }
 
 async function applyProductionTopicToOneRepoAndMessageTeams(
-	repoName: string,
+	fullRepoName: string,
 	teamNameSlugs: string[],
 	octokit: Octokit,
 	config: Config,
 ) {
 	const owner = 'guardian';
 	const topic = 'production';
-	await applyTopics(repoName, owner, octokit, topic);
+	const shortRepoName = removeGuardian(fullRepoName);
+	await applyTopics(shortRepoName, owner, octokit, topic);
 	for (const teamNameSlug of teamNameSlugs) {
-		await notifyOneTeam(`${owner}/repoName`, config, teamNameSlug);
+		await notifyOneTeam(fullRepoName, config, teamNameSlug);
 	}
 }
 


### PR DESCRIPTION
## What does this change?

This should fix the running of the production topic monitor by passing the repo name in the correct format.

## Why?

It was broken!

## How has it been verified?

This will only run on PROD so testing will be by manually running repocop.