### PR TITLE
refactor: improve the messaging for production topic monitor

### DIFF
--- a/packages/repocop/src/remediations/repository-06-topic-monitor-production.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-production.ts
@@ -24,10 +24,7 @@ async function notifyOneTeam(
 	const client = new Anghammarad();
 	await client.notify({
 		subject: `Production topic monitoring (for GitHub team ${teamSlug})`,
-		message:
-			`The production topic has applied to ${fullRepoName} as it appears to have a PROD or INFRA stack in AWS.` +
-			`Repositories should have one of the following topics, to help understand what is in production: production, testing, documentation, hackday, prototype, learning, interactive` +
-			`Visit the links below to learn more.`,
+		message: `The 'production' topic has applied to ${fullRepoName} as it appears to have a PROD or INFRA stack in AWS. Repositories should have one of the following topics, to help understand what is in production: 'production', 'testing', 'documentation', 'hackday', 'prototype', 'learning', 'interactive'. Visit the links below to learn more about topics and how to add/remove them if you need to.`,
 		actions: topicMonitoringProductionTagCtas(fullRepoName, teamSlug),
 		target: { GithubTeamSlug: teamSlug },
 		channel: RequestedChannel.PreferHangouts,


### PR DESCRIPTION
## What does this change?

- Improves the spacing between sentences in the Anghammarad message for the production topic monitor.
- Slight rewording to hopefully make it clearer.

## Why?

What I thought might be separate lines were actually just concatenated together without spacing.

![image](https://github.com/guardian/service-catalogue/assets/15648334/09d0ecb4-0583-47a1-b982-b8622c73a401)


## How has it been verified?

It will only affect future repos found to be in production, so their team(s) will see the improved messaging.