### PR TITLE
feat(cdk): Add link to logs within RepoCop alarms

### DIFF
--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -36,6 +36,7 @@ import {
 	ParameterTier,
 	StringParameter,
 } from 'aws-cdk-lib/aws-ssm';
+import { getCentralElkLink } from 'common/src/logs';
 import { addCloudqueryEcsCluster } from './cloudquery';
 import { addDataAuditLambda } from './data-audit';
 import { InteractiveMonitor } from './interactive-monitor';
@@ -153,17 +154,25 @@ export class ServiceCatalogue extends GuStack {
 		const anghammaradTopicParameter =
 			GuAnghammaradTopicParameter.getInstance(this);
 
-		const prodMonitoring: GuLambdaErrorPercentageMonitoringProps = {
+		const repocopProdMonitoring: GuLambdaErrorPercentageMonitoringProps = {
 			toleratedErrorPercentage: 50,
 			lengthOfEvaluationPeriod: Duration.minutes(1),
 			numberOfEvaluationPeriodsAboveThresholdBeforeAlarm: 1,
 			snsTopicName: 'devx-alerts',
+			alarmDescription: `RepoCop error percentage is too high. Find the logs here ${getCentralElkLink(
+				{
+					filters: {
+						stage,
+						app: 'repocop',
+					},
+				},
+			)}`,
 		};
 
-		const codeMonitoring: NoMonitoring = { noMonitoring: true };
+		const repocopCodeMonitoring: NoMonitoring = { noMonitoring: true };
 
-		const stageAwareMonitoringConfiguration =
-			stage === 'PROD' ? prodMonitoring : codeMonitoring;
+		const repocopMonitoringConfiguration =
+			stage === 'PROD' ? repocopProdMonitoring : repocopCodeMonitoring;
 
 		const interactiveMonitor = new InteractiveMonitor(this);
 
@@ -186,7 +195,7 @@ export class ServiceCatalogue extends GuStack {
 			nonProdSchedule ?? Schedule.cron({ minute: '0', hour: '15' }),
 			anghammaradTopic,
 			db,
-			stageAwareMonitoringConfiguration,
+			repocopMonitoringConfiguration,
 			vpc,
 			interactiveMonitor.topic,
 			applicationToPostgresSecurityGroup,

--- a/packages/cli/src/aws.ts
+++ b/packages/cli/src/aws.ts
@@ -8,6 +8,7 @@ import {
 } from '@aws-sdk/client-ecs';
 import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
 import { awsClientConfig } from 'common/aws.js';
+import { getCentralElkLink } from 'common/logs';
 import terminalLink from 'terminal-link';
 
 interface EcsResourceTags {
@@ -287,7 +288,14 @@ export const runAllTasks = async (
 };
 
 function printLogsUrl(app: string, stage: string, taskDefinition: string) {
-	const url = `https://logs.gutools.co.uk/s/devx/app/discover#/?_a=(columns:!(table,resources,errors,client,message,error))&_g=(filters:!((query:(match_phrase:(app:${app}))),(query:(match_phrase:(stage:${stage}))),(query:(match_phrase:(ecs_task_arn:'${taskDefinition}')))))`;
+	const url = getCentralElkLink({
+		filters: {
+			app,
+			stage,
+			ecs_task_arn: taskDefinition,
+		},
+		columns: ['table', 'resources', 'errors', 'client', 'message', 'error'],
+	});
 
 	terminalLink.isSupported
 		? console.log(

--- a/packages/common/src/logs.test.ts
+++ b/packages/common/src/logs.test.ts
@@ -1,0 +1,30 @@
+import { getCentralElkLink } from './logs';
+
+describe('getCentralElkUrl', () => {
+	it('should form a valid link', () => {
+		const actual = getCentralElkLink({
+			filters: {
+				stack: 'deploy',
+				stage: 'CODE',
+				app: 'service-catalogue',
+			},
+		});
+		const expected =
+			"https://logs.gutools.co.uk/s/devx/app/discover#/?_g=(filters:!((query:(match_phrase:(stack:'deploy'))),(query:(match_phrase:(stage:'CODE'))),(query:(match_phrase:(app:'service-catalogue')))))";
+		expect(actual).toEqual(expected);
+	});
+
+	it('should form a valid link with columns', () => {
+		const actual = getCentralElkLink({
+			filters: {
+				stack: 'deploy',
+				stage: 'CODE',
+				app: 'service-catalogue',
+			},
+			columns: ['message'],
+		});
+		const expected =
+			"https://logs.gutools.co.uk/s/devx/app/discover#/?_g=(filters:!((query:(match_phrase:(stack:'deploy'))),(query:(match_phrase:(stage:'CODE'))),(query:(match_phrase:(app:'service-catalogue')))))&_a=(columns:!(message))";
+		expect(actual).toEqual(expected);
+	});
+});

--- a/packages/common/src/logs.ts
+++ b/packages/common/src/logs.ts
@@ -1,0 +1,39 @@
+interface CentralElkProps {
+	/**
+	 * Fields to filter the logs by.
+	 */
+	filters: Record<string, string>;
+
+	/**
+	 * Which columns to display in the Kibana table.
+	 */
+	columns?: string[];
+}
+
+/**
+ * Builds a deep link to the logs within Central ELK.
+ */
+export function getCentralElkLink(props: CentralElkProps): string {
+	const { filters, columns } = props;
+
+	const kibanaFilters = Object.entries(filters).map(([key, value]) => {
+		return `(query:(match_phrase:(${key}:'${value}')))`;
+	});
+
+	// The `#/` at the end is important for Kibana to correctly parse the query string
+	// The `URL` object moves this to the end of the string, which breaks the link.
+	const base = 'https://logs.gutools.co.uk/s/devx/app/discover#/';
+
+	const query = {
+		_g: `(filters:!(${kibanaFilters.join(',')}))`,
+		...(columns && {
+			_a: `(columns:!(${columns.join(',')}))`,
+		}),
+	};
+
+	const queryString = Object.entries(query)
+		.map(([key, value]) => `${key}=${value}`)
+		.join('&');
+
+	return `${base}?${queryString}`;
+}


### PR DESCRIPTION
## What does this change, and why?
Updates the alarm description for the RepoCop lambda, adding a link to the logs within Central ELK. This is aimed at making it easier to triage alarms.

Here is an example of the current alarm received over email:

<img width="792" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/f0f339fb-e21f-4c5e-bdc4-92ce807123c2">

## How has it been verified?
Kibana links are tricky to craft. This change refactors #532, moving the link building into a function. I've confirmed that the link is still valid by starting an ECS task via our CLI tool.

## Notes
cc @guardian/devx-reliability as maybe [GuCDK's `defaultDescription`](https://github.com/search?q=repo%3Aguardian%2Fcdk%20defaultDescription&type=code) should include a link to Central ELK?