### PR TITLE
Catch more interactives

### DIFF
--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -66,6 +66,6 @@ export async function getConfig(): Promise<Config> {
 			'guardian/esd-', // ESD team
 			'guardian/pluto-', // Multimedia team
 		],
-		interactivesCount: stage === 'PROD' ? 8 : 1,
+		interactivesCount: stage === 'PROD' ? 15 : 1,
 	};
 }


### PR DESCRIPTION

## What does this change?

Increases the number of repos sent to interactive monitor

## Why?

We are making fewer s3 requests per repo, so can check more repos