### PR TITLE
chore(repocop): only run repocop on weekdays

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -15022,9 +15022,9 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
-    "repocoprepocopcron01504E53EA84": {
+    "repocoprepocopcron015MONFRI02BD16E22": {
       "Properties": {
-        "ScheduleExpression": "cron(0 15 * * ? *)",
+        "ScheduleExpression": "cron(0 15 ? * MON-FRI *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -15040,7 +15040,7 @@ spec:
       },
       "Type": "AWS::Events::Rule",
     },
-    "repocoprepocopcron0150AllowEventRuleServiceCataloguerepocop7BEB58921D341946": {
+    "repocoprepocopcron015MONFRI0AllowEventRuleServiceCataloguerepocop7BEB5892F4DF00FA": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -15052,7 +15052,7 @@ spec:
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "repocoprepocopcron01504E53EA84",
+            "repocoprepocopcron015MONFRI02BD16E22",
             "Arn",
           ],
         },

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -190,9 +190,15 @@ export class ServiceCatalogue extends GuStack {
 			},
 		);
 
+		const prodSchedule = Schedule.cron({
+			weekDay: 'MON-FRI',
+			hour: '15',
+			minute: '0',
+		});
+
 		new Repocop(
 			this,
-			nonProdSchedule ?? Schedule.cron({ minute: '0', hour: '15' }),
+			nonProdSchedule ?? prodSchedule,
 			anghammaradTopic,
 			db,
 			repocopMonitoringConfiguration,


### PR DESCRIPTION
## What does this change?

Restrict repocop runs to weekdays only.

## Why?

Currently, repocop could potentially be sending messages out to teams every day. Messages sent on the weekend are more likely to be missed, and don't contribute to a healthy work-life balance. Let's avoid this!
