### PR TITLE
Increase Snyk job memory to 1GB to deal with OOM issues

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -13154,7 +13154,7 @@ spec:
           ],
         },
         "Family": "ServiceCatalogueCloudquerySourceSnykAllTaskDefinitionBFF67A0E",
-        "Memory": "512",
+        "Memory": "1024",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -409,6 +409,7 @@ export function addCloudqueryEcsCluster(
 			secrets: {
 				SNYK_API_KEY: Secret.fromSecretsManager(snykCredentials, 'api-key'),
 			},
+			memoryLimitMiB: 1024,
 		},
 		{
 			name: 'GuardianCustomSnykProjects',


### PR DESCRIPTION
## What does this change?

Increase Snyk task memory from 512MB to 1GB

## Why?

Job is getting terminated due to OOM in PROD

<img width="552" alt="image" src="https://github.com/guardian/service-catalogue/assets/21217225/1ded48c4-dc10-4d21-bdd1-d590517fc528">

## How has it been verified?

Deployed to CODE and ran