### PR TITLE
Enable GOMEMLIMIT, adding a soft limit of how much memory a task can use

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -4749,7 +4749,7 @@ spec:
             "Environment": [
               {
                 "Name": "GOMEMLIMIT",
-                "Value": "409MiB",
+                "Value": "13107MiB",
               },
             ],
             "Essential": true,

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -212,6 +212,12 @@ spec:
             "EntryPoint": [
               "",
             ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
+            ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
@@ -868,6 +874,12 @@ spec:
             "EntryPoint": [
               "",
             ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "1638MiB",
+              },
+            ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
@@ -1487,6 +1499,12 @@ spec:
             "EntryPoint": [
               "",
             ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
+            ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
@@ -2105,6 +2123,12 @@ spec:
             },
             "EntryPoint": [
               "",
+            ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
             ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
@@ -2737,6 +2761,12 @@ spec:
             },
             "EntryPoint": [
               "",
+            ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
             ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
@@ -3574,6 +3604,12 @@ spec:
             "EntryPoint": [
               "",
             ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
+            ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
@@ -4033,6 +4069,12 @@ spec:
             },
             "EntryPoint": [
               "",
+            ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
             ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
@@ -4703,6 +4745,12 @@ spec:
             },
             "EntryPoint": [
               "",
+            ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
             ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
@@ -5390,6 +5438,12 @@ spec:
             "EntryPoint": [
               "",
             ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
+            ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
@@ -5998,6 +6052,12 @@ spec:
             },
             "EntryPoint": [
               "",
+            ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
             ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
@@ -6623,6 +6683,12 @@ spec:
             },
             "EntryPoint": [
               "",
+            ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
             ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
@@ -7278,6 +7344,12 @@ spec:
             },
             "EntryPoint": [
               "",
+            ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
             ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
@@ -8074,6 +8146,12 @@ spec:
             "EntryPoint": [
               "",
             ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
+            ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
@@ -8498,6 +8576,12 @@ spec:
             },
             "EntryPoint": [
               "",
+            ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
             ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
@@ -9131,6 +9215,12 @@ spec:
             },
             "EntryPoint": [
               "",
+            ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
             ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
@@ -9812,6 +9902,12 @@ spec:
             },
             "EntryPoint": [
               "",
+            ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
             ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
@@ -10639,6 +10735,12 @@ spec:
             "EntryPoint": [
               "",
             ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
+            ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
@@ -11063,6 +11165,12 @@ spec:
             },
             "EntryPoint": [
               "",
+            ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
             ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
@@ -11742,6 +11850,12 @@ spec:
             },
             "EntryPoint": [
               "",
+            ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "1638MiB",
+              },
             ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
@@ -12574,6 +12688,12 @@ spec:
             "EntryPoint": [
               "",
             ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "409MiB",
+              },
+            ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
             "LogConfiguration": {
@@ -13031,6 +13151,12 @@ spec:
             },
             "EntryPoint": [
               "",
+            ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "819MiB",
+              },
             ],
             "Essential": true,
             "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",

--- a/packages/cdk/lib/cloudquery/ecs/task.ts
+++ b/packages/cdk/lib/cloudquery/ecs/task.ts
@@ -130,7 +130,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			enabled,
 			secrets,
 			additionalCommands = [],
-			memoryLimitMiB,
+			memoryLimitMiB = 512,
 			cpu,
 			extraSecurityGroups,
 			runAsSingleton,
@@ -165,6 +165,9 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 		const cloudqueryTask = task.addContainer(`${id}Container`, {
 			image: cloudqueryImage,
 			entryPoint: [''],
+			environment: {
+				GOMEMLIMIT: `${Math.floor(memoryLimitMiB * 0.8)}MiB`,
+			},
 			secrets: {
 				...secrets,
 				DB_USERNAME: Secret.fromSecretsManager(db.secret, 'username'),


### PR DESCRIPTION
## What does this change?

Enable GOMEMLIMIT, adding a soft limit of how much memory a task can use before Go aggressively garbage collects.

Currently configured to be 80% of the allocated memory for a task to provide:
- Memory headroom for tasks running in sidecars
- Time for Go to GC before AWS terminates the task due to OOM.

Inspired by https://weaviate.io/blog/gomemlimit-a-game-changer-for-high-memory-applications

## Why?

This might help prevent future OOM issues. The downside to this is that a task will run slower when it exceeds 80% memory usage due to the GC having to be ran aggressively.

## How has it been verified?

Ran in code
