### PR TITLE
Add a new schema which holds tables and functions dedicated to monitoring cloudquery status

### DIFF
--- a/packages/cdk/lib/cloudquery/ecs/cluster.ts
+++ b/packages/cdk/lib/cloudquery/ecs/cluster.ts
@@ -27,6 +27,8 @@ export interface CloudquerySource {
 
 	/**
 	 * The rate at which to collect data.
+	 *
+	 * If this schedule is daily or weekly you should add an equivalent entry to the `cloudquery_table_frequency` table.
 	 */
 	schedule: Schedule;
 

--- a/packages/common/prisma/migrations/20231205105200_monitoring/migration.sql
+++ b/packages/common/prisma/migrations/20231205105200_monitoring/migration.sql
@@ -83,7 +83,7 @@ BEGIN
         -- Unfortunately we rely on rows existing in a table in order to know when it was last synced
         -- in a future iteration we may want to consider adding a rule to require that some tables have data
         -- to be considered "in sync"
-        cloudquery_table_status.in_sync := coalesce(last_sync, NOW()) >=
+        cloudquery_table_status.in_sync := COALESCE(last_sync, NOW()) >=
             CASE
                 WHEN table_to_check.frequency = 'DAILY'  THEN NOW() - INTERVAL '36' HOUR
                 WHEN table_to_check.frequency = 'WEEKLY' THEN NOW() - INTERVAL '8'  DAY

--- a/packages/common/prisma/migrations/20231205105200_monitoring/migration.sql
+++ b/packages/common/prisma/migrations/20231205105200_monitoring/migration.sql
@@ -1,0 +1,94 @@
+CREATE SCHEMA IF NOT EXISTS monitoring;
+
+-- This migration creates a bit more of a robust solution of this function.
+DROP FUNCTION public.cq_last_synced();
+
+-- List of all tables to monitor for out of sync issues
+-- Ideally we could generate this list automatically, but for now its hardcoded
+DROP TABLE IF EXISTS  monitoring.cloudquery_table_frequency;
+CREATE TABLE monitoring.cloudquery_table_frequency (
+     table_name TEXT,
+     frequency TEXT
+);
+INSERT INTO monitoring.cloudquery_table_frequency(table_name, frequency) VALUES
+    -- AWS
+    ('aws_s3_%', 'DAILY'),
+    ('aws_accessanalyzer_%', 'DAILY'),
+    ('aws_securityhub_%', 'DAILY'),
+    ('aws_cloudformation_%', 'DAILY'),
+    ('aws_elbv1_%', 'DAILY'),
+    ('aws_elbv2_%', 'DAILY'),
+    ('aws_acm%', 'DAILY'),
+    ('aws_dynamodb%', 'DAILY'),
+    ('aws_cloudwatch_alarms', 'DAILY'),
+    ('aws_inspector_findings', 'DAILY'),
+    ('aws_inspector2_findings', 'DAILY'),
+    ('aws_ec2_instances', 'DAILY'),
+    ('aws_ec2_security_groups', 'DAILY'),
+    ('aws_ec2_images', 'DAILY'),
+    ('aws_autoscaling_groups', 'DAILY'),
+    ('aws_costexplorer_%', 'WEEKLY'),
+    -- Github
+    ('github_repositories', 'DAILY'),
+    ('github_repository_branches', 'DAILY'),
+    ('github_workflows', 'DAILY'),
+    ('github_issues', 'DAILY'),
+    ('github_organizations', 'WEEKLY'),
+    ('github_organization_members', 'WEEKLY'),
+    ('github_teams', 'WEEKLY'),
+    ('github_team_members', 'WEEKLY'),
+    ('github_team_repositories', 'WEEKLY'),
+    -- Fastly
+    ('fastly_services', 'DAILY'),
+    ('fastly_service_versions', 'DAILY'),
+    ('fastly_service_backends', 'DAILY'),
+    ('fastly_service_domains', 'DAILY'),
+    ('fastly_service_health_checks', 'DAILY'),
+    -- Galaxies
+    ('galaxies_%', 'DAILY'),
+    -- Snyk
+    ('snyk_dependencies', 'DAILY'),
+    ('snyk_groups', 'DAILY'),
+    ('snyk_group_members', 'DAILY'),
+    ('snyk_integrations', 'DAILY'),
+    ('snyk_organizations', 'DAILY'),
+    ('snyk_organization_members', 'DAILY'),
+    ('snyk_reporting_issues', 'DAILY'),
+    ('snyk_reporting_latest_issues', 'DAILY'),
+    ('snyk_projects', 'DAILY'),
+    -- RiffRaff
+    ('riffraff_%', 'DAILY');
+
+-- Check the last sync time of all tables defined by cloudquery_table_frequency
+-- and verify that their last sync time matches their frequency
+CREATE OR REPLACE FUNCTION monitoring.cloudquery_table_status()
+    RETURNS TABLE(table_name text, last_sync timestamp, frequency text, in_sync boolean) AS
+$$
+DECLARE
+    table_to_check record;
+    last_sync timestamp;
+BEGIN
+    FOR table_to_check IN
+        SELECT DISTINCT information_schema.columns.table_name, ctf.frequency
+        FROM information_schema.columns
+        INNER JOIN monitoring.cloudquery_table_frequency ctf on columns.table_name LIKE ctf.table_name
+        ORDER BY information_schema.columns.table_name
+    LOOP
+        EXECUTE format('SELECT _cq_sync_time FROM %I LIMIT 1', table_to_check.table_name) INTO last_sync;
+
+        cloudquery_table_status.table_name := table_to_check.table_name;
+        cloudquery_table_status.last_sync := last_sync;
+        cloudquery_table_status.frequency := table_to_check.frequency;
+
+        -- Unfortunately we rely on rows existing in a table in order to know when it was last synced
+        -- in a future iteration we may want to consider adding a rule to require that some tables have data
+        -- to be considered "in sync"
+        cloudquery_table_status.in_sync := coalesce(last_sync, NOW()) >=
+            CASE
+                WHEN table_to_check.frequency = 'DAILY'  THEN NOW() - INTERVAL '36' HOUR
+                WHEN table_to_check.frequency = 'WEEKLY' THEN NOW() - INTERVAL '8'  DAY
+            END;
+        RETURN NEXT;
+    END LOOP;
+END
+$$ LANGUAGE plpgsql;

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -15843,6 +15843,13 @@ model audit_results {
   vendor_total     Int
 }
 
+model cloudquery_table_frequency {
+  table_name String?
+  frequency  String?
+
+  @@ignore
+}
+
 view view_repo_ownership {
   github_team_id     BigInt
   github_team_name   String


### PR DESCRIPTION
## What does this change?

Drops the old (well, older) cq_sync_time() function and replace it with a new function which is aware of exactly which tables to check and what their frequencies should be.

## Why?

The list of tables and their frequencies is current spread out across a few different dashboards and alerts in Grafana and its a bit of a pain in the arse to make sure they're all using the same query.

Part of this PR creates a new `monitoring.cloudquery_table_frequency` table, it has hardcoded values at the moment, but I'm hoping that at some point we'll be able to populate this table at runtime when a task starts. Maybe by running a little script at the start of a task which takes the `tables` config and appends it to this table.

## How has it been verified?

Ran on CODE

<img width="434" alt="image" src="https://github.com/guardian/service-catalogue/assets/21217225/8103da23-4b1a-4dc5-8fb2-93f484e691f9">

<img width="1080" alt="image" src="https://github.com/guardian/service-catalogue/assets/21217225/3b92934a-ea4c-464a-88cd-2b2dd4e0e868">

