### PR TITLE
refactor: Share function to remove owner from repo name

### DIFF
--- a/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-interactive.ts
@@ -3,6 +3,7 @@ import type { repocop_github_repository_rules } from '@prisma/client';
 import { awsClientConfig } from 'common/src/aws';
 import { shuffle } from 'common/src/functions';
 import type { Config } from '../config';
+import { removeRepoOwner } from './shared-utilities';
 
 export function findPotentialInteractives(
 	evaluatedRepos: repocop_github_repository_rules[],
@@ -19,8 +20,8 @@ export async function sendPotentialInteractives(
 	const potentialInteractives: string[] = shuffle(
 		findPotentialInteractives(evaluatedRepos),
 	)
-		.map((repo) => repo.split('/')[1])
-		.filter((repo) => repo !== undefined) as string[];
+		.map((repo) => removeRepoOwner(repo))
+		.filter((repo) => repo !== '');
 
 	const snsBatchMaximum = Math.min(
 		potentialInteractives.length,

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-production.test.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-production.test.ts
@@ -1,9 +1,6 @@
 import type { github_repositories } from '@prisma/client';
 import { nullRepo } from '../rules/repository.test';
-import {
-	getRepoNamesWithoutProductionTopic,
-	removeGuardian,
-} from './repository-06-topic-monitor-production';
+import { getRepoNamesWithoutProductionTopic } from './repository-06-topic-monitor-production';
 
 describe('getReposWithoutProductionTopic', () => {
 	it('should return an empty array when unarchivedRepos array is empty', () => {
@@ -43,13 +40,5 @@ describe('getReposWithoutProductionTopic', () => {
 		const result: string[] =
 			getRepoNamesWithoutProductionTopic(unarchivedRepos);
 		expect(result).toEqual(['guardian/repo-good-1', 'guardian/repo-good-2']);
-	});
-});
-
-describe('removeGuardian', () => {
-	it('should strip "guardian/" from the full repo name', () => {
-		const fullRepoName = 'guardian/repo-1';
-		const result: string = removeGuardian(fullRepoName);
-		expect(result).toEqual('repo-1');
 	});
 });

--- a/packages/repocop/src/remediations/repository-06-topic-monitor-production.ts
+++ b/packages/repocop/src/remediations/repository-06-topic-monitor-production.ts
@@ -9,7 +9,11 @@ import type { AWSCloudformationStack } from 'common/types';
 import type { Octokit } from 'octokit';
 import type { Config } from '../config';
 import { findProdCfnStacks, getRepoOwnership, getTeams } from '../query';
-import { findContactableOwners, getGuRepoName } from './shared-utilities';
+import {
+	findContactableOwners,
+	getGuRepoName,
+	removeRepoOwner,
+} from './shared-utilities';
 
 async function notifyOneTeam(
 	fullRepoName: string,
@@ -107,11 +111,6 @@ async function findReposInProdWithoutProductionTopic(
 	return reposInProdWithoutProductionTopic;
 }
 
-export function removeGuardian(fullRepoName: string): string {
-	const reponame = fullRepoName.split('/')[1];
-	return reponame ?? '';
-}
-
 async function applyProductionTopicToOneRepoAndMessageTeams(
 	fullRepoName: string,
 	teamNameSlugs: string[],
@@ -120,7 +119,7 @@ async function applyProductionTopicToOneRepoAndMessageTeams(
 ): Promise<void> {
 	const owner = 'guardian';
 	const topic = 'production';
-	const shortRepoName = removeGuardian(fullRepoName);
+	const shortRepoName = removeRepoOwner(fullRepoName);
 	await applyTopics(shortRepoName, owner, octokit, topic);
 	for (const teamNameSlug of teamNameSlugs) {
 		await notifyOneTeam(fullRepoName, config, teamNameSlug);

--- a/packages/repocop/src/remediations/shared-utilities.test.ts
+++ b/packages/repocop/src/remediations/shared-utilities.test.ts
@@ -117,7 +117,7 @@ describe('Parsing the tags from an aws_cloudformation_stacks_object', () => {
 });
 
 describe('removeRepoOwner', () => {
-	it('should strip "guardian/" from the full repo name', () => {
+	it('should strip the owner from the full repo name', () => {
 		const fullRepoName = 'guardian/repo-1';
 		const result: string = removeRepoOwner(fullRepoName);
 		expect(result).toEqual('repo-1');

--- a/packages/repocop/src/remediations/shared-utilities.test.ts
+++ b/packages/repocop/src/remediations/shared-utilities.test.ts
@@ -4,6 +4,7 @@ import {
 	createSqsEntry,
 	getGuRepoName,
 	parseTagsFromStack,
+	removeRepoOwner,
 } from './shared-utilities';
 
 const nullStack: aws_cloudformation_stacks = {
@@ -112,5 +113,13 @@ describe('Parsing the tags from an aws_cloudformation_stacks_object', () => {
 		const result = parseTagsFromStack(stack);
 
 		expect(result.guRepoName).toBeUndefined();
+	});
+});
+
+describe('removeRepoOwner', () => {
+	it('should strip "guardian/" from the full repo name', () => {
+		const fullRepoName = 'guardian/repo-1';
+		const result: string = removeRepoOwner(fullRepoName);
+		expect(result).toEqual('repo-1');
 	});
 });

--- a/packages/repocop/src/remediations/shared-utilities.ts
+++ b/packages/repocop/src/remediations/shared-utilities.ts
@@ -175,3 +175,8 @@ export async function sendNotifications(
 		console.error(error);
 	}
 }
+
+export function removeRepoOwner(fullRepoName: string): string {
+	const reponame = fullRepoName.split('/')[1];
+	return reponame ?? '';
+}


### PR DESCRIPTION
## What does this change?

- Renames `removeGuardian` function to `removeRepoOwner` to make it more generic, reflecting how the owner is referred to in the rest of the codebase. The owner is currently always 'guardian'.
- Moves the function to shared utilities file from the production topic monitor.
- Reuses the function in the interactive topic monitor.


## Why?
To make the codebase DRYer.

## How has it been verified?
Local tests ran successfully.