### PR TITLE
refactor: rename topic monitor files and move to own folder

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -10,9 +10,9 @@ import type { Config } from './config';
 import { getConfig } from './config';
 import { getRepositories, getStacks, getUnarchivedRepositories } from './query';
 import { protectBranches } from './remediations/branch-protector/branch-protection';
-import { sendPotentialInteractives } from './remediations/repository-06-topic-monitor-interactive';
-import { applyProductionTopicAndMessageTeams } from './remediations/repository-06-topic-monitor-production';
 import { parseTagsFromStack } from './remediations/shared-utilities';
+import { sendPotentialInteractives } from './remediations/topics/topic-monitor-interactive';
+import { applyProductionTopicAndMessageTeams } from './remediations/topics/topic-monitor-production';
 import { evaluateRepositories, findStacks } from './rules/repository';
 import type { RepoAndArchiveStatus, RepoAndStack } from './types';
 

--- a/packages/repocop/src/remediations/topics/topic-monitor-interactive.test.ts
+++ b/packages/repocop/src/remediations/topics/topic-monitor-interactive.test.ts
@@ -1,5 +1,5 @@
 import type { repocop_github_repository_rules } from '@prisma/client';
-import { findPotentialInteractives } from './repository-06-topic-monitor-interactive';
+import { findPotentialInteractives } from './topic-monitor-interactive';
 
 describe('findPotentialInteractives', () => {
 	it('should return an empty array when evaluatedRepos is empty', () => {

--- a/packages/repocop/src/remediations/topics/topic-monitor-interactive.ts
+++ b/packages/repocop/src/remediations/topics/topic-monitor-interactive.ts
@@ -2,8 +2,8 @@ import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
 import type { repocop_github_repository_rules } from '@prisma/client';
 import { awsClientConfig } from 'common/src/aws';
 import { shuffle } from 'common/src/functions';
-import type { Config } from '../config';
-import { removeRepoOwner } from './shared-utilities';
+import type { Config } from '../../config';
+import { removeRepoOwner } from '../shared-utilities';
 
 export function findPotentialInteractives(
 	evaluatedRepos: repocop_github_repository_rules[],

--- a/packages/repocop/src/remediations/topics/topic-monitor-production.test.ts
+++ b/packages/repocop/src/remediations/topics/topic-monitor-production.test.ts
@@ -1,6 +1,6 @@
 import type { github_repositories } from '@prisma/client';
-import { nullRepo } from '../rules/repository.test';
-import { getRepoNamesWithoutProductionTopic } from './repository-06-topic-monitor-production';
+import { nullRepo } from '../../rules/repository.test';
+import { getRepoNamesWithoutProductionTopic } from './topic-monitor-production';
 
 describe('getReposWithoutProductionTopic', () => {
 	it('should return an empty array when unarchivedRepos array is empty', () => {

--- a/packages/repocop/src/remediations/topics/topic-monitor-production.ts
+++ b/packages/repocop/src/remediations/topics/topic-monitor-production.ts
@@ -7,13 +7,13 @@ import {
 } from 'common/src/functions';
 import type { AWSCloudformationStack } from 'common/types';
 import type { Octokit } from 'octokit';
-import type { Config } from '../config';
-import { findProdCfnStacks, getRepoOwnership, getTeams } from '../query';
+import type { Config } from '../../config';
+import { findProdCfnStacks, getRepoOwnership, getTeams } from '../../query';
 import {
 	findContactableOwners,
 	getGuRepoName,
 	removeRepoOwner,
-} from './shared-utilities';
+} from '../shared-utilities';
 
 async function notifyOneTeam(
 	fullRepoName: string,


### PR DESCRIPTION
## What does this change?

- Renames the topic monitor files to remove 'repository-06' from them.
- Moves the files into their own 'topics' folder.

## Why?
To make the filenames shorter and thus easier to read and to keep related files together.

## How has it been verified?
Ran local tests successfully.