### PR TITLE
shrink the repo type, and make always-there fields required

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -1,5 +1,4 @@
 import type {
-	github_repositories,
 	PrismaClient,
 	repocop_github_repository_rules,
 } from '@prisma/client';
@@ -19,7 +18,7 @@ import { parseTagsFromStack } from './remediations/shared-utilities';
 import { sendPotentialInteractives } from './remediations/topics/topic-monitor-interactive';
 import { applyProductionTopicAndMessageTeams } from './remediations/topics/topic-monitor-production';
 import { evaluateRepositories, findStacks } from './rules/repository';
-import type { RepoAndArchiveStatus, RepoAndStack } from './types';
+import type { RepoAndStack, Repository } from './types';
 
 async function writeEvaluationTable(
 	evaluatedRepos: repocop_github_repository_rules[],
@@ -36,35 +35,17 @@ async function writeEvaluationTable(
 	console.log('Finished writing to table');
 }
 
-function toRepoAndArchiveStatus(
-	repo: github_repositories,
-): RepoAndArchiveStatus | undefined {
-	if (!repo.archived || !repo.name || !repo.full_name) {
-		return undefined;
-	} else {
-		return {
-			archived: repo.archived,
-			name: repo.name,
-			fullName: repo.full_name,
-		};
-	}
-}
-
 function findArchivedReposWithStacks(
-	archivedRepositories: github_repositories[],
-	unarchivedRepositories: github_repositories[],
+	archivedRepositories: Repository[],
+	unarchivedRepositories: Repository[],
 	stacks: AWSCloudformationStack[],
 ) {
-	const archivedRepos: RepoAndArchiveStatus[] = archivedRepositories
-		.map((repo) => toRepoAndArchiveStatus(repo))
-		.filter((r): r is RepoAndArchiveStatus => !!r);
-	const unarchivedRepos = unarchivedRepositories
-		.map((repo) => toRepoAndArchiveStatus(repo))
-		.filter((r): r is RepoAndArchiveStatus => !!r);
+	const archivedRepos = archivedRepositories;
+	const unarchivedRepos = unarchivedRepositories;
 
 	const stacksWithoutAnUnarchivedRepoMatch: AWSCloudformationStack[] =
 		stacks.filter((stack) =>
-			unarchivedRepos.some((repo) => !(repo.fullName === stack.guRepoName)),
+			unarchivedRepos.some((repo) => !(repo.full_name === stack.guRepoName)),
 		);
 
 	const archivedReposWithPotentialStacks: RepoAndStack[] = archivedRepos

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -18,7 +18,17 @@ function toRepository(r: github_repositories): Repository | undefined {
 	if (!r.archived || !r.name || !r.full_name || !r.created_at || !r.id) {
 		return undefined;
 	} else {
-		return r as Repository;
+		return {
+			archived: r.archived,
+			name: r.name,
+			full_name: r.full_name,
+			topics: r.topics,
+			updated_at: r.updated_at,
+			pushed_at: r.pushed_at,
+			created_at: r.created_at,
+			id: r.id,
+			default_branch: r.default_branch,
+		};
 	}
 }
 

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -23,11 +23,11 @@ function toRepository(r: github_repositories): Repository | undefined {
 			name: r.name,
 			full_name: r.full_name,
 			topics: r.topics,
-			updated_at: r.updated_at, //empty repos don't have an updated_at
-			pushed_at: r.pushed_at, //empty repos don't have a pushed_at
+			updated_at: r.updated_at,
+			pushed_at: r.pushed_at,
 			created_at: r.created_at,
 			id: r.id,
-			default_branch: r.default_branch, //wiki repos don't have a default branch
+			default_branch: r.default_branch,
 		};
 	}
 }

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -1,6 +1,5 @@
 import type {
 	aws_cloudformation_stacks,
-	github_repositories,
 	github_repository_branches,
 	github_teams,
 	Prisma,
@@ -13,24 +12,6 @@ import type {
 	AWSCloudformationTag,
 } from 'common/types';
 import type { Repository } from './types';
-
-function toRepository(r: github_repositories): Repository | undefined {
-	if (!r.archived || !r.name || !r.full_name || !r.created_at || !r.id) {
-		return undefined;
-	} else {
-		return {
-			archived: r.archived,
-			name: r.name,
-			full_name: r.full_name,
-			topics: r.topics,
-			updated_at: r.updated_at,
-			pushed_at: r.pushed_at,
-			created_at: r.created_at,
-			id: r.id,
-			default_branch: r.default_branch,
-		};
-	}
-}
 
 export async function getRepositories(
 	client: PrismaClient,
@@ -50,9 +31,7 @@ export async function getRepositories(
 	});
 
 	console.log(`Found ${repositories.length} repositories`);
-	return repositories
-		.map((repo) => toRepository(repo))
-		.filter((r): r is Repository => !!r);
+	return repositories.map((r) => r as Repository);
 }
 
 // We only care about branches from repos we've selected, so lets only pull those to save us some time/memory

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -18,17 +18,7 @@ function toRepository(r: github_repositories): Repository | undefined {
 	if (!r.archived || !r.name || !r.full_name || !r.created_at || !r.id) {
 		return undefined;
 	} else {
-		return {
-			archived: r.archived,
-			name: r.name,
-			full_name: r.full_name,
-			topics: r.topics,
-			updated_at: r.updated_at,
-			pushed_at: r.pushed_at,
-			created_at: r.created_at,
-			id: r.id,
-			default_branch: r.default_branch,
-		};
+		return r as Repository;
 	}
 }
 

--- a/packages/repocop/src/remediations/branch-protector/branch-protection.ts
+++ b/packages/repocop/src/remediations/branch-protector/branch-protection.ts
@@ -1,5 +1,4 @@
 import type {
-	github_repositories,
 	github_teams,
 	PrismaClient,
 	repocop_github_repository_rules,
@@ -10,6 +9,7 @@ import type { UpdateMessageEvent } from 'common/types';
 import type { Octokit } from 'octokit';
 import type { Config } from '../../config';
 import { getRepoOwnership, getTeams } from '../../query';
+import type { Repository } from '../../types';
 import { findContactableOwners } from '../shared-utilities';
 import { notify } from './aws-requests';
 import {
@@ -47,7 +47,7 @@ export async function protectBranches(
 	prisma: PrismaClient,
 	evaluatedRepos: repocop_github_repository_rules[],
 	config: Config,
-	unarchivedRepositories: github_repositories[],
+	unarchivedRepositories: Repository[],
 	octokit: Octokit,
 ) {
 	const repoOwners = await getRepoOwnership(prisma);

--- a/packages/repocop/src/remediations/topics/topic-monitor-production.test.ts
+++ b/packages/repocop/src/remediations/topics/topic-monitor-production.test.ts
@@ -1,17 +1,17 @@
-import type { github_repositories } from '@prisma/client';
 import { nullRepo } from '../../rules/repository.test';
+import type { Repository } from '../../types';
 import { getRepoNamesWithoutProductionTopic } from './topic-monitor-production';
 
 describe('getReposWithoutProductionTopic', () => {
 	it('should return an empty array when unarchivedRepos array is empty', () => {
-		const unarchivedRepos: github_repositories[] = [];
+		const unarchivedRepos: Repository[] = [];
 		const result: string[] =
 			getRepoNamesWithoutProductionTopic(unarchivedRepos);
 		expect(result).toEqual([]);
 	});
 
 	it('should return only repositories without production or interactive topics and without "interactive" in the repo name', () => {
-		const unarchivedRepos: github_repositories[] = [
+		const unarchivedRepos: Repository[] = [
 			{
 				...nullRepo,
 				full_name: 'guardian/repo-bad-1',

--- a/packages/repocop/src/remediations/topics/topic-monitor-production.ts
+++ b/packages/repocop/src/remediations/topics/topic-monitor-production.ts
@@ -1,5 +1,5 @@
 import { Anghammarad, RequestedChannel } from '@guardian/anghammarad';
-import type { github_repositories, PrismaClient } from '@prisma/client';
+import type { PrismaClient } from '@prisma/client';
 import {
 	anghammaradThreadKey,
 	applyTopics,
@@ -9,6 +9,7 @@ import type { AWSCloudformationStack } from 'common/types';
 import type { Octokit } from 'octokit';
 import type { Config } from '../../config';
 import { findProdCfnStacks, getRepoOwnership, getTeams } from '../../query';
+import type { Repository } from '../../types';
 import {
 	findContactableOwners,
 	getGuRepoName,
@@ -40,7 +41,7 @@ async function notifyOneTeam(
 }
 
 export function getRepoNamesWithoutProductionTopic(
-	unarchivedRepos: github_repositories[],
+	unarchivedRepos: Repository[],
 ): string[] {
 	return unarchivedRepos
 		.filter(
@@ -49,8 +50,8 @@ export function getRepoNamesWithoutProductionTopic(
 				!repo.topics.includes('interactive'),
 		)
 		.map((repo) => repo.full_name)
-		.filter((name) => !name?.includes('interactive'))
-		.filter((name) => !!name) as string[];
+		.filter((name) => !name.includes('interactive'))
+		.filter((name) => !!name);
 }
 
 export function getReposInProdWithoutProductionTopic(
@@ -67,7 +68,7 @@ export function getReposInProdWithoutProductionTopic(
 
 async function findReposInProdWithoutProductionTopic(
 	prisma: PrismaClient,
-	unarchivedRepos: github_repositories[],
+	unarchivedRepos: Repository[],
 ) {
 	console.log('Discovering Cloudformation stacks with PROD or INFRA tags.');
 
@@ -128,7 +129,7 @@ async function applyProductionTopicToOneRepoAndMessageTeams(
 
 export async function applyProductionTopicAndMessageTeams(
 	prisma: PrismaClient,
-	unarchivedRepos: github_repositories[],
+	unarchivedRepos: Repository[],
 	octokit: Octokit,
 	config: Config,
 ): Promise<void> {

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -1,123 +1,8 @@
-import type {
-	github_repositories,
-	github_repository_branches,
-} from '@prisma/client';
+import type { github_repository_branches } from '@prisma/client';
 import type { AWSCloudformationStack } from 'common/types';
 import type { RepositoryTeam } from '../query';
-import type { RepoAndArchiveStatus } from '../types';
+import type { Repository } from '../types';
 import { evaluateOneRepo, findStacks } from './repository';
-
-export const nullRepo: github_repositories = {
-	cq_sync_time: null,
-	cq_source_name: null,
-	cq_id: '',
-	cq_parent_id: null,
-	org: '',
-	id: 0n,
-	node_id: null,
-	owner: null,
-	name: null,
-	full_name: null,
-	description: null,
-	homepage: null,
-	code_of_conduct: null,
-	default_branch: null,
-	master_branch: null,
-	created_at: null,
-	pushed_at: null,
-	updated_at: null,
-	html_url: null,
-	clone_url: null,
-	git_url: null,
-	mirror_url: null,
-	ssh_url: null,
-	svn_url: null,
-	language: null,
-	fork: null,
-	forks_count: null,
-	network_count: null,
-	open_issues_count: null,
-	open_issues: null,
-	stargazers_count: null,
-	subscribers_count: null,
-	watchers_count: null,
-	watchers: null,
-	size: null,
-	auto_init: null,
-	parent: null,
-	source: null,
-	template_repository: null,
-	organization: null,
-	permissions: null,
-	allow_rebase_merge: null,
-	allow_update_branch: null,
-	allow_squash_merge: null,
-	allow_merge_commit: null,
-	allow_auto_merge: null,
-	allow_forking: null,
-	delete_branch_on_merge: null,
-	use_squash_pr_title_as_default: null,
-	squash_merge_commit_title: null,
-	squash_merge_commit_message: null,
-	merge_commit_title: null,
-	merge_commit_message: null,
-	topics: [],
-	archived: null,
-	disabled: null,
-	license: null,
-	private: null,
-	has_issues: null,
-	has_wiki: null,
-	has_pages: null,
-	has_projects: null,
-	has_downloads: null,
-	has_discussions: null,
-	is_template: null,
-	license_template: null,
-	gitignore_template: null,
-	security_and_analysis: null,
-	team_id: null,
-	url: null,
-	archive_url: null,
-	assignees_url: null,
-	blobs_url: null,
-	branches_url: null,
-	collaborators_url: null,
-	comments_url: null,
-	commits_url: null,
-	compare_url: null,
-	contents_url: null,
-	contributors_url: null,
-	deployments_url: null,
-	downloads_url: null,
-	events_url: null,
-	forks_url: null,
-	git_commits_url: null,
-	git_refs_url: null,
-	git_tags_url: null,
-	hooks_url: null,
-	issue_comment_url: null,
-	issue_events_url: null,
-	issues_url: null,
-	keys_url: null,
-	labels_url: null,
-	languages_url: null,
-	merges_url: null,
-	milestones_url: null,
-	notifications_url: null,
-	pulls_url: null,
-	releases_url: null,
-	stargazers_url: null,
-	statuses_url: null,
-	subscribers_url: null,
-	subscription_url: null,
-	tags_url: null,
-	trees_url: null,
-	teams_url: null,
-	text_matches: null,
-	visibility: null,
-	role_name: null,
-};
 
 const nullBranch: github_repository_branches = {
 	cq_sync_time: null,
@@ -132,18 +17,32 @@ const nullBranch: github_repository_branches = {
 	protected: null,
 };
 
-const thePerfectRepo: github_repositories = {
+export const nullRepo: Repository = {
+	full_name: '',
+	name: '',
+	archived: false,
+	id: BigInt(0),
+	created_at: new Date(),
+	updated_at: null,
+	pushed_at: null,
+	topics: [],
+	default_branch: null,
+};
+
+const thePerfectRepo: Repository = {
 	...nullRepo,
 	full_name: 'repo1',
-	default_branch: 'main',
-	topics: ['production'],
+	name: 'repo1',
+	archived: false,
 	id: BigInt(1),
+	topics: ['production'],
+	default_branch: 'main',
 };
 
 describe('default_branch_name should be false when the default branch is not main', () => {
 	test('branch is not main', () => {
 		const badRepo = { ...thePerfectRepo, default_branch: 'notMain' };
-		const repos: github_repositories[] = [thePerfectRepo, badRepo];
+		const repos: Repository[] = [thePerfectRepo, badRepo];
 		const evaluation = repos.map((repo) => evaluateOneRepo(repo, [], []));
 
 		expect(evaluation.map((repo) => repo.default_branch_name)).toEqual([
@@ -185,7 +84,7 @@ describe('Repositories should have branch protection', () => {
 		expect(actual.branch_protection).toEqual(false);
 	});
 	test('Repos with no branches do not need protecting, and should be considered protected', () => {
-		const repo: github_repositories = {
+		const repo: Repository = {
 			...thePerfectRepo,
 			default_branch: null,
 		};
@@ -194,7 +93,7 @@ describe('Repositories should have branch protection', () => {
 		expect(actual.branch_protection).toEqual(true);
 	});
 	test('Repos with exempted topics should be considered adequately protected, even if they have an unprotected main branch', () => {
-		const repo: github_repositories = {
+		const repo: Repository = {
 			...thePerfectRepo,
 			topics: ['hackday'],
 		};
@@ -206,7 +105,7 @@ describe('Repositories should have branch protection', () => {
 
 describe('Repository admin access', () => {
 	test('Should return false when there is no admin team', () => {
-		const repo: github_repositories = {
+		const repo: Repository = {
 			...nullRepo,
 			full_name: 'guardian/service-catalogue',
 			id: 1234n,
@@ -224,7 +123,7 @@ describe('Repository admin access', () => {
 	});
 
 	test('Should return true when there is an admin team', () => {
-		const repo: github_repositories = {
+		const repo: Repository = {
 			...nullRepo,
 			full_name: 'guardian/service-catalogue',
 			id: 1234n,
@@ -247,7 +146,7 @@ describe('Repository admin access', () => {
 
 	test(`Should validate repositories with a 'hackday' topic`, () => {
 		//We are not interested in making sure hackday projects are kept up to date
-		const repo: github_repositories = {
+		const repo: Repository = {
 			...nullRepo,
 			full_name: 'guardian/service-catalogue',
 			id: 1234n,
@@ -259,7 +158,7 @@ describe('Repository admin access', () => {
 	});
 
 	test(`Should evaluate repositories with a 'production' topic`, () => {
-		const repo: github_repositories = {
+		const repo: Repository = {
 			...nullRepo,
 			full_name: 'guardian/service-catalogue',
 			id: 1234n,
@@ -281,7 +180,7 @@ describe('Repository admin access', () => {
 	});
 
 	test(`Should return false if all topics are unrecognised`, () => {
-		const repo: github_repositories = {
+		const repo: Repository = {
 			...nullRepo,
 			full_name: 'guardian/service-catalogue',
 			id: 1234n,
@@ -295,7 +194,7 @@ describe('Repository admin access', () => {
 
 describe('Repository topics', () => {
 	test('Should return true when there is a single recognised topic', () => {
-		const repo: github_repositories = {
+		const repo: Repository = {
 			...nullRepo,
 			topics: ['production'],
 		};
@@ -305,7 +204,7 @@ describe('Repository topics', () => {
 	});
 
 	test(`Should validate repos with an interactive topic`, () => {
-		const repo: github_repositories = {
+		const repo: Repository = {
 			...nullRepo,
 			full_name: 'guardian/service-catalogue',
 			id: 1234n,
@@ -319,7 +218,7 @@ describe('Repository topics', () => {
 	test('Should return false when there are multiple recognised topics', () => {
 		// Having more than one recognised topic creates confusion about how the repo
 		// is being used, and could also confuse repocop.
-		const repo: github_repositories = {
+		const repo: Repository = {
 			...nullRepo,
 			topics: ['production', 'hackday'],
 		};
@@ -329,7 +228,7 @@ describe('Repository topics', () => {
 	});
 
 	test('Should return true when there is are multiple topics, not all are recognised', () => {
-		const repo: github_repositories = {
+		const repo: Repository = {
 			...nullRepo,
 			topics: ['production', 'android'],
 		};
@@ -339,7 +238,7 @@ describe('Repository topics', () => {
 	});
 
 	test('Should return false when there are no topics', () => {
-		const repo: github_repositories = {
+		const repo: Repository = {
 			...nullRepo,
 			topics: [],
 		};
@@ -349,7 +248,7 @@ describe('Repository topics', () => {
 	});
 
 	test('Should return false when there are no recognised topics', () => {
-		const repo: github_repositories = {
+		const repo: Repository = {
 			...nullRepo,
 			topics: ['android', 'mobile'],
 		};
@@ -361,12 +260,12 @@ describe('Repository topics', () => {
 
 describe('Repository maintenance', () => {
 	test('should have happened at some point in the last two years', () => {
-		const recentRepo: github_repositories = {
+		const recentRepo: Repository = {
 			...nullRepo,
 			created_at: new Date(),
 		};
 
-		const oldRepo: github_repositories = {
+		const oldRepo: Repository = {
 			...nullRepo,
 			created_at: new Date('2019-01-01'),
 		};
@@ -377,7 +276,7 @@ describe('Repository maintenance', () => {
 		expect(oldEval.archiving).toEqual(false);
 	});
 	test('should be based only on the most recent date provided', () => {
-		const recentlyUpdatedRepo: github_repositories = {
+		const recentlyUpdatedRepo: Repository = {
 			...nullRepo,
 			updated_at: new Date(),
 			//these two dates are more than two years in the past, but should be
@@ -390,7 +289,7 @@ describe('Repository maintenance', () => {
 		expect(actual.archiving).toEqual(true);
 	});
 	test('is not a concern if no dates are found', () => {
-		const recentlyUpdatedRepo: github_repositories = {
+		const recentlyUpdatedRepo: Repository = {
 			...nullRepo,
 		};
 
@@ -405,8 +304,9 @@ describe('Repositories with related stacks on AWS', () => {
 		const tags = {
 			'gu:repo': full_name,
 		};
-		const repo: RepoAndArchiveStatus = {
-			fullName: full_name,
+		const repo: Repository = {
+			...nullRepo,
+			full_name,
 			name: 'repo1',
 			archived: false,
 		};
@@ -421,8 +321,9 @@ describe('Repositories with related stacks on AWS', () => {
 		expect(result).toEqual(1);
 	});
 	test('should be findable if the repo name is part of the stack name', () => {
-		const repo: RepoAndArchiveStatus = {
-			fullName: 'guardian/repo1',
+		const repo: Repository = {
+			...nullRepo,
+			full_name: 'guardian/repo1',
 			name: 'repo1',
 			archived: false,
 		};
@@ -439,8 +340,9 @@ describe('Repositories with related stacks on AWS', () => {
 
 describe('Repositories without any related stacks on AWS', () => {
 	test('should not be findable', () => {
-		const repo: RepoAndArchiveStatus = {
-			fullName: 'guardian/someRepo',
+		const repo: Repository = {
+			...nullRepo,
+			full_name: 'guardian/someRepo',
 			name: 'someRepo',
 			archived: false,
 		};

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -1,18 +1,16 @@
-import type { github_repositories } from '@prisma/client';
-
 export interface RepoAndStack {
 	fullName: string;
 	stacks: string[];
 }
 
-type RequiredRepositoryFields = Pick<
-	NonNullable<github_repositories>,
-	'archived' | 'created_at' | 'full_name' | 'id' | 'name' | 'topics'
->;
-
-type OptionalRepositoryFields = Pick<
-	github_repositories,
-	'updated_at' | 'pushed_at' | 'default_branch'
->;
-
-export type Repository = RequiredRepositoryFields & OptionalRepositoryFields;
+export interface Repository {
+	archived: boolean;
+	name: string;
+	full_name: string;
+	topics: string[];
+	updated_at: Date | null;
+	pushed_at: Date | null;
+	created_at: Date;
+	id: bigint;
+	default_branch: string | null;
+}

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -1,16 +1,18 @@
+import type { github_repositories } from '@prisma/client';
+
 export interface RepoAndStack {
 	fullName: string;
 	stacks: string[];
 }
 
-export interface Repository {
-	archived: boolean;
-	name: string;
-	full_name: string;
-	topics: string[];
-	updated_at: Date | null;
-	pushed_at: Date | null;
-	created_at: Date;
-	id: bigint;
-	default_branch: string | null;
-}
+type RequiredRepositoryFields = Pick<
+	NonNullable<github_repositories>,
+	'archived' | 'created_at' | 'full_name' | 'id' | 'name' | 'topics'
+>;
+
+type OptionalRepositoryFields = Pick<
+	github_repositories,
+	'updated_at' | 'pushed_at' | 'default_branch'
+>;
+
+export type Repository = RequiredRepositoryFields & OptionalRepositoryFields;

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -1,16 +1,26 @@
+import type { github_repositories } from '@prisma/client';
+
 export interface RepoAndStack {
 	fullName: string;
 	stacks: string[];
 }
 
-export interface Repository {
-	archived: boolean;
-	name: string;
-	full_name: string;
-	topics: string[];
-	updated_at: Date | null;
-	pushed_at: Date | null;
-	created_at: Date;
-	id: bigint;
-	default_branch: string | null;
+export type RepositoryFields = Pick<
+	github_repositories,
+	| 'archived'
+	| 'name'
+	| 'full_name'
+	| 'topics'
+	| 'updated_at'
+	| 'pushed_at'
+	| 'created_at'
+	| 'id'
+	| 'default_branch'
+>;
+
+export interface Repository extends RepositoryFields {
+	archived: NonNullable<RepositoryFields['archived']>;
+	name: NonNullable<RepositoryFields['name']>;
+	full_name: NonNullable<RepositoryFields['full_name']>;
+	id: NonNullable<RepositoryFields['id']>;
 }

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -3,8 +3,14 @@ export interface RepoAndStack {
 	stacks: string[];
 }
 
-export interface RepoAndArchiveStatus {
-	fullName: string;
-	name: string;
+export interface Repository {
 	archived: boolean;
+	name: string;
+	full_name: string;
+	topics: string[];
+	updated_at: Date | null;
+	pushed_at: Date | null;
+	created_at: Date;
+	id: bigint;
+	default_branch: string | null;
 }


### PR DESCRIPTION
## What does this change?

Creates a new type, `Repository`, which is a subset of `github_repositories`, and stops fields being nullable if they are never actually null in reality

## Why?

- Doing the conversion from `T | undefined => T` at the query stage means much less null checking later on
- Using a type that's smaller than the original makes it clear which fields we actually care about, and reduces memory usage in the lambda.

## How has it been verified?

Deployed to CODE, running the lambda produces the expected results, consistent with previous outputs
