### PR TITLE
feat: log out Anghammarad  message if not in PROD

### DIFF
--- a/packages/repocop/src/remediations/topics/topic-monitor-production.ts
+++ b/packages/repocop/src/remediations/topics/topic-monitor-production.ts
@@ -144,7 +144,7 @@ async function applyProductionTopicToOneRepoAndMessageTeams(
 		await applyTopics(shortRepoName, owner, octokit, topic);
 	} else {
 		console.log(
-			`Would have applied the ${topic} topic to ${shortRepoName} with stack ${stackName} owned by ${owner}`,
+			`Would have applied the ${topic} topic to ${shortRepoName} with stack ${stackName} if stage was PROD.`,
 		);
 	}
 	for (const teamNameSlug of teamNameSlugs) {

--- a/packages/repocop/src/remediations/topics/topic-monitor-production.ts
+++ b/packages/repocop/src/remediations/topics/topic-monitor-production.ts
@@ -108,10 +108,10 @@ export function findReposInProdWithoutProductionTopic(
 
 	const prodStacks: AWSCloudformationStack[] = stacks.filter(isProdStack);
 
-	const numberOfMonths = new Date();
-	numberOfMonths.setMonth(numberOfMonths.getMonth() - MONTHS);
+	const cutoffDate = new Date();
+	cutoffDate.setMonth(cutoffDate.getMonth() - MONTHS);
 	const prodStacksOverNumberOfMonths: AWSCloudformationStack[] =
-		prodStacks.filter((stack) => stackIsOlderThan(stack, numberOfMonths));
+		prodStacks.filter((stack) => stackIsOlderThan(stack, cutoffDate));
 	console.log(
 		`Found ${prodStacksOverNumberOfMonths.length} Cloudformation stacks with a Stage tag of PROD or INFRA that are over ${MONTHS} months old.`,
 	);


### PR DESCRIPTION
## What does this change?

- Pulls the creation of the Anghammarad message for `topic-monitor'-production` into a separate function.
- Console logs out the contents of the message.
- Moves the logic to perform the topic addition and messaging according to the stage closer to their calls, to allow for easier logging.

## Why?

This will allow us to preview the messaging on CODE so we can see if it is formatted correctly. 

## How has it been verified?

Tested on CODE.