### PR TITLE
Demonstrate we are able to detect if a repo has sufficient vulnerability tracking.

### DIFF
--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -89,5 +89,5 @@ export async function getStacks(
 export async function getSnykProjects(
 	client: PrismaClient,
 ): Promise<snyk_projects[]> {
-	return (await client.snyk_projects.findMany({})).map((project) => project);
+	return await client.snyk_projects.findMany({});
 }

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -3,6 +3,7 @@ import type {
 	github_teams,
 	Prisma,
 	PrismaClient,
+	snyk_projects,
 	view_repo_ownership,
 } from '@prisma/client';
 import type { GetFindResult } from '@prisma/client/runtime/library';
@@ -83,4 +84,10 @@ export async function getStacks(
 	return (await client.aws_cloudformation_stacks.findMany({})).map(
 		(stack) => stack as AwsCloudFormationStack,
 	);
+}
+
+export async function getSnykProjects(
+	client: PrismaClient,
+): Promise<snyk_projects[]> {
+	return (await client.snyk_projects.findMany({})).map((project) => project);
 }

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -430,7 +430,7 @@ describe('Dependency tracking', () => {
 		org_id: null,
 	};
 
-	const supportedLanguages = ['JavaScript'];
+	const fullySupportedLanguages = ['JavaScript'];
 	const snykSupportedLanguages = ['Scala'];
 	const unsupportedLanguages = ['Julia'];
 
@@ -444,7 +444,7 @@ describe('Dependency tracking', () => {
 			...nullSnykProject,
 			tags: [{ key: 'repo', value: 'guardian/some-repo' }],
 		};
-		const actual = verifyDependencyTracking(repo, supportedLanguages, [
+		const actual = verifyDependencyTracking(repo, fullySupportedLanguages, [
 			project,
 		]);
 		expect(actual).toEqual(true);
@@ -455,7 +455,7 @@ describe('Dependency tracking', () => {
 			topics: ['production'],
 			full_name: 'guardian/some-repo',
 		};
-		const actual = verifyDependencyTracking(repo, supportedLanguages, []);
+		const actual = verifyDependencyTracking(repo, fullySupportedLanguages, []);
 		expect(actual).toEqual(true);
 	});
 	test('should be unhappy if a project is not on snyk, and uses a language dependabot does not support', () => {

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -483,7 +483,7 @@ describe('Dependency tracking', () => {
 			full_name: 'guardian/some-repo',
 		};
 		const actual = verifyDependencyTracking(repo, unsupportedLanguages, []);
-		expect(actual).toEqual(false);
+		expect(actual).toEqual(true);
 	});
 	test('should be happy if a repository has a non-production tag', () => {
 		const repo: Repository = {
@@ -492,6 +492,6 @@ describe('Dependency tracking', () => {
 			full_name: 'guardian/some-repo',
 		};
 		const actual = verifyDependencyTracking(repo, unsupportedLanguages, []);
-		expect(actual).toEqual(false);
+		expect(actual).toEqual(true);
 	});
 });

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -163,13 +163,16 @@ export function verifyDependencyTracking(
 		'Visual Basic .NET',
 	].concat(supportedDependabotLanguages);
 
-	const allReposOnSnyk = snyk_projects
-		.map((project) => parseSnykTags(project))
-		.map((p) => p.repo);
+	const allProjectTags = snyk_projects.map((project) => parseSnykTags(project));
 
-	//TODO check the commit and branch tags too
-	const repoIsOnSnyk =
-		!!repo.full_name && allReposOnSnyk.includes(repo.full_name);
+	const matchingSnykProject = allProjectTags.find(
+		(allProjectTags) =>
+			!!repo.full_name &&
+			allProjectTags.repo == repo.full_name &&
+			allProjectTags.branch === repo.default_branch,
+	);
+
+	const repoIsOnSnyk = !!matchingSnykProject;
 
 	if (repoIsOnSnyk) {
 		const containsOnlySnykSupportedLanguages = languages.every((language) =>

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -154,9 +154,9 @@ export function verifyDependencyTracking(
 		return true;
 	}
 
-	const untestedLanguages = ['HTML', 'CSS', 'Shell'];
+	const ignoredLanguages = ['HTML', 'CSS', 'Shell'];
 
-	const supportedDependabotLanguages = [
+	const commonSupportedLanguages = [
 		'C#',
 		'Go',
 		'Java',
@@ -164,9 +164,8 @@ export function verifyDependencyTracking(
 		'Python',
 		'Swift',
 		'TypeScript',
-	].concat(untestedLanguages);
-
-	const supportedSnykLanguages = [
+	];
+	const snykOnlySupportedLanguages = [
 		'C',
 		'C++',
 		'Apex',
@@ -179,7 +178,15 @@ export function verifyDependencyTracking(
 		'Scala',
 		'Objective-C',
 		'Visual Basic .NET',
-	].concat(supportedDependabotLanguages);
+	];
+
+	const supportedDependabotLanguages = ignoredLanguages.concat(
+		commonSupportedLanguages,
+	);
+
+	const supportedSnykLanguages = ignoredLanguages
+		.concat(commonSupportedLanguages)
+		.concat(snykOnlySupportedLanguages);
 
 	const allProjectTags = snyk_projects.map((project) => parseSnykTags(project));
 

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -130,6 +130,7 @@ export function parseSnykTags(snyk_projects: snyk_projects) {
 	return snykTags;
 }
 
+//TODO - create a CQ plugin to retrieve languages from the repo, reducing our reliance on the GitHub API
 export async function getRepoLanguages(octokit: Octokit, repo: Repository) {
 	const languages = await octokit.paginate(
 		octokit.rest.repos.listLanguages,
@@ -184,6 +185,8 @@ export function verifyDependencyTracking(
 
 	const matchingSnykProject = allProjectTags.find(
 		(tags) =>
+			//TODO - this is a close enough match for now, but in the future we should use commit hashes
+			//to make sure the projects are in sync
 			!!repo.full_name &&
 			tags.repo == repo.full_name &&
 			tags.branch === repo.default_branch,

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -166,10 +166,10 @@ export function verifyDependencyTracking(
 	const allProjectTags = snyk_projects.map((project) => parseSnykTags(project));
 
 	const matchingSnykProject = allProjectTags.find(
-		(allProjectTags) =>
+		(tags) =>
 			!!repo.full_name &&
-			allProjectTags.repo == repo.full_name &&
-			allProjectTags.branch === repo.default_branch,
+			tags.repo == repo.full_name &&
+			tags.branch === repo.default_branch,
 	);
 
 	const repoIsOnSnyk = !!matchingSnykProject;

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -129,11 +129,15 @@ export function parseSnykTags(snyk_projects: snyk_projects) {
 	return snykTags;
 }
 
-export function hasSufficientDependencyTracking(
-	repo: github_repositories,
+export function verifyDependencyTracking(
+	repo: Repository,
 	languages: string[],
 	snyk_projects: snyk_projects[],
 ): boolean {
+	if (!repo.topics.includes('production') || repo.archived) {
+		return true;
+	}
+
 	const supportedDependabotLanguages = [
 		'C#',
 		'Go',
@@ -179,7 +183,6 @@ export function hasSufficientDependencyTracking(
 		return containsOnlyDependabotSupportedLanguages;
 	}
 }
-
 /**
  * Evaluate the following rule for a Github repository:
  *   > Archived repositories should not have corresponding stacks on AWS.

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -153,6 +153,8 @@ export function verifyDependencyTracking(
 		return true;
 	}
 
+	const untestedLanguages = ['HTML', 'CSS', 'Shell'];
+
 	const supportedDependabotLanguages = [
 		'C#',
 		'Go',
@@ -161,7 +163,7 @@ export function verifyDependencyTracking(
 		'Python',
 		'Swift',
 		'TypeScript',
-	];
+	].concat(untestedLanguages);
 
 	const supportedSnykLanguages = [
 		'C',

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -163,6 +163,7 @@ export function hasSufficientDependencyTracking(
 		.map((project) => parseSnykTags(project))
 		.map((p) => p.repo);
 
+	//TODO check the commit and branch tags too
 	const repoIsOnSnyk =
 		!!repo.full_name && allReposOnSnyk.includes(repo.full_name);
 


### PR DESCRIPTION
## What does this change?

Creates a method that

1. Checks if vulnerability tracking is required for a repo
2. Retrieves the languages used by that repo
3. Looks for the repo on Snyk
3a. Checks that all languages used by the repo are supported by Snyk
4. If not on Snyk, checks that all languages used by the repo are supported by dependabot.


## Why?

We expect all production repositories to have dependency tracking enabled, either via Snyk or Dependabot. This feature allows us to track if teams are complying with this requirement. Teams that are not using more niche languages such as Scala, do not 

## How has it been verified?

All new and old tests pass. Deployed to CODE, logs look happy.
