### PR TITLE
Move functions out of index. Create a parent function for experimental features

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -18,10 +18,9 @@ import { sendPotentialInteractives } from './remediations/topics/topic-monitor-i
 import { applyProductionTopicAndMessageTeams } from './remediations/topics/topic-monitor-production';
 import {
 	evaluateRepositories,
-	findStacks,
-	isTracked,
+	testExperimentalRepocopFeatures,
 } from './rules/repository';
-import type { AwsCloudFormationStack, RepoAndStack, Repository } from './types';
+import type { AwsCloudFormationStack } from './types';
 
 async function writeEvaluationTable(
 	evaluatedRepos: repocop_github_repository_rules[],
@@ -36,28 +35,6 @@ async function writeEvaluationTable(
 	});
 
 	console.log('Finished writing to table');
-}
-
-function findArchivedReposWithStacks(
-	archivedRepositories: Repository[],
-	unarchivedRepositories: Repository[],
-	stacks: AwsCloudFormationStack[],
-) {
-	const archivedRepos = archivedRepositories;
-	const unarchivedRepos = unarchivedRepositories;
-
-	const stacksWithoutAnUnarchivedRepoMatch: AwsCloudFormationStack[] =
-		stacks.filter((stack) =>
-			unarchivedRepos.some(
-				(repo) => !(repo.full_name === stack.tags['gu:repo']),
-			),
-		);
-
-	const archivedReposWithPotentialStacks: RepoAndStack[] = archivedRepos
-		.map((repo) => findStacks(repo, stacksWithoutAnUnarchivedRepoMatch))
-		.filter((result) => result.stacks.length > 0);
-
-	return archivedReposWithPotentialStacks;
 }
 
 export async function main() {
@@ -77,32 +54,16 @@ export async function main() {
 	const evaluatedRepos: repocop_github_repository_rules[] =
 		evaluateRepositories(unarchivedRepos, branches, teams);
 
-	const unmaintinedReposCount = evaluatedRepos.filter(
-		(repo) => repo.archiving === false,
-	).length;
-
-	console.log(
-		`Found ${unmaintinedReposCount} unmaintained repositories of ${unarchivedRepos.length}.`,
-	);
-
-	const archivedWithStacks = findArchivedReposWithStacks(
-		archivedRepos,
-		unarchivedRepos,
-		nonPlaygroundStacks,
-	);
-
-	console.log(`Found ${archivedWithStacks.length} archived repos with stacks.`);
-
-	console.log(
-		'Archived repos with live stacks, first 10 results:',
-		archivedWithStacks.slice(0, 10),
-	);
-
 	const octokit = await stageAwareOctokit(config.stage);
-	unarchivedRepos
-		.filter((r) => r.topics.includes('production'))
-		.slice(0, 10)
-		.map((r) => isTracked(octokit, r, snykProjects));
+
+	testExperimentalRepocopFeatures(
+		octokit,
+		evaluatedRepos,
+		unarchivedRepos,
+		archivedRepos,
+		nonPlaygroundStacks,
+		snykProjects,
+	);
 
 	await writeEvaluationTable(evaluatedRepos, prisma);
 	if (config.enableMessaging) {


### PR DESCRIPTION
## What does this change?

There's a lot going on in the main file. This PR moves a lot of it out to the `repository` file, and creates a function for evaluating experimental repocop features

## Why?

Readability. The main method is less cluttered, and its easy to tell which features are and aren't experimental
