### PR TITLE
Run repocop at 10:30

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -15148,9 +15148,9 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
-    "repocoprepocopcron015MONFRI02BD16E22": {
+    "repocoprepocopcron3010MONFRI09611B07D": {
       "Properties": {
-        "ScheduleExpression": "cron(0 15 ? * MON-FRI *)",
+        "ScheduleExpression": "cron(30 10 ? * MON-FRI *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -15166,7 +15166,7 @@ spec:
       },
       "Type": "AWS::Events::Rule",
     },
-    "repocoprepocopcron015MONFRI0AllowEventRuleServiceCataloguerepocop7BEB5892F4DF00FA": {
+    "repocoprepocopcron3010MONFRI0AllowEventRuleServiceCataloguerepocop7BEB589205008C24": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -15178,7 +15178,7 @@ spec:
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "repocoprepocopcron015MONFRI02BD16E22",
+            "repocoprepocopcron3010MONFRI09611B07D",
             "Arn",
           ],
         },

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -192,8 +192,8 @@ export class ServiceCatalogue extends GuStack {
 
 		const prodSchedule = Schedule.cron({
 			weekDay: 'MON-FRI',
-			hour: '15',
-			minute: '0',
+			hour: '10',
+			minute: '30',
 		});
 
 		new Repocop(


### PR DESCRIPTION
## What does this change?

Previously, repocop was running at 3pm, change this to 10:30

## Why?

- Early enough that CloudQuery is still reasonably in sync
- Early enough that if something goes wrong, we'll have found out by standup.
- Late enough that most people should have started working by then, and will see the notifications
