### PR TITLE
Ditch branch protector temporarily

### DIFF
--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -72,6 +72,6 @@ export async function getConfig(): Promise<Config> {
 			'guardian/pluto-', // Multimedia team
 		],
 		interactivesCount: stage === 'PROD' ? 15 : 1,
-		branchProtectionEnabled: process.env.BRANCH_PROTECTION_ENABLED === 'false',
+		branchProtectionEnabled: process.env.BRANCH_PROTECTION_ENABLED === 'true',
 	};
 }

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -42,6 +42,11 @@ export interface Config extends PrismaConfig {
 	 * The number of repositories to send to the interactive monitor for evaluation.
 	 */
 	interactivesCount: number;
+
+	/**
+	 * Flag to enable branch protection.
+	 */
+	branchProtectionEnabled: boolean;
 }
 
 export async function getConfig(): Promise<Config> {
@@ -67,5 +72,6 @@ export async function getConfig(): Promise<Config> {
 			'guardian/pluto-', // Multimedia team
 		],
 		interactivesCount: stage === 'PROD' ? 15 : 1,
+		branchProtectionEnabled: process.env.BRANCH_PROTECTION_ENABLED === 'false',
 	};
 }

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -74,14 +74,16 @@ export async function main() {
 		const repoOwners = await getRepoOwnership(prisma);
 		const teams = await getTeams(prisma);
 
-		await protectBranches(
-			evaluatedRepos,
-			repoOwners,
-			teams,
-			config,
-			unarchivedRepos,
-			octokit,
-		);
+		if (config.branchProtectionEnabled) {
+			await protectBranches(
+				evaluatedRepos,
+				repoOwners,
+				teams,
+				config,
+				unarchivedRepos,
+				octokit,
+			);
+		}
 		await applyProductionTopicAndMessageTeams(
 			teams,
 			unarchivedRepos,

--- a/packages/repocop/src/remediations/branch-protector/branch-protection.ts
+++ b/packages/repocop/src/remediations/branch-protector/branch-protection.ts
@@ -98,7 +98,7 @@ async function protectBranch(
 
 	const stageIsProd = config.stage === 'PROD';
 
-	if (stageIsProd && !branchIsProtected && config.branchProtectionEnabled) {
+	if (stageIsProd && !branchIsProtected) {
 		await updateBranchProtection(octokit, owner, repo, defaultBranchName);
 		for (const slug of event.teamNameSlugs) {
 			await notify(event.fullName, config, slug);

--- a/packages/repocop/src/remediations/branch-protector/branch-protection.ts
+++ b/packages/repocop/src/remediations/branch-protector/branch-protection.ts
@@ -98,7 +98,7 @@ async function protectBranch(
 
 	const stageIsProd = config.stage === 'PROD';
 
-	if (stageIsProd && !branchIsProtected) {
+	if (stageIsProd && !branchIsProtected && config.branchProtectionEnabled) {
 		await updateBranchProtection(octokit, owner, repo, defaultBranchName);
 		for (const slug of event.teamNameSlugs) {
 			await notify(event.fullName, config, slug);


### PR DESCRIPTION
## What does this change?

Temporarily stop branch protector from running until we have a solution that allows us to publish libraries

## Why?

It's interfering with library releases.
