### PR TITLE
Nt/teams mem

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -4749,7 +4749,7 @@ spec:
             "Environment": [
               {
                 "Name": "GOMEMLIMIT",
-                "Value": "6553MiB",
+                "Value": "3276MiB",
               },
             ],
             "Essential": true,
@@ -4894,7 +4894,7 @@ spec:
             "Name": "CloudquerySource-GitHubTeamsFirelens",
           },
         ],
-        "Cpu": "4096",
+        "Cpu": "2048",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "CloudquerySourceGitHubTeamsTaskDefinitionExecutionRole9DEDACFD",
@@ -4902,7 +4902,7 @@ spec:
           ],
         },
         "Family": "ServiceCatalogueCloudquerySourceGitHubTeamsTaskDefinition5CFD9707",
-        "Memory": "8192",
+        "Memory": "4096",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -4749,7 +4749,7 @@ spec:
             "Environment": [
               {
                 "Name": "GOMEMLIMIT",
-                "Value": "13107MiB",
+                "Value": "6553MiB",
               },
             ],
             "Essential": true,
@@ -4894,7 +4894,7 @@ spec:
             "Name": "CloudquerySource-GitHubTeamsFirelens",
           },
         ],
-        "Cpu": "8192",
+        "Cpu": "4096",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "CloudquerySourceGitHubTeamsTaskDefinitionExecutionRole9DEDACFD",
@@ -4902,7 +4902,7 @@ spec:
           ],
         },
         "Family": "ServiceCatalogueCloudquerySourceGitHubTeamsTaskDefinition5CFD9707",
-        "Memory": "16384",
+        "Memory": "8192",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -317,8 +317,8 @@ export function addCloudqueryEcsCluster(
 			}),
 			secrets: githubSecrets,
 			additionalCommands: additionalGithubCommands,
-			memoryLimitMiB: 16384,
-			cpu: 8192,
+			memoryLimitMiB: 8192,
+			cpu: 4096,
 		},
 		{
 			name: 'GitHubIssues',

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -317,8 +317,8 @@ export function addCloudqueryEcsCluster(
 			}),
 			secrets: githubSecrets,
 			additionalCommands: additionalGithubCommands,
-			memoryLimitMiB: 8192,
-			cpu: 4096,
+			memoryLimitMiB: 4096,
+			cpu: 2048,
 		},
 		{
 			name: 'GitHubIssues',


### PR DESCRIPTION
## What does this change?

Use 1/4 of the previous memory, and 1/4 of the previous CPU allocation

## Why?

Cost saving

## How has it been verified?

Deployed and run successfully on CODE.

We probably could keep tuning this job further, but it's not something that's worth spending all day on/constantly context switching back and forth for as we get diminishing cost saving returns with every iteration.
