### PR TITLE
Bump memory usage of various failing tasks to 1024MB

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -3607,7 +3607,7 @@ spec:
             "Environment": [
               {
                 "Name": "GOMEMLIMIT",
-                "Value": "409MiB",
+                "Value": "819MiB",
               },
             ],
             "Essential": true,
@@ -3760,7 +3760,7 @@ spec:
           ],
         },
         "Family": "ServiceCatalogueCloudquerySourceGitHubIssuesTaskDefinition750BB414",
-        "Memory": "512",
+        "Memory": "1024",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",
@@ -7981,7 +7981,7 @@ spec:
             "Environment": [
               {
                 "Name": "GOMEMLIMIT",
-                "Value": "409MiB",
+                "Value": "819MiB",
               },
             ],
             "Essential": true,
@@ -8092,7 +8092,7 @@ spec:
           ],
         },
         "Family": "ServiceCatalogueCloudquerySourceOrgWideCloudFormationTaskDefinitionC6E96023",
-        "Memory": "512",
+        "Memory": "1024",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",
@@ -10539,7 +10539,7 @@ spec:
             "Environment": [
               {
                 "Name": "GOMEMLIMIT",
-                "Value": "409MiB",
+                "Value": "819MiB",
               },
             ],
             "Essential": true,
@@ -10650,7 +10650,7 @@ spec:
           ],
         },
         "Family": "ServiceCatalogueCloudquerySourceOrgWideInspectorTaskDefinition280F3CC7",
-        "Memory": "512",
+        "Memory": "1024",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -102,6 +102,7 @@ export function addCloudqueryEcsCluster(
 				tables: ['aws_cloudformation_*'],
 			}),
 			policies: [listOrgsPolicy, cloudqueryAccess('*')],
+			memoryLimitMiB: 1024,
 		},
 		{
 			name: 'AwsCostExplorer',
@@ -161,6 +162,7 @@ export function addCloudqueryEcsCluster(
 				tables: ['aws_inspector_findings', 'aws_inspector2_findings'],
 			}),
 			policies: [listOrgsPolicy, cloudqueryAccess('*')],
+			memoryLimitMiB: 1024,
 		},
 		{
 			name: 'OrgWideS3',
@@ -358,6 +360,7 @@ export function addCloudqueryEcsCluster(
 			}),
 			secrets: githubSecrets,
 			additionalCommands: additionalGithubCommands,
+			memoryLimitMiB: 1024,
 		},
 	];
 


### PR DESCRIPTION
## What does this change?

Bump `GitHubIssuesTask`, `OrgWideCloudFormation`, and `OrgWideInspectorTask`

## Why?

It looks like these 3 tasks are running out of memory

<img width="1626" alt="image" src="https://github.com/guardian/service-catalogue/assets/21217225/f669e9f9-da10-4846-bc92-53105c6bfa1d">

(Ignore the EC2, I'm not sure why thats failing just yet)
