### PR TITLE
Drop unused `riffraff_deploy_logs` table.

### DIFF
--- a/packages/common/prisma/migrations/20231220170100_drop_old_tables/migration.sql
+++ b/packages/common/prisma/migrations/20231220170100_drop_old_tables/migration.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS riffraff_deploy_logs;


### PR DESCRIPTION
## What does this change?

We previously populated this table when we integrated riffraff into CloudQuery, but we've since stopped using it as it was quite large and resource intensive.

Its not referenced in our prisma schema so I guess I could have just dropped it without a migration? But I suppose a PR preserves history.