### PR TITLE
Allow interactive monitor to read from gdn-cdn bucket

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -16065,6 +16065,11 @@ spec:
                 "Ref": "interactivemonitorgithubapp9777D674",
               },
             },
+            {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::gdn-cdn",
+            },
           ],
           "Version": "2012-10-17",
         },

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -16151,6 +16151,7 @@ spec:
             "GITHUB_APP_SECRET": {
               "Ref": "branchprotectorgithubappauth4E91892E",
             },
+            "INTERACTIVES_COUNT": "15",
             "INTERACTIVE_MONITOR_TOPIC_ARN": {
               "Ref": "TopicBFC7AF6E",
             },

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -16068,7 +16068,10 @@ spec:
             {
               "Action": "s3:ListBucket",
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::gdn-cdn",
+              "Resource": [
+                "arn:aws:s3:::gdn-cdn",
+                "arn:aws:s3:::gdn-cdn/*",
+              ],
             },
           ],
           "Version": "2012-10-17",

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -39,7 +39,7 @@ export class InteractiveMonitor {
 		const policyStatementProps: PolicyStatementProps = {
 			effect: Effect.ALLOW,
 			actions: ['s3:ListBucket'],
-			resources: ['arn:aws:s3:::gdn-cdn'],
+			resources: ['arn:aws:s3:::gdn-cdn', 'arn:aws:s3:::gdn-cdn/*'],
 		};
 
 		const ps = new PolicyStatement(policyStatementProps);

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -1,5 +1,7 @@
 import { type GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
+import type { PolicyStatementProps } from 'aws-cdk-lib/aws-iam';
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { Topic } from 'aws-cdk-lib/aws-sns';
@@ -33,5 +35,15 @@ export class InteractiveMonitor {
 		githubCredentials.grantRead(lambda);
 		topic.addSubscription(new LambdaSubscription(lambda, {}));
 		this.topic = topic;
+
+		const policyStatementProps: PolicyStatementProps = {
+			effect: Effect.ALLOW,
+			actions: ['s3:ListBucket'],
+			resources: ['arn:aws:s3:::gdn-cdn'],
+		};
+
+		const ps = new PolicyStatement(policyStatementProps);
+
+		lambda.addToRolePolicy(ps);
 	}
 }

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -40,6 +40,7 @@ export class Repocop {
 				QUERY_LOGGING: 'false', // Set this to 'true' to enable SQL query logging
 				INTERACTIVE_MONITOR_TOPIC_ARN: interactiveMonitorTopic.topicArn,
 				GITHUB_APP_SECRET: githubAppSecret.secretArn,
+				INTERACTIVES_COUNT: '15',
 			},
 			vpc,
 			securityGroups: [dbSecurityGroup],

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -71,7 +71,7 @@ export async function getConfig(): Promise<Config> {
 			'guardian/esd-', // ESD team
 			'guardian/pluto-', // Multimedia team
 		],
-		interactivesCount: stage === 'PROD' ? 15 : 1,
+		interactivesCount: Number(getEnvOrThrow('INTERACTIVES_COUNT')),
 		branchProtectionEnabled: process.env.BRANCH_PROTECTION_ENABLED === 'true',
 	};
 }


### PR DESCRIPTION
## What does this change?

## Why?

## How has it been verified?
