### PR TITLE
Double interactive monitor capacity

### DIFF
--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -40,7 +40,7 @@ export class Repocop {
 				QUERY_LOGGING: 'false', // Set this to 'true' to enable SQL query logging
 				INTERACTIVE_MONITOR_TOPIC_ARN: interactiveMonitorTopic.topicArn,
 				GITHUB_APP_SECRET: githubAppSecret.secretArn,
-				INTERACTIVES_COUNT: guStack.stage === 'PROD' ? '20' : '3',
+				INTERACTIVES_COUNT: guStack.stage === 'PROD' ? '40' : '3',
 			},
 			vpc,
 			securityGroups: [dbSecurityGroup],


### PR DESCRIPTION
## What does this change?

Increases the number of repos we check for interactives from 20 to 40

## Why?

Testing a larger subsection of repos means that we find new interactives faster.

## How has it been verified?

Manually increased the interactive count to 40 on PROD, and ran the lambda to verify that the memory/timeouts/API could handle it.

n.b. the lambda now takes 8 seconds to run, rather than 5.
