### PR TITLE
Add the ability to override a tasks plugin with a binary downloaded from a specified URL

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -9917,10 +9917,10 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "wget -O /usr/local/share/ca-certificates/global-bundle.crt -q https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem && update-ca-certificates;printf 'kind: source
+              "wget -O /usr/local/share/ca-certificates/global-bundle.crt -q https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem && update-ca-certificates;echo "Downloading plugin binary from: https://github.com/AshCorr/aoc2023/releases/download/test/aws";wget -O /plugin -q https://github.com/AshCorr/aoc2023/releases/download/test/aws;chmod +x /plugin;printf 'kind: source
 spec:
   name: aws
-  path: cloudquery/aws
+  path: /plugin
   version: v23.3.1
   tables:
     - aws_ec2_instances
@@ -9941,6 +9941,7 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+  registry: local
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/cloudquery/cluster.ts
+++ b/packages/cdk/lib/cloudquery/cluster.ts
@@ -83,6 +83,18 @@ export interface CloudquerySource {
 	 * @default false
 	 */
 	runAsSingleton?: boolean;
+
+	/**
+	 * For testing purposes, does nothing if undefined.
+	 *
+	 * Use this property to specify the URL to a plugin binary to be downloaded instead of relying on the CloudQuery registry.
+	 *
+	 * Plugins should be build for AMD64 architectures and Linux. For official CloudQuery plugins you can usually build a binary by running
+	 * the following command in the plugins root folder: `GOOS=linux GOARCH=amd64 make build` and an executable should appear in the same folder.
+	 *
+	 * @see https://docs.cloudquery.io/docs/developers/running-locally
+	 */
+	pluginBinaryUrl?: string;
 }
 
 interface CloudqueryClusterProps extends AppIdentity {
@@ -160,6 +172,7 @@ export class CloudqueryCluster extends Cluster {
 				cpu,
 				additionalSecurityGroups,
 				runAsSingleton = false,
+				pluginBinaryUrl,
 			}) => {
 				new ScheduledCloudqueryTask(scope, `CloudquerySource-${name}`, {
 					...taskProps,
@@ -174,10 +187,12 @@ export class CloudqueryCluster extends Cluster {
 					cpu,
 					additionalSecurityGroups,
 					runAsSingleton,
+
 					cloudQueryApiKey: Secret.fromSecretsManager(
 						cloudqueryApiKey,
 						'api-key',
 					),
+					pluginBinaryUrl,
 				});
 			},
 		);

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -42,6 +42,22 @@ export function postgresDestinationConfig(): CloudqueryConfig {
 	};
 }
 
+export function overrideLocalPlugin(
+	config: CloudqueryConfig,
+	override: boolean,
+): CloudqueryConfig {
+	return override
+		? {
+				...config,
+				spec: {
+					...config.spec,
+					registry: 'local',
+					path: '/plugin',
+				},
+			}
+		: config;
+}
+
 export function awsSourceConfig(
 	tableConfig: CloudqueryTableConfig,
 	extraConfig: Record<string, unknown> = {},

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -224,6 +224,8 @@ export function addCloudqueryEcsCluster(
 			}),
 			policies: [listOrgsPolicy, cloudqueryAccess('*')],
 			runAsSingleton: true,
+			pluginBinaryUrl:
+				'https://github.com/AshCorr/aoc2023/releases/download/test/aws',
 		},
 	];
 


### PR DESCRIPTION
## What does this change?

Allows developers to specify a `pluginBinaryUrl` property on a CloudQuery source which specifies the URL to a plugin binary. This will prompt our ECS task to download the specified binary and use it instead of fetching the plugin from CloudQuery Hub or Github.

## Why?

When building cloudquery plugins from source, for example when making fixes upstream, it can be quite annoying to test, especially if you don't happen to have Janus permissions to the particular account that you want to run CloudQuery on.

This allows us to build a fix on our local machine, and then check it on CODE using Service Catalogues access instead of our individual permissions.

## How has it been verified?

Tested in CODE
<img width="1538" alt="image" src="https://github.com/guardian/service-catalogue/assets/21217225/a75cb8fd-465c-49b6-a3af-3eccae005c80">
