### PR TITLE
chore(deps): Configure Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,15 @@ updates:
       - dependency-name: "aws-cdk"
       - dependency-name: "aws-cdk-lib"
       - dependency-name: "constructs"
+    
+    groups:
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+      prisma:
+        patterns:
+          - "prisma"
+          - "@prisma/client"
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
## What does this change?
Use [grouping](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) to bump AWS SDK libraries together, and Prisma libraries together. This should result in fewer PRs.

For example, these five open PRs would become two:
<img width="1225" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/b70b9a94-69e2-4752-bbec-01bcca1f9356">
