### PR TITLE
feat(cloudquery): Authenticate with CloudQuery

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@
 # Environment variables shared between ci and DEV.
 
 # See https://github.com/cloudquery/cloudquery/releases?q=cli
-CQ_CLI=3.28.0
+CQ_CLI=4.3.5
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-destination-postgresql
 CQ_POSTGRES_DESTINATION=7.0.1

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -277,6 +277,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -535,6 +549,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -939,6 +963,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -1167,6 +1205,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -1564,6 +1612,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -1792,6 +1854,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -2203,6 +2275,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -2402,6 +2488,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -2827,6 +2923,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -3085,6 +3195,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -3534,6 +3654,16 @@ spec:
             },
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -3707,6 +3837,20 @@ spec:
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
                       ":password::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
                     ],
                   ],
                 },
@@ -4177,6 +4321,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -4445,6 +4603,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -4853,6 +5021,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -5121,6 +5303,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -5517,6 +5709,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -5755,6 +5961,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -6118,6 +6334,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -6376,6 +6606,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -6751,6 +6991,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -7009,6 +7263,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -7382,6 +7646,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -7640,6 +7918,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -8043,6 +8331,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -8271,6 +8573,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -8705,6 +9017,16 @@ spec:
             },
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -8840,6 +9162,20 @@ spec:
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
                       ":password::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
                     ],
                   ],
                 },
@@ -9275,6 +9611,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -9533,6 +9883,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -9914,6 +10274,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -10198,6 +10572,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -10587,6 +10971,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -10845,6 +11243,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -11279,6 +11687,16 @@ spec:
             },
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -11415,6 +11833,20 @@ spec:
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
                       ":password::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
                     ],
                   ],
                 },
@@ -11911,6 +12343,16 @@ spec:
             },
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -12049,6 +12491,20 @@ spec:
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
                       ":password::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
                     ],
                   ],
                 },
@@ -12484,6 +12940,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -12742,6 +13212,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -13176,6 +13656,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -13434,6 +13928,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -13881,6 +14385,16 @@ spec:
             },
             {
               "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
+              },
+            },
+            {
+              "Action": [
                 "logs:CreateLogStream",
                 "logs:PutLogEvents",
               ],
@@ -14051,6 +14565,20 @@ spec:
                         "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
                       },
                       ":password::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
                     ],
                   ],
                 },
@@ -14491,6 +15019,20 @@ spec:
                   ],
                 },
               },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
             ],
           },
           {
@@ -14759,6 +15301,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
               },
             },
             {
@@ -15631,6 +16183,33 @@ spec:
       "Properties": {
         "GenerateSecretString": {},
         "Name": "/TEST/deploy/service-catalogue/branch-protector-github-app-secret",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "cloudqueryapikeyCCF82F53": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "GenerateSecretString": {},
+        "Name": "/TEST/deploy/service-catalogue/cloudquery-api-key",
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -219,7 +219,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -905,7 +905,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -1554,7 +1554,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -2203,7 +2203,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -2865,7 +2865,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -3741,7 +3741,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -4221,7 +4221,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -4921,7 +4921,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -5637,7 +5637,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -6276,7 +6276,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -6933,7 +6933,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -7588,7 +7588,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -8273,7 +8273,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -9108,7 +9108,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -9553,7 +9553,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -10216,7 +10216,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -10913,7 +10913,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -11779,7 +11779,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -12437,7 +12437,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -12882,7 +12882,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -13598,7 +13598,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -14469,7 +14469,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -14947,7 +14947,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/cloudquery/cloudquery:3.28.0",
+            "Image": "ghcr.io/cloudquery/cloudquery:4.3.5",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {

--- a/packages/cdk/lib/cloudquery/task.ts
+++ b/packages/cdk/lib/cloudquery/task.ts
@@ -110,6 +110,14 @@ export interface ScheduledCloudqueryTaskProps
 	 * Useful to help avoid overlapping runs.
 	 */
 	runAsSingleton: boolean;
+
+	/**
+	 * The CloudQuery API key, stored in AWS Secrets Manager.
+	 *
+	 * @see https://docs.cloudquery.io/docs/deployment/generate-api-key
+	 * @see https://cloud.cloudquery.io/teams/the-guardian/api-keys
+	 */
+	cloudQueryApiKey: Secret;
 }
 
 export class ScheduledCloudqueryTask extends ScheduledFargateTask {
@@ -134,6 +142,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			cpu,
 			extraSecurityGroups,
 			runAsSingleton,
+			cloudQueryApiKey,
 		} = props;
 		const { region, stack, stage } = scope;
 		const thisRepo = 'guardian/service-catalogue'; // TODO get this from GuStack
@@ -173,6 +182,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 				DB_USERNAME: Secret.fromSecretsManager(db.secret, 'username'),
 				DB_HOST: Secret.fromSecretsManager(db.secret, 'host'),
 				DB_PASSWORD: Secret.fromSecretsManager(db.secret, 'password'),
+				CLOUDQUERY_API_KEY: cloudQueryApiKey,
 			},
 			dockerLabels: {
 				Stack: stack,


### PR DESCRIPTION
## What does this change?
Sets the `CLOUDQUERY_API_KEY` environment variable to [authenticate with CloudQuery](https://docs.cloudquery.io/docs/deployment/generate-api-key). By authenticating, we provide CloudQuery with more telemetry data, which they can use to understand our usage rates.

Being authenticated also enables us to use premium plugins, such as the latest Snyk version.

## How has it been verified?
By itself, this should be a no-op change. Paired with #623, we're able to update the Snyk plugin.