### PR TITLE
chore: Update CloudQuery Snyk plugin version

### DIFF
--- a/.env
+++ b/.env
@@ -25,7 +25,7 @@ CQ_GUARDIAN_GALAXIES=1.1.0
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-snyk
 # Do not advance this plugin past 3.1.10, as more recent versions are paywalled, and will fail to run.
-CQ_SNYK=3.1.10
+CQ_SNYK=4.0.2
 
 # See https://github.com/guardian/cq-source-snyk-full-project
 CQ_GUARDIAN_SNYK=0.1.1

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -14899,7 +14899,7 @@ spec:
 spec:
   name: snyk
   path: cloudquery/snyk
-  version: v3.1.10
+  version: v4.0.2
   tables:
     - snyk_dependencies
     - snyk_groups


### PR DESCRIPTION
## What does this change?
Updates the Snyk CloudQuery source plugin to the latest version. This version is listed as a premium plugin, and requires login, which is done in #622.

AFAICT there aren't any new tables in [this version](https://hub.cloudquery.io/plugins/source/cloudquery/snyk/v4.0.2/versions?search=snyk).

See:
  - https://github.com/guardian/service-catalogue/pull/510
  - https://github.com/cloudquery/cloudquery/pull/15191

## Why?

## How has it been verified?
Deployed to CODE, ran the Snyk task, and observed the logs showing data is being collected.