### PR TITLE
refactor(cdk): Move image references to own file

### DIFF
--- a/packages/cdk/lib/cloudquery/images.ts
+++ b/packages/cdk/lib/cloudquery/images.ts
@@ -1,0 +1,12 @@
+import { ContainerImage } from 'aws-cdk-lib/aws-ecs';
+import { Versions } from './versions';
+
+export const Images = {
+	cloudquery: ContainerImage.fromRegistry(
+		`ghcr.io/cloudquery/cloudquery:${Versions.CloudqueryCli}`,
+	),
+	devxLogs: ContainerImage.fromRegistry('ghcr.io/guardian/devx-logs:2'),
+	amazonLinux: ContainerImage.fromRegistry(
+		'public.ecr.aws/amazonlinux/amazonlinux:latest',
+	),
+};


### PR DESCRIPTION
## What does this change, and why?
This is an attempt to make `task.ts` a bit smaller/easier to reason about.

## How has it been verified?
N/A. This is a no-op, as demonstrated by the CDK snapshots not changing.