### PR TITLE
refactor(cdk): Updates for consistency/simplicity

### DIFF
--- a/packages/cdk/lib/cloudquery/cluster.ts
+++ b/packages/cdk/lib/cloudquery/cluster.ts
@@ -71,9 +71,10 @@ export interface CloudquerySource {
 	cpu?: 256 | 512 | 1024 | 2048 | 4096 | 8192 | 16384;
 
 	/**
-	 * Extra security groups applied to the task for accessing resources such as RiffRaff
+	 * Any additional security groups applied to the task.
+	 * For example, a group allowing access to Riff-Raff.
 	 */
-	extraSecurityGroups?: ISecurityGroup[];
+	additionalSecurityGroups?: ISecurityGroup[];
 
 	/**
 	 * Run this task as a singleton?
@@ -157,7 +158,7 @@ export class CloudqueryCluster extends Cluster {
 				additionalCommands,
 				memoryLimitMiB,
 				cpu,
-				extraSecurityGroups,
+				additionalSecurityGroups,
 				runAsSingleton = false,
 			}) => {
 				new ScheduledCloudqueryTask(scope, `CloudquerySource-${name}`, {
@@ -171,7 +172,7 @@ export class CloudqueryCluster extends Cluster {
 					additionalCommands,
 					memoryLimitMiB,
 					cpu,
-					extraSecurityGroups,
+					additionalSecurityGroups,
 					runAsSingleton,
 					cloudQueryApiKey: Secret.fromSecretsManager(
 						cloudqueryApiKey,

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -468,7 +468,7 @@ export function addCloudqueryEcsCluster(
 		description: "Source deployment data directly from riff-raff's database",
 		schedule: nonProdSchedule ?? Schedule.cron({ minute: '0', hour: '0' }),
 		config: riffraffSourcesConfig(),
-		extraSecurityGroups: [applicationToRiffRaffDatabaseSecurityGroup],
+		additionalSecurityGroups: [applicationToRiffRaffDatabaseSecurityGroup],
 		secrets: {
 			RIFFRAFF_DB_USERNAME: Secret.fromSecretsManager(
 				cloudqueryRiffRaffDatabaseCredentials,

--- a/packages/cdk/lib/cloudquery/task.ts
+++ b/packages/cdk/lib/cloudquery/task.ts
@@ -26,18 +26,18 @@ export interface ScheduledCloudqueryTaskProps
 	extends AppIdentity,
 		Omit<ScheduledFargateTaskProps, 'Cluster'> {
 	/**
-	 * The name of the source.
+	 * The name of the task.
 	 * This will get added to the `Name` tag of the task definition.
 	 */
 	name: string;
 
 	/**
-	 * THe Postgres database for ServiceCatalogue to connect to.
+	 * The Postgres database for CloudQuery to connect to.
 	 */
 	db: DatabaseInstance;
 
 	/**
-	 * The security group to allow ServiceCatalogue to connect to the database.
+	 * The security group to allow CloudQuery to connect to the database.
 	 */
 	dbAccess: GuSecurityGroup;
 
@@ -52,22 +52,24 @@ export interface ScheduledCloudqueryTaskProps
 	loggingStreamName: string;
 
 	/**
-	 * The IAM managed policies to attach to the task.
+	 * Any IAM managed policies to attach to the task.
 	 */
 	managedPolicies: IManagedPolicy[];
 
 	/**
-	 * The IAM policies to attach to the task.
+	 * IAM policies to attach to the task.
 	 */
 	policies: PolicyStatement[];
 
 	/**
-	 * The ServiceCatalogue config to use to collect data from.
+	 * The CloudQuery config to use to collect data from.
+	 *
+	 * @see https://docs.cloudquery.io/docs/reference/source-spec
 	 */
 	sourceConfig: CloudqueryConfig;
 
 	/**
-	 * Any secrets to pass to the ServiceCatalogue container.
+	 * Any secrets to pass to the CloudQuery container.
 	 *
 	 * @see https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.ContainerDefinitionOptions.html#secrets
 	 * @see https://repost.aws/knowledge-center/ecs-data-security-container-task
@@ -75,12 +77,14 @@ export interface ScheduledCloudqueryTaskProps
 	secrets?: Record<string, Secret>;
 
 	/**
-	 * Additional commands to run within the ServiceCatalogue container, executed first.
+	 * Any additional commands to run within the CloudQuery container.
+	 * These are executed first.
 	 */
 	additionalCommands?: string[];
 
 	/**
-	 * Extra security groups applied to the task for accessing resources such as RiffRaff
+	 * Any extra security groups applied to the task.
+	 * For example, a group allowing access to Riff-Raff.
 	 */
 	extraSecurityGroups?: ISecurityGroup[];
 

--- a/packages/cdk/lib/cloudquery/task.ts
+++ b/packages/cdk/lib/cloudquery/task.ts
@@ -220,7 +220,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 						// How many more of me are there?
 						`RUNNING=$(aws ecs list-tasks --cluster $ECS_CLUSTER --family $ECS_FAMILY | jq '.taskArns | length')`,
 
-						// Exit zero (successfull) if I'm the only one running
+						// Exit zero (successful) if I'm the only one running
 						'[[ ${RUNNING} > 1 ]] && exit 114 || exit 0',
 					].join(';'),
 				],

--- a/packages/cdk/lib/cloudquery/task.ts
+++ b/packages/cdk/lib/cloudquery/task.ts
@@ -83,10 +83,10 @@ export interface ScheduledCloudqueryTaskProps
 	additionalCommands?: string[];
 
 	/**
-	 * Any extra security groups applied to the task.
+	 * Any additional security groups applied to the task.
 	 * For example, a group allowing access to Riff-Raff.
 	 */
-	extraSecurityGroups?: ISecurityGroup[];
+	additionalSecurityGroups?: ISecurityGroup[];
 
 	/**
 	 * Run this task as a singleton?
@@ -122,7 +122,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			additionalCommands = [],
 			memoryLimitMiB = 512,
 			cpu,
-			extraSecurityGroups,
+			additionalSecurityGroups = [],
 			runAsSingleton,
 			cloudQueryApiKey,
 		} = props;
@@ -271,7 +271,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			scheduledFargateTaskDefinitionOptions: {
 				taskDefinition: task,
 			},
-			securityGroups: [dbAccess, ...(extraSecurityGroups ?? [])],
+			securityGroups: [dbAccess, ...additionalSecurityGroups],
 			enabled,
 		});
 

--- a/packages/cdk/lib/cloudquery/task.ts
+++ b/packages/cdk/lib/cloudquery/task.ts
@@ -202,6 +202,9 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 		});
 
 		if (runAsSingleton) {
+			const operationInProgress = 114;
+			const success = 0;
+
 			const singletonTask = task.addContainer(`${id}AwsCli`, {
 				image: Images.amazonLinux,
 				entryPoint: [''],
@@ -221,7 +224,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 						`RUNNING=$(aws ecs list-tasks --cluster $ECS_CLUSTER --family $ECS_FAMILY | jq '.taskArns | length')`,
 
 						// Exit zero (successful) if I'm the only one running
-						'[[ ${RUNNING} > 1 ]] && exit 114 || exit 0',
+						`[[ $\{RUNNING} > 1 ]] && exit ${operationInProgress} || exit ${success}`,
 					].join(';'),
 				],
 				logging: fireLensLogDriver,


### PR DESCRIPTION
## What does this change?
Following from #625, some (rather pedantic) refactors for correctness/consistency/simplicity:
- Reuse the Fire Lens log driver
- Update some doc strings to reference CloudQuery not Service Catalogue
- Rename `extraSecurityGroups` to `additionalSecurityGroups` to match the naming of `additionalCommands`
- Remove some [magic numbers](https://en.wikipedia.org/wiki/Magic_number_(programming))

## How has it been verified?
N/A. This is a no-op, as demonstrated by the CDK snapshots not changing.