### PR TITLE
Bump AWS Source plugin to 23.3.1

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ CQ_POSTGRES_DESTINATION=7.0.1
 CQ_POSTGRES_SOURCE=3.0.7
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-aws
-CQ_AWS=22.18.0
+CQ_AWS=23.3.1
 
 # See https://github.com/cloudquery/cloudquery/releases?q=plugins-source-github
 CQ_GITHUB=7.4.2

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -113,7 +113,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_costexplorer_*
   destinations:
@@ -746,7 +746,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_accessanalyzer_*
     - aws_securityhub_*
@@ -1345,7 +1345,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_organization*
   destinations:
@@ -6299,7 +6299,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_autoscaling_groups
   destinations:
@@ -6902,7 +6902,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_backup_protected_resources
     - aws_backup_vaults
@@ -7507,7 +7507,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_acm*
   destinations:
@@ -8140,7 +8140,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_cloudformation_*
   destinations:
@@ -8923,7 +8923,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_cloudwatch_alarms
   destinations:
@@ -9316,7 +9316,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_dynamodb*
   destinations:
@@ -9919,7 +9919,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_ec2_instances
     - aws_ec2_security_groups
@@ -10571,7 +10571,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_inspector_findings
     - aws_inspector2_findings
@@ -11385,7 +11385,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_elbv1_*
     - aws_elbv2_*
@@ -11989,7 +11989,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_rds_instances
     - aws_rds_clusters
@@ -12385,7 +12385,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_s3*
   destinations:
@@ -12988,7 +12988,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_*
   skip_tables:

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -35,7 +35,7 @@ describe('Config generation, and converting to YAML', () => {
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_s3_buckets
   destinations:
@@ -67,7 +67,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - '*'
   skip_tables:
@@ -104,7 +104,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v22.18.0
+  version: v23.3.1
   tables:
     - aws_accessanalyzer_analyzers
     - aws_accessanalyzer_analyzer_archive_rules


### PR DESCRIPTION
## What does this change?

Bumps AWS Source plugin to 23.3.1

## Why?

This fixes a bug with `aws_backup_vault_recovery_points` throwing errors which causes are alerts to go off.

https://github.com/cloudquery/cloudquery/pull/15781

## How has it been verified?

Ran `OrgWideEc2` task on CODE to verify cloudquery can still fetch the plugin as it was moved to the Cloudquery registry instead of Github.
