### PR TITLE
Fetch Galaxies and Snyk-Full-Project plugin from Github

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -5724,6 +5724,7 @@ spec:
 spec:
   name: guardian-snyk
   path: guardian/snyk-full-project
+  registry: github
   version: v0.1.1
   tables:
     - snyk_projects

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -2532,6 +2532,7 @@ spec:
 spec:
   name: galaxies
   path: guardian/galaxies
+  registry: github
   version: v1.1.0
   destinations:
     - postgresql

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -275,6 +275,7 @@ export function guardianSnykSourceConfig(
 		spec: {
 			name: 'guardian-snyk',
 			path: 'guardian/snyk-full-project',
+			registry: 'github',
 			version: `v${Versions.CloudquerySnykGuardian}`,
 			tables,
 			skip_tables: skipTables,

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -188,6 +188,7 @@ export function galaxiesSourceConfig(bucketName: string): CloudqueryConfig {
 		spec: {
 			name: 'galaxies',
 			path: 'guardian/galaxies',
+			registry: 'github',
 			version: `v${Versions.CloudqueryGalaxies}`,
 			destinations: ['postgresql'],
 			tables: [


### PR DESCRIPTION
## What does this change?

Source the Galaxies plugin from the `github` registry.

## Why?

Cloudquery started defaulting to their private registry in CQ CLI 4.0 https://github.com/cloudquery/cloudquery/releases/tag/cli-v4.0.0 which we updated to in https://github.com/guardian/service-catalogue/commit/60d08178a9073b9d0ea240ef13749c21c6b84776
