### PR TITLE
Alter "creation_date" and "deprecation_time" columns to TIMESTAMPS instead of TEXT and re-creates dependant views and functions

### DIFF
--- a/packages/common/prisma/migrations/20240102121400_aws_ec2_images_timestamp/migration.sql
+++ b/packages/common/prisma/migrations/20240102121400_aws_ec2_images_timestamp/migration.sql
@@ -1,0 +1,37 @@
+-- Drop old View and Function to avoid cascade issues
+DROP VIEW IF EXISTS view_old_ec2_instances;
+DROP FUNCTION IF EXISTS coalesce_dates(image_creation_time text, instance_launch_time timestamp);
+
+-- creation_date and deprecation_date were changed to TIMESTAMP in https://github.com/cloudquery/cloudquery/pull/15378
+TRUNCATE TABLE "aws_ec2_images";
+ALTER TABLE "aws_ec2_images" DROP COLUMN "creation_date";
+ALTER TABLE "aws_ec2_images" ADD COLUMN "creation_date" TIMESTAMP(6);
+
+ALTER TABLE "aws_ec2_images" DROP COLUMN "deprecation_time";
+ALTER TABLE "aws_ec2_images" ADD COLUMN "deprecation_time" TIMESTAMP(6);
+
+-- From ../20231026180015_view_old_ec2_instances/migration.sql
+CREATE OR REPLACE FUNCTION coalesce_dates(image_creation_time timestamp, instance_launch_time timestamp) RETURNS date
+    LANGUAGE SQL
+    IMMUTABLE
+RETURN coalesce(cast(image_creation_time as date), cast(instance_launch_time as date));
+
+create or replace view view_old_ec2_instances as
+select ac.id                                              as account_id
+     , ac.name                                            as account_name
+     , ec2.instance_id
+     , ec2.state ->> 'Name'                               as state
+     , ec2.tags ->> 'Stack'                               as stack
+     , ec2.tags ->> 'Stage'                               as stage
+     , ec2.tags ->> 'App'                                 as app
+     , ec2.tags ->> 'gu:repo'                             as repo
+     , ec2.region
+     , coalesce_dates(img.creation_date, ec2.launch_time) as creation_or_launch_time
+from aws_ec2_instances ec2
+         left join aws_ec2_images img on ec2.image_id = img.image_id
+         left join aws_accounts ac on ec2.account_id = ac.id
+where (
+        coalesce_dates(img.creation_date, ec2.launch_time) is null
+        or coalesce_dates(img.creation_date, ec2.launch_time) < NOW() - INTERVAL '30 days'
+    )
+  and ec2.state ->> 'Name' = 'running';

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -4675,8 +4675,6 @@ model aws_ec2_images {
   architecture          String?
   block_device_mappings Json?
   boot_mode             String?
-  creation_date         String?
-  deprecation_time      String?
   description           String?
   ena_support           Boolean?
   hypervisor            String?
@@ -4701,6 +4699,8 @@ model aws_ec2_images {
   tpm_support           String?
   usage_operation       String?
   virtualization_type   String?
+  creation_date         DateTime? @db.Timestamp(6)
+  deprecation_time      DateTime? @db.Timestamp(6)
 
   @@id([account_id, region, arn], map: "aws_ec2_images_cqpk")
   @@ignore


### PR DESCRIPTION
## What does this change?

Alter "creation_date" and "deprecation_time" columns to TIMESTAMPS instead of TEXT and re-creates dependant views and functions.

## Why?

These columns were changed to TIMESTAMP in https://github.com/cloudquery/cloudquery/pull/15378 . Our CloudQuery EC2 task is currently failing as it can't update the underlying table for these views and functions.

## How has it been verified?

Ran on CODE.

<img width="560" alt="image" src="https://github.com/guardian/service-catalogue/assets/21217225/771b2814-ffbc-40e8-921c-7a60174fdff5">

