### PR TITLE
feat: Adjust Prisma schema for Github languages

### DIFF
--- a/packages/common/prisma/migrations/20240103120510_add_vulnerability_tracking_column/migration.sql
+++ b/packages/common/prisma/migrations/20240103120510_add_vulnerability_tracking_column/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - Added the required column `vulnerability_tracking` to the `repocop_github_repository_rules` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "repocop_github_repository_rules" ADD COLUMN     "vulnerability_tracking" BOOLEAN NOT NULL;
+
+-- CreateTable
+CREATE TABLE "github_languages" (
+    "_cq_sync_time" TIMESTAMP(6),
+    "_cq_source_name" TEXT,
+    "_cq_id" UUID NOT NULL,
+    "_cq_parent_id" UUID,
+    "full_name" TEXT,
+    "name" TEXT,
+    "languages" TEXT[],
+
+    CONSTRAINT "github_languages_cqpk" PRIMARY KEY ("_cq_id")
+);

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -15848,6 +15848,16 @@ model cloudquery_table_frequency {
   @@ignore
 }
 
+model github_languages {
+  cq_sync_time   DateTime? @map("_cq_sync_time") @db.Timestamp(6)
+  cq_source_name String?   @map("_cq_source_name")
+  cq_id          String    @id(map: "github_languages_cqpk") @map("_cq_id") @db.Uuid
+  cq_parent_id   String?   @map("_cq_parent_id") @db.Uuid
+  full_name      String?
+  name           String?
+  languages      String[]
+}
+
 view view_repo_ownership {
   github_team_id     BigInt
   github_team_name   String

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -15764,15 +15764,16 @@ model snyk_reporting_latest_issues {
 }
 
 model repocop_github_repository_rules {
-  full_name           String   @unique
-  default_branch_name Boolean
-  branch_protection   Boolean
-  team_based_access   Boolean
-  admin_access        Boolean
-  archiving           Boolean?
-  topics              Boolean
-  contents            Boolean?
-  evaluated_on        DateTime
+  full_name              String   @unique
+  default_branch_name    Boolean
+  branch_protection      Boolean
+  team_based_access      Boolean
+  admin_access           Boolean
+  archiving              Boolean?
+  topics                 Boolean
+  contents               Boolean?
+  evaluated_on           DateTime
+  vulnerability_tracking Boolean
 }
 
 model galaxies_people_profile_info_table {

--- a/packages/repocop/src/remediations/branch-protector/branch-protection.test.ts
+++ b/packages/repocop/src/remediations/branch-protector/branch-protection.test.ts
@@ -34,6 +34,7 @@ describe('Team slugs should be findable for every team associated with a repo', 
 			archiving: true,
 			topics: true,
 			contents: true,
+			vulnerability_tracking: false,
 			evaluated_on: new Date(),
 		};
 
@@ -65,6 +66,7 @@ describe('Team slugs should be findable for every team associated with a repo', 
 			archiving: true,
 			topics: true,
 			contents: true,
+			vulnerability_tracking: false,
 			evaluated_on: new Date(),
 		};
 

--- a/packages/repocop/src/remediations/topics/topic-monitor-interactive.test.ts
+++ b/packages/repocop/src/remediations/topics/topic-monitor-interactive.test.ts
@@ -18,6 +18,7 @@ describe('findPotentialInteractives', () => {
 			archiving: true,
 			topics: true,
 			contents: true,
+			vulnerability_tracking: false,
 			evaluated_on: new Date(),
 		};
 

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -341,6 +341,8 @@ export function evaluateOneRepo(
 		archiving: isMaintained(repo),
 		topics: hasStatusTopic(repo),
 		contents: null,
+		// TODO Determine whether we're actually tracking vulnerabilities for repo
+		vulnerability_tracking: false,
 		evaluated_on: new Date(),
 	};
 }


### PR DESCRIPTION
Co-authored by @tjsilver @NovemberTang @akash1810 @chrislomaxjones.

## What does this change?

This PR primarily makes two schema changes:
1. Add the `github_languages` model to the Prisma schema file. This was done by running `npm -w cli start migrate -- --stage DEV`, which in turn runs [`prisma db pull`](https://www.prisma.io/docs/orm/reference/prisma-cli-reference#db-pull). Generating a new Prisma client then allows us to be begin consuming this model from within the application itself.
2. Add a boolean `vulnerability_tracking` column to the `repocop_github_repository_rules` table/Prisma model, and generate an associated migration (note this migration also contains a `CREATE TABLE github_languages ...` statement for the previous step). Since this field is non-nullable we currently hardcode any required usages as `false` in the source.

## Why?

The first change mentioned above allows us to read from the new `github_languages` table within the app itself, and the second change will allow us to begin recording vulnerability tracking against each repo. The next step is to actually implement this application logic.

## How has it been verified?

_TODO_
