### PR TITLE
Authenticate CQ github plugin with GitHub app locally

### DIFF
--- a/packages/cloudquery/dev-config/cloudquery.yaml
+++ b/packages/cloudquery/dev-config/cloudquery.yaml
@@ -18,7 +18,11 @@ spec:
   tables: ['*']
   destinations: ['postgresql']
   spec:
-    access_token: ${GITHUB_ACCESS_TOKEN}
+    app_auth:
+      - org: guardian
+        private_key_path: /private-key.pem
+        app_id: '${file:/app-id}'
+        installation_id: '${file:/installation-id}'
     repos: [
         # example devX owned repos
         'guardian/cdk',

--- a/packages/cloudquery/docker-compose.yaml
+++ b/packages/cloudquery/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
       CQ_AWS: ${CQ_AWS}
       CQ_GITHUB: ${CQ_GITHUB}
       CQ_SNYK: ${CQ_SNYK}
+      GITHUB_ACCESS_TOKEN: ${GITHUB_ACCESS_TOKEN}
       SNYK_TOKEN: ${SNYK_TOKEN}
       GALAXIES_BUCKET: ${GALAXIES_BUCKET}
     command: sync /dev-config.yaml --log-console --log-level info

--- a/packages/cloudquery/docker-compose.yaml
+++ b/packages/cloudquery/docker-compose.yaml
@@ -16,13 +16,15 @@ services:
     volumes:
       - ~/.aws/credentials:/.aws/credentials
       - ./dev-config/cloudquery.yaml:/dev-config.yaml
+      - ~/.gu/service_catalogue/app-id:/app-id
+      - ~/.gu/service_catalogue/installation-id:/installation-id
+      - ~/.gu/service_catalogue/private-key.pem:/private-key.pem
     environment:
       AWS_SHARED_CREDENTIALS_FILE: '/.aws/credentials'
       CQ_POSTGRES_DESTINATION: ${CQ_POSTGRES_DESTINATION}
       CQ_AWS: ${CQ_AWS}
       CQ_GITHUB: ${CQ_GITHUB}
       CQ_SNYK: ${CQ_SNYK}
-      GITHUB_ACCESS_TOKEN: ${GITHUB_ACCESS_TOKEN}
       SNYK_TOKEN: ${SNYK_TOKEN}
       GALAXIES_BUCKET: ${GALAXIES_BUCKET}
     command: sync /dev-config.yaml --log-console --log-level info

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -87,10 +87,11 @@ setup_environment() {
   snyk_info_url="https://docs.snyk.io/snyk-api-info/authentication-for-api"
 
   JSON_STRING=$(aws secretsmanager get-secret-value --secret-id /CODE/deploy/service-catalogue/github-credentials  --profile deployTools --region eu-west-1 --output text | awk '{print $4}')
-  APP_ID=$(echo "$JSON_STRING" | jq -r '."app-id"') #keys need to be quoted otherwise the hyphen is interpreted as a minus sign
-  INSTALLATION_ID=$(echo "$JSON_STRING" | jq -r '."installation-id"')
+echo "$JSON_STRING" | jq -rc '."app-id"' | xargs echo -n > "$local_env_file_dir"/app-id #keys need to be quoted otherwise the hyphen is interpreted as a minus sign
+echo "$JSON_STRING" | jq  -rc '."installation-id"' | xargs echo -n > "$local_env_file_dir"/installation-id
+  GITHUB_PRIVATE_KEY_PATH=$local_env_file_dir/private-key.pem
 
-echo "$JSON_STRING" | jq -r '."private-key"' | base64 --decode > "${local_env_file_dir}"/private-key.pem
+echo "$JSON_STRING" | jq -r '."private-key"' | base64 --decode > "$GITHUB_PRIVATE_KEY_PATH"
 
   token_text="
 # See $snyk_info_url
@@ -102,6 +103,7 @@ ANGHAMMARAD_SNS_ARN=${ANGHAMMARAD_SNS_ARN}
 INTERACTIVE_MONITOR_TOPIC_ARN=${INTERACTIVE_MONITOR_TOPIC_ARN}
 GITHUB_APP_ID=${APP_ID}
 GITHUB_INSTALLATION_ID=${INSTALLATION_ID}
+GITHUB_PRIVATE_KEY_PATH=${GITHUB_PRIVATE_KEY_PATH}
 "
 
   # Check if .env.local file exists in ~/.gu/service_catalogue/

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -84,13 +84,15 @@ setup_environment() {
 
   INTERACTIVE_MONITOR_TOPIC_ARN=$(aws sns list-topics --profile deployTools --region eu-west-1 --output text --query 'Topics[*]' | grep interactive-monitor-CODE)
 
-  github_info_url="https://github.com/settings/tokens?type=beta"
-
   snyk_info_url="https://docs.snyk.io/snyk-api-info/authentication-for-api"
 
-  token_text="# See $github_info_url
-GITHUB_ACCESS_TOKEN=
+  JSON_STRING=$(aws secretsmanager get-secret-value --secret-id /CODE/deploy/service-catalogue/github-credentials  --profile deployTools --region eu-west-1 --output text | awk '{print $4}')
+  APP_ID=$(echo "$JSON_STRING" | jq -r '."app-id"') #keys need to be quoted otherwise the hyphen is interpreted as a minus sign
+  INSTALLATION_ID=$(echo "$JSON_STRING" | jq -r '."installation-id"')
 
+echo "$JSON_STRING" | jq -r '."private-key"' | base64 --decode > "${local_env_file_dir}"/private-key.pem
+
+  token_text="
 # See $snyk_info_url
 SNYK_TOKEN="
   
@@ -98,6 +100,8 @@ SNYK_TOKEN="
 GALAXIES_BUCKET=${GALAXIES_BUCKET}
 ANGHAMMARAD_SNS_ARN=${ANGHAMMARAD_SNS_ARN}
 INTERACTIVE_MONITOR_TOPIC_ARN=${INTERACTIVE_MONITOR_TOPIC_ARN}
+GITHUB_APP_ID=${APP_ID}
+GITHUB_INSTALLATION_ID=${INSTALLATION_ID}
 "
 
   # Check if .env.local file exists in ~/.gu/service_catalogue/
@@ -123,19 +127,12 @@ INTERACTIVE_MONITOR_TOPIC_ARN=${INTERACTIVE_MONITOR_TOPIC_ARN}
     echo "No .env.local file found - creating it in $local_env_file_dir"
     mkdir -p "$HOME"/.gu/service_catalogue
     touch -a "$local_env_file_dir"/.env.local
-    echo "Adding Github and Snyk token names and required environment variables"
+    echo "Adding Snyk token name and required environment variables"
     echo "$token_text" >> "$local_env_file"
     echo "$env_var_text" >> "$local_env_file"
   fi
 
 source "$local_env_file"
-
-  # Check if GitHub token is set
-  if [ -z "$GITHUB_ACCESS_TOKEN" ]
-  then
-    echo -e "${yellow}Please create or retrieve a GitHub token${clear}.
-Visit ${cyan}$github_info_url${clear}, and add it to ${cyan}$local_env_file${clear}"
-  fi
 
   # Check if Snyk token is set
   if [ -z "$SNYK_TOKEN" ]


### PR DESCRIPTION
## What does this change?

CloudQuery's github plugin now uses the CODE auth

## Why?

This is part of the work to simplify project setup. Eventually, all GitHub plugins on CODE will use GitHub app auth so the user does not have to mess around setting up PATs with the right permisisons. Next steps are:

- Move github-languages plugin to GitHub app only auth
- Use snyk equivalent instead of requiring users to get their own tokens

The snyk work will significantly reduce the chance of accidents, as snyk API tokens are always scoped to the permissions of the user, which in the case of DevX engineers, is quite broad.

## How has it been verified?

Tested locally and verified that we are able to collect data

## Additional notes/concerns

**NB:** users will need to delete their `.env.local` and rerun the setup script in order to run CloudQuery locally. Make sure to retain a copy your GitHub and Snyk tokens first.

With several people using the GitHub token, there's a potential concern of us being rate limited. I don't think this is a significant issue as

- The CODE infrastructure only runs once a month
- Cloudquery DEV has been set up locally in such a way that it's only gathering information for four repositories, so we are making about 1/1000 of the number of calls we would be on PROD or CODE
