### PR TITLE
Give OrgWideEc2 task 1GB of memory

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -9972,7 +9972,7 @@ spec:
             "Environment": [
               {
                 "Name": "GOMEMLIMIT",
-                "Value": "409MiB",
+                "Value": "819MiB",
               },
             ],
             "Essential": true,
@@ -10123,7 +10123,7 @@ spec:
           ],
         },
         "Family": "ServiceCatalogueCloudquerySourceOrgWideEc2TaskDefinition93B6B037",
-        "Memory": "512",
+        "Memory": "1024",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -224,6 +224,7 @@ export function addCloudqueryEcsCluster(
 			}),
 			policies: [listOrgsPolicy, cloudqueryAccess('*')],
 			runAsSingleton: true,
+			memoryLimitMiB: 1024,
 		},
 	];
 


### PR DESCRIPTION
## What does this change?

Gives OrgWideEc2 1GB of memory (up from 512MB)

## Why?

This task was ocassionally running out of memory in PROD

<img width="635" alt="image" src="https://github.com/guardian/service-catalogue/assets/21217225/92723a9a-69b6-4d25-85f0-df58d0dd7196">
