### PR TITLE
Retrieve CloudQuery API key for local development

### DIFF
--- a/packages/cloudquery/dev-config/cloudquery.yaml
+++ b/packages/cloudquery/dev-config/cloudquery.yaml
@@ -116,6 +116,7 @@ spec:
     - snyk_projects
   destinations:
     - postgresql
+  registry: github
   spec:
     api_key: ${SNYK_TOKEN}
 ---
@@ -128,6 +129,7 @@ spec:
     - postgresql
   tables:
     - galaxies_*
+  registry: github
   spec:
     bucket: ${GALAXIES_BUCKET}
 ---

--- a/packages/cloudquery/docker-compose.yaml
+++ b/packages/cloudquery/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
       GITHUB_ACCESS_TOKEN: ${GITHUB_ACCESS_TOKEN}
       SNYK_TOKEN: ${SNYK_TOKEN}
       GALAXIES_BUCKET: ${GALAXIES_BUCKET}
+      CLOUDQUERY_API_KEY: ${CLOUDQUERY_API_KEY}
     command: sync /dev-config.yaml --log-console --log-level info
   grafana:
     image: grafana/grafana-oss:9.4.7

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -83,6 +83,13 @@ setup_environment() {
   ANGHAMMARAD_SNS_ARN=$(aws ssm get-parameter --name /account/services/anghammarad.topic.arn --profile deployTools --region eu-west-1 | jq '.Parameter.Value' | tr -d '"')
 
   INTERACTIVE_MONITOR_TOPIC_ARN=$(aws sns list-topics --profile deployTools --region eu-west-1 --output text --query 'Topics[*]' | grep interactive-monitor-CODE)
+
+  CLOUDQUERY_API_KEY=$(
+    aws secretsmanager get-secret-value \
+    --secret-id /CODE/deploy/service-catalogue/cloudquery-api-key \
+    --profile deployTools --region eu-west-1 | jq '.SecretString | fromjson["api-key"]'
+  )
+
   github_info_url="https://github.com/settings/tokens?type=beta"
   snyk_info_url="https://docs.snyk.io/snyk-api-info/authentication-for-api"
 
@@ -104,6 +111,7 @@ GALAXIES_BUCKET=${GALAXIES_BUCKET}
 ANGHAMMARAD_SNS_ARN=${ANGHAMMARAD_SNS_ARN}
 INTERACTIVE_MONITOR_TOPIC_ARN=${INTERACTIVE_MONITOR_TOPIC_ARN}
 GITHUB_PRIVATE_KEY_PATH=${GITHUB_PRIVATE_KEY_PATH}
+CLOUDQUERY_API_KEY=${CLOUDQUERY_API_KEY}
 "
 
   # Check if .env.local file exists in ~/.gu/service_catalogue/


### PR DESCRIPTION
## What does this change?

As part of the setup script, retrieve a `CLOUDQUERY_API_KEY` from AWS Secrets Manager, and append it to the `.env.local` file.`docker-compose.yml` is changed to make it available within the CloudQuery container itself.

As a small drive-by change, I've also added `registry: github`  to plugins that produced the following errors:
```
ERR exiting with error error="failed to download plugin source guardian/galaxies@v1.1.0: plugin version not found. If you're trying to use a private plugin you'll need to run `cloudquery login` first. Hint: make sure to use the latest plugin version from hub.cloudquery.io or to keep using an outdated version add `registry: github` to your configuration" module=cli
```

## Why?

Some of the CloudQuery plugins used for local development require a `CLOUDQUERY_API_KEY` to run. This PR retrieves a key from Secrets Manager, for use locally.

## How has it been verified?

I've deleted my `.env.local` file and regenerated it using `scripts/setup.sh`. This successfully populates the `CLOUDQUERY_API_KEY` environment variable, and CloudQuery succeeds in populating the tables locally.
