### PR TITLE
Do not require snyk token for setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -91,7 +91,7 @@ setup_environment() {
   CLOUDQUERY_API_KEY=$(
     aws secretsmanager get-secret-value \
     --secret-id /CODE/deploy/service-catalogue/cloudquery-api-key \
-    --profile deployTools --region eu-west-1 | jq '.SecretString | fromjson["api-key"]'
+    --profile "$PROFILE" --region "$REGION" | jq '.SecretString | fromjson["api-key"]'
   )
 
   github_info_url="https://github.com/settings/tokens?type=beta"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,8 +8,6 @@ clear='\033[0m'
 yellow='\033[1;33m'
 cyan='\033[0;36m'
 
-PROFILE=deployTools
-REGION=eu-west-1
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=$(realpath "${DIR}/..")
 STEP_COUNT=0
@@ -159,7 +157,7 @@ setup_hook() {
 setup_hook pre-commit
 check_node_version
 install_dependencies
-check_credentials "$PROFILE"
-setup_environment "$PROFILE" "$REGION"
+check_credentials deployTools
+setup_environment deployTools eu-west-1
 
 echo -e "\n${cyan}Setup complete${clear} ✅"


### PR DESCRIPTION
## What does this change?

This is a follow up from #642

Pulls the CODE snyk credentials from secrets manager during repo setup

## Why?

The user no longer needs to set up their own snyk token.
The token provided has the correctly scoped permissions. Snyk user tokens are given the same level of permissions as the respective users, and this cannot be changed. Using the service account token closes this security loophole

## How has it been verified?

Verified that local setup succeeds
