### PR TITLE
Use Github Languages table to determine dependency tracking 

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -10,6 +10,7 @@ import {
 	getRepoOwnership,
 	getRepositories,
 	getRepositoryBranches,
+	getRepositoryLanguages,
 	getSnykProjects,
 	getStacks,
 	getTeamRepositories,
@@ -49,22 +50,27 @@ export async function main() {
 	);
 	const branches = await getRepositoryBranches(prisma, unarchivedRepos);
 	const repoTeams = await getTeamRepositories(prisma);
+	const repoLanguages = await getRepositoryLanguages(prisma);
 	const nonPlaygroundStacks: AwsCloudFormationStack[] = (
 		await getStacks(prisma)
 	).filter((s) => s.tags.Stack !== 'playground');
 	const snykProjects = await getSnykProjects(prisma);
 	const evaluatedRepos: repocop_github_repository_rules[] =
-		evaluateRepositories(unarchivedRepos, branches, repoTeams);
+		evaluateRepositories(
+			unarchivedRepos,
+			branches,
+			repoTeams,
+			repoLanguages,
+			snykProjects,
+		);
 
 	const octokit = await stageAwareOctokit(config.stage);
 
 	testExperimentalRepocopFeatures(
-		octokit,
 		evaluatedRepos,
 		unarchivedRepos,
 		archivedRepos,
 		nonPlaygroundStacks,
-		snykProjects,
 	);
 
 	await writeEvaluationTable(evaluatedRepos, prisma);

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -1,4 +1,5 @@
 import type {
+	github_languages,
 	github_repository_branches,
 	PrismaClient,
 	snyk_projects,
@@ -99,4 +100,10 @@ export async function getSnykProjects(
 	client: PrismaClient,
 ): Promise<snyk_projects[]> {
 	return await client.snyk_projects.findMany({});
+}
+
+export async function getRepositoryLanguages(
+	client: PrismaClient,
+): Promise<github_languages[]> {
+	return await client.github_languages.findMany({});
 }

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -148,7 +148,15 @@ export function hasDependencyTracking(
 			(repoLanguage) => repoLanguage.full_name === repo.full_name,
 		)?.languages ?? [];
 
-	const ignoredLanguages = ['HTML', 'CSS', 'Shell'];
+	const ignoredLanguages = [
+		'HTML',
+		'CSS',
+		'Shell',
+		'Jupyter Notebook',
+		'Makefile',
+		'Dockerfile',
+		'PLpgSQL',
+	];
 
 	const commonSupportedLanguages = [
 		'C#',

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -143,7 +143,6 @@ export function hasDependencyTracking(
 		return true;
 	}
 
-	//TODO: test to make sure [] => true
 	const languages: string[] =
 		repoLanguages.find(
 			(repoLanguage) => repoLanguage.full_name === repo.full_name,
@@ -198,9 +197,6 @@ export function hasDependencyTracking(
 
 	const repoIsOnSnyk = !!matchingSnykProject;
 
-	// TODO: Sort out logging for dep tracking
-	// console.log(`${repo.name} has valid dependency tracking: `, isVerified);
-
 	if (repoIsOnSnyk) {
 		const containsOnlySnykSupportedLanguages = languages.every((language) =>
 			supportedSnykLanguages.includes(language),
@@ -210,6 +206,13 @@ export function hasDependencyTracking(
 		const containsOnlyDependabotSupportedLanguages = languages.every(
 			(language) => supportedDependabotLanguages.includes(language),
 		);
+		if (!containsOnlyDependabotSupportedLanguages) {
+			console.log(
+				`${repo.name} does not have valid dependency tracking: `,
+				languages,
+			);
+		}
+
 		return containsOnlyDependabotSupportedLanguages;
 	}
 }

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -148,8 +148,6 @@ export function hasDependencyTracking(
 			(repoLanguage) => repoLanguage.full_name === repo.full_name,
 		)?.languages ?? [];
 
-	console.log(`${repo.name} has languages: `, languages);
-
 	const ignoredLanguages = ['HTML', 'CSS', 'Shell'];
 
 	const commonSupportedLanguages = [


### PR DESCRIPTION
## What does this change?

Make dependency tracking validation a feature of repocop, and remove it from the experiments section.

## Why?

As of #639 , we are able to pull repo languages directly from cloudquery, meaning we don't have to make a request to octokit for every one. As a result, we are able to quickly evaluate whether or not a repository's languages are supported by our respective vulnerability trackers. This means we can count the number of repos that are not correctly integrated with a tracker, and fix this issue.

## How has it been verified?

~TODO: Deploy to CODE and check via grafana.~

This PR has been deployed to CODE and the vulnerability tracking field is now being correctly set in the repocop table.
