### PR TITLE
Create test PRs for Snyk remediation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9974,6 +9974,27 @@
         "node": ">= 18"
       }
     },
+    "node_modules/octokit-plugin-create-pull-request": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/octokit-plugin-create-pull-request/-/octokit-plugin-create-pull-request-5.1.1.tgz",
+      "integrity": "sha512-kHbo3bB9pkzQGNVJPTv6hkpFbXL/s2tbrQm+7uqtS46C6c6R/BDgFvk1nEPWBczXvftwinb33pLWXTKH10Rx1Q==",
+      "dependencies": {
+        "@octokit/types": "^8.0.0"
+      }
+    },
+    "node_modules/octokit-plugin-create-pull-request/node_modules/@octokit/openapi-types": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
+      "integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw=="
+    },
+    "node_modules/octokit-plugin-create-pull-request/node_modules/@octokit/types": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-8.2.1.tgz",
+      "integrity": "sha512-8oWMUji8be66q2B9PmEIUyQm00VPDPun07umUWSaCwxmeaquFBro4Hcc3ruVoDo3zkQyZBlRvhIMEYS3pBhanw==",
+      "dependencies": {
+        "@octokit/openapi-types": "^14.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -12507,6 +12528,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-sns": "^3.484.0",
+        "octokit-plugin-create-pull-request": "^5.1.1",
         "ts-markdown": "^1.0.0",
         "yaml": "^2.3.4"
       },

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -12,6 +12,7 @@
 	"dependencies": {
 		"@aws-sdk/client-sns": "^3.484.0",
 		"ts-markdown": "^1.0.0",
+		"octokit-plugin-create-pull-request": "^5.1.1",
 		"yaml": "^2.3.4"
 	}
 }

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -47,6 +47,11 @@ export interface Config extends PrismaConfig {
 	 * Flag to enable branch protection.
 	 */
 	branchProtectionEnabled: boolean;
+
+	/**
+	 * Flag to enable creation of Snyk integration PRs
+	 */
+	snykIntegrationPREnabled: boolean;
 }
 
 export async function getConfig(): Promise<Config> {
@@ -73,5 +78,7 @@ export async function getConfig(): Promise<Config> {
 		],
 		interactivesCount: Number(getEnvOrThrow('INTERACTIVES_COUNT')),
 		branchProtectionEnabled: process.env.BRANCH_PROTECTION_ENABLED === 'true',
+		snykIntegrationPREnabled:
+			process.env.SNYK_INTEGRATION_PR_ENABLED === 'true',
 	};
 }

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -67,6 +67,7 @@ export async function main() {
 	const octokit = await stageAwareOctokit(config.stage);
 
 	await testExperimentalRepocopFeatures(
+		config,
 		evaluatedRepos,
 		unarchivedRepos,
 		archivedRepos,

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -66,11 +66,12 @@ export async function main() {
 
 	const octokit = await stageAwareOctokit(config.stage);
 
-	testExperimentalRepocopFeatures(
+	await testExperimentalRepocopFeatures(
 		evaluatedRepos,
 		unarchivedRepos,
 		archivedRepos,
 		nonPlaygroundStacks,
+		octokit,
 	);
 
 	await writeEvaluationTable(evaluatedRepos, prisma);

--- a/packages/repocop/src/remediations/snyk-integrator/create-pull-request.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/create-pull-request.ts
@@ -1,7 +1,5 @@
-import { randomBytes } from 'crypto';
 import type { Octokit } from 'octokit';
 import { composeCreatePullRequest } from 'octokit-plugin-create-pull-request';
-import { createYaml, generatePr } from './snyk-integrator';
 
 interface CreatePullRequestOptions {
 	fullRepoName: string;
@@ -37,31 +35,5 @@ export async function createPullRequest(
 			commit: commitMessage,
 			files: files,
 		})),
-	});
-}
-
-export async function createSnykPullRequest(
-	octokit: Octokit,
-	fullRepoName: string,
-	repoLanguages: string[],
-) {
-	// Introduce a random suffix to allow the same PR to be raised multiple times
-	// Useful for testing, but may be less useful in production
-	const branchName = `integrate-snyk-${randomBytes(8).toString('hex')}`;
-	const snykFileContents = createYaml(repoLanguages);
-	const [title, body] = generatePr(repoLanguages, branchName, fullRepoName);
-	return await createPullRequest(octokit, {
-		fullRepoName,
-		title,
-		body,
-		branchName,
-		changes: [
-			{
-				commitMessage: 'Add Snyk.yml',
-				files: {
-					'snyk.yml': snykFileContents,
-				},
-			},
-		],
 	});
 }

--- a/packages/repocop/src/remediations/snyk-integrator/create-pull-request.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/create-pull-request.ts
@@ -1,0 +1,77 @@
+import { randomBytes } from 'crypto';
+import type { Octokit } from 'octokit';
+import { composeCreatePullRequest } from 'octokit-plugin-create-pull-request';
+import { createYaml } from './snyk-integrator';
+
+interface CreatePullRequestOptions {
+	repoName: string;
+	title: string;
+	body: string;
+	branchName: string;
+	baseBranch?: string;
+	changes: Array<{
+		commitMessage: string;
+		files: Record<string, string>;
+	}>;
+}
+
+export async function createPullRequest(
+	octokit: Octokit,
+	{
+		repoName,
+		title,
+		body,
+		branchName,
+		baseBranch = 'main',
+		changes,
+	}: CreatePullRequestOptions,
+) {
+	return await composeCreatePullRequest(octokit, {
+		owner: 'guardian',
+		repo: repoName,
+		title,
+		body,
+		head: branchName,
+		base: baseBranch,
+		changes: changes.map(({ commitMessage, files }) => ({
+			commit: commitMessage,
+			files: files,
+		})),
+	});
+}
+
+function createPullRequestTitle(languages: string[]) {
+	return `Integrate ${languages.join(', ')} code with Snyk`;
+}
+
+function createPullRequestBody(languages: string[]) {
+	// TODO Use actual pull request body
+	return `Example PR body (languages: ${languages.join(', ')})`;
+}
+
+export async function createSnykPullRequest(
+	octokit: Octokit,
+	repoName: string,
+	languages: string[],
+) {
+	// Introduce a random suffix to allow the same PR to be raised multiple times
+	// Useful for testing, but may be less useful in production
+	const branchName = `integrate-snyk-${randomBytes(8).toString('hex')}`;
+	const snykFileContents = createYaml(languages);
+	const title = createPullRequestTitle(languages);
+	const body = createPullRequestBody(languages);
+	return await createPullRequest(octokit, {
+		repoName,
+		title,
+		body,
+		branchName,
+		changes: [
+			{
+				commitMessage: 'Add Snyk.yml',
+				files: {
+					'snyk.yml': snykFileContents,
+				},
+			},
+		],
+	});
+}

--- a/packages/repocop/src/remediations/snyk-integrator/create-pull-request.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/create-pull-request.ts
@@ -2,7 +2,7 @@ import type { Octokit } from 'octokit';
 import { composeCreatePullRequest } from 'octokit-plugin-create-pull-request';
 
 interface CreatePullRequestOptions {
-	fullRepoName: string;
+	repoName: string;
 	title: string;
 	body: string;
 	branchName: string;
@@ -16,7 +16,7 @@ interface CreatePullRequestOptions {
 export async function createPullRequest(
 	octokit: Octokit,
 	{
-		fullRepoName,
+		repoName,
 		title,
 		body,
 		branchName,
@@ -26,7 +26,7 @@ export async function createPullRequest(
 ) {
 	return await composeCreatePullRequest(octokit, {
 		owner: 'guardian',
-		repo: fullRepoName,
+		repo: repoName,
 		title,
 		body,
 		head: branchName,

--- a/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.test.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.test.ts
@@ -69,6 +69,8 @@ describe('A generated PR', () => {
 	});
 	it('Should create a body with the correct GitHub CLI command', () => {
 		const body = generatePr(['Scala'], 'main', 'myRepo')[1];
-		expect(body).toContain('gh workflow run snyk.yml --ref main --repo myRepo');
+		expect(body).toContain(
+			'gh workflow run snyk.yml --ref main --repo guardian/myRepo',
+		);
 	});
 });

--- a/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.test.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.test.ts
@@ -69,6 +69,6 @@ describe('A generated PR', () => {
 	});
 	it('Should create a body with the correct GitHub CLI command', () => {
 		const body = generatePr(['Scala'], 'main', 'myRepo')[1];
-		expect(body).toContain('gh workflow run ci.yml --ref main --repo myRepo');
+		expect(body).toContain('gh workflow run snyk.yml --ref main --repo myRepo');
 	});
 });

--- a/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.ts
@@ -74,7 +74,7 @@ function checklist(items: string[]): string {
 	return items.map((item) => `- [ ] ${item}`).join('\n');
 }
 
-function generatePrBody(branchName: string, fullRepoName: string): string {
+function generatePrBody(branchName: string, repoName: string): string {
 	const body = [
 		h2('What does this change?'),
 		p(
@@ -99,7 +99,7 @@ function generatePrBody(branchName: string, fullRepoName: string): string {
 		]),
 		h2('How do I check this works?'),
 		checklist([
-			`Run the action via the GitHub CLI \`gh workflow run snyk.yml --ref ${branchName} --repo ${fullRepoName}\``,
+			`Run the action via the GitHub CLI \`gh workflow run snyk.yml --ref ${branchName} --repo guardian/${repoName}\``,
 			`View the action output, verify it has generated one project per dependency manifest.`,
 		]),
 	];
@@ -109,7 +109,7 @@ function generatePrBody(branchName: string, fullRepoName: string): string {
 export function generatePr(
 	repoLanguages: string[],
 	branch: string,
-	fullRepoName: string,
+	repoName: string,
 ): [string, string] {
 	const workflowLanguages = [
 		'Scala',
@@ -129,21 +129,21 @@ export function generatePr(
 	}
 
 	const header = generatePrHeader(workflowSupportedLanguages);
-	const body = generatePrBody(branch, fullRepoName);
+	const body = generatePrBody(branch, repoName);
 
 	return [header, body];
 }
 
 export async function createSnykPullRequest(
 	octokit: Octokit,
-	fullRepoName: string,
+	repoName: string,
 	branchName: string,
 	repoLanguages: string[],
 ) {
 	const snykFileContents = createYaml(repoLanguages);
-	const [title, body] = generatePr(repoLanguages, branchName, fullRepoName);
+	const [title, body] = generatePr(repoLanguages, branchName, repoName);
 	return await createPullRequest(octokit, {
-		fullRepoName,
+		repoName,
 		title,
 		body,
 		branchName,

--- a/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.ts
@@ -151,7 +151,7 @@ export async function createSnykPullRequest(
 			{
 				commitMessage: 'Add Snyk.yml',
 				files: {
-					'snyk.yml': snykFileContents,
+					'.github/workflows/snyk.yml': snykFileContents,
 				},
 			},
 		],

--- a/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.ts
@@ -99,7 +99,7 @@ function generatePrBody(branchName: string, fullRepoName: string): string {
 		]),
 		h2('How do I check this works?'),
 		checklist([
-			`Run the action via the GitHub CLI \`gh workflow run ci.yml --ref ${branchName} --repo ${fullRepoName}\``,
+			`Run the action via the GitHub CLI \`gh workflow run snyk.yml --ref ${branchName} --repo ${fullRepoName}\``,
 			`View the action output, verify it has generated one project per dependency manifest.`,
 		]),
 	];

--- a/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from 'node:crypto';
 import type { Octokit } from 'octokit';
 import { h2, p, tsMarkdown } from 'ts-markdown';
 import { stringify } from 'yaml';
@@ -138,11 +137,9 @@ export function generatePr(
 export async function createSnykPullRequest(
 	octokit: Octokit,
 	fullRepoName: string,
+	branchName: string,
 	repoLanguages: string[],
 ) {
-	// Introduce a random suffix to allow the same PR to be raised multiple times
-	// Useful for testing, but may be less useful in production
-	const branchName = `integrate-snyk-${randomBytes(8).toString('hex')}`;
 	const snykFileContents = createYaml(repoLanguages);
 	const [title, body] = generatePr(repoLanguages, branchName, fullRepoName);
 	return await createPullRequest(octokit, {

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -300,8 +300,6 @@ export async function testExperimentalRepocopFeatures(
 	nonPlaygroundStacks: AwsCloudFormationStack[],
 	octokit: Octokit,
 ) {
-	const { stage } = config;
-
 	const unmaintinedReposCount = evaluatedRepos.filter(
 		(repo) => repo.archiving === false,
 	).length;
@@ -327,7 +325,7 @@ export async function testExperimentalRepocopFeatures(
 	console.log(createYaml(['Scala', 'Python', 'Shell']));
 	console.log(createYaml(['Go', 'Dockerfile', 'TypeScript']));
 
-	if (stage === 'PROD') {
+	if (config.snykIntegrationPREnabled) {
 		console.log('Creating a test Snyk Pull Request against test-repocop-prs');
 		const response = await createSnykPullRequest(
 			octokit,
@@ -338,6 +336,10 @@ export async function testExperimentalRepocopFeatures(
 			['Scala', 'Python', 'Shell'],
 		);
 		console.log('Pull request successfully created:', response?.data.html_url);
+	} else {
+		console.log(
+			'Skipping creating a test Snyk Pull Request (feature is not enabled)',
+		);
 	}
 }
 

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -5,8 +5,10 @@ import type {
 	snyk_projects,
 } from '@prisma/client';
 import type { Octokit } from 'octokit';
-import { createSnykPullRequest } from '../remediations/snyk-integrator/create-pull-request';
-import { createYaml } from '../remediations/snyk-integrator/snyk-integrator';
+import {
+	createSnykPullRequest,
+	createYaml,
+} from '../remediations/snyk-integrator/snyk-integrator';
 import type {
 	AwsCloudFormationStack,
 	RepoAndStack,

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -331,7 +331,7 @@ export async function testExperimentalRepocopFeatures(
 		console.log('Creating a test Snyk Pull Request against test-repocop-prs');
 		const response = await createSnykPullRequest(
 			octokit,
-			'test-repocop-prs',
+			'guardian/test-repocop-prs',
 			// Introduce a random suffix to allow the same PR to be raised multiple times
 			// Useful for testing, but may be less useful in production
 			`integrate-snyk-${randomBytes(8).toString('hex')}`,

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import type {
 	github_languages,
 	github_repository_branches,
@@ -322,12 +323,15 @@ export async function testExperimentalRepocopFeatures(
 	console.log(createYaml(['Scala', 'Python', 'Shell']));
 	console.log(createYaml(['Go', 'Dockerfile', 'TypeScript']));
 
-	console.log('Creating a test pull request');
-	const response = await createSnykPullRequest(octokit, 'test-repocop-prs', [
-		'Scala',
-		'Python',
-		'Shell',
-	]);
+	console.log('Creating a test Snyk Pull Request against test-repocop-prs');
+	const response = await createSnykPullRequest(
+		octokit,
+		'test-repocop-prs',
+		// Introduce a random suffix to allow the same PR to be raised multiple times
+		// Useful for testing, but may be less useful in production
+		`integrate-snyk-${randomBytes(8).toString('hex')}`,
+		['Scala', 'Python', 'Shell'],
+	);
 	console.log('Pull request successfully created:', response?.data.html_url);
 }
 

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -4,6 +4,8 @@ import type {
 	repocop_github_repository_rules,
 	snyk_projects,
 } from '@prisma/client';
+import type { Octokit } from 'octokit';
+import { createSnykPullRequest } from '../remediations/snyk-integrator/create-pull-request';
 import { createYaml } from '../remediations/snyk-integrator/snyk-integrator';
 import type {
 	AwsCloudFormationStack,
@@ -286,11 +288,12 @@ function findArchivedReposWithStacks(
 	return archivedReposWithPotentialStacks;
 }
 
-export function testExperimentalRepocopFeatures(
+export async function testExperimentalRepocopFeatures(
 	evaluatedRepos: repocop_github_repository_rules[],
 	unarchivedRepos: Repository[],
 	archivedRepos: Repository[],
 	nonPlaygroundStacks: AwsCloudFormationStack[],
+	octokit: Octokit,
 ) {
 	const unmaintinedReposCount = evaluatedRepos.filter(
 		(repo) => repo.archiving === false,
@@ -316,6 +319,14 @@ export function testExperimentalRepocopFeatures(
 	console.log('Testing snyk.yml generation');
 	console.log(createYaml(['Scala', 'Python', 'Shell']));
 	console.log(createYaml(['Go', 'Dockerfile', 'TypeScript']));
+
+	console.log('Creating a test pull request');
+	const response = await createSnykPullRequest(octokit, 'test-repocop-prs', [
+		'Scala',
+		'Python',
+		'Shell',
+	]);
+	console.log('Pull request successfully created:', response?.data.html_url);
 }
 
 /**

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -329,7 +329,7 @@ export async function testExperimentalRepocopFeatures(
 		console.log('Creating a test Snyk Pull Request against test-repocop-prs');
 		const response = await createSnykPullRequest(
 			octokit,
-			'guardian/test-repocop-prs',
+			'test-repocop-prs',
 			// Introduce a random suffix to allow the same PR to be raised multiple times
 			// Useful for testing, but may be less useful in production
 			`integrate-snyk-${randomBytes(8).toString('hex')}`,


### PR DESCRIPTION
## What does this change?

Add the ability to create pull requests against repositories within the Guardian organisation:

- This change is currently introduced as an experimental feature, and is hardcoded to create a pull request against [test-repocop-prs](https://github.com/guardian/test-repocop-prs/pulls) with a hardcoded set of languages.
- It uses logic introduced in #656 to generate the PR title/body.
- It uses the [`octokit-create-pull-request`](https://www.npmjs.com/package/octokit-plugin-create-pull-request) package (thanks for pointer @NovemberTang) to handle the creation of the pull request itself. I've wrapped this in a small wrapper, so we could drop this dependency in the future with minimal refactoring of the caller. This package can be used as an Octokit plugin, although this seemed more fiddly than just passing an instance of Octokit in directly, hence the usage of `composeCreatePullRequest`.

## Why?

This will allow us to begin automatically raising pull requests against repositories that require Snyk integration.

## How has it been verified?

I've tested this using my own Github PAT locally and am able to create PRs against [test-repocop-prs](https://github.com/guardian/test-repocop-prs/pulls).

See https://github.com/guardian/test-repocop-prs/pull/8 for an example of a successful invocation. For now, we're hiding the logic behind a feature flag.