### PR TITLE
Fix Snyk Python options

### DIFF
--- a/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.test.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.test.ts
@@ -36,6 +36,8 @@ jobs:
       ORG: <SNYK_ORG_ID>
       SKIP_PYTHON: false
       PYTHON_VERSION: <MAJOR.MINOR>
+	  PIP_REQUIREMENTS_FILES: <PATH_TO_REQUIREMENTS> # Space separated list of requirements files. Only use one of this or PIPFILES
+      PIPFILES: <PATH_TO_PIPFILES> # Space separated list of pipfiles. Only use one of this or PIP_REQUIREMENTS_FILES
       SKIP_GO: false
     secrets:
       SNYK_TOKEN: ${'$'}{{ secrets.SNYK_TOKEN }}

--- a/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.test.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.test.ts
@@ -23,26 +23,18 @@ jobs:
 	});
 	it('should not skip python and go if they are provided', () => {
 		const yaml = createYaml(['Scala', 'TypeScript', 'Python', 'Go']);
-		const result = String.raw`name: Snyk
-on:
-  push:
-    branches:
-      - main
-  workflow_dispatch: 
-jobs:
-  security:
-    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
-    with:
-      ORG: <SNYK_ORG_ID>
-      SKIP_PYTHON: false
-      PYTHON_VERSION: <MAJOR.MINOR>
-	  PIP_REQUIREMENTS_FILES: <PATH_TO_REQUIREMENTS> # Space separated list of requirements files. Only use one of this or PIPFILES
-      PIPFILES: <PATH_TO_PIPFILES> # Space separated list of pipfiles. Only use one of this or PIP_REQUIREMENTS_FILES
-      SKIP_GO: false
-    secrets:
-      SNYK_TOKEN: ${'$'}{{ secrets.SNYK_TOKEN }}
-`;
-		expect(yaml).toEqual(result);
+
+		const expectedInputKeys = [
+			'ORG',
+			'SKIP_PYTHON',
+			'PYTHON_VERSION',
+			'PIP_REQUIREMENTS_FILES',
+			'PIPFILES',
+			'SKIP_GO',
+		];
+		expectedInputKeys.forEach((key) => {
+			expect(yaml).toContain(key);
+		});
 	});
 });
 

--- a/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.test.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.test.ts
@@ -2,12 +2,13 @@ import { createYaml, generatePr } from './snyk-integrator';
 
 describe('createYaml', () => {
 	it('should skip node and sbt if no languages are provided', () => {
-		const yaml = createYaml([]);
+		const yaml = createYaml([], 'branch');
 		const result = String.raw`name: Snyk
 on:
   push:
     branches:
       - main
+      - branch
   workflow_dispatch: 
 jobs:
   security:
@@ -22,7 +23,7 @@ jobs:
 		expect(yaml).toEqual(result);
 	});
 	it('should not skip python and go if they are provided', () => {
-		const yaml = createYaml(['Scala', 'TypeScript', 'Python', 'Go']);
+		const yaml = createYaml(['Scala', 'TypeScript', 'Python', 'Go'], 'branch');
 
 		const expectedInputKeys = [
 			'ORG',

--- a/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.ts
@@ -31,7 +31,7 @@ interface SnykSchema {
 	};
 }
 
-export function createYaml(languages: string[]): string {
+export function createYaml(languages: string[], prBranch: string): string {
 	const inputs: SnykInputs = {
 		ORG: '<SNYK_ORG_ID>',
 		SKIP_SBT: languages.includes('Scala') ? undefined : true,
@@ -54,7 +54,7 @@ export function createYaml(languages: string[]): string {
 		name: 'Snyk',
 		on: {
 			push: {
-				branches: ['main'],
+				branches: ['main', prBranch],
 			},
 			workflow_dispatch: {}, //There isn't an elegant way to do this in TypeScript, so we'll remove the {} at the end
 		},

--- a/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.ts
@@ -69,7 +69,9 @@ export function createYaml(languages: string[]): string {
 		},
 	};
 
-	return stringify(snykWorkflowJson).replace('{}', '').replace(`"`, '');
+	return stringify(snykWorkflowJson, { lineWidth: 120 })
+		.replace('{}', '')
+		.replaceAll(`"`, '');
 }
 
 function generatePrHeader(languages: string[]): string {

--- a/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/snyk-integrator.ts
@@ -7,6 +7,8 @@ interface SnykInputs {
 	SKIP_NODE?: boolean;
 	SKIP_PYTHON?: boolean;
 	PYTHON_VERSION?: string;
+	PIP_REQUIREMENTS_FILES?: string;
+	PIPFILES?: string;
 	SKIP_GO?: boolean;
 }
 
@@ -39,6 +41,12 @@ export function createYaml(languages: string[]): string {
 				: true,
 		SKIP_PYTHON: languages.includes('Python') ? false : undefined,
 		PYTHON_VERSION: languages.includes('Python') ? '<MAJOR.MINOR>' : undefined,
+		PIP_REQUIREMENTS_FILES: languages.includes('Python')
+			? '<PATH_TO_REQUIREMENTS> # Space separated list of requirements files. Only use one of this or PIPFILES'
+			: undefined,
+		PIPFILES: languages.includes('Python')
+			? '<PATH_TO_PIPFILES> # Space separated list of pipfiles. Only use one of this or PIP_REQUIREMENTS_FILES'
+			: undefined,
 		SKIP_GO: languages.includes('Go') ? false : undefined,
 	};
 
@@ -61,7 +69,7 @@ export function createYaml(languages: string[]): string {
 		},
 	};
 
-	return stringify(snykWorkflowJson).replace('{}', '');
+	return stringify(snykWorkflowJson).replace('{}', '').replace(`"`, '');
 }
 
 function generatePrHeader(languages: string[]): string {

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -314,8 +314,8 @@ export function testExperimentalRepocopFeatures(
 	);
 
 	console.log('Testing snyk.yml generation');
-	console.log(createYaml(['Scala', 'Python', 'Shell']));
-	console.log(createYaml(['Go', 'Dockerfile', 'TypeScript']));
+	console.log(createYaml(['Scala', 'Python', 'Shell'], 'branch'));
+	console.log(createYaml(['Go', 'Dockerfile', 'TypeScript'], 'branch'));
 }
 
 /**


### PR DESCRIPTION
## What does this change?

Add options `PIP_REQUIREMENTS_FILES` and `PIPFILES` to the Snyk inputs. 

We also modify the workflow so that it is run when commits are pushed to the generated branch containing the snyk.yml file.

## Why?

These options are required to properly run the Snyk workflow when a repository contains Python dependencies.

## How has it been verified?

See the updated tests.
