### PR TITLE
Make vulnerability tracker logging more useful

### DIFF
--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -157,6 +157,11 @@ export function hasDependencyTracking(
 		'Makefile',
 		'Dockerfile',
 		'PLpgSQL',
+		'Thrift',
+		'SCSS',
+		'Batchfile',
+		'HCL',
+		'VCL',
 	];
 
 	const commonSupportedLanguages = [

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -228,7 +228,7 @@ export function hasDependencyTracking(
 		);
 		if (!containsOnlyDependabotSupportedLanguages) {
 			console.log(
-				`${repo.name} contains the following languagesnot supported by Dependabot: `,
+				`${repo.name} contains the following languages not supported by Dependabot: `,
 				languages.filter(
 					(language) => !supportedDependabotLanguages.includes(language),
 				),

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -208,6 +208,14 @@ export function hasDependencyTracking(
 		const containsOnlySnykSupportedLanguages = languages.every((language) =>
 			supportedSnykLanguages.includes(language),
 		);
+		if (!containsOnlySnykSupportedLanguages) {
+			console.log(
+				`${repo.name} contains the following languages not supported by Snyk: `,
+				languages.filter(
+					(language) => !supportedSnykLanguages.includes(language),
+				),
+			);
+		}
 		return containsOnlySnykSupportedLanguages;
 	} else {
 		const containsOnlyDependabotSupportedLanguages = languages.every(
@@ -215,8 +223,10 @@ export function hasDependencyTracking(
 		);
 		if (!containsOnlyDependabotSupportedLanguages) {
 			console.log(
-				`${repo.name} does not have valid dependency tracking: `,
-				languages,
+				`${repo.name} contains the following languagesnot supported by Dependabot: `,
+				languages.filter(
+					(language) => !supportedDependabotLanguages.includes(language),
+				),
 			);
 		}
 


### PR DESCRIPTION
## What does this change?

Make logs more useful by telling the user which platform the repo has been evaluated against, and which languages are missing.

## Why?

Easier to tell **why** a repo has failed the vulnerbaility tracking check

## How has it been verified?

All tests still passed, deployed to CODE and observed expected result

`<REPO> contains the following languages not supported by <PLATFORM>:  [ '<LANGUAGE>' ]`

