### PR TITLE
Check for existence of snyk workflow file

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -15,6 +15,7 @@ import {
 	getStacks,
 	getTeamRepositories,
 	getTeams,
+	getWorkflowFiles,
 } from './query';
 import { protectBranches } from './remediations/branch-protector/branch-protection';
 import { sendPotentialInteractives } from './remediations/topics/topic-monitor-interactive';
@@ -51,6 +52,7 @@ export async function main() {
 	const branches = await getRepositoryBranches(prisma, unarchivedRepos);
 	const repoTeams = await getTeamRepositories(prisma);
 	const repoLanguages = await getRepositoryLanguages(prisma);
+	const workflowFiles = await getWorkflowFiles(prisma);
 	const nonPlaygroundStacks: AwsCloudFormationStack[] = (
 		await getStacks(prisma)
 	).filter((s) => s.tags.Stack !== 'playground');
@@ -62,6 +64,7 @@ export async function main() {
 			repoTeams,
 			repoLanguages,
 			snykProjects,
+			workflowFiles,
 		);
 
 	const octokit = await stageAwareOctokit(config.stage);

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -1,6 +1,7 @@
 import type {
 	github_languages,
 	github_repository_branches,
+	github_workflows,
 	PrismaClient,
 	snyk_projects,
 	view_repo_ownership,
@@ -108,14 +109,21 @@ export async function getStacks(
 	return toNonEmptyArray(stacks);
 }
 
+//allow it to return an empty array while getWorkflowFiles exists
 export async function getSnykProjects(
 	client: PrismaClient,
-): Promise<NonEmptyArray<snyk_projects>> {
-	return toNonEmptyArray(await client.snyk_projects.findMany({}));
+): Promise<snyk_projects[]> {
+	return await client.snyk_projects.findMany({});
 }
 
 export async function getRepositoryLanguages(
 	client: PrismaClient,
 ): Promise<NonEmptyArray<github_languages>> {
 	return toNonEmptyArray(await client.github_languages.findMany({}));
+}
+
+export async function getWorkflowFiles(
+	client: PrismaClient,
+): Promise<NonEmptyArray<github_workflows>> {
+	return toNonEmptyArray(await client.github_workflows.findMany({}));
 }

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -588,4 +588,39 @@ describe('Dependency tracking', () => {
 		const actual = hasDependencyTracking(repo, [noLanguages], [], []);
 		expect(actual).toEqual(true);
 	});
+	test('is valid if a repository has a snyk.yml', () => {
+		const repo: Repository = {
+			...nullRepo,
+			topics: ['production'],
+			full_name: 'guardian/some-repo',
+			id: 1n,
+		};
+		const workflow: github_workflows = {
+			cq_sync_time: null,
+			cq_source_name: null,
+			cq_id: '',
+			cq_parent_id: null,
+			id: 1n,
+			name: null,
+			path: '.github/workflows/snyk.yml',
+			repository_id: 1n,
+			org: 'guardian',
+			contents: null,
+			node_id: null,
+			state: null,
+			created_at: null,
+			updated_at: null,
+			url: null,
+			html_url: null,
+			badge_url: null,
+		};
+
+		const actual = hasDependencyTracking(
+			repo,
+			[snykSupportedLanguages],
+			[],
+			[workflow],
+		);
+		expect(actual).toEqual(true);
+	});
 });

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -588,31 +588,31 @@ describe('Dependency tracking', () => {
 		const actual = hasDependencyTracking(repo, [noLanguages], [], []);
 		expect(actual).toEqual(true);
 	});
+	const workflow: github_workflows = {
+		cq_sync_time: null,
+		cq_source_name: null,
+		cq_id: '',
+		cq_parent_id: null,
+		id: 1n,
+		name: null,
+		path: '.github/workflows/snyk.yml',
+		repository_id: 1n,
+		org: 'guardian',
+		contents: null,
+		node_id: null,
+		state: null,
+		created_at: null,
+		updated_at: null,
+		url: null,
+		html_url: null,
+		badge_url: null,
+	};
 	test('is valid if a repository has a snyk.yml', () => {
 		const repo: Repository = {
 			...nullRepo,
 			topics: ['production'],
 			full_name: 'guardian/some-repo',
 			id: 1n,
-		};
-		const workflow: github_workflows = {
-			cq_sync_time: null,
-			cq_source_name: null,
-			cq_id: '',
-			cq_parent_id: null,
-			id: 1n,
-			name: null,
-			path: '.github/workflows/snyk.yml',
-			repository_id: 1n,
-			org: 'guardian',
-			contents: null,
-			node_id: null,
-			state: null,
-			created_at: null,
-			updated_at: null,
-			url: null,
-			html_url: null,
-			badge_url: null,
 		};
 
 		const actual = hasDependencyTracking(
@@ -622,5 +622,25 @@ describe('Dependency tracking', () => {
 			[workflow],
 		);
 		expect(actual).toEqual(true);
+	});
+	test('is not valid if a repository does not have a snyk.yml', () => {
+		const repo: Repository = {
+			...nullRepo,
+			topics: ['production'],
+			full_name: 'guardian/some-repo',
+			id: 1n,
+		};
+		const nonMatchingWorkflow: github_workflows = {
+			...workflow,
+			path: '.github/workflows/other.yml',
+		};
+
+		const actual = hasDependencyTracking(
+			repo,
+			[unsupportedLanguages],
+			[],
+			[nonMatchingWorkflow],
+		);
+		expect(actual).toEqual(false);
 	});
 });

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -1,6 +1,7 @@
 import type {
 	github_languages,
 	github_repository_branches,
+	github_workflows,
 	snyk_projects,
 } from '@prisma/client';
 import type {
@@ -14,6 +15,24 @@ import {
 	hasDependencyTracking,
 	parseSnykTags,
 } from './repository';
+
+function evaluateRepoTestHelper(
+	repo: Repository,
+	branches: github_repository_branches[] = [],
+	teams: TeamRepository[] = [],
+	languages: github_languages[] = [],
+	snykProjects: snyk_projects[] = [],
+	githubWorkflows: github_workflows[] = [],
+) {
+	return evaluateOneRepo(
+		repo,
+		branches,
+		teams,
+		languages,
+		snykProjects,
+		githubWorkflows,
+	);
+}
 
 const nullBranch: github_repository_branches = {
 	cq_sync_time: null,
@@ -54,9 +73,7 @@ describe('default_branch_name should be false when the default branch is not mai
 	test('branch is not main', () => {
 		const badRepo = { ...thePerfectRepo, default_branch: 'notMain' };
 		const repos: Repository[] = [thePerfectRepo, badRepo];
-		const evaluation = repos.map((repo) =>
-			evaluateOneRepo(repo, [], [], [], []),
-		);
+		const evaluation = repos.map((repo) => evaluateRepoTestHelper(repo));
 
 		expect(evaluation.map((repo) => repo.default_branch_name)).toEqual([
 			true,
@@ -84,24 +101,17 @@ describe('Repositories should have branch protection', () => {
 			name: 'side-branch',
 		};
 
-		const actual = evaluateOneRepo(
-			thePerfectRepo,
-			[protectedMainBranch, unprotectedSideBranch],
-			[],
-			[],
-			[],
-		);
+		const actual = evaluateRepoTestHelper(thePerfectRepo, [
+			protectedMainBranch,
+			unprotectedSideBranch,
+		]);
 
 		expect(actual.branch_protection).toEqual(true);
 	});
 	test('We should get a negative result when the default branch of a production repo is not protected', () => {
-		const actual = evaluateOneRepo(
-			thePerfectRepo,
-			[unprotectedMainBranch],
-			[],
-			[],
-			[],
-		);
+		const actual = evaluateRepoTestHelper(thePerfectRepo, [
+			unprotectedMainBranch,
+		]);
 		expect(actual.branch_protection).toEqual(false);
 	});
 	test('Repos with no branches do not need protecting, and should be considered protected', () => {
@@ -110,7 +120,7 @@ describe('Repositories should have branch protection', () => {
 			default_branch: null,
 		};
 
-		const actual = evaluateOneRepo(repo, [], [], [], []);
+		const actual = evaluateRepoTestHelper(repo);
 		expect(actual.branch_protection).toEqual(true);
 	});
 	test('Repos with exempted topics should be considered adequately protected, even if they have an unprotected main branch', () => {
@@ -119,7 +129,7 @@ describe('Repositories should have branch protection', () => {
 			topics: ['hackday'],
 		};
 
-		const actual = evaluateOneRepo(repo, [unprotectedMainBranch], [], [], []);
+		const actual = evaluateRepoTestHelper(repo, [unprotectedMainBranch]);
 		expect(actual.branch_protection).toEqual(true);
 	});
 });
@@ -140,7 +150,7 @@ describe('Repository admin access', () => {
 			},
 		];
 
-		const actual = evaluateOneRepo(repo, [], teams, [], []);
+		const actual = evaluateRepoTestHelper(repo, [], teams);
 		expect(actual.admin_access).toEqual(false);
 	});
 
@@ -164,7 +174,7 @@ describe('Repository admin access', () => {
 			},
 		];
 
-		const actual = evaluateOneRepo(repo, [], teams, [], []);
+		const actual = evaluateRepoTestHelper(repo, [], teams);
 		expect(actual.admin_access).toEqual(true);
 	});
 
@@ -177,7 +187,7 @@ describe('Repository admin access', () => {
 			topics: ['hackday'],
 		};
 
-		const actual = evaluateOneRepo(repo, [], [], [], []);
+		const actual = evaluateRepoTestHelper(repo);
 		expect(actual.admin_access).toEqual(true);
 	});
 
@@ -201,7 +211,7 @@ describe('Repository admin access', () => {
 				team_id: 2n,
 			},
 		];
-		const actual = evaluateOneRepo(repo, [], teams, [], []);
+		const actual = evaluateRepoTestHelper(repo, [], teams);
 		expect(actual.admin_access).toEqual(true);
 	});
 
@@ -213,7 +223,7 @@ describe('Repository admin access', () => {
 			topics: ['avocado'],
 		};
 
-		const actual = evaluateOneRepo(repo, [], [], [], []);
+		const actual = evaluateRepoTestHelper(repo);
 		expect(actual.admin_access).toEqual(false);
 	});
 });
@@ -225,7 +235,7 @@ describe('Repository topics', () => {
 			topics: ['production'],
 		};
 
-		const actual = evaluateOneRepo(repo, [], [], [], []);
+		const actual = evaluateRepoTestHelper(repo);
 		expect(actual.topics).toEqual(true);
 	});
 
@@ -237,7 +247,7 @@ describe('Repository topics', () => {
 			topics: ['interactive'],
 		};
 
-		const actual = evaluateOneRepo(repo, [], [], [], []);
+		const actual = evaluateRepoTestHelper(repo);
 		expect(actual.topics).toEqual(true);
 	});
 
@@ -249,7 +259,7 @@ describe('Repository topics', () => {
 			topics: ['production', 'hackday'],
 		};
 
-		const actual = evaluateOneRepo(repo, [], [], [], []);
+		const actual = evaluateRepoTestHelper(repo);
 		expect(actual.topics).toEqual(false);
 	});
 
@@ -259,7 +269,7 @@ describe('Repository topics', () => {
 			topics: ['production', 'android'],
 		};
 
-		const actual = evaluateOneRepo(repo, [], [], [], []);
+		const actual = evaluateRepoTestHelper(repo);
 		expect(actual.topics).toEqual(true);
 	});
 
@@ -269,7 +279,7 @@ describe('Repository topics', () => {
 			topics: [],
 		};
 
-		const actual = evaluateOneRepo(repo, [], [], [], []);
+		const actual = evaluateRepoTestHelper(repo);
 		expect(actual.topics).toEqual(false);
 	});
 
@@ -279,7 +289,7 @@ describe('Repository topics', () => {
 			topics: ['android', 'mobile'],
 		};
 
-		const actual = evaluateOneRepo(repo, [], [], [], []);
+		const actual = evaluateRepoTestHelper(repo);
 		expect(actual.topics).toEqual(false);
 	});
 });
@@ -296,8 +306,8 @@ describe('Repository maintenance', () => {
 			created_at: new Date('2019-01-01'),
 		};
 
-		const recentEval = evaluateOneRepo(recentRepo, [], [], [], []);
-		const oldEval = evaluateOneRepo(oldRepo, [], [], [], []);
+		const recentEval = evaluateRepoTestHelper(recentRepo);
+		const oldEval = evaluateRepoTestHelper(oldRepo);
 		expect(recentEval.archiving).toEqual(true);
 		expect(oldEval.archiving).toEqual(false);
 	});
@@ -311,7 +321,7 @@ describe('Repository maintenance', () => {
 			pushed_at: new Date('2020-01-01'),
 		};
 
-		const actual = evaluateOneRepo(recentlyUpdatedRepo, [], [], [], []);
+		const actual = evaluateRepoTestHelper(recentlyUpdatedRepo);
 		expect(actual.archiving).toEqual(true);
 	});
 	test('is not a concern if no dates are found', () => {
@@ -319,7 +329,7 @@ describe('Repository maintenance', () => {
 			...nullRepo,
 		};
 
-		const actual = evaluateOneRepo(recentlyUpdatedRepo, [], [], [], []);
+		const actual = evaluateRepoTestHelper(recentlyUpdatedRepo);
 		expect(actual.archiving).toEqual(true);
 	});
 });
@@ -502,6 +512,7 @@ describe('Dependency tracking', () => {
 			repo,
 			[snykSupportedLanguages],
 			[project],
+			[],
 		);
 		expect(actual).toEqual(true);
 	});
@@ -511,7 +522,12 @@ describe('Dependency tracking', () => {
 			topics: ['production'],
 			full_name: 'guardian/some-repo',
 		};
-		const actual = hasDependencyTracking(repo, [fullySupportedLanguages], []);
+		const actual = hasDependencyTracking(
+			repo,
+			[fullySupportedLanguages],
+			[],
+			[],
+		);
 		expect(actual).toEqual(true);
 	});
 	test('is not valid if a project is not on snyk, and uses a language dependabot does not support', () => {
@@ -520,7 +536,12 @@ describe('Dependency tracking', () => {
 			topics: ['production'],
 			full_name: 'guardian/some-repo',
 		};
-		const actual = hasDependencyTracking(repo, [snykSupportedLanguages], []);
+		const actual = hasDependencyTracking(
+			repo,
+			[snykSupportedLanguages],
+			[],
+			[],
+		);
 		expect(actual).toEqual(false);
 	});
 	test('is not valids not valid if a project is on snyk, and uses a language not supported by snyk', () => {
@@ -529,7 +550,7 @@ describe('Dependency tracking', () => {
 			topics: ['production'],
 			full_name: 'guardian/some-repo',
 		};
-		const actual = hasDependencyTracking(repo, [unsupportedLanguages], []);
+		const actual = hasDependencyTracking(repo, [unsupportedLanguages], [], []);
 		expect(actual).toEqual(false);
 	});
 	test('is valid if a repository has been archived', () => {
@@ -538,7 +559,7 @@ describe('Dependency tracking', () => {
 			archived: true,
 			full_name: 'guardian/some-repo',
 		};
-		const actual = hasDependencyTracking(repo, [unsupportedLanguages], []);
+		const actual = hasDependencyTracking(repo, [unsupportedLanguages], [], []);
 		expect(actual).toEqual(true);
 	});
 	test('is valid if a repository has a non-production tag', () => {
@@ -547,7 +568,7 @@ describe('Dependency tracking', () => {
 			topics: [],
 			full_name: 'guardian/some-repo',
 		};
-		const actual = hasDependencyTracking(repo, [unsupportedLanguages], []);
+		const actual = hasDependencyTracking(repo, [unsupportedLanguages], [], []);
 		expect(actual).toEqual(true);
 	});
 	test('is valid if a repository has no languages', () => {
@@ -564,7 +585,7 @@ describe('Dependency tracking', () => {
 			languages: [],
 		};
 
-		const actual = hasDependencyTracking(repo, [noLanguages], []);
+		const actual = hasDependencyTracking(repo, [noLanguages], [], []);
 		expect(actual).toEqual(true);
 	});
 });

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -201,12 +201,16 @@ export function hasDependencyTracking(
 
 	//This is a temporary workaround until we get the snyk_projects table back.
 	function findSnykYaml(repo: Repository, workflowFiles: github_workflows[]) {
-		return workflowFiles.find(
+		const result = workflowFiles.find(
 			(file) =>
 				file.repository_id === repo.id &&
 				!!file.path &&
 				file.path.includes('snyk'),
 		);
+		if (result !== undefined) {
+			console.log(`${repo.name} has a snyk workflow file.`);
+		}
+		return result;
 	}
 
 	function findMatchingSnykProject(


### PR DESCRIPTION
## What does this change?

While we can't check snyk project tags directly, we can use the presence of a snyk workflow file as an indicator that a repo is integrated with snyk.

Adds a helper function to the tests. Rather than having to declare all empty arrays up front, we use a function that defaults them to empty unless otherwise specified. This means if we add or remove a field from `evaluateOneRepo`, there's far fewer changes we need to make to keep the tests happy.

Removes the non-empty check from snyk_projects while we have the snyk workflow check in place, as the latter is a workaround for the former being empty.

## Why?

To allow us to continue to measure and make progress on our OKR while work to bring back the table continues, albeit with slightly lowered precision

## How has it been verified?

Added new unit test to verify new behaviour.
Deployed to code and verified number of unintegrated repos dropped to about expected level. (Expected ~60 based on last week's numbers. Actual = 56)
