### PR TITLE
update PR body

### DIFF
--- a/packages/snyk-integrator/src/remediations/snyk-integrator/snyk-integrator.test.ts
+++ b/packages/snyk-integrator/src/remediations/snyk-integrator/snyk-integrator.test.ts
@@ -62,10 +62,4 @@ describe('A generated PR', () => {
 		expect(() => generateServiceCataloguePr(['Rust', 'Kotlin'])).toThrow();
 		expect(() => generateServiceCataloguePr([])).toThrow();
 	});
-	it('Should create a body with the correct GitHub CLI command', () => {
-		const body = generatePr(['Scala'], 'main', 'myRepo')[1];
-		expect(body).toContain(
-			'gh workflow run snyk.yml --ref main --repo guardian/myRepo',
-		);
-	});
 });

--- a/packages/snyk-integrator/src/remediations/snyk-integrator/snyk-integrator.test.ts
+++ b/packages/snyk-integrator/src/remediations/snyk-integrator/snyk-integrator.test.ts
@@ -42,7 +42,7 @@ jobs:
 describe('A generated PR', () => {
 	//higher level function that takes in just languages and returns a PR
 	function generateServiceCataloguePr(languages: string[]): [string, string] {
-		return generatePr(languages, 'main', 'guardian/service-catalogue');
+		return generatePr(languages, 'main');
 	}
 
 	it('should have only the supported languages in its header', () => {

--- a/packages/snyk-integrator/src/remediations/snyk-integrator/snyk-integrator.ts
+++ b/packages/snyk-integrator/src/remediations/snyk-integrator/snyk-integrator.ts
@@ -108,7 +108,7 @@ function generatePrBody(branchName: string, repoName: string): string {
 			'Replace the relevant python fields, if they exist in the file. If not, skip this step',
 			'The job should run automatically on every commit to this branch. ' +
 				'View the action output and verify it has generated one project per dependency manifest.',
-			`When you are happy the action works, remove ${branchName} option from the list of branches in the workflow, approve, and merge.`,
+			`When you are happy the action works, remove the \`${branchName}\` option from the list of branches in the workflow, approve, and merge.`,
 		]),
 	];
 	return tsMarkdown(body);

--- a/packages/snyk-integrator/src/remediations/snyk-integrator/snyk-integrator.ts
+++ b/packages/snyk-integrator/src/remediations/snyk-integrator/snyk-integrator.ts
@@ -105,12 +105,10 @@ function generatePrBody(branchName: string, repoName: string): string {
 		checklist([
 			'Replace the SNYK_ORG variable with one that your team already uses (you should have other repos integrated with Snyk. ' +
 				'If you can’t find any, reach out to DevX)',
-			'Replace the python version with the version your repo uses',
-		]),
-		h2('How do I check this works?'),
-		checklist([
-			`Run the action via the GitHub CLI \`gh workflow run snyk.yml --ref ${branchName} --repo guardian/${repoName}\``,
-			`View the action output, verify it has generated one project per dependency manifest.`,
+			'Replace the relevant python fields, if they exist in the file. If not, skip this step',
+			'The job should run automatically on every commit to this branch. ' +
+				'View the action output and verify it has generated one project per dependency manifest.',
+			`When you are happy the action works, remove ${branchName} option from the list of branches in the workflow, approve, and merge.`,
 		]),
 	];
 	return tsMarkdown(body);

--- a/packages/snyk-integrator/src/remediations/snyk-integrator/snyk-integrator.ts
+++ b/packages/snyk-integrator/src/remediations/snyk-integrator/snyk-integrator.ts
@@ -84,7 +84,7 @@ function checklist(items: string[]): string {
 	return items.map((item) => `- [ ] ${item}`).join('\n');
 }
 
-function generatePrBody(branchName: string, repoName: string): string {
+function generatePrBody(branchName: string): string {
 	const body = [
 		h2('What does this change?'),
 		p(
@@ -117,7 +117,6 @@ function generatePrBody(branchName: string, repoName: string): string {
 export function generatePr(
 	repoLanguages: string[],
 	branch: string,
-	repoName: string,
 ): [string, string] {
 	const workflowLanguages = [
 		'Scala',
@@ -137,7 +136,7 @@ export function generatePr(
 	}
 
 	const header = generatePrHeader(workflowSupportedLanguages);
-	const body = generatePrBody(branch, repoName);
+	const body = generatePrBody(branch);
 
 	return [header, body];
 }
@@ -149,7 +148,7 @@ export async function createSnykPullRequest(
 	repoLanguages: string[],
 ) {
 	const snykFileContents = createYaml(repoLanguages, branchName);
-	const [title, body] = generatePr(repoLanguages, branchName, repoName);
+	const [title, body] = generatePr(repoLanguages, branchName);
 	return await createPullRequest(octokit, {
 		repoName,
 		title,


### PR DESCRIPTION
## What does this change?

Adds more detailed instructions to the PR body. Removes gh cli step.

## Why?

The yaml generated includes a field that will run on every push to the feature branch. This is because a user cannot run an action manually if it has not been kicked off by github at least once. Now we are running on every push, we don't need to instruct users to run the action via the CLI.

Python is not used in every repo, so make clear that this part is optional. In future, maybe we could only display that checklist item if we detect python in the repo?

## How has it been verified?

Unit tests verify expected behaviour
