### PR TITLE
Allow snyk integrator lambda to take input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12899,6 +12899,7 @@
       },
       "devDependencies": {
         "@octokit/types": "^12.4.0",
+        "@types/aws-lambda": "^8.10.131",
         "prisma": "^5.7.1"
       }
     },

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -17148,7 +17148,7 @@ spec:
             "STAGE": "TEST",
           },
         },
-        "Handler": "index.main",
+        "Handler": "index.handler",
         "MemorySize": 1024,
         "Role": {
           "Fn::GetAtt": [
@@ -17195,6 +17195,22 @@ spec:
         },
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "snykintegratorAllowInvokeServiceCataloguesnykintegratorinputtopicTEST8ADE3A2EDEF3DA67": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "snykintegrator1EF519CF",
+            "Arn",
+          ],
+        },
+        "Principal": "sns.amazonaws.com",
+        "SourceArn": {
+          "Ref": "snykintegratorinputtopicTEST6BCA9CE1",
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "snykintegratorSecurityGroup158665A3": {
       "Properties": {
@@ -17435,6 +17451,45 @@ spec:
       },
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
+    },
+    "snykintegratorinputtopicTEST6BCA9CE1": {
+      "Properties": {
+        "DisplayName": "Snyk Integrator Input Topic",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "snykintegratorsnykintegratorinputtopicTEST80B8842E": {
+      "Properties": {
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "snykintegrator1EF519CF",
+            "Arn",
+          ],
+        },
+        "Protocol": "lambda",
+        "TopicArn": {
+          "Ref": "snykintegratorinputtopicTEST6BCA9CE1",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
     },
   },
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -17,7 +17,8 @@
 	},
 	"devDependencies": {
 		"prisma": "^5.7.1",
-		"@octokit/types": "^12.4.0"
+		"@octokit/types": "^12.4.0",
+		"@types/aws-lambda": "^8.10.131"
 	},
 	"prisma": {
 		"schema": "prisma/schema.prisma"

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -68,7 +68,6 @@ export async function stageAwareOctokit(stage: string) {
 	}
 }
 
-//TODO test me
 export function parseEvent<T>(event: SNSEvent): T[] {
 	return event.Records.map((record) => JSON.parse(record.Sns.Message) as T);
 }

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -1,6 +1,7 @@
 import { SecretsManager } from '@aws-sdk/client-secrets-manager';
 import type { Action } from '@guardian/anghammarad';
 import { createAppAuth } from '@octokit/auth-app';
+import type { SNSEvent } from 'aws-lambda';
 import { Octokit } from 'octokit';
 import type { GitHubAppConfig, GithubAppSecret } from 'common/types';
 
@@ -67,6 +68,10 @@ export async function stageAwareOctokit(stage: string) {
 	}
 }
 
+//TODO test me
+export function parseEvent<T>(event: SNSEvent): T[] {
+	return event.Records.map((record) => JSON.parse(record.Sns.Message) as T);
+}
 export function branchProtectionCtas(
 	fullRepoName: string,
 	teamSlug: string,

--- a/packages/snyk-integrator/src/run-locally.ts
+++ b/packages/snyk-integrator/src/run-locally.ts
@@ -6,5 +6,9 @@ config({ path: `../../.env` }); // Load `.env` file at the root of the repositor
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
 if (require.main === module) {
-	void (async () => await main())();
+	void (async () =>
+		await main({
+			name: 'service-catalogue',
+			languages: ['Scala', 'Go'],
+		}))();
 }


### PR DESCRIPTION
## What does this change?

`snyk-integrator` is triggered in response SNS events. It tries to unwrap those events and generate PRs based on their contents.

## What does this NOT change?

`repocop` does not currently send notifications to snyk integrator via this queue. This will be set up via a separate PR to keep this one manageable.

## Why?

So repocop can (eventually) tell snyk integrator which repos require PRs to be raised.

## How has it been verified?

Tested on CODE