### PR TITLE
chore(deps): Update `@guardian/eslint-config-typescript` from 9.0.1 to 9.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@guardian/eslint-config-typescript": "9.0.1",
+        "@guardian/eslint-config-typescript": "9.0.2",
         "@guardian/prettier": "7.0.0",
         "@guardian/tsconfig": "^0.2.0",
         "@types/jest": "^29.5.11",
@@ -2579,9 +2579,9 @@
       }
     },
     "node_modules/@guardian/eslint-config-typescript": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@guardian/eslint-config-typescript/-/eslint-config-typescript-9.0.1.tgz",
-      "integrity": "sha512-m6DZbfZGLSgObkQWhz0aKKGSKd3UqDsTZPeIDS8AEHqMjsn6DerOe6Pn1wH8939D2rW/c2RsrdmJxkHo/OF5+w==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@guardian/eslint-config-typescript/-/eslint-config-typescript-9.0.2.tgz",
+      "integrity": "sha512-UkuEDeEpIZ7njAK9pZm5RIGECfBFdqsOnY+HIB1XntUMG42VRd43XaNjgsblJ7aOO2L4opOauDUUyOycWxgFww==",
       "dev": true,
       "dependencies": {
         "@guardian/eslint-config": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "packages/*"
   ],
   "devDependencies": {
-    "@guardian/eslint-config-typescript": "9.0.1",
+    "@guardian/eslint-config-typescript": "9.0.2",
     "@guardian/prettier": "7.0.0",
     "@guardian/tsconfig": "^0.2.0",
     "@types/jest": "^29.5.11",


### PR DESCRIPTION
## What does this change?
Update `@guardian/eslint-config-typescript` from 9.0.1 to 9.0.2 to get some performance improvements. See https://github.com/guardian/csnx/pull/1083.

This shaves a few seconds off the build time. The latest build of `main` took [1m47s](https://github.com/guardian/service-catalogue/actions/runs/7542308573). The build of this branch took [1m33s](https://github.com/guardian/service-catalogue/actions/runs/7542377709). See also https://github.com/guardian/service-catalogue/pull/685#issuecomment-1893433003.