### PR TITLE
Get repocop to send messages to the snyk integrator

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -16754,6 +16754,9 @@ spec:
               "Ref": "TopicBFC7AF6E",
             },
             "QUERY_LOGGING": "false",
+            "SNYK_INTEGRATOR_INPUT_TOPIC_ARN": {
+              "Ref": "snykintegratorinputtopicTEST6BCA9CE1",
+            },
             "STACK": "deploy",
             "STAGE": "TEST",
           },

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -17018,6 +17018,13 @@ spec:
               },
             },
             {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "snykintegratorinputtopicTEST6BCA9CE1",
+              },
+            },
+            {
               "Action": "cloudwatch:PutMetricData",
               "Condition": {
                 "StringEquals": {

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -81,6 +81,7 @@ export class Repocop {
 		repocopGithubSecret.grantRead(repocopLambda);
 		anghammaradTopic.grantPublish(repocopLambda);
 		interactiveMonitorTopic.grantPublish(repocopLambda);
+		snykIntegratorInputTopic.grantPublish(repocopLambda);
 		repocopLambda.addToRolePolicy(policyStatement);
 
 		const snykIntegratorSecret = new Secret(

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -53,6 +53,7 @@ export class Repocop {
 				INTERACTIVE_MONITOR_TOPIC_ARN: interactiveMonitorTopic.topicArn,
 				GITHUB_APP_SECRET: repocopGithubSecret.secretArn,
 				INTERACTIVES_COUNT: guStack.stage === 'PROD' ? '40' : '3',
+				SNYK_INTEGRATOR_INPUT_TOPIC_ARN: snykIntegratorInputTopic.topicArn,
 			},
 			vpc,
 			securityGroups: [dbSecurityGroup],

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -16,3 +16,8 @@ export type GitHubAppConfig = {
 	strategyOptions: StrategyOptions;
 	installationId: string;
 };
+
+export interface SnykIntegratorEvent {
+	name: string;
+	languages: string[];
+}

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -57,6 +57,11 @@ export interface Config extends PrismaConfig {
 	 * Flag to enable creation of Snyk integration PRs
 	 */
 	snykIntegrationPREnabled: boolean;
+
+	/**
+	 * The ARN of the Snyk Integrator input topic.
+	 */
+	snykIntegratorTopic: string;
 }
 
 export async function getConfig(): Promise<Config> {
@@ -86,5 +91,6 @@ export async function getConfig(): Promise<Config> {
 		branchProtectionEnabled: process.env.BRANCH_PROTECTION_ENABLED === 'true',
 		snykIntegrationPREnabled:
 			process.env.SNYK_INTEGRATION_PR_ENABLED === 'true',
+		snykIntegratorTopic: getEnvOrThrow('SNYK_INTEGRATOR_INPUT_TOPIC_ARN'),
 	};
 }

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -21,6 +21,7 @@ import {
 	getWorkflowFiles,
 } from './query';
 import { protectBranches } from './remediations/branch-protector/branch-protection';
+import { sendUnprotectedRepo } from './remediations/snyk-integrator/send-to-sns';
 import { sendPotentialInteractives } from './remediations/topics/topic-monitor-interactive';
 import { applyProductionTopicAndMessageTeams } from './remediations/topics/topic-monitor-production';
 import {
@@ -83,11 +84,12 @@ export async function main() {
 		nonPlaygroundStacks,
 	);
 
+	const repoOwners = await getRepoOwnership(prisma);
+	await sendUnprotectedRepo(evaluatedRepos, config, repoOwners, repoLanguages);
 	await writeEvaluationTable(evaluatedRepos, prisma);
 	if (config.enableMessaging) {
 		await sendPotentialInteractives(evaluatedRepos, config);
 
-		const repoOwners = await getRepoOwnership(prisma);
 		const teams = await getTeams(prisma);
 
 		if (config.branchProtectionEnabled) {

--- a/packages/repocop/src/languages.ts
+++ b/packages/repocop/src/languages.ts
@@ -1,0 +1,46 @@
+export const ignoredLanguages = [
+	'HTML',
+	'CSS',
+	'Shell',
+	'Jupyter Notebook',
+	'Makefile',
+	'Dockerfile',
+	'PLpgSQL',
+	'Thrift',
+	'SCSS',
+	'Batchfile',
+	'HCL',
+	'VCL',
+];
+
+const commonSupportedLanguages = [
+	'C#',
+	'Go',
+	'Java',
+	'JavaScript',
+	'Python',
+	'Swift',
+	'TypeScript',
+];
+const snykOnlySupportedLanguages = [
+	'C',
+	'C++',
+	'Apex',
+	'Bazel',
+	'Elixir',
+	'Kotlin',
+	'PHP',
+	'Ruby',
+	'Rust',
+	'Scala',
+	'Objective-C',
+	'Visual Basic .NET',
+];
+
+export const supportedDependabotLanguages = ignoredLanguages.concat(
+	commonSupportedLanguages,
+);
+
+export const supportedSnykLanguages = ignoredLanguages
+	.concat(commonSupportedLanguages)
+	.concat(snykOnlySupportedLanguages);

--- a/packages/repocop/src/languages.ts
+++ b/packages/repocop/src/languages.ts
@@ -39,7 +39,7 @@ const snykOnlySupportedLanguages = [
 
 export const actionSupportedLanguages = ignoredLanguages.concat(
 	'Scala',
-	'Typescript',
+	'TypeScript',
 	'Go',
 	'Python',
 	'JavaScript',

--- a/packages/repocop/src/languages.ts
+++ b/packages/repocop/src/languages.ts
@@ -37,6 +37,14 @@ const snykOnlySupportedLanguages = [
 	'Visual Basic .NET',
 ];
 
+export const actionSupportedLanguages = ignoredLanguages.concat(
+	'Scala',
+	'Typescript',
+	'Go',
+	'Python',
+	'JavaScript',
+);
+
 export const supportedDependabotLanguages = ignoredLanguages.concat(
 	commonSupportedLanguages,
 );

--- a/packages/repocop/src/remediations/snyk-integrator/send-to-sns.test.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/send-to-sns.test.ts
@@ -1,0 +1,90 @@
+import type {
+	github_languages,
+	repocop_github_repository_rules,
+} from '@prisma/client';
+import { findUntrackedReposWhereIntegrationWillWork } from './send-to-sns';
+
+function createEvaluatedRepo(
+	fullName: string,
+	vulnerabilityTracking: boolean,
+): repocop_github_repository_rules {
+	return {
+		full_name: fullName,
+		vulnerability_tracking: vulnerabilityTracking,
+		default_branch_name: true,
+		branch_protection: true,
+		topics: true,
+		contents: true,
+		team_based_access: true,
+		admin_access: true,
+		archiving: true,
+		evaluated_on: new Date(),
+	};
+}
+
+function repoWithLanguages(
+	fullName: string,
+	languages: string[],
+): github_languages {
+	return {
+		cq_sync_time: null,
+		cq_parent_id: null,
+		cq_id: '',
+		cq_source_name: null,
+		full_name: fullName,
+		name: fullName,
+		languages,
+	};
+}
+
+function trackedRepo(fullName: string): repocop_github_repository_rules {
+	return createEvaluatedRepo(fullName, true);
+}
+
+function untrackedRepo(fullName: string): repocop_github_repository_rules {
+	return createEvaluatedRepo(fullName, false);
+}
+
+function withGoodLanguages(fullName: string): github_languages {
+	return repoWithLanguages(fullName, ['Scala', 'TypeScript']);
+}
+
+function withBadLanguages(fullName: string): github_languages {
+	return repoWithLanguages(fullName, ['Rust']);
+}
+
+function withGoodAndBadLanguages(fullName: string): github_languages {
+	return repoWithLanguages(fullName, ['Scala', 'TypeScript', 'Rust']);
+}
+
+describe('When trying to find untracked repos where snyk integration will work', () => {
+	test('return a result if an untracked repo contains only languages our action supports', () => {
+		const actual = findUntrackedReposWhereIntegrationWillWork(
+			[untrackedRepo('repo1')],
+			[withGoodLanguages('repo1')],
+		);
+
+		expect(actual.length).toEqual(1);
+	});
+	test('do not return a result if an untracked repo contains only unsupported languages', () => {
+		const actual = findUntrackedReposWhereIntegrationWillWork(
+			[untrackedRepo('repo2')],
+			[withBadLanguages('repo2')],
+		);
+		expect(actual.length).toEqual(0);
+	});
+	test('do not return a result if an untracked repo contains a mixture of supported and unsupported languages', () => {
+		const actual = findUntrackedReposWhereIntegrationWillWork(
+			[untrackedRepo('repo3')],
+			[withGoodAndBadLanguages('repo3')],
+		);
+		expect(actual.length).toEqual(0);
+	});
+	test('do not return a result if repository is tracked', () => {
+		const actual = findUntrackedReposWhereIntegrationWillWork(
+			[trackedRepo('repo4')],
+			[withGoodLanguages('repo4')],
+		);
+		expect(actual.length).toEqual(0);
+	});
+});

--- a/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
@@ -40,10 +40,9 @@ function eventContainsOnlyActionSupportedLanguages(
 		actionSupportedLanguages.includes(lang),
 	);
 }
-//TODO test me
-function findReposWhereIntegrationWillWork(
+
+export function findUntrackedReposWhereIntegrationWillWork(
 	evaluatedRepos: repocop_github_repository_rules[],
-	owners: view_repo_ownership[],
 	githubLanguages: github_languages[],
 ) {
 	const unprotectedRepos = findUnprotectedRepos(evaluatedRepos);
@@ -64,6 +63,10 @@ function findReposWhereIntegrationWillWork(
 			eventContainsOnlyActionSupportedLanguages(event),
 		);
 
+	console.log(
+		`Found ${reposWhereAllLanguagesAreSupported.length} untracked repos that can be integrated with Snyk`,
+	);
+
 	return reposWhereAllLanguagesAreSupported;
 }
 
@@ -75,9 +78,8 @@ export async function sendUnprotectedRepo(
 ) {
 	const devXRepos = findDevXRepos(owners, evaluatedRepos);
 
-	const eventToSend = findReposWhereIntegrationWillWork(
+	const eventToSend = findUntrackedReposWhereIntegrationWillWork(
 		devXRepos,
-		owners,
 		githubLanguages,
 	)[0];
 

--- a/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
@@ -7,7 +7,7 @@ import type {
 import { awsClientConfig } from 'common/src/aws';
 import type { SnykIntegratorEvent } from 'common/src/types';
 import type { Config } from '../../config';
-import { ignoredLanguages } from '../../languages';
+import { actionSupportedLanguages } from '../../languages';
 import { removeRepoOwner } from '../shared-utilities';
 
 export function findUnprotectedRepos(
@@ -36,15 +36,8 @@ function findDevXRepos(
 function eventContainsOnlyActionSupportedLanguages(
 	event: SnykIntegratorEvent,
 ): boolean {
-	const actionSuppoertedLanguages = ignoredLanguages.concat(
-		'Scala',
-		'Typescript',
-		'Go',
-		'Python',
-		'JavaScript',
-	);
 	return event.languages.every((lang) =>
-		actionSuppoertedLanguages.includes(lang),
+		actionSupportedLanguages.includes(lang),
 	);
 }
 //TODO test me

--- a/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
@@ -64,7 +64,8 @@ export function findUntrackedReposWhereIntegrationWillWork(
 		);
 
 	console.log(
-		`Found ${reposWhereAllLanguagesAreSupported.length} untracked repos that can be integrated with Snyk`,
+		`Found ${reposWhereAllLanguagesAreSupported.length} untracked repos that can be integrated with Snyk: `,
+		reposWhereAllLanguagesAreSupported.join(','),
 	);
 
 	return reposWhereAllLanguagesAreSupported;
@@ -76,6 +77,7 @@ export async function sendUnprotectedRepo(
 	owners: view_repo_ownership[],
 	githubLanguages: github_languages[],
 ) {
+	//Only use internal repos while we are testing.
 	const devXRepos = findDevXRepos(owners, evaluatedRepos);
 
 	const eventToSend = findUntrackedReposWhereIntegrationWillWork(

--- a/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
@@ -1,0 +1,88 @@
+import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
+import type {
+	github_languages,
+	repocop_github_repository_rules,
+	view_repo_ownership,
+} from '@prisma/client';
+import { awsClientConfig } from 'common/src/aws';
+import { shuffle } from 'common/src/functions';
+import type { SnykIntegratorEvent } from 'common/src/types';
+import type { Config } from '../../config';
+import { ignoredLanguages } from '../../languages';
+import { removeRepoOwner } from '../shared-utilities';
+
+export function findUnprotectedRepos(
+	evaluatedRepos: repocop_github_repository_rules[],
+): repocop_github_repository_rules[] {
+	return evaluatedRepos.filter((repo) => !repo.vulnerability_tracking);
+}
+
+function findDevXRepos(
+	owners: view_repo_ownership[],
+	repos: repocop_github_repository_rules[],
+): repocop_github_repository_rules[] {
+	const devXTeams = owners
+		.filter(
+			(owner) =>
+				owner.github_team_name === 'DevX Security' ||
+				owner.github_team_name === 'Developer Experience',
+		)
+		.map((owner) => owner.repo_name);
+
+	const devXRepos = repos.filter((repo) => devXTeams.includes(repo.full_name));
+
+	return devXRepos;
+}
+
+function eventContainsOnlyActionSupportedLanguages(
+	event: SnykIntegratorEvent,
+): boolean {
+	const actionSuppoertedLanguages = ignoredLanguages.concat(
+		'Scala',
+		'Typescript',
+		'Go',
+		'Python',
+		'JavaScript',
+	);
+	return event.languages.every((lang) =>
+		actionSuppoertedLanguages.includes(lang),
+	);
+}
+
+export async function sendUnprotectedRepo(
+	evaluatedRepos: repocop_github_repository_rules[],
+	config: Config,
+	owners: view_repo_ownership[],
+	githubLanguages: github_languages[],
+) {
+	const unprotectedDevXRepos = findDevXRepos(
+		owners,
+		findUnprotectedRepos(evaluatedRepos),
+	);
+
+	const unprotectedDevXReposWithLanguages: SnykIntegratorEvent[] =
+		unprotectedDevXRepos.map((repo) => {
+			const languages =
+				githubLanguages.find((lang) => lang.full_name === repo.full_name)
+					?.languages ?? [];
+			return {
+				name: removeRepoOwner(repo.full_name),
+				languages,
+			};
+		});
+
+	const reposWhereAllLanguagesAreSupported =
+		unprotectedDevXReposWithLanguages.filter((event) =>
+			eventContainsOnlyActionSupportedLanguages(event),
+		);
+
+	const eventToSend = reposWhereAllLanguagesAreSupported[0];
+
+	const publishRequestEntry = new PublishCommand({
+		Message: JSON.stringify(reposWhereAllLanguagesAreSupported[0]),
+		TopicArn: '', //TODO fix this
+	});
+
+	console.log(`Sending ${eventToSend?.name} to Snyk Integrator`);
+	await new SNSClient(awsClientConfig(config.stage)).send(publishRequestEntry);
+}

--- a/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
@@ -53,13 +53,10 @@ function findReposWhereIntegrationWillWork(
 	owners: view_repo_ownership[],
 	githubLanguages: github_languages[],
 ) {
-	const unprotectedDevXRepos = findDevXRepos(
-		owners,
-		findUnprotectedRepos(evaluatedRepos),
-	);
+	const unprotectedRepos = findUnprotectedRepos(evaluatedRepos);
 
-	const unprotectedDevXReposWithLanguages: SnykIntegratorEvent[] =
-		unprotectedDevXRepos.map((repo) => {
+	const unprotectedReposWithLanguages: SnykIntegratorEvent[] =
+		unprotectedRepos.map((repo) => {
 			const languages =
 				githubLanguages.find((lang) => lang.full_name === repo.full_name)
 					?.languages ?? [];
@@ -70,7 +67,7 @@ function findReposWhereIntegrationWillWork(
 		});
 
 	const reposWhereAllLanguagesAreSupported =
-		unprotectedDevXReposWithLanguages.filter((event) =>
+		unprotectedReposWithLanguages.filter((event) =>
 			eventContainsOnlyActionSupportedLanguages(event),
 		);
 
@@ -83,8 +80,10 @@ export async function sendUnprotectedRepo(
 	owners: view_repo_ownership[],
 	githubLanguages: github_languages[],
 ) {
+	const devXRepos = findDevXRepos(owners, evaluatedRepos);
+
 	const eventToSend = findReposWhereIntegrationWillWork(
-		evaluatedRepos,
+		devXRepos,
 		owners,
 		githubLanguages,
 	)[0];

--- a/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
@@ -5,7 +5,6 @@ import type {
 	view_repo_ownership,
 } from '@prisma/client';
 import { awsClientConfig } from 'common/src/aws';
-import { shuffle } from 'common/src/functions';
 import type { SnykIntegratorEvent } from 'common/src/types';
 import type { Config } from '../../config';
 import { ignoredLanguages } from '../../languages';
@@ -48,10 +47,9 @@ function eventContainsOnlyActionSupportedLanguages(
 		actionSuppoertedLanguages.includes(lang),
 	);
 }
-
-export async function sendUnprotectedRepo(
+//TODO test me
+function findReposWhereIntegrationWillWork(
 	evaluatedRepos: repocop_github_repository_rules[],
-	config: Config,
 	owners: view_repo_ownership[],
 	githubLanguages: github_languages[],
 ) {
@@ -76,10 +74,23 @@ export async function sendUnprotectedRepo(
 			eventContainsOnlyActionSupportedLanguages(event),
 		);
 
-	const eventToSend = reposWhereAllLanguagesAreSupported[0];
+	return reposWhereAllLanguagesAreSupported;
+}
+
+export async function sendUnprotectedRepo(
+	evaluatedRepos: repocop_github_repository_rules[],
+	config: Config,
+	owners: view_repo_ownership[],
+	githubLanguages: github_languages[],
+) {
+	const eventToSend = findReposWhereIntegrationWillWork(
+		evaluatedRepos,
+		owners,
+		githubLanguages,
+	)[0];
 
 	const publishRequestEntry = new PublishCommand({
-		Message: JSON.stringify(reposWhereAllLanguagesAreSupported[0]),
+		Message: JSON.stringify(eventToSend),
 		TopicArn: '', //TODO fix this
 	});
 

--- a/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
@@ -85,7 +85,7 @@ export async function sendUnprotectedRepo(
 
 	const publishRequestEntry = new PublishCommand({
 		Message: JSON.stringify(eventToSend),
-		TopicArn: '', //TODO fix this
+		TopicArn: config.snykIntegratorTopic,
 	});
 
 	console.log(`Sending ${eventToSend?.name} to Snyk Integrator`);

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -5,6 +5,10 @@ import type {
 	repocop_github_repository_rules,
 	snyk_projects,
 } from '@prisma/client';
+import {
+	supportedDependabotLanguages,
+	supportedSnykLanguages,
+} from '../languages';
 import type {
 	AwsCloudFormationStack,
 	RepoAndStack,
@@ -149,53 +153,6 @@ export function hasDependencyTracking(
 		repoLanguages.find(
 			(repoLanguage) => repoLanguage.full_name === repo.full_name,
 		)?.languages ?? [];
-
-	const ignoredLanguages = [
-		'HTML',
-		'CSS',
-		'Shell',
-		'Jupyter Notebook',
-		'Makefile',
-		'Dockerfile',
-		'PLpgSQL',
-		'Thrift',
-		'SCSS',
-		'Batchfile',
-		'HCL',
-		'VCL',
-	];
-
-	const commonSupportedLanguages = [
-		'C#',
-		'Go',
-		'Java',
-		'JavaScript',
-		'Python',
-		'Swift',
-		'TypeScript',
-	];
-	const snykOnlySupportedLanguages = [
-		'C',
-		'C++',
-		'Apex',
-		'Bazel',
-		'Elixir',
-		'Kotlin',
-		'PHP',
-		'Ruby',
-		'Rust',
-		'Scala',
-		'Objective-C',
-		'Visual Basic .NET',
-	];
-
-	const supportedDependabotLanguages = ignoredLanguages.concat(
-		commonSupportedLanguages,
-	);
-
-	const supportedSnykLanguages = ignoredLanguages
-		.concat(commonSupportedLanguages)
-		.concat(snykOnlySupportedLanguages);
 
 	const allProjectTags = snyk_projects.map((project) => parseSnykTags(project));
 

--- a/packages/snyk-integrator/src/index.ts
+++ b/packages/snyk-integrator/src/index.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from 'crypto';
 import type { SNSHandler } from 'aws-lambda';
 import { parseEvent, stageAwareOctokit } from 'common/functions';
+import type { SnykIntegratorEvent } from 'common/src/types';
 import type { Config } from './config';
 import { getConfig } from './config';
 import {
@@ -33,11 +34,6 @@ export async function main(event: SnykIntegratorEvent) {
 		);
 	}
 	console.log('Done');
-}
-
-export interface SnykIntegratorEvent {
-	name: string;
-	languages: string[];
 }
 
 export const handler: SNSHandler = async (event) => {


### PR DESCRIPTION
## What does this change?

Added an additional feature to repocop. It grabs DevX repos that are not correctly integrated with Snyk, and sends one of them to the Snyk Integrator lambda for processing. I am limiting it to DevX repos for now so that we can verify the first set of PRs before rolling out to the rest of the department

It will only send a repo on if **ALL** of its languages are supported by our action. Currently, this includes Scala, Typescript, JavaScript, Rust and Python. We hope to add a few more in the coming weeks.

## Why?

Automatically raising PRs against repos that we know can be successfully integrated with snyk makes it much easier for teams to track their vulnerablities accurately.

## How has it been verified?

- Unit tests have been added.
- This change has been deployed to CODE and tested end to end. Snyk integrator is able to pick up the message and create the correct looking snyk.yml