### PR TITLE
Add Steampipe container and use it in Grafana

### DIFF
--- a/packages/dev-environment/dev-config/grafana-datasource.yaml
+++ b/packages/dev-environment/dev-config/grafana-datasource.yaml
@@ -17,3 +17,17 @@ datasources:
       connMaxLifetime: 14400
       postgresVersion: 1000
       timescaledb: false
+  - name: Steampipe
+    type: postgres
+    url: steampipe:9193
+    user: steampipe
+    secureJsonData:
+      password: 'steampipe'
+    jsonData:
+      database: steampipe
+      sslmode: 'disable'
+      maxOpenConns: 0
+      maxIdleConns: 2
+      connMaxLifetime: 14400
+      postgresVersion: 1000
+      timescaledb: false

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -8,32 +8,24 @@ services:
       POSTGRES_DB: ${DATABASE_HOSTNAME}
       POSTGRES_USER: ${DATABASE_USER}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
-  cloudquery:
-    image: ghcr.io/cloudquery/cloudquery:${CQ_CLI}
-    platform: linux/amd64
-    depends_on:
-      - postgres
-    volumes:
-      - ~/.aws/credentials:/.aws/credentials
-      - ./dev-config/cloudquery.yaml:/dev-config.yaml
-      - ~/.gu/service_catalogue/app-id:/app-id
-      - ~/.gu/service_catalogue/installation-id:/installation-id
-      - ~/.gu/service_catalogue/private-key.pem:/private-key.pem
+  steampipe:
+    image: ghcr.io/turbot/steampipe:latest
+    ports:
+      - '9193:9193'
     environment:
-      AWS_SHARED_CREDENTIALS_FILE: '/.aws/credentials'
-      CQ_POSTGRES_DESTINATION: ${CQ_POSTGRES_DESTINATION}
-      CQ_AWS: ${CQ_AWS}
-      CQ_GITHUB: ${CQ_GITHUB}
-      CQ_SNYK: ${CQ_SNYK}
-      GITHUB_ACCESS_TOKEN: ${GITHUB_ACCESS_TOKEN}
-      SNYK_TOKEN: ${SNYK_TOKEN}
-      GALAXIES_BUCKET: ${GALAXIES_BUCKET}
-      CLOUDQUERY_API_KEY: ${CLOUDQUERY_API_KEY}
-    command: sync /dev-config.yaml --log-console --log-level info
+      STEAMPIPE_DATABASE_PASSWORD: steampipe
+      GITHUB_TOKEN: (secret)
+    entrypoint:
+      [
+        '/bin/sh',
+        '-c',
+        'steampipe plugin install github; steampipe plugin list; steampipe service start --foreground',
+      ]
   grafana:
     image: grafana/grafana-oss:9.4.7
     depends_on:
       - postgres
+      - steampipe
     ports:
       - '3000:3000'
     volumes:

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -8,19 +8,28 @@ services:
       POSTGRES_DB: ${DATABASE_HOSTNAME}
       POSTGRES_USER: ${DATABASE_USER}
       POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
-  steampipe:
-    image: ghcr.io/turbot/steampipe:latest
-    ports:
-      - '9193:9193'
+  cloudquery:
+    image: ghcr.io/cloudquery/cloudquery:${CQ_CLI}
+    platform: linux/amd64
+    depends_on:
+      - postgres
+    volumes:
+      - ~/.aws/credentials:/.aws/credentials
+      - ./dev-config/cloudquery.yaml:/dev-config.yaml
+      - ~/.gu/service_catalogue/app-id:/app-id
+      - ~/.gu/service_catalogue/installation-id:/installation-id
+      - ~/.gu/service_catalogue/private-key.pem:/private-key.pem
     environment:
-      STEAMPIPE_DATABASE_PASSWORD: steampipe
-      GITHUB_TOKEN: (secret)
-    entrypoint:
-      [
-        '/bin/sh',
-        '-c',
-        'steampipe plugin install github; steampipe plugin list; steampipe service start --foreground',
-      ]
+      AWS_SHARED_CREDENTIALS_FILE: '/.aws/credentials'
+      CQ_POSTGRES_DESTINATION: ${CQ_POSTGRES_DESTINATION}
+      CQ_AWS: ${CQ_AWS}
+      CQ_GITHUB: ${CQ_GITHUB}
+      CQ_SNYK: ${CQ_SNYK}
+      GITHUB_ACCESS_TOKEN: ${GITHUB_ACCESS_TOKEN}
+      SNYK_TOKEN: ${SNYK_TOKEN}
+      GALAXIES_BUCKET: ${GALAXIES_BUCKET}
+      CLOUDQUERY_API_KEY: ${CLOUDQUERY_API_KEY}
+    command: sync /dev-config.yaml --log-console --log-level info
   grafana:
     image: grafana/grafana-oss:9.4.7
     depends_on:
@@ -31,3 +40,16 @@ services:
     volumes:
       - ./dev-config/grafana.ini:/etc/grafana/grafana.ini
       - ./dev-config/grafana-datasource.yaml:/etc/grafana/provisioning/datasources/cloudquery.yaml
+  steampipe:
+    image: ghcr.io/turbot/steampipe:latest
+    ports:
+      - '9193:9193'
+    environment:
+      STEAMPIPE_DATABASE_PASSWORD: steampipe
+      GITHUB_TOKEN: ${GITHUB_ACCESS_TOKEN}
+    entrypoint:
+      [
+        '/bin/sh',
+        '-c',
+        'steampipe plugin install github; steampipe plugin list; steampipe service start --foreground',
+      ]

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -41,15 +41,12 @@ services:
       - ./dev-config/grafana.ini:/etc/grafana/grafana.ini
       - ./dev-config/grafana-datasource.yaml:/etc/grafana/provisioning/datasources/cloudquery.yaml
   steampipe:
-    image: ghcr.io/turbot/steampipe:latest
+    build:
+      context: steampipe
+      dockerfile: Dockerfile
     ports:
       - '9193:9193'
     environment:
       STEAMPIPE_DATABASE_PASSWORD: steampipe
       GITHUB_TOKEN: ${GITHUB_ACCESS_TOKEN}
-    entrypoint:
-      [
-        '/bin/sh',
-        '-c',
-        'steampipe plugin install github; steampipe plugin list; steampipe service start --foreground',
-      ]
+    command: ["service", "start", "--foreground"]

--- a/packages/dev-environment/steampipe/Dockerfile
+++ b/packages/dev-environment/steampipe/Dockerfile
@@ -1,0 +1,2 @@
+FROM ghcr.io/turbot/steampipe
+RUN  steampipe plugin install steampipe github@0.39.0


### PR DESCRIPTION
## What does this change?
Runs [Steampipe](https://steampipe.io/) locally with the GitHub plugin. The data is also queryable in the local Grafana instance; we can run queries like this:

```sql
select name
from github_my_repository
limit 10;
```

Note: The GitHub plugin only supports GitHub Personal Access Tokens. We're using the token from the `~/.gu/service-catalogue/.env.local` file created during setup.

<details><summary>Example of querying Steampipe with Grafana</summary>
<p>

![image](https://github.com/guardian/service-catalogue/assets/836140/4dc0694a-e91a-41ba-8cf5-151de4684de1)

</p>
</details> 

## Why?
Exploring real-time data querying.