### PR TITLE
Add PRs to project board

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3448,7 +3448,8 @@
     },
     "node_modules/@octokit/graphql": {
       "version": "7.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.2.tgz",
+      "integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
       "dependencies": {
         "@octokit/request": "^8.0.1",
         "@octokit/types": "^12.0.0",
@@ -13316,6 +13317,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-sns": "^3.490.0",
+        "@octokit/graphql": "^7.0.2",
         "octokit-plugin-create-pull-request": "^5.1.1",
         "ts-markdown": "^1.0.0",
         "yaml": "^2.3.4"

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -75,7 +75,7 @@ export async function stageAwareGraphQlClient(stage: string) {
 		const graphqlWithAuth = octokit.graphql;
 		return graphqlWithAuth;
 	} else {
-		//NB this runs into issues with SAML authentication
+		//NB you may have to validate your PAT with SAML to use the GraphQL API
 		const token = getEnvOrThrow('GITHUB_ACCESS_TOKEN');
 		const { graphql } = await import('@octokit/graphql');
 		const graphqlWithAuth = graphql.defaults({

--- a/packages/snyk-integrator/package.json
+++ b/packages/snyk-integrator/package.json
@@ -11,8 +11,9 @@
 	},
 	"dependencies": {
 		"@aws-sdk/client-sns": "^3.490.0",
-		"ts-markdown": "^1.0.0",
+		"@octokit/graphql": "^7.0.2",
 		"octokit-plugin-create-pull-request": "^5.1.1",
+		"ts-markdown": "^1.0.0",
 		"yaml": "^2.3.4"
 	}
 }

--- a/packages/snyk-integrator/src/index.ts
+++ b/packages/snyk-integrator/src/index.ts
@@ -4,6 +4,7 @@ import { parseEvent, stageAwareOctokit } from 'common/functions';
 import type { SnykIntegratorEvent } from 'common/src/types';
 import type { Config } from './config';
 import { getConfig } from './config';
+import { addPrToProject } from './projects-graphql';
 import {
 	createSnykPullRequest,
 	createYaml,
@@ -21,11 +22,12 @@ export async function main(event: SnykIntegratorEvent) {
 		const response = await createSnykPullRequest(
 			octokit,
 			event.name,
-
 			branch,
 			event.languages,
 		);
 		console.log('Pull request successfully created:', response?.data.html_url);
+
+		await addPrToProject(config.stage, event);
 	} else {
 		console.log('Testing snyk.yml generation');
 		console.log(createYaml(event.languages, branch));

--- a/packages/snyk-integrator/src/index.ts
+++ b/packages/snyk-integrator/src/index.ts
@@ -28,6 +28,7 @@ export async function main(event: SnykIntegratorEvent) {
 		console.log('Pull request successfully created:', response?.data.html_url);
 
 		await addPrToProject(config.stage, event);
+		console.log('Updated project board');
 	} else {
 		console.log('Testing snyk.yml generation');
 		console.log(createYaml(event.languages, branch));

--- a/packages/snyk-integrator/src/projects-graphql.test.ts
+++ b/packages/snyk-integrator/src/projects-graphql.test.ts
@@ -1,0 +1,29 @@
+import { getLastPrsQuery } from './projects-graphql';
+
+/*
+** We are testing the string interpolation as the query construction logic is
+** quite fragile and needs to be exactly correct. It's also very unlikely to
+** change in the near future, so these tests will not need to be updated often
+*/
+
+describe('Formatting graphQL queries', () => {
+	it('should return a valid graphQL object when constructing the query for getting the most recent PRs', () => {
+		const actual = getLastPrsQuery('test-repo');
+		const expected = String.raw`{
+        organization(login: "guardian") {
+          repository(name: "test-repo") {
+            pullRequests(last: 5, states:[OPEN]) {
+              nodes {
+                author {
+                  login
+                }
+                id
+              }
+            }
+          }
+        }
+      }`;
+
+		expect(actual).toEqual(expected);
+	});
+});

--- a/packages/snyk-integrator/src/projects-graphql.test.ts
+++ b/packages/snyk-integrator/src/projects-graphql.test.ts
@@ -1,14 +1,18 @@
-import { getLastPrsQuery } from './projects-graphql';
+import { addToProjectQuery, getLastPrsQuery } from './projects-graphql';
 
 /*
-** We are testing the string interpolation as the query construction logic is
-** quite fragile and needs to be exactly correct. It's also very unlikely to
-** change in the near future, so these tests will not need to be updated often
-*/
+ ** We are testing the string interpolation as the query construction logic is
+ ** quite fragile and a stray bracket can cause a failure.
+ **
+ ** The structure of the queries is very stable, and will not change very
+ ** often, so these tests will not need to be frequently updated, and are
+ ** mostly here as a typo safeguard for future travellers.
+ */
 
 describe('Formatting graphQL queries', () => {
 	it('should return a valid graphQL object when constructing the query for getting the most recent PRs', () => {
 		const actual = getLastPrsQuery('test-repo');
+		console.log(actual);
 		const expected = String.raw`{
         organization(login: "guardian") {
           repository(name: "test-repo") {
@@ -24,6 +28,14 @@ describe('Formatting graphQL queries', () => {
         }
       }`;
 
+		expect(actual).toEqual(expected);
+	});
+	it('should return a valid graphQL object when constructing the query for adding a PR to a project', () => {
+		const actual = addToProjectQuery('test-project-id', 'test-pr-id')
+			.replaceAll('\t', '') //getting the spacing right in this query is a pain, and unimportant, so remove it
+			.replaceAll('\n', '');
+		console.log(actual);
+		const expected = String.raw`mutation {addProjectV2ItemById(input: {projectId: "test-project-id" contentId: "test-pr-id"}) {  item {id  }}  }`;
 		expect(actual).toEqual(expected);
 	});
 });

--- a/packages/snyk-integrator/src/projects-graphql.ts
+++ b/packages/snyk-integrator/src/projects-graphql.ts
@@ -2,7 +2,9 @@ import { stageAwareGraphQlClient } from 'common/functions';
 import type { SnykIntegratorEvent } from 'common/types';
 import type { ProjectId, PullRequestDetails } from './types';
 
-function getLastPrsQuery(repoName: string, last: number) {
+function getLastPrsQuery(repoName: string) {
+	//It's really unlikely that we'll need to pull as many as 5 PRs,
+	//but this is not an expensive query, so we may as well.
 	return `{
         organization(login: "guardian") {
           repository(name: "${repoName}") {
@@ -40,7 +42,7 @@ export async function addPrToProject(
 
 	//TODO can we filter this to only PRs raised by gu-snyk-integrator?
 	const prDetails: PullRequestDetails = await graphqlWithAuth(
-		getLastPrsQuery(event.name, 5),
+		getLastPrsQuery(event.name),
 	);
 
 	const pullRequestIds = prDetails.organization.repository.pullRequests.nodes

--- a/packages/snyk-integrator/src/projects-graphql.ts
+++ b/packages/snyk-integrator/src/projects-graphql.ts
@@ -2,7 +2,15 @@ import { stageAwareGraphQlClient } from 'common/functions';
 import type { SnykIntegratorEvent } from 'common/types';
 import type { ProjectId, PullRequestDetails } from './types';
 
-function getLastPrsQuery(repoName: string) {
+/*
+ ** GitHub's v2 projects API is accessible via GraphQL only.
+ ** We could use classic projects and the REST API, but then we would lose
+ ** features like PRs moving across the board automatically when their status
+ ** changes(i.e. when they are merged).
+ */
+
+//TODO test me
+ function getLastPrsQuery(repoName: string) {
 	//It's really unlikely that we'll need to pull as many as 5 PRs,
 	//but this is not an expensive query, so we may as well.
 	return `{

--- a/packages/snyk-integrator/src/projects-graphql.ts
+++ b/packages/snyk-integrator/src/projects-graphql.ts
@@ -10,7 +10,7 @@ import type { ProjectId, PullRequestDetails } from './types';
  */
 
 //TODO test me
- function getLastPrsQuery(repoName: string) {
+function getLastPrsQuery(repoName: string) {
 	//It's really unlikely that we'll need to pull as many as 5 PRs,
 	//but this is not an expensive query, so we may as well.
 	return `{
@@ -27,6 +27,17 @@ import type { ProjectId, PullRequestDetails } from './types';
           }
         }
       }`;
+}
+
+//TODO test
+function addToProjectQuery(projectId: string, pullRequestId: string): string {
+	return `mutation {
+		addProjectV2ItemById(input: {projectId: "${projectId}" contentId: "${pullRequestId}"}) {
+		  item {
+			id
+		  }
+		}
+	  }`;
 }
 
 export async function addPrToProject(
@@ -59,13 +70,9 @@ export async function addPrToProject(
 
 	console.log(pullRequestIds);
 
-	const addToProjectString = `mutation {
-		addProjectV2ItemById(input: {projectId: "${projectId}" contentId: "${pullRequestIds[0]}"}) {
-		  item {
-			id
-		  }
-		}
-	  }`;
-
-	return addToProjectString;
+	await Promise.all(
+		pullRequestIds.map(async (prId) => {
+			await graphqlWithAuth(addToProjectQuery(projectId, prId));
+		}),
+	);
 }

--- a/packages/snyk-integrator/src/projects-graphql.ts
+++ b/packages/snyk-integrator/src/projects-graphql.ts
@@ -4,18 +4,18 @@ import type { ProjectId, PullRequestDetails } from './types';
 
 function getLastPrsQuery(repoName: string, last: number) {
 	return `{
-        organization(login: "guardian"){
-              repository(name: "${repoName}"){
-            pullRequests(last: ${last}}){
-              nodes{
-                author{
+        organization(login: "guardian") {
+          repository(name: "${repoName}") {
+            pullRequests(last: 5, states:[OPEN]) {
+              nodes {
+                author {
                   login
                 }
                 id
               }
             }
           }
-          }
+        }
       }`;
 }
 

--- a/packages/snyk-integrator/src/projects-graphql.ts
+++ b/packages/snyk-integrator/src/projects-graphql.ts
@@ -1,5 +1,5 @@
-import { stageAwareGraphQlClient } from 'common/functions';
-import type { SnykIntegratorEvent } from 'common/types';
+import { stageAwareGraphQlClient } from 'common/src/functions';
+import type { SnykIntegratorEvent } from 'common/src/types';
 import type { ProjectId, PullRequestDetails } from './types';
 
 /*
@@ -9,8 +9,7 @@ import type { ProjectId, PullRequestDetails } from './types';
  ** changes(i.e. when they are merged).
  */
 
-//TODO test me
-function getLastPrsQuery(repoName: string) {
+export function getLastPrsQuery(repoName: string) {
 	//It's really unlikely that we'll need to pull as many as 5 PRs,
 	//but this is not an expensive query, so we may as well.
 	return `{

--- a/packages/snyk-integrator/src/projects-graphql.ts
+++ b/packages/snyk-integrator/src/projects-graphql.ts
@@ -28,8 +28,10 @@ export function getLastPrsQuery(repoName: string) {
       }`;
 }
 
-//TODO test
-function addToProjectQuery(projectId: string, pullRequestId: string): string {
+export function addToProjectQuery(
+	projectId: string,
+	pullRequestId: string,
+): string {
 	return `mutation {
 		addProjectV2ItemById(input: {projectId: "${projectId}" contentId: "${pullRequestId}"}) {
 		  item {

--- a/packages/snyk-integrator/src/projects-graphql.ts
+++ b/packages/snyk-integrator/src/projects-graphql.ts
@@ -1,0 +1,61 @@
+import { stageAwareGraphQlClient } from 'common/functions';
+import type { SnykIntegratorEvent } from 'common/types';
+import type { ProjectId, PullRequestDetails } from './types';
+
+function getLastPrsQuery(repoName: string, last: number) {
+	return `{
+        organization(login: "guardian"){
+              repository(name: "${repoName}"){
+            pullRequests(last: ${last}}){
+              nodes{
+                author{
+                  login
+                }
+                id
+              }
+            }
+          }
+          }
+      }`;
+}
+
+export async function addPrToProject(
+	stage: string,
+	event: SnykIntegratorEvent,
+) {
+	const graphqlWithAuth = await stageAwareGraphQlClient(stage);
+
+	const projectDetails: ProjectId = await graphqlWithAuth(
+		`{
+			organization(login: "guardian"){
+				projectV2(number: 110) {
+				  id
+				}
+			  }
+		  }`,
+	);
+
+	const projectId = projectDetails.organization.projectV2.id;
+	console.log(projectId);
+
+	//TODO can we filter this to only PRs raised by gu-snyk-integrator?
+	const prDetails: PullRequestDetails = await graphqlWithAuth(
+		getLastPrsQuery(event.name, 5),
+	);
+
+	const pullRequestIds = prDetails.organization.repository.pullRequests.nodes
+		.filter((pr) => pr.author.login === 'gu-snyk-integrator')
+		.map((pr) => pr.id);
+
+	console.log(pullRequestIds);
+
+	const addToProjectString = `mutation {
+		addProjectV2ItemById(input: {projectId: "${projectId}" contentId: "${pullRequestIds[0]}"}) {
+		  item {
+			id
+		  }
+		}
+	  }`;
+
+	return addToProjectString;
+}

--- a/packages/snyk-integrator/src/types.ts
+++ b/packages/snyk-integrator/src/types.ts
@@ -1,0 +1,25 @@
+//GraphQL response types
+interface PullRequestIdAndAuthor {
+    author: {
+        login: string;
+    };
+    id: string;
+}
+
+export interface PullRequestDetails {
+    organization: {
+        repository: {
+            pullRequests: {
+                nodes: [PullRequestIdAndAuthor];
+            };
+        };
+    };
+}
+
+export interface ProjectId {
+    organization: {
+        projectV2: {
+            id: string;
+        };
+    };
+}

--- a/packages/snyk-integrator/src/types.ts
+++ b/packages/snyk-integrator/src/types.ts
@@ -1,25 +1,25 @@
 //GraphQL response types
 interface PullRequestIdAndAuthor {
-    author: {
-        login: string;
-    };
-    id: string;
+	author: {
+		login: string;
+	};
+	id: string;
 }
 
 export interface PullRequestDetails {
-    organization: {
-        repository: {
-            pullRequests: {
-                nodes: [PullRequestIdAndAuthor];
-            };
-        };
-    };
+	organization: {
+		repository: {
+			pullRequests: {
+				nodes: [PullRequestIdAndAuthor];
+			};
+		};
+	};
 }
 
 export interface ProjectId {
-    organization: {
-        projectV2: {
-            id: string;
-        };
-    };
+	organization: {
+		projectV2: {
+			id: string;
+		};
+	};
 }


### PR DESCRIPTION
## What does this change?

In PROD, once a PR has been raised, we should add it to the [project board](https://github.com/orgs/guardian/projects/110/views/1)

## Why?

Allows us to keep track of the PRs we've raised, so we know who we might need to follow up with

## How has it been verified?

Deployed to PROD and verified that the PRs are raised and added to the project board

## Images

<img width="1175" alt="Screenshot 2024-01-18 at 12 09 40" src="https://github.com/guardian/service-catalogue/assets/67543397/92127a6b-c3c3-448a-8196-fc5190b9e1db">
