### PR TITLE
Only trigger snyk integrator if a repo exists

### DIFF
--- a/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
@@ -85,11 +85,17 @@ export async function sendUnprotectedRepo(
 		githubLanguages,
 	)[0];
 
-	const publishRequestEntry = new PublishCommand({
-		Message: JSON.stringify(eventToSend),
-		TopicArn: config.snykIntegratorTopic,
-	});
+	if (eventToSend) {
+		const publishRequestEntry = new PublishCommand({
+			Message: JSON.stringify(eventToSend),
+			TopicArn: config.snykIntegratorTopic,
+		});
 
-	console.log(`Sending ${eventToSend?.name} to Snyk Integrator`);
-	await new SNSClient(awsClientConfig(config.stage)).send(publishRequestEntry);
+		console.log(`Sending ${eventToSend.name} to Snyk Integrator`);
+		await new SNSClient(awsClientConfig(config.stage)).send(
+			publishRequestEntry,
+		);
+	} else {
+		console.log('No untracked repos found');
+	}
 }


### PR DESCRIPTION
## What does this change?

Previously, repocop would try to pass an undefined value to SNS, which would cause a failure. Now, we are checking to make sure the value exists first.

## Why?

Prevent repocop failures
