### PR TITLE
Tweak logging

### DIFF
--- a/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
@@ -68,7 +68,7 @@ export function findUntrackedReposWhereIntegrationWillWork(
 
 	console.log(
 		`Found ${reposWhereAllLanguagesAreSupported.length} untracked repos that can be integrated with Snyk: `,
-		reposWhereAllLanguagesAreSupported.join(','),
+		reposWhereAllLanguagesAreSupported.map((x) => JSON.stringify(x)).join(','),
 	);
 
 	return reposWhereAllLanguagesAreSupported;

--- a/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
@@ -66,10 +66,14 @@ export function findUntrackedReposWhereIntegrationWillWork(
 			eventContainsOnlyActionSupportedLanguages(event),
 		);
 
-	console.log(
-		`Found ${reposWhereAllLanguagesAreSupported.length} untracked repos that can be integrated with Snyk: `,
-		reposWhereAllLanguagesAreSupported.map((x) => JSON.stringify(x)).join(','),
-	);
+	if (reposWhereAllLanguagesAreSupported.length > 0) {
+		console.log(
+			`Found ${reposWhereAllLanguagesAreSupported.length} untracked repos that can be integrated with Snyk: `,
+			reposWhereAllLanguagesAreSupported
+				.map((x) => JSON.stringify(x))
+				.join(','),
+		);
+	}
 
 	return reposWhereAllLanguagesAreSupported;
 }

--- a/packages/repocop/src/remediations/topics/topic-monitor-production.ts
+++ b/packages/repocop/src/remediations/topics/topic-monitor-production.ts
@@ -195,9 +195,11 @@ export async function applyProductionTopicAndMessageTeams(
 		})
 		.filter((contactableRepo) => contactableRepo.teamNameSlugs.length > 0);
 
-	console.log(
-		`Found ${reposWithContactableOwners.length} repos with contactable owners for addition of the production topic`,
-	);
+	if (reposWithContactableOwners.length > 0) {
+		console.log(
+			`Found ${reposWithContactableOwners.length} repos with contactable owners for addition of the production topic`,
+		);
+	}
 
 	await Promise.all(
 		reposWithContactableOwners.map((repo) =>

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -351,7 +351,6 @@ describe('Repositories with related stacks on AWS', () => {
 			creation_time: new Date(),
 			tags,
 		};
-		console.log(findStacks(repo, [stack]));
 		const result = findStacks(repo, [stack]).stacks.length;
 		expect(result).toEqual(1);
 	});

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -168,9 +168,6 @@ export function hasDependencyTracking(
 				file.path.includes('snyk'),
 		);
 		const exists = result !== undefined;
-		if (exists) {
-			console.log(`${repo.full_name} has a snyk workflow file.`);
-		}
 		return exists;
 	}
 
@@ -184,9 +181,6 @@ export function hasDependencyTracking(
 				tags.branch === repo.default_branch,
 		);
 		const exists = result !== undefined;
-		if (exists) {
-			console.log(`${repo.name} has a snyk project.`);
-		}
 		return exists;
 	}
 

--- a/packages/snyk-integrator/src/projects-graphql.test.ts
+++ b/packages/snyk-integrator/src/projects-graphql.test.ts
@@ -12,7 +12,6 @@ import { addToProjectQuery, getLastPrsQuery } from './projects-graphql';
 describe('Formatting graphQL queries', () => {
 	it('should return a valid graphQL object when constructing the query for getting the most recent PRs', () => {
 		const actual = getLastPrsQuery('test-repo');
-		console.log(actual);
 		const expected = String.raw`{
         organization(login: "guardian") {
           repository(name: "test-repo") {
@@ -34,7 +33,6 @@ describe('Formatting graphQL queries', () => {
 		const actual = addToProjectQuery('test-project-id', 'test-pr-id')
 			.replaceAll('\t', '') //getting the spacing right in this query is a pain, and unimportant, so remove it
 			.replaceAll('\n', '');
-		console.log(actual);
 		const expected = String.raw`mutation {addProjectV2ItemById(input: {projectId: "test-project-id" contentId: "test-pr-id"}) {  item {id  }}  }`;
 		expect(actual).toEqual(expected);
 	});

--- a/packages/snyk-integrator/src/projects-graphql.ts
+++ b/packages/snyk-integrator/src/projects-graphql.ts
@@ -58,9 +58,7 @@ export async function addPrToProject(
 	);
 
 	const projectId = projectDetails.organization.projectV2.id;
-	console.log(projectId);
 
-	//TODO can we filter this to only PRs raised by gu-snyk-integrator?
 	const prDetails: PullRequestDetails = await graphqlWithAuth(
 		getLastPrsQuery(event.name),
 	);
@@ -68,8 +66,6 @@ export async function addPrToProject(
 	const pullRequestIds = prDetails.organization.repository.pullRequests.nodes
 		.filter((pr) => pr.author.login === 'gu-snyk-integrator')
 		.map((pr) => pr.id);
-
-	console.log(pullRequestIds);
 
 	await Promise.all(
 		pullRequestIds.map(async (prId) => {


### PR DESCRIPTION
## What does this change?

1. Remove log lines in `packages/repocop/src/rules/repository.ts` that show up hundreds of times
2. Logs in `send-to-sns.ts` returns a string rather than [Object object]
3. Only log repos with contactable owners if we find some

## Why?

Make the logs less noisy
Number 3 in particular was taking up a lot of space in the test output
