### PR TITLE
fix(cloudquery): Skip the `aws_emr_supported_instance_types` table

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -15307,6 +15307,7 @@ spec:
     - aws_elasticache_parameter_groups
     - aws_elasticache_reserved_cache_nodes_offerings
     - aws_elasticache_service_updates
+    - aws_emr_supported_instance_types
     - aws_neptune_cluster_parameter_groups
     - aws_neptune_db_parameter_groups
     - aws_rds_cluster_parameter_groups

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -333,6 +333,7 @@ export const skipTables = [
 	'aws_elasticache_parameter_groups',
 	'aws_elasticache_reserved_cache_nodes_offerings',
 	'aws_elasticache_service_updates',
+	'aws_emr_supported_instance_types',
 	'aws_neptune_cluster_parameter_groups',
 	'aws_neptune_db_parameter_groups',
 	'aws_rds_cluster_parameter_groups',

--- a/packages/common/prisma/migrations/20240119145931_remove_emr_types/migration.sql
+++ b/packages/common/prisma/migrations/20240119145931_remove_emr_types/migration.sql
@@ -1,0 +1,1 @@
+DROP TABLE aws_emr_supported_instance_types;

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -7075,30 +7075,6 @@ model aws_emr_studios {
   @@ignore
 }
 
-model aws_emr_supported_instance_types {
-  cq_sync_time             DateTime? @map("_cq_sync_time") @db.Timestamp(6)
-  cq_source_name           String?   @map("_cq_source_name")
-  cq_id                    String    @unique @map("_cq_id") @db.Uuid
-  cq_parent_id             String?   @map("_cq_parent_id") @db.Uuid
-  account_id               String
-  region                   String
-  release_label            String
-  architecture             String?
-  ebs_optimized_available  Boolean?
-  ebs_optimized_by_default Boolean?
-  ebs_storage_only         Boolean?
-  instance_family_id       String?
-  is64_bits_only           Boolean?
-  memory_gb                Float?
-  number_of_disks          BigInt?
-  storage_gb               BigInt?
-  type                     String
-  vcpu                     BigInt?
-
-  @@id([account_id, region, release_label, type], map: "aws_emr_supported_instance_types_cqpk")
-  @@ignore
-}
-
 model aws_eventbridge_api_destinations {
   cq_sync_time                     DateTime? @map("_cq_sync_time") @db.Timestamp(6)
   cq_source_name                   String?   @map("_cq_source_name")


### PR DESCRIPTION
## What does this change, and why?
This table has ~5 million rows, and isn't especially useful.

It lists the instance types we could use, and their specification. It is fairly repetitive across all regions and AWS accounts.

As we don't use AWS EMR, skip the table.

See https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-supported-instance-types.html.

Note: We'll need to [apply the migration](https://github.com/guardian/service-catalogue/blob/main/docs/database-migrations.md) manually.

<details><summary>Exactly how many rows?</summary>
<p>

```sql
SELECT relname, reltuples AS estimate 
FROM pg_class 
WHERE relname IN (
  SELECT TABLE_NAME
  FROM information_schema.tables
  WHERE TABLE_NAME not like 'pg_%' AND table_schema in ('public')
) 
ORDER BY estimate DESC
limit 5;
```

| relname | estimate |
|--------|--------|
| aws_cloudtrail_events | 5870568 |
| aws_emr_supported_instance_types | 4968076 | 
| aws_securityhub_findings | 1076861 | 
| riffraff_deploys | 711383 | 
| aws_iam_policy_last_accessed_details | 229564 | 


</p>
</details> 