### PR TITLE
Improve PR instructions

### DIFF
--- a/packages/snyk-integrator/src/index.ts
+++ b/packages/snyk-integrator/src/index.ts
@@ -8,6 +8,7 @@ import { addPrToProject } from './projects-graphql';
 import {
 	createSnykPullRequest,
 	createYaml,
+	generatePr,
 } from './snyk-integrator/snyk-integrator';
 
 export async function main(event: SnykIntegratorEvent) {
@@ -32,9 +33,10 @@ export async function main(event: SnykIntegratorEvent) {
 	} else {
 		console.log('Testing snyk.yml generation');
 		console.log(createYaml(event.languages, branch));
-		console.log(
-			'Skipping creating a test Snyk Pull Request (feature is not enabled)',
-		);
+		console.log('Testing PR generation');
+		const [head, body] = generatePr(event.languages, branch);
+		console.log('Title:\n', head);
+		console.log('Body:\n', body);
 	}
 	console.log('Done');
 }

--- a/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
+++ b/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
@@ -86,14 +86,21 @@ function checklist(items: string[]): string {
 
 function createPRChecklist(languages: string[], branchName: string): string[] {
 	const pythonText = ['Replace the relevant python fields'];
-	const defaultText = [
-		'Replace the SNYK_ORG variable with one that your team already uses (you should have other repos integrated with Snyk. ' +
-			'If you can’t find any, reach out to DevX)',
-		'Replace the relevant python fields, if they exist in the file. If not, skip this step',
+	const step1 =
+		'Replace the SNYK_ORG variable with the org name that your team ' +
+		'already uses (you should have other repos integrated with Snyk. ' +
+		'If you can’t find any, reach out to DevX). Examples are ' +
+		'`guardian-devtools` and `guardian-dotcom-n2y`';
+	const step2 =
 		'The job should run automatically on every commit to this branch. ' +
-			'View the action output and verify it has generated one project per dependency manifest (except pnpm and deno).',
-		`When you are happy the action works, remove the \`${branchName}\` option from the list of branches in the workflow, approve, and merge.`,
-	];
+		'View the action output and verify it has generated one project per ' +
+		'dependency manifest (except pnpm and deno). ' +
+		'Examples of dependency manifests are a build.sbt, or a package-lock.json.';
+	const step3 =
+		'When you are happy the action works, remove the ' +
+		`\`${branchName}\` option from the list of branches in the workflow, ` +
+		'approve, and merge.';
+	const defaultText = [step1, step2, step3];
 	const checklistItems = languages.includes('Python')
 		? pythonText.concat(defaultText)
 		: defaultText;

--- a/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
+++ b/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
@@ -92,10 +92,12 @@ function createPRChecklist(languages: string[], branchName: string): string[] {
 		'If you can’t find any, reach out to DevX). Examples are ' +
 		'`guardian-devtools` and `guardian-dotcom-n2y`';
 	const step2 =
-		'The job should run automatically on every commit to this branch. ' +
-		'View the action output and verify it has generated one project per ' +
-		'dependency manifest (except pnpm and deno). ' +
-		'Examples of dependency manifests are a build.sbt, or a package-lock.json.';
+		'The Snyk job should run automatically on every commit to this branch. ' +
+		'Click through to see the logs of the latest Snyk status check on ' +
+		'this PR, and verify it has generated one project per dependency manifest ' +
+		'(except pnpm and deno). ' +
+		'Examples of dependency manifests are a build.sbt, or a package-lock.json, ' +
+		'essentially, any file that lists the dependencies of your project.';
 	const step3 =
 		'When you are happy the action works, remove the ' +
 		`\`${branchName}\` option from the list of branches in the workflow, ` +

--- a/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
+++ b/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
@@ -84,6 +84,22 @@ function checklist(items: string[]): string {
 	return items.map((item) => `- [ ] ${item}`).join('\n');
 }
 
+function createPRChecklist(languages: string[], branchName: string): string[] {
+	const pythonText = ['Replace the relevant python fields'];
+	const defaultText = [
+		'Replace the SNYK_ORG variable with one that your team already uses (you should have other repos integrated with Snyk. ' +
+			'If you can’t find any, reach out to DevX)',
+		'Replace the relevant python fields, if they exist in the file. If not, skip this step',
+		'The job should run automatically on every commit to this branch. ' +
+			'View the action output and verify it has generated one project per dependency manifest (except pnpm and deno).',
+		`When you are happy the action works, remove the \`${branchName}\` option from the list of branches in the workflow, approve, and merge.`,
+	];
+	const checklistItems = languages.includes('Python')
+		? pythonText.concat(defaultText)
+		: defaultText;
+	return checklistItems;
+}
+
 function generatePrBody(branchName: string): string {
 	const body = [
 		h2('What does this change?'),
@@ -102,14 +118,7 @@ function generatePrBody(branchName: string): string {
 				'If your repository contains other languages not included here, integration may not work the way you expect it to.',
 		),
 		h2('What do I need to do?'),
-		checklist([
-			'Replace the SNYK_ORG variable with one that your team already uses (you should have other repos integrated with Snyk. ' +
-				'If you can’t find any, reach out to DevX)',
-			'Replace the relevant python fields, if they exist in the file. If not, skip this step',
-			'The job should run automatically on every commit to this branch. ' +
-				'View the action output and verify it has generated one project per dependency manifest (except pnpm and deno).',
-			`When you are happy the action works, remove the \`${branchName}\` option from the list of branches in the workflow, approve, and merge.`,
-		]),
+		checklist(createPRChecklist(['Python'], branchName)),
 	];
 	return tsMarkdown(body);
 }

--- a/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
+++ b/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
@@ -109,7 +109,7 @@ function createPRChecklist(languages: string[], branchName: string): string[] {
 	return checklistItems;
 }
 
-function generatePrBody(branchName: string): string {
+function generatePrBody(branchName: string, languages: string[]): string {
 	const body = [
 		h2('What does this change?'),
 		p(
@@ -127,7 +127,7 @@ function generatePrBody(branchName: string): string {
 				'If your repository contains other languages not included here, integration may not work the way you expect it to.',
 		),
 		h2('What do I need to do?'),
-		checklist(createPRChecklist(['Python'], branchName)),
+		checklist(createPRChecklist(languages, branchName)),
 	];
 	return tsMarkdown(body);
 }
@@ -154,7 +154,7 @@ export function generatePr(
 	}
 
 	const header = generatePrHeader(workflowSupportedLanguages);
-	const body = generatePrBody(branch);
+	const body = generatePrBody(branch, repoLanguages);
 
 	return [header, body];
 }

--- a/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
+++ b/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
@@ -84,6 +84,7 @@ function checklist(items: string[]): string {
 	return items.map((item) => `- [ ] ${item}`).join('\n');
 }
 
+//TODO test the python text only shows up when it's supposed to.
 function createPRChecklist(languages: string[], branchName: string): string[] {
 	const pythonText = ['Replace the relevant python fields'];
 	const step1 =

--- a/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
+++ b/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
@@ -93,15 +93,14 @@ function createPRChecklist(languages: string[], branchName: string): string[] {
 		'`guardian-devtools` and `guardian-dotcom-n2y`';
 	const step2 =
 		'The Snyk job should run automatically on every commit to this branch. ' +
-		'Click through to see the logs of the latest Snyk status check on ' +
+		'Click through on the Snyk status check see the logs of the latest run on ' +
 		'this PR, and verify it has generated one project per dependency manifest ' +
 		'(except pnpm and deno). ' +
 		'Examples of dependency manifests are a build.sbt, or a package-lock.json, ' +
 		'essentially, any file that lists the dependencies of your project.';
 	const step3 =
-		'When you are happy the action works, remove the ' +
-		`\`${branchName}\` option from the list of branches in the workflow, ` +
-		'approve, and merge.';
+		`When you are happy the action works, remove the branch name \`${branchName}\`` +
+		'trigger from the snyk.yml (aka delete line 6), approve, and merge.';
 	const defaultText = [step1, step2, step3];
 	const checklistItems = languages.includes('Python')
 		? pythonText.concat(defaultText)


### PR DESCRIPTION
Thanks to @michaelwmcnamara for his invaluable feedback on the PR body

## What does this change?

While testing this feature on some repos belonging to other DevX streams, we received feedback that the instructions were not as clear as they could be. This PR aims to rectify that, by using more specific language, and clarifying terms where required.

We now also log the PR title and body on CODE and DEV

## Why?

To make it easier for teams to follow the instructions

## How has it been verified?

- PR body still formats as expected
- Verified that the Python checklist item shows up when Python is listed as a language, and vice versa.
