### PR TITLE
refactor: Make it easier to create multi-line strings 

### DIFF
--- a/packages/common/src/string.test.ts
+++ b/packages/common/src/string.test.ts
@@ -1,0 +1,11 @@
+import { stripMargin } from './string';
+
+describe('stripMargin', () => {
+	it('should strip the margin from a string', () => {
+		const message = stripMargin`
+      |Hello
+      |From
+      |The Guardian`;
+		expect(message).toEqual('Hello\nFrom\nThe Guardian');
+	});
+});

--- a/packages/common/src/string.ts
+++ b/packages/common/src/string.ts
@@ -1,0 +1,23 @@
+/**
+ * A helper function to make user data strings easier to write.
+ *
+ * Example usage:
+ * ```typescript
+ * const message = stripMargin`
+ *   |Hello
+ *   |From
+ *   |The Guardian`;
+ * ```
+ *
+ * @param template a template string
+ * @param args extra arguments
+ */
+export function stripMargin(
+	template: TemplateStringsArray,
+	...args: unknown[]
+): string {
+	const result = template.reduce((acc, part, i) =>
+		[acc, args[i - 1], part].join(''),
+	);
+	return result.replace(/\r?(\n)\s*\|/g, '$1').trim();
+}

--- a/packages/repocop/src/remediations/topics/topic-monitor-production.test.ts
+++ b/packages/repocop/src/remediations/topics/topic-monitor-production.test.ts
@@ -1,6 +1,7 @@
 import { nullRepo } from '../../rules/repository.test';
 import type { AwsCloudFormationStack, Repository } from '../../types';
 import {
+	createMessage,
 	findReposInProdWithoutProductionTopic,
 	getRepoNamesWithoutProductionTopic,
 } from './topic-monitor-production';
@@ -146,5 +147,23 @@ describe('getReposInProdWithoutProductionTopic', () => {
 			[myRepoProdStackNew],
 		);
 		expect(result).toEqual([]);
+	});
+});
+
+describe('createMessage', () => {
+	it('asd', () => {
+		const actual = createMessage(
+			'guardian/service-catalogue',
+			'service-catalogue-PROD',
+			'developer-experience',
+			1,
+		);
+
+		expect(actual).toEqual({
+			message:
+				"The 'production' topic has applied to guardian/service-catalogue which has the stack service-catalogue-PROD.  This is because stack is over 1 months old and has PROD or INFRA tags. Repositories with PROD or INFRA stacks should have a 'production' topic to help with security. Visit the links below to learn more about topics and how to add/remove them if you need to.",
+			subject:
+				'Production topic monitoring (for GitHub team developer-experience)',
+		});
 	});
 });

--- a/packages/repocop/src/remediations/topics/topic-monitor-production.test.ts
+++ b/packages/repocop/src/remediations/topics/topic-monitor-production.test.ts
@@ -151,7 +151,7 @@ describe('getReposInProdWithoutProductionTopic', () => {
 });
 
 describe('createMessage', () => {
-	it('asd', () => {
+	it('its response', () => {
 		const actual = createMessage(
 			'guardian/service-catalogue',
 			'service-catalogue-PROD',
@@ -161,7 +161,7 @@ describe('createMessage', () => {
 
 		expect(actual).toEqual({
 			message:
-				"The 'production' topic has applied to guardian/service-catalogue which has the stack service-catalogue-PROD.  This is because stack is over 1 months old and has PROD or INFRA tags. Repositories with PROD or INFRA stacks should have a 'production' topic to help with security. Visit the links below to learn more about topics and how to add/remove them if you need to.",
+				"The 'production' topic has applied to guardian/service-catalogue which has the stack service-catalogue-PROD.\nThis is because stack is over 1 months old and has PROD or INFRA tags.\nRepositories with PROD or INFRA stacks should have a 'production' topic to help with security.\nVisit the links below to learn more about topics and how to add/remove them if you need to.",
 			subject:
 				'Production topic monitoring (for GitHub team developer-experience)',
 		});

--- a/packages/repocop/src/remediations/topics/topic-monitor-production.ts
+++ b/packages/repocop/src/remediations/topics/topic-monitor-production.ts
@@ -5,6 +5,7 @@ import {
 	applyTopics,
 	topicMonitoringProductionTagCtas,
 } from 'common/src/functions';
+import { stripMargin } from 'common/src/string';
 import type { Octokit } from 'octokit';
 import type { Config } from '../../config';
 import type { AwsCloudFormationStack, Repository, Team } from '../../types';
@@ -24,11 +25,11 @@ export function createMessage(
 ) {
 	return {
 		subject: `Production topic monitoring (for GitHub team ${teamSlug})`,
-		message:
-			`The 'production' topic has applied to ${fullRepoName} which has the stack ${stackName}. ` +
-			` This is because stack is over ${months} months old and has PROD or INFRA tags.` +
-			` Repositories with PROD or INFRA stacks should have a 'production' topic to help with security.` +
-			' Visit the links below to learn more about topics and how to add/remove them if you need to.',
+		message: stripMargin`
+			|The 'production' topic has applied to ${fullRepoName} which has the stack ${stackName}.
+			|This is because stack is over ${months} months old and has PROD or INFRA tags.
+			|Repositories with PROD or INFRA stacks should have a 'production' topic to help with security.
+			|Visit the links below to learn more about topics and how to add/remove them if you need to.`,
 	};
 }
 


### PR DESCRIPTION
## What does this change?
Create a function that utilises [tagged templates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates) to replicate Scala's `stripMargin`.

## Why?
Easier to read, and create long strings?

## How has it been verified?
See added tests.