### PR TITLE
Get critical dependabot vulnerabilities for some production repos

### DIFF
--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -6,7 +6,7 @@
 	},
 	"scripts": {
 		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@aws-sdk --external:@prisma/client --external:prisma",
-		"start": "APP=repocop tsx src/run-locally.ts",
+		"start": "APP=repocop STACK=deploy tsx src/run-locally.ts",
 		"test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects repocop"
 	},
 	"dependencies": {

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -6,7 +6,7 @@
 	},
 	"scripts": {
 		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@aws-sdk --external:@prisma/client --external:prisma",
-		"start": "APP=repocop STACK=deploy tsx src/run-locally.ts",
+		"start": "APP=repocop tsx src/run-locally.ts",
 		"test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects repocop"
 	},
 	"dependencies": {

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -270,7 +270,7 @@ function findArchivedReposWithStacks(
 	return archivedReposWithPotentialStacks;
 }
 
-async function getAlertForRepo(octokit: Octokit, name: string) {
+async function getAlertsForRepo(octokit: Octokit, name: string) {
 	if (name.startsWith('guardian/')) {
 		name = name.replace('guardian/', '');
 	}
@@ -283,6 +283,13 @@ async function getAlertForRepo(octokit: Octokit, name: string) {
 	});
 
 	return alert;
+}
+
+interface DependabotAlert {
+	created_at: string;
+	security_vulnerability: {
+		severity: string;
+	};
 }
 
 export async function testExperimentalRepocopFeatures(
@@ -298,8 +305,14 @@ export async function testExperimentalRepocopFeatures(
 
 	await Promise.all(
 		prodRepos.slice(0, 10).map(async (repo) => {
-			const alert = await getAlertForRepo(octokit, repo.full_name);
-			console.log(JSON.stringify(alert.data));
+			console.log(`Getting alerts for ${repo.full_name}`);
+			const alerts = await getAlertsForRepo(octokit, repo.full_name);
+			console.log(`Printing raw alerts`);
+			console.log(JSON.stringify(alerts.data));
+			console.log(`Printing alerts after casting to DependabotAlert[]`);
+			const x = alerts.data as DependabotAlert[];
+			console.log(x);
+			// console.log(JSON.stringify(alerts.data));
 		}),
 	);
 

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -5,6 +5,7 @@ import type {
 	repocop_github_repository_rules,
 	snyk_projects,
 } from '@prisma/client';
+import { shuffle } from 'common/src/functions';
 import type { Octokit } from 'octokit';
 import {
 	supportedDependabotLanguages,
@@ -299,21 +300,23 @@ export async function testExperimentalRepocopFeatures(
 	archivedRepos: Repository[],
 	nonPlaygroundStacks: AwsCloudFormationStack[],
 ) {
-	const prodRepos = unarchivedRepos.filter((repo) =>
-		repo.topics.includes('production'),
-	);
+	// const prodRepos = unarchivedRepos.filter((repo) =>
+	// 	repo.topics.includes('production'),
+	// );
 
 	await Promise.all(
-		prodRepos.slice(0, 10).map(async (repo) => {
-			console.log(`Getting alerts for ${repo.full_name}`);
-			const alerts = await getAlertsForRepo(octokit, repo.full_name);
-			console.log(`Printing raw alerts`);
-			console.log(JSON.stringify(alerts.data));
-			console.log(`Printing alerts after casting to DependabotAlert[]`);
-			const x = alerts.data as DependabotAlert[];
-			console.log(x);
-			// console.log(JSON.stringify(alerts.data));
-		}),
+		shuffle(unarchivedRepos)
+			.slice(0, 10)
+			.map(async (repo) => {
+				console.log(`Getting alerts for ${repo.full_name}`);
+				const alerts = await getAlertsForRepo(octokit, repo.full_name);
+				console.log(`Printing raw alerts`);
+				console.log(JSON.stringify(alerts.data));
+				console.log(`Printing alerts after casting to DependabotAlert[]`);
+				const x = alerts.data as DependabotAlert[];
+				console.log(x);
+				// console.log(JSON.stringify(alerts.data));
+			}),
 	);
 
 	const unmaintinedReposCount = evaluatedRepos.filter(

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -285,7 +285,7 @@ export async function getAlertsForRepo(
 			owner: 'guardian',
 			repo: name,
 			per_page: 100,
-			// severity: 'critical',
+			severity: 'critical', //eventually this should be "critical,high"
 			state: 'open',
 		});
 

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -1,3 +1,4 @@
+import type { Endpoints } from '@octokit/types';
 import type {
 	aws_cloudformation_stacks,
 	github_repositories,
@@ -61,3 +62,8 @@ export interface TeamRepository extends TeamRepositoryFields {
 	team_id: NonNullable<TeamRepositoryFields['team_id']>;
 	role_name: NonNullable<TeamRepositoryFields['role_name']>;
 }
+
+type DependabotVulnResponse =
+	Endpoints['GET /repos/{owner}/{repo}/dependabot/alerts']['response'];
+
+export type Alert = DependabotVulnResponse['data'][number];


### PR DESCRIPTION
## What does this change?

Creates a function that, given a repo, will return the first page of dependabot alerts for that repo.

## Why?

So we know if a repository has dependabot vulnerabilities that need addressing.

## How has it been verified?

Run locally using known vulnerable repos, returns expected output. Run on CODE, verified output, and that error handling works as expected

## Additional notes

Sometimes the request fails because dependabot scanning is not enabled for the repo. We should look into whether or not this is opt-in or opt-out, and whether it's appropriate/possible to switch it on at the org level for production repos, similar to branch protection rulesets.