### PR TITLE
refactor: Remove IIFEs from `run-locally.ts` files

### DIFF
--- a/packages/data-audit/src/run-locally.ts
+++ b/packages/data-audit/src/run-locally.ts
@@ -5,5 +5,5 @@ import { main } from './index';
 config({ path: `../../.env` });
 
 if (require.main === module) {
-	void (async () => await main())();
+	void main();
 }

--- a/packages/interactive-monitor/src/run-locally.ts
+++ b/packages/interactive-monitor/src/run-locally.ts
@@ -8,4 +8,4 @@ config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
 const testRepo = 'ofm-awards-label-2019-atom';
 const devConfig = getConfig();
-void (async () => await assessRepo(testRepo, 'guardian', devConfig))();
+void assessRepo(testRepo, 'guardian', devConfig);

--- a/packages/repocop/src/run-locally.ts
+++ b/packages/repocop/src/run-locally.ts
@@ -6,5 +6,5 @@ config({ path: `../../.env` }); // Load `.env` file at the root of the repositor
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
 if (require.main === module) {
-	void (async () => await main())();
+	void main();
 }

--- a/packages/snyk-integrator/src/run-locally.ts
+++ b/packages/snyk-integrator/src/run-locally.ts
@@ -6,9 +6,8 @@ config({ path: `../../.env` }); // Load `.env` file at the root of the repositor
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
 if (require.main === module) {
-	void (async () =>
-		await main({
-			name: 'service-catalogue',
-			languages: ['Scala', 'Go'],
-		}))();
+	void main({
+		name: 'service-catalogue',
+		languages: ['Scala', 'Go'],
+	});
 }


### PR DESCRIPTION
## What does this change?

Remove the [immediately invoked function expressions](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) from the `run-locally.ts` files.

## Why?

They aren't strictly necessary, as we don't need to do a top-level await when we wrap all of our logic in an async `main` function.
