### PR TITLE
Prevent Snyk integrator raising duplicate pull requests

### DIFF
--- a/packages/snyk-integrator/src/index.ts
+++ b/packages/snyk-integrator/src/index.ts
@@ -1,13 +1,14 @@
-import { randomBytes } from 'crypto';
 import type { SNSHandler } from 'aws-lambda';
 import { parseEvent, stageAwareOctokit } from 'common/functions';
 import type { SnykIntegratorEvent } from 'common/src/types';
 import type { Config } from './config';
 import { getConfig } from './config';
 import { addPrToProject } from './projects-graphql';
+import { getPullRequest } from './snyk-integrator/pull-requests';
 import {
 	createSnykPullRequest,
 	createYaml,
+	generateBranchName,
 	generatePr,
 } from './snyk-integrator/snyk-integrator';
 
@@ -15,21 +16,32 @@ export async function main(event: SnykIntegratorEvent) {
 	console.log(`Generating Snyk PR for ${event.name}`);
 	const config: Config = getConfig();
 
-	// Introduce a random suffix to allow the same PR to be raised multiple times
-	// Useful for testing, but may be less useful in production
-	const branch = `integrate-snyk-${randomBytes(8).toString('hex')}`;
+	const branch = generateBranchName(event.languages);
 	if (config.stage === 'PROD') {
 		const octokit = await stageAwareOctokit(config.stage);
-		const response = await createSnykPullRequest(
+
+		const existingPullRequest = await getPullRequest(
 			octokit,
 			event.name,
 			branch,
-			event.languages,
 		);
-		console.log('Pull request successfully created:', response?.data.html_url);
 
-		await addPrToProject(config.stage, event);
-		console.log('Updated project board');
+		if (!existingPullRequest) {
+			const response = await createSnykPullRequest(
+				octokit,
+				event.name,
+				branch,
+				event.languages,
+			);
+			console.log(
+				'Pull request successfully created:',
+				response?.data.html_url,
+			);
+			await addPrToProject(config.stage, event);
+			console.log('Updated project board');
+		} else {
+			console.log(`Existing pull request found with branch ${branch}`);
+		}
 	} else {
 		console.log('Testing snyk.yml generation');
 		console.log(createYaml(event.languages, branch));

--- a/packages/snyk-integrator/src/snyk-integrator/pull-requests.ts
+++ b/packages/snyk-integrator/src/snyk-integrator/pull-requests.ts
@@ -43,11 +43,10 @@ export async function getPullRequest(
 	repoName: string,
 	branchName: string,
 ) {
-	// TODO(@chrislomaxjones) pagination necessary?
-	const pulls = await octokit.rest.pulls.list({
+	const pulls = await octokit.paginate(octokit.rest.pulls.list, {
 		owner: 'guardian',
 		repo: repoName,
 		state: 'open',
 	});
-	return pulls.data.find((pull) => pull.head.ref === branchName);
+	return pulls.find((pull) => pull.head.ref === branchName);
 }

--- a/packages/snyk-integrator/src/snyk-integrator/pull-requests.ts
+++ b/packages/snyk-integrator/src/snyk-integrator/pull-requests.ts
@@ -37,3 +37,17 @@ export async function createPullRequest(
 		})),
 	});
 }
+
+export async function getPullRequest(
+	octokit: Octokit,
+	repoName: string,
+	branchName: string,
+) {
+	// TODO(@chrislomaxjones) pagination necessary?
+	const pulls = await octokit.rest.pulls.list({
+		owner: 'guardian',
+		repo: repoName,
+		state: 'open',
+	});
+	return pulls.data.find((pull) => pull.head.ref === branchName);
+}

--- a/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.test.ts
+++ b/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.test.ts
@@ -1,4 +1,4 @@
-import { createYaml, generatePr } from './snyk-integrator';
+import { createYaml, generateBranchName, generatePr } from './snyk-integrator';
 
 describe('createYaml', () => {
 	it('should skip node and sbt if no languages are provided', () => {
@@ -61,5 +61,19 @@ describe('A generated PR', () => {
 	it('should throw if no supported languages are provided', () => {
 		expect(() => generateServiceCataloguePr(['Rust', 'Kotlin'])).toThrow();
 		expect(() => generateServiceCataloguePr([])).toThrow();
+	});
+});
+
+describe('generateBranchName', () => {
+	it('should output same branch name for the same languages', () => {
+		const branch1 = generateBranchName(['TypeScript', 'Scala', 'Python']);
+		const branch2 = generateBranchName(['TypeScript', 'Scala', 'Python']);
+		expect(branch1).toBe(branch2);
+	});
+
+	it('should output same branch name for the same languages, regardless of order', () => {
+		const branch1 = generateBranchName(['TypeScript', 'Scala', 'Python']);
+		const branch2 = generateBranchName(['Scala', 'Python', 'TypeScript']);
+		expect(branch1).toBe(branch2);
 	});
 });

--- a/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
+++ b/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
@@ -184,5 +184,8 @@ export async function createSnykPullRequest(
 }
 
 export function generateBranchName(languages: string[]) {
-	return `integrate-snyk-${languages.sort().join('-')}`;
+	return `integrate-snyk-${languages
+		.sort()
+		.map((language) => language.toLowerCase())
+		.join('-')}`;
 }

--- a/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
+++ b/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
@@ -1,7 +1,7 @@
 import type { Octokit } from 'octokit';
 import { h2, p, tsMarkdown } from 'ts-markdown';
 import { stringify } from 'yaml';
-import { createPullRequest } from './create-pull-request';
+import { createPullRequest } from './pull-requests';
 
 interface SnykInputs {
 	ORG: string;

--- a/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
+++ b/packages/snyk-integrator/src/snyk-integrator/snyk-integrator.ts
@@ -182,3 +182,7 @@ export async function createSnykPullRequest(
 		],
 	});
 }
+
+export function generateBranchName(languages: string[]) {
+	return `integrate-snyk-${languages.sort().join('-')}`;
+}


### PR DESCRIPTION
## What does this change?

This PR contains two main changes:

1. Check if a PR already exists for Snyk integration on a given repo, before creating the integration PR. We check for PR existence by searching the PRs for a given branch name.
2. The branch name is now derived from the set of languages passed to the snyk-integrator lambda. We take the languages into account here so that if we raise a Snyk integration PR and at a later date a new language is added to the repo (that requires integration), we'll go ahead and raise another PR.

## Why?

Prevent the same Snyk integration PR being raised multiple times between the `snyk.yml` file actually being merged. For example: https://github.com/guardian/devx-backup-monitoring/pull/14 https://github.com/guardian/devx-backup-monitoring/pull/16.

## How has it been verified?

I tested this locally against [test-repocop-prs](https://github.com/guardian/test-repocop-prs/pulls), removing the PROD check in the snyk integrator temporarily. The test plan was as follows:

1. Run the Snyk integrator with input `{ name: "test-repocop-prs", languages: ["Scala", "TypeScript"] }`. This created [this PR](https://github.com/guardian/test-repocop-prs/pull/15) in the repository.
2. Running the Snyk integrator again with the same input `{ name: "test-repocop-prs", languages: ["Scala", "TypeScript"] }` **does not** cause another PR to be created.
3. Running the Snyk integrator with a new languages `{ name: "test-repocop-prs", languages: ["Scala", "TypeScript", "Go"] }` causes [another PR ](https://github.com/guardian/test-repocop-prs/pull/16)to be created, to integrate all of the languages 

## Potential future work

1) When we detect that an open PR already exists, we could consider adding a follow-up nudge or comment on the PR if some amount of time has passed since it opened?
2) If a new language is detected and a PR is open, we could consider closing the existing PR?