### PR TITLE
Increase test coverage in common package

### DIFF
--- a/packages/common/src/functions.test.ts
+++ b/packages/common/src/functions.test.ts
@@ -114,7 +114,6 @@ describe('parseSecretJson', () => {
 		const actual = parseSecretJson(
 			'{"appId": "myAppId", "base64PrivateKey": "aGVsbG8=", "clientId": "myClientId", "clientSecret": "myClientSecret", "installationId": "myInstallationId"}',
 		);
-		console.log(actual.strategyOptions);
 		//check that the correct fields are in the correct values, and that base64PrivateKey has been decoded
 		expect(actual.installationId).toEqual('myInstallationId');
 		expect(actual.strategyOptions.appId).toEqual('myAppId');

--- a/packages/common/src/functions.test.ts
+++ b/packages/common/src/functions.test.ts
@@ -110,7 +110,7 @@ describe('getGitHubAppSecret', () => {
 });
 
 describe('parseSecretJson', () => {
-	it('should do the right thing', () => {
+	it('put the right values in the right fields, if the JSON string has the correct fields', () => {
 		const actual = parseSecretJson(
 			'{"appId": "myAppId", "base64PrivateKey": "aGVsbG8=", "clientId": "myClientId", "clientSecret": "myClientSecret", "installationId": "myInstallationId"}',
 		);
@@ -122,6 +122,14 @@ describe('parseSecretJson', () => {
 		expect(actual.strategyOptions.clientSecret).toEqual('myClientSecret');
 		expect(actual.strategyOptions.installationId).toEqual('myInstallationId');
 		expect(actual.strategyOptions.privateKey).toEqual('hello');
+	});
+	it('should throw an error if the input string is not valid JSON', () => {
+		const input = 'not valid JSON';
+		expect(() => parseSecretJson(input)).toThrow();
+	});
+	it('should throw an error if the input string is not a valid GithubAppSecret', () => {
+		const input = '{"not": "a valid GithubAppSecret"}';
+		expect(() => parseSecretJson(input)).toThrow();
 	});
 });
 

--- a/packages/common/src/functions.test.ts
+++ b/packages/common/src/functions.test.ts
@@ -100,7 +100,7 @@ describe('getEnvOrThrow', () => {
 });
 
 describe('getGitHubAppSecret', () => {
-	it('should throw iff the GITHUB_APP_SECRET environment variable is not set', async () => {
+	it('should throw if the GITHUB_APP_SECRET environment variable is not set', async () => {
 		const err = 'Environment variable GITHUB_APP_SECRET is not set.';
 		const secret = process.env.GITHUB_APP_SECRET;
 		delete process.env.GITHUB_APP_SECRET;

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -68,28 +68,10 @@ export async function stageAwareOctokit(stage: string) {
 	}
 }
 
-export async function stageAwareGraphQlClient(stage: string) {
-	if (stage === 'CODE' || stage === 'PROD') {
-		const githubAppConfig: GitHubAppConfig = await getGitHubAppConfig();
-		const octokit: Octokit = await getGithubClient(githubAppConfig);
-		const graphqlWithAuth = octokit.graphql;
-		return graphqlWithAuth;
-	} else {
-		//NB you may have to validate your PAT with SAML to use the GraphQL API
-		const token = getEnvOrThrow('GITHUB_ACCESS_TOKEN');
-		const { graphql } = await import('@octokit/graphql');
-		const graphqlWithAuth = graphql.defaults({
-			headers: {
-				authorization: `token ${token}`,
-			},
-		});
-		return graphqlWithAuth;
-	}
-}
-
 export function parseEvent<T>(event: SNSEvent): T[] {
 	return event.Records.map((record) => JSON.parse(record.Sns.Message) as T);
 }
+
 export function branchProtectionCtas(
 	fullRepoName: string,
 	teamSlug: string,

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -27,7 +27,7 @@ export function getEnvOrThrow(key: string): string {
 	return value;
 }
 
-async function getGithubAppSecret(): Promise<string> {
+export async function getGithubAppSecret(): Promise<string> {
 	const SecretId = getEnvOrThrow('GITHUB_APP_SECRET');
 	const secretsManager = new SecretsManager();
 

--- a/packages/snyk-integrator/src/projects-graphql.ts
+++ b/packages/snyk-integrator/src/projects-graphql.ts
@@ -1,4 +1,4 @@
-import { stageAwareGraphQlClient } from 'common/src/functions';
+import { stageAwareOctokit } from 'common/src/functions';
 import type { SnykIntegratorEvent } from 'common/src/types';
 import type { ProjectId, PullRequestDetails } from './types';
 
@@ -45,7 +45,7 @@ export async function addPrToProject(
 	stage: string,
 	event: SnykIntegratorEvent,
 ) {
-	const graphqlWithAuth = await stageAwareGraphQlClient(stage);
+	const graphqlWithAuth = (await stageAwareOctokit(stage)).graphql;
 
 	const projectDetails: ProjectId = await graphqlWithAuth(
 		`{


### PR DESCRIPTION
## What does this change?

- Removes the custom graphQL auth function, as it's just duplicating regular octokit logic (less code means less untested code!)
- Add unit tests to untested parts of the common package

## Why?
This package in particular is used by several parts of the service catalogue, and it's important that its behaviour is well-understood, -documented and -tested

## How has it been verified?

`npm run test -w common -- --coverage`

nb: I think that using jest rather than ts-jest has has confused the coverage tool, as some of the details about which lines are covered/uncovered don't add up (any advice on how to make this more accurate is welcome) - but the general idea is that coverage (especially of non-async code) has increased significantly.

### Before

File          | % Stmts | % Branch | % Funcs | % Lines | 
--------------|---------|----------|---------|---------|
All files     |      68 |    53.57 |      64 |   67.14 |
 functions.ts |   52.52 |     37.5 |   51.42 |   52.12 |
 logs.ts      |     100 |    76.92 |     100 |     100 | 
 string.ts    |   95.65 |    72.72 |   85.71 |   95.23 | 

### After

File          | % Stmts | % Branch | % Funcs | % Lines | 
--------------|---------|----------|---------|---------|
All files     |    78.1 |    66.66 |      75 |   77.34 |
 functions.ts |   66.27 |    57.14 |   66.66 |   65.85 | 
 logs.ts      |     100 |    76.92 |     100 |     100 |
 string.ts    |   95.65 |    72.72 |   85.71 |   95.23 | 

## Additional notes

There's a lot of async functions in the service catalogue, so 100% test coverage is not achievable, but should we have a coverage target for each module? It might remind developers to write tests, and encourage writing code in a more testable, functional style.