### PR TITLE
Fixes Postgres container making every other container exit

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -250,7 +250,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -960,7 +960,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -1633,7 +1633,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -2320,7 +2320,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -2993,7 +2993,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -3935,7 +3935,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -4418,7 +4418,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -5112,7 +5112,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -5836,7 +5836,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -6549,7 +6549,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -7226,7 +7226,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -7905,7 +7905,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -8586,7 +8586,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -9265,7 +9265,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -9974,7 +9974,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -10833,7 +10833,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -11302,7 +11302,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -12015,7 +12015,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -12710,7 +12710,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -13600,7 +13600,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -14282,7 +14282,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -14751,7 +14751,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -15492,7 +15492,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -16429,7 +16429,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
@@ -16903,7 +16903,7 @@ spec:
             "EntryPoint": [
               "",
             ],
-            "Essential": true,
+            "Essential": false,
             "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",

--- a/packages/cdk/lib/cloudquery/task.ts
+++ b/packages/cdk/lib/cloudquery/task.ts
@@ -302,6 +302,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 					].join(';'),
 				],
 				logging: fireLensLogDriver,
+				essential: false,
 			});
 		}
 


### PR DESCRIPTION
## What does this change?

Mark Postgres container as non-essential


## Why?

Last week I merged https://github.com/guardian/service-catalogue/pull/653 which added a new Postgres container to tasks, it turns out that when this container completes ECS kills all the containers as this one container is marked as "essential"

Annoyingly at the same time I purged the `cloudquery_table_frequency` table as the new postgres container was meant to populate it automatically, meaning that we stopped getting alerted to data sync issues.