### PR TITLE
ci(prisma): Ensure views directory is added

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,12 @@ jobs:
 
       - name: check schema.prisma file hasn't changed
         run: git diff --exit-code packages/common/prisma/schema.prisma
+
+      - name: check for untracked files
+        run: |
+          UNTRACKED_FILES=$(git ls-files --others --exclude-standard packages/common/prisma | wc -l)
+          if [ "$UNTRACKED_FILES" -gt 0 ]; then
+            echo "Untracked files found:"
+            git ls-files --others --exclude-standard packages/common/prisma
+            exit 1
+          fi

--- a/packages/common/prisma/views/public/aws_accounts.sql
+++ b/packages/common/prisma/views/public/aws_accounts.sql
@@ -1,0 +1,15 @@
+SELECT
+  DISTINCT acc.id,
+  acc.name,
+  acc.email,
+  acc.status,
+  acc.joined_timestamp,
+  COALESCE(ou.name, 'ROOT' :: text) AS organizational_unit
+FROM
+  (
+    (
+      aws_organizations_accounts acc
+      LEFT JOIN aws_organizations_account_parents par ON ((acc.id = par.id))
+    )
+    LEFT JOIN aws_organizations_organizational_units ou ON ((par.parent_id = ou.id))
+  );

--- a/packages/common/prisma/views/public/view_old_ec2_instances.sql
+++ b/packages/common/prisma/views/public/view_old_ec2_instances.sql
@@ -1,0 +1,31 @@
+SELECT
+  ac.id AS account_id,
+  ac.name AS account_name,
+  ec2.instance_id,
+  (ec2.state ->> 'Name' :: text) AS state,
+  (ec2.tags ->> 'Stack' :: text) AS stack,
+  (ec2.tags ->> 'Stage' :: text) AS stage,
+  (ec2.tags ->> 'App' :: text) AS app,
+  (ec2.tags ->> 'gu:repo' :: text) AS repo,
+  ec2.region,
+  coalesce_dates(img.creation_date, ec2.launch_time) AS creation_or_launch_time
+FROM
+  (
+    (
+      aws_ec2_instances ec2
+      LEFT JOIN aws_ec2_images img ON ((ec2.image_id = img.image_id))
+    )
+    LEFT JOIN aws_accounts ac ON ((ec2.account_id = ac.id))
+  )
+WHERE
+  (
+    (
+      (
+        coalesce_dates(img.creation_date, ec2.launch_time) IS NULL
+      )
+      OR (
+        coalesce_dates(img.creation_date, ec2.launch_time) < (NOW() - '30 days' :: INTERVAL)
+      )
+    )
+    AND ((ec2.state ->> 'Name' :: text) = 'running' :: text)
+  );

--- a/packages/common/prisma/views/public/view_repo_ownership.sql
+++ b/packages/common/prisma/views/public/view_repo_ownership.sql
@@ -1,0 +1,19 @@
+SELECT
+  ght.id AS github_team_id,
+  ght.name AS github_team_name,
+  tr.full_name AS repo_name,
+  tr.full_name,
+  tr.role_name,
+  tr.archived,
+  gtt.team_name AS galaxies_team,
+  gtt.team_contact_email
+FROM
+  (
+    (
+      github_team_repositories tr
+      JOIN github_teams ght ON ((tr.team_id = ght.id))
+    )
+    LEFT JOIN galaxies_teams_table gtt ON ((ght.slug = gtt.team_primary_github_team))
+  )
+WHERE
+  (tr.role_name = 'admin' :: text);

--- a/packages/common/prisma/views/public/view_running_instances.sql
+++ b/packages/common/prisma/views/public/view_running_instances.sql
@@ -1,0 +1,59 @@
+WITH id_and_tags AS (
+  SELECT
+    aws_ec2_images.image_id,
+    (aws_ec2_images.tags ->> 'BuiltBy' :: text) AS built_by
+  FROM
+    aws_ec2_images
+  WHERE
+    (aws_ec2_images.tags IS NOT NULL)
+  ORDER BY
+    aws_ec2_images.image_id
+),
+aggregated_images AS (
+  SELECT
+    id_and_tags.image_id,
+    CASE
+      WHEN (
+        'amigo' :: text = ANY (array_agg(id_and_tags.built_by))
+      ) THEN TRUE
+      ELSE false
+    END AS built_by_amigo
+  FROM
+    id_and_tags
+  GROUP BY
+    id_and_tags.image_id,
+    id_and_tags.built_by
+  ORDER BY
+    id_and_tags.image_id
+)
+SELECT
+  DISTINCT ON (instances.instance_id) accts.name AS account_name,
+  (instances.tags ->> 'App' :: text) AS app,
+  (instances.tags ->> 'Stack' :: text) AS stack,
+  (instances.tags ->> 'Stage' :: text) AS stage,
+  instances.image_id,
+  instances.instance_id,
+  CASE
+    WHEN images.built_by_amigo THEN TRUE
+    ELSE false
+  END AS built_by_amigo,
+  instances.launch_time,
+  instances.instance_type AS TYPE
+FROM
+  (
+    (
+      aws_ec2_instances instances
+      LEFT JOIN aggregated_images images ON ((instances.image_id = images.image_id))
+    )
+    LEFT JOIN aws_organizations_accounts accts ON ((instances.account_id = accts.id))
+  )
+WHERE
+  (
+    (instances.state ->> 'Name' :: text) = 'running' :: text
+  )
+ORDER BY
+  instances.instance_id,
+  CASE
+    WHEN images.built_by_amigo THEN TRUE
+    ELSE false
+  END DESC;

--- a/packages/common/prisma/views/public/view_snyk_project_tags.sql
+++ b/packages/common/prisma/views/public/view_snyk_project_tags.sql
@@ -1,0 +1,41 @@
+WITH all_tags AS (
+  SELECT
+    snyk_projects.id,
+    jsonb_array_elements(snyk_projects.tags) AS tags
+  FROM
+    snyk_projects
+),
+projects_with_hashes AS (
+  SELECT
+    all_tags.id,
+    (all_tags.tags ->> 'value' :: text) AS COMMIT
+  FROM
+    all_tags
+  WHERE
+    ((all_tags.tags ->> 'key' :: text) = 'commit' :: text)
+),
+projects_with_repos AS (
+  SELECT
+    all_tags.id,
+    (all_tags.tags ->> 'value' :: text) AS repo
+  FROM
+    all_tags
+  WHERE
+    ((all_tags.tags ->> 'key' :: text) = 'repo' :: text)
+)
+SELECT
+  p.id,
+  p.org_id,
+  p.name,
+  r.repo,
+  h.commit
+FROM
+  (
+    (
+      snyk_projects p
+      LEFT JOIN projects_with_hashes h ON ((p.id = h.id))
+    )
+    LEFT JOIN projects_with_repos r ON ((p.id = r.id))
+  )
+ORDER BY
+  h.commit;


### PR DESCRIPTION
## What does this change?
Ensure the [directory created by Prisma for views](https://www.prisma.io/docs/orm/prisma-schema/data-model/views#the-views-directory) is tracked in VCS.

This directory gets re-created whenever we perform a [migration](https://github.com/guardian/service-catalogue/blob/main/docs/database-migrations.md), so add it for ease[^1], and check in CI that it's up-to-date.

The content has cross-over with the [`migrations` directory](https://github.com/search?q=repo%3Aguardian%2Fservice-catalogue+path%3Apackages%2Fcommon%2Fprisma%2Fmigrations%2F*view*%2Fmigration.sql&type=code), so it might turn out that we can `.gitignore` it...

## How has it been verified?
With untracked files, CI fails with this output:

<img width="772" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/1f9ecd64-4170-48a7-87bd-a8e0045b1dfc">

[^1]: Ease, as in I can `git add .` on a feature branch again without fear of adding unrelated files 😄 