### PR TITLE
Log if a repo contains a vulnerability older than it should

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -95,8 +95,7 @@ export async function main() {
 	const cloudwatch = new CloudWatchClient(awsConfig);
 	await sendToCloudwatch(evaluatedRepos, cloudwatch, config);
 
-	await testExperimentalRepocopFeatures(
-		octokit,
+	testExperimentalRepocopFeatures(
 		evaluatedRepos,
 		unarchivedRepos,
 		archivedRepos,

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -64,7 +64,8 @@ export async function main() {
 	).filter((s) => s.tags.Stack !== 'playground');
 	const snykProjects = await getSnykProjects(prisma);
 	const evaluatedRepos: repocop_github_repository_rules[] =
-		evaluateRepositories(
+		await evaluateRepositories(
+			octokit,
 			unarchivedRepos,
 			branches,
 			repoTeams,

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -27,6 +27,7 @@ import { applyProductionTopicAndMessageTeams } from './remediations/topics/topic
 import {
 	evaluateRepositories,
 	getAlertsForRepo,
+	hasOldAlerts,
 	testExperimentalRepocopFeatures,
 } from './rules/repository';
 import type { AwsCloudFormationStack, RepoAndAlerts } from './types';
@@ -78,11 +79,12 @@ export async function main() {
 		)
 	).filter((x) => !!x.alerts);
 
-	alerts.forEach((alert) => {
+	alerts.slice(0, 20).forEach((alert) => {
 		if (alert.alerts) {
 			console.log(
 				`Found ${alert.alerts.length} alerts for ${alert.shortName}: `,
-				alert.alerts.map((x) => x.created_at),
+				alert.alerts.map((x) => x.created_at).slice(0, 5),
+				hasOldAlerts(alert.alerts, alert.shortName),
 			);
 		} else {
 			console.log(`Found no alerts for ${alert.shortName}`);

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -79,15 +79,12 @@ export async function main() {
 		)
 	).filter((x) => !!x.alerts);
 
-	alerts.slice(0, 20).forEach((alert) => {
-		if (alert.alerts) {
+	alerts.forEach((alert) => {
+		if (alert.alerts && alert.alerts.length > 0) {
 			console.log(
 				`Found ${alert.alerts.length} alerts for ${alert.shortName}: `,
-				alert.alerts.map((x) => x.created_at).slice(0, 5),
-				hasOldAlerts(alert.alerts, alert.shortName),
 			);
-		} else {
-			console.log(`Found no alerts for ${alert.shortName}`);
+			hasOldAlerts(alert.alerts, alert.shortName);
 		}
 	});
 

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -78,6 +78,17 @@ export async function main() {
 		)
 	).filter((x) => !!x.alerts);
 
+	alerts.forEach((alert) => {
+		if (alert.alerts) {
+			console.log(
+				`Found ${alert.alerts.length} alerts for ${alert.shortName}: `,
+				alert.alerts.map((x) => x.created_at),
+			);
+		} else {
+			console.log(`Found no alerts for ${alert.shortName}`);
+		}
+	});
+
 	console.log(`Found ${alerts.length} repos with alerts`);
 
 	const evaluatedRepos: repocop_github_repository_rules[] =

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -6,6 +6,7 @@ import type {
 } from '@prisma/client';
 import type {
 	AwsCloudFormationStack,
+	PartialAlert,
 	Repository,
 	TeamRepository,
 } from '../types';
@@ -23,8 +24,10 @@ function evaluateRepoTestHelper(
 	languages: github_languages[] = [],
 	snykProjects: snyk_projects[] = [],
 	githubWorkflows: github_workflows[] = [],
+	alerts: PartialAlert[] = [],
 ) {
 	return evaluateOneRepo(
+		alerts,
 		repo,
 		branches,
 		teams,

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -281,7 +281,7 @@ export async function getAlertsForRepo(
 				owner: 'guardian',
 				repo: name,
 				per_page: 100,
-				severity: 'critical', //eventually this should be "critical,high"
+				severity: 'critical,high',
 				state: 'open',
 				sort: 'created',
 				direction: 'asc', //retrieve oldest vulnerabilities first

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -19,7 +19,6 @@ import type {
 	Repository,
 	TeamRepository,
 } from '../types';
-import { isProduction } from '../utils';
 
 /**
  * Evaluate the following rule for a Github repository:
@@ -372,19 +371,20 @@ export function evaluateOneRepo(
 	snykProjects: snyk_projects[],
 	workflowFiles: github_workflows[],
 ): repocop_github_repository_rules {
-	if (isProduction(repo) && alerts) {
-		console.log(`Evaluating ${repo.name} for Dependabot alerts`);
-		console.log(
-			`Alerts for ${repo.name}: `,
-			JSON.stringify(alerts.map((a) => a.dependency)),
-		);
-		const isVulnerable = hasOldAlerts(alerts, repo.name);
-		if (isVulnerable) {
-			console.log(`${repo.name} is vulnerable`);
-		}
-	} else {
-		console.log(`No Dependabot alerts for ${repo.name}`);
-	}
+	// if (isProduction(repo) && alerts) {
+	// 	console.log(`Evaluating ${repo.name} for Dependabot alerts`);
+	// 	console.log(
+	// 		`Alerts for ${repo.name}: `,
+	// 		JSON.stringify(alerts.map((a) => a.dependency)),
+	// 	);
+	// 	const isVulnerable = hasOldAlerts(alerts, repo.name);
+	// 	if (isVulnerable) {
+	// 		console.log(`${repo.name} is vulnerable`);
+	// 	}
+	// } else {
+	// 	console.log(`No Dependabot alerts for ${repo.name}`);
+	// }
+	alerts = undefined;
 
 	return {
 		full_name: repo.full_name,

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -415,18 +415,20 @@ export async function evaluateOneRepo(
 	};
 }
 
-export function evaluateRepositories(
+export async function evaluateRepositories(
+	octokit: Octokit,
 	repositories: Repository[],
 	branches: github_repository_branches[],
 	teams: TeamRepository[],
 	repoLanguages: github_languages[],
 	snykProjects: snyk_projects[],
 	workflowFiles: github_workflows[],
-): repocop_github_repository_rules[] {
-	return repositories.map((r) => {
+): Promise<repocop_github_repository_rules[]> {
+	const evaluatedRepos = repositories.map(async (r) => {
 		const teamsForRepo = teams.filter((t) => t.id === r.id);
 		const branchesForRepo = branches.filter((b) => b.repository_id === r.id);
-		return evaluateOneRepo(
+		return await evaluateOneRepo(
+			octokit,
 			r,
 			branchesForRepo,
 			teamsForRepo,
@@ -435,4 +437,5 @@ export function evaluateRepositories(
 			workflowFiles,
 		);
 	});
+	return await Promise.all(evaluatedRepos);
 }

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -287,7 +287,7 @@ export async function getAlertsForRepo(
 				direction: 'asc', //retrieve oldest vulnerabilities first
 			});
 
-		return alert.data.map((a) => a as PartialAlert);
+		return alert.data as PartialAlert[];
 	} catch (error) {
 		return undefined;
 	}

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -303,28 +303,33 @@ function isOldForSeverity(
 }
 
 export function hasOldAlerts(alerts: PartialAlert[], repo: string): boolean {
-	const twoWeeksAgo = new Date();
-	twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
-	twoWeeksAgo.setHours(0, 0, 0, 0);
+	const highDayCount = 14;
+	const criticalDayCount = 1;
 
-	const yesterday = new Date();
-	yesterday.setDate(yesterday.getDate() - 1);
-	yesterday.setHours(0, 0, 0, 0);
+	const highVulnCutOff = new Date();
+	highVulnCutOff.setDate(highVulnCutOff.getDate() - highDayCount);
+	highVulnCutOff.setHours(0, 0, 0, 0);
+
+	const criticalVulnCutOff = new Date();
+	criticalVulnCutOff.setDate(criticalVulnCutOff.getDate() - criticalDayCount);
+	criticalVulnCutOff.setHours(0, 0, 0, 0);
 	const oldHighAlerts = alerts.filter((alert) =>
-		isOldForSeverity(twoWeeksAgo, 'high', alert),
+		isOldForSeverity(highVulnCutOff, 'high', alert),
 	);
 	const oldCriticalAlerts = alerts.filter((alert) =>
-		isOldForSeverity(yesterday, 'critical', alert),
+		isOldForSeverity(criticalVulnCutOff, 'critical', alert),
 	);
 	if (oldCriticalAlerts.length > 0) {
 		console.log(
-			`Dependabot - ${repo}: has ${oldCriticalAlerts.length} critical alerts older than one day`,
+			`Dependabot - ${repo}: has ${oldCriticalAlerts.length} critical alerts older than ${criticalDayCount} days`,
 		);
-	} else if (oldHighAlerts.length > 0) {
+	}
+	if (oldHighAlerts.length > 0) {
 		console.log(
-			`Dependabot - ${repo}: has ${oldHighAlerts.length} high alerts older than two weeks`,
+			`Dependabot - ${repo}: has ${oldHighAlerts.length} high alerts older than ${highDayCount} weeks`,
 		);
-	} else {
+	}
+	if (oldCriticalAlerts.length === 0 && oldHighAlerts.length === 0) {
 		console.log(`Dependabot - ${repo}: has no old alerts`);
 	}
 
@@ -371,19 +376,6 @@ export function evaluateOneRepo(
 	snykProjects: snyk_projects[],
 	workflowFiles: github_workflows[],
 ): repocop_github_repository_rules {
-	// if (isProduction(repo) && alerts) {
-	// 	console.log(`Evaluating ${repo.name} for Dependabot alerts`);
-	// 	console.log(
-	// 		`Alerts for ${repo.name}: `,
-	// 		JSON.stringify(alerts.map((a) => a.dependency)),
-	// 	);
-	// 	const isVulnerable = hasOldAlerts(alerts, repo.name);
-	// 	if (isVulnerable) {
-	// 		console.log(`${repo.name} is vulnerable`);
-	// 	}
-	// } else {
-	// 	console.log(`No Dependabot alerts for ${repo.name}`);
-	// }
 	alerts = undefined;
 
 	return {

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -63,7 +63,7 @@ export interface TeamRepository extends TeamRepositoryFields {
 	role_name: NonNullable<TeamRepositoryFields['role_name']>;
 }
 
-type DependabotVulnResponse =
+export type DependabotVulnResponse =
 	Endpoints['GET /repos/{owner}/{repo}/dependabot/alerts']['response'];
 
 export type Alert = DependabotVulnResponse['data'][number];
@@ -72,3 +72,11 @@ export type PartialAlert = Pick<
 	Alert,
 	'state' | 'dependency' | 'security_vulnerability' | 'created_at'
 >;
+
+export interface RepoAndAlerts {
+	shortName: string;
+	/*
+	 ** alerts is undefined if we catch an error, typically because dependabot is not enabled
+	 */
+	alerts: PartialAlert[] | undefined;
+}

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -67,3 +67,8 @@ type DependabotVulnResponse =
 	Endpoints['GET /repos/{owner}/{repo}/dependabot/alerts']['response'];
 
 export type Alert = DependabotVulnResponse['data'][number];
+
+export type PartialAlert = Pick<
+	Alert,
+	'state' | 'dependency' | 'security_vulnerability' | 'created_at'
+>;

--- a/packages/repocop/src/utils.test.ts
+++ b/packages/repocop/src/utils.test.ts
@@ -1,0 +1,25 @@
+import type { Repository } from './types';
+import { isProduction } from './utils';
+
+describe('test', () => {
+	test('pass', () => {
+		const prodRepo: Repository = {
+			archived: false,
+			full_name: 'test',
+			id: 1n,
+			name: 'test',
+			topics: ['production'],
+			default_branch: 'main',
+			created_at: new Date(),
+			pushed_at: new Date(),
+			updated_at: new Date(),
+		};
+		const nonProdRepo: Repository = {
+			...prodRepo,
+			topics: [],
+		};
+
+		expect(isProduction(prodRepo)).toBe(true);
+		expect(isProduction(nonProdRepo)).toBe(false);
+	});
+});

--- a/packages/repocop/src/utils.test.ts
+++ b/packages/repocop/src/utils.test.ts
@@ -1,8 +1,8 @@
 import type { Repository } from './types';
 import { isProduction } from './utils';
 
-describe('test', () => {
-	test('pass', () => {
+describe('isProduction', () => {
+	test('should return correct values for prod and non-prod repos', () => {
 		const prodRepo: Repository = {
 			archived: false,
 			full_name: 'test',

--- a/packages/repocop/src/utils.ts
+++ b/packages/repocop/src/utils.ts
@@ -1,0 +1,5 @@
+import type { Repository } from './types';
+
+export function isProduction(repo: Repository) {
+	return repo.topics.includes('production') && !repo.archived;
+}


### PR DESCRIPTION
## What does this change?

- Pull all the first page of critical alerts from dependabot (oldest first)
- If a repo has old, unresolved critical or high vulnerabilities, log it.

## Why?

95% of dependabot alerts are not relevant as they pertain to old, decomissioned, or otherwise non-production repos. This feature will allow us to highlight to developers which repositories with vulnerabilities need addressing, focusing the noisy output from GitHub

## How has it been verified?

Deployed to CODE and saw expected behaviour in the logs

## Additional notes

Currently we do not collect dependabot data via CloudQuery as the job takes over 48 hours to complete (potentially much longer). We could probably collect it in a more timely way if we were able to provide the job with a list of repos we cared about. I've spoken to @guardian/devx-operations about this, and we have added this work to their backlog, but for now we are proceeding this way as it allows us to continue with our work this quarter without [yak-shaving](https://en.wiktionary.org/wiki/yak_shaving).