### PR TITLE
refactor: Properly type parameters for fetching PRs

### DIFF
--- a/packages/snyk-integrator/src/snyk-integrator/pull-requests.ts
+++ b/packages/snyk-integrator/src/snyk-integrator/pull-requests.ts
@@ -1,3 +1,4 @@
+import type { Endpoints } from '@octokit/types';
 import type { Octokit } from 'octokit';
 import { composeCreatePullRequest } from 'octokit-plugin-create-pull-request';
 
@@ -38,6 +39,9 @@ export async function createPullRequest(
 	});
 }
 
+type PullRequestParameters =
+	Endpoints['GET /repos/{owner}/{repo}/pulls']['parameters'];
+
 export async function getPullRequest(
 	octokit: Octokit,
 	repoName: string,
@@ -47,6 +51,6 @@ export async function getPullRequest(
 		owner: 'guardian',
 		repo: repoName,
 		state: 'open',
-	});
+	} satisfies PullRequestParameters);
 	return pulls.find((pull) => pull.head.ref === branchName);
 }


### PR DESCRIPTION
## What does this change?

Check that the type of parameters we use to retrieve pull requests conforms to the set of allowed parameters.

## Why?

Combining listing pull requests with pagination seems to lose us some type safety. Adding in this type should avoid allowing us to pass in parameters that do not exist.


