### PR TITLE
Remove DevX filter from snyk integrator

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -86,7 +86,7 @@ export async function main() {
 	);
 
 	const repoOwners = await getRepoOwnership(prisma);
-	await sendUnprotectedRepo(evaluatedRepos, config, repoOwners, repoLanguages);
+	await sendUnprotectedRepo(evaluatedRepos, config, repoLanguages);
 	await writeEvaluationTable(evaluatedRepos, prisma);
 	if (config.enableMessaging) {
 		await sendPotentialInteractives(evaluatedRepos, config);


### PR DESCRIPTION
## What does this change?

Removes the DevX filter that was only sending internal repos to the Snyk Integrator

## Why?

We are ready to release to the wider department

## How has it been verified?

CI passes
