### PR TITLE
Add aws plugin and get credentials via policy arn

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19780,7 +19780,7 @@ spec:
               "-c",
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/steampipe:1",
+            "Image": "ghcr.io/guardian/service-catalogue/steampipe:2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -20026,6 +20026,9 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/packages/cdk/lib/cloudquery/images.ts
+++ b/packages/cdk/lib/cloudquery/images.ts
@@ -18,6 +18,6 @@ export const Images = {
 		'public.ecr.aws/docker/library/postgres:16-alpine',
 	),
 	steampipe: ContainerImage.fromRegistry(
-		'ghcr.io/guardian/service-catalogue/steampipe:1',
+		'ghcr.io/guardian/service-catalogue/steampipe:2',
 	),
 };

--- a/packages/cdk/lib/steampipe/service.ts
+++ b/packages/cdk/lib/steampipe/service.ts
@@ -23,7 +23,7 @@ import {
 	NetworkLoadBalancer,
 	Protocol,
 } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
-import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { Effect, ManagedPolicy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Secret as SecretsManager } from 'aws-cdk-lib/aws-secretsmanager';
 import { Images } from '../cloudquery/images';
@@ -218,6 +218,14 @@ export class SteampipeService extends FargateService {
 		});
 
 		taskPolicies.forEach((policy) => task.addToTaskRolePolicy(policy));
+
+		task.taskRole.addManagedPolicy(
+			ManagedPolicy.fromManagedPolicyArn(
+				scope,
+				'SteampipeReadOnlyPolicy',
+				'arn:aws:iam::aws:policy/ReadOnlyAccess',
+			),
+		);
 
 		const nlb = new NetworkLoadBalancer(scope, `steampipe-nlb`, {
 			vpc: cluster.vpc,

--- a/packages/dev-environment/steampipe/Dockerfile
+++ b/packages/dev-environment/steampipe/Dockerfile
@@ -1,2 +1,3 @@
 FROM ghcr.io/turbot/steampipe
-RUN  steampipe plugin install steampipe github@0.39.0
+RUN  steampipe plugin install steampipe github@0.39.0 aws@0.129.0
+


### PR DESCRIPTION
## What does this change?
We added the steampipe aws plugin and gave a policy read-only

## Why?
We want to query aws tables
