### PR TITLE
feat(cdk): Enable local CFN stack diffing

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -11,6 +11,7 @@ new ServiceCatalogue(app, 'ServiceCatalogue-PROD', {
 	stage: 'PROD',
 	env: { region: 'eu-west-1' },
 	steampipeDomainName: 'steampipe.gutools.co.uk',
+	cloudFormationStackName: 'deploy-PROD-service-catalogue',
 });
 
 new ServiceCatalogue(app, 'ServiceCatalogue-CODE', {
@@ -20,4 +21,5 @@ new ServiceCatalogue(app, 'ServiceCatalogue-CODE', {
 	schedule: Schedule.rate(Duration.days(30)),
 	rdsDeletionProtection: false,
 	steampipeDomainName: 'steampipe.code.dev-gutools.co.uk',
+	cloudFormationStackName: 'deploy-CODE-service-catalogue',
 });

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects cdk",
-    "synth": "cdk synth --path-metadata false --version-reporting false"
+    "synth": "cdk synth --path-metadata false --version-reporting false",
+    "diff:code": "cdk diff --path-metadata false --version-reporting false --profile deployTools ServiceCatalogue-CODE"
   },
   "devDependencies": {
     "@guardian/cdk": "53.0.3",


### PR DESCRIPTION
## What does this change, and why?
It is sometimes useful to see the delta between the current branch and the CODE CloudFormation stack.

This change allows us to run:

```bash
npm -w cdk run diff:code
```

to yield something like this:

```console
Stack ServiceCatalogue-CODE (deploy-CODE-service-catalogue)
Creating a change set, this may take a while...
IAM Policy Changes
┌───┬─────────────────────────────────────┬────────────────────────────────────────┐
│   │ Resource                            │ Managed Policy ARN                     │
├───┼─────────────────────────────────────┼────────────────────────────────────────┤
│ - │ ${steampipeTaskDefinition/TaskRole} │ arn:aws:iam::aws:policy/ReadOnlyAccess │
└───┴─────────────────────────────────────┴────────────────────────────────────────┘
(NOTE: There may be security-related changes not in this list. See https://github.com/aws/aws-cdk/issues/1299)

Resources
[~] AWS::IAM::Role steampipeTaskDefinition/TaskRole steampipeTaskDefinitionTaskRole8DC44379
 └─ [-] ManagedPolicyArns
     └─ ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
[~] AWS::ECS::TaskDefinition steampipeTaskDefinition steampipeTaskDefinition767BA166 replace
 └─ [~] ContainerDefinitions (requires replacement)
     └─ @@ -11,7 +11,7 @@
        [ ]   "App": "service-catalogue"
        [ ] },
        [ ] "Essential": true,
        [-] "Image": "ghcr.io/guardian/service-catalogue/steampipe:2",
        [+] "Image": "ghcr.io/guardian/service-catalogue/steampipe:1",
        [ ] "LogConfiguration": {
        [ ]   "LogDriver": "awsfirelens",
        [ ]   "Options": {

✨  Number of stacks with differences: 1
```
