### PR TITLE
Allow repocop to access the snyk secret

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4404,7 +4404,6 @@
       "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.121.1.tgz",
       "integrity": "sha512-T8UFuNGDnXNmcHagCGeQ8xQA3zU/o2ENuyGXO/ho+U3KyYs7tnWIr++ovrp2FvhiBpmBv6SuKiueBA6OW7utBw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -4432,7 +4431,6 @@
         "yaml"
       ],
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.201",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
@@ -4459,15 +4457,13 @@
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
       "version": "8.12.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4484,7 +4480,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4494,7 +4489,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4510,7 +4504,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4519,15 +4512,13 @@
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
       "version": "1.1.11",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4538,7 +4529,6 @@
       "dev": true,
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -4548,7 +4538,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4560,36 +4549,31 @@
       "version": "1.1.4",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "11.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -4603,15 +4587,13 @@
       "version": "4.2.11",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
       "version": "5.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -4621,7 +4603,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4630,15 +4611,13 @@
       "version": "1.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -4651,7 +4630,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -4660,15 +4638,13 @@
       "version": "4.4.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/lru-cache": {
       "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4681,7 +4657,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4694,7 +4669,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4704,7 +4678,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4714,7 +4687,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4730,7 +4702,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -4748,7 +4719,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4763,7 +4733,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4776,7 +4745,6 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
@@ -4793,7 +4761,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -4803,7 +4770,6 @@
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -4812,15 +4778,13 @@
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -4833,7 +4797,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -11973,6 +11936,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.496.0",
+        "@aws-sdk/client-secrets-manager": "^3.496.0",
         "@aws-sdk/client-sns": "^3.496.0",
         "octokit-plugin-create-pull-request": "^5.1.1",
         "ts-markdown": "^1.0.0",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -18765,6 +18765,9 @@ spec:
               "Ref": "TopicBFC7AF6E",
             },
             "QUERY_LOGGING": "false",
+            "SNYK_API_KEY_ARN": {
+              "Ref": "snykcredentials4D951A18",
+            },
             "SNYK_INTEGRATOR_INPUT_TOPIC_ARN": {
               "Ref": "snykintegratorinputtopicTEST6BCA9CE1",
             },
@@ -19044,6 +19047,16 @@ spec:
               },
               "Effect": "Allow",
               "Resource": "*",
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "snykcredentials4D951A18",
+              },
             },
           ],
           "Version": "2012-10-17",

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -33,6 +33,7 @@ interface CloudqueryEcsClusterProps {
 	db: DatabaseInstance;
 	dbAccess: GuSecurityGroup;
 	nonProdSchedule?: Schedule;
+	snykCredentials: SecretsManager;
 }
 
 export function addCloudqueryEcsCluster(
@@ -419,10 +420,6 @@ export function addCloudqueryEcsCluster(
 		},
 	];
 
-	const snykCredentials = new SecretsManager(scope, 'snyk-credentials', {
-		secretName: `/${stage}/${stack}/${app}/snyk-credentials`,
-	});
-
 	const snykSources: CloudquerySource[] = [
 		{
 			name: 'SnykAll',
@@ -442,7 +439,10 @@ export function addCloudqueryEcsCluster(
 				skipTables: ['snyk_organization_provisions'],
 			}),
 			secrets: {
-				SNYK_API_KEY: Secret.fromSecretsManager(snykCredentials, 'api-key'),
+				SNYK_API_KEY: Secret.fromSecretsManager(
+					props.snykCredentials,
+					'api-key',
+				),
 			},
 			memoryLimitMiB: 1024,
 		},
@@ -455,7 +455,10 @@ export function addCloudqueryEcsCluster(
 				tables: ['snyk_projects'],
 			}),
 			secrets: {
-				SNYK_API_KEY: Secret.fromSecretsManager(snykCredentials, 'api-key'),
+				SNYK_API_KEY: Secret.fromSecretsManager(
+					props.snykCredentials,
+					'api-key',
+				),
 			},
 		},
 	];

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -29,6 +29,7 @@ export class Repocop {
 		interactiveMonitorTopic: Topic,
 		dbSecurityGroup: SecurityGroup,
 		repocopGithubSecret: Secret,
+		snykCredentialsSecret: Secret,
 	) {
 		const snykIntegratorInputTopic = new Topic(
 			guStack,
@@ -54,6 +55,7 @@ export class Repocop {
 				GITHUB_APP_SECRET: repocopGithubSecret.secretArn,
 				INTERACTIVES_COUNT: guStack.stage === 'PROD' ? '40' : '3',
 				SNYK_INTEGRATOR_INPUT_TOPIC_ARN: snykIntegratorInputTopic.topicArn,
+				SNYK_API_KEY_ARN: snykCredentialsSecret.secretArn,
 			},
 			vpc,
 			securityGroups: [dbSecurityGroup],
@@ -83,6 +85,7 @@ export class Repocop {
 		interactiveMonitorTopic.grantPublish(repocopLambda);
 		snykIntegratorInputTopic.grantPublish(repocopLambda);
 		repocopLambda.addToRolePolicy(policyStatement);
+		snykCredentialsSecret.grantRead(repocopLambda);
 
 		const snykIntegatorLambda = stageAwareSnykIntegrator(guStack, vpc);
 

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -179,11 +179,16 @@ export class ServiceCatalogue extends GuStack {
 			dataType: ParameterDataType.TEXT,
 		});
 
+		const snykCredentials = new Secret(this, 'snyk-credentials', {
+			secretName: `/${stage}/${stack}/${app}/snyk-credentials`,
+		});
+
 		const cluster = addCloudqueryEcsCluster(this, {
 			nonProdSchedule,
 			db,
 			vpc,
 			dbAccess: applicationToPostgresSecurityGroup,
+			snykCredentials,
 		});
 
 		const anghammaradTopicParameter =

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -246,6 +246,7 @@ export class ServiceCatalogue extends GuStack {
 			interactiveMonitor.topic,
 			applicationToPostgresSecurityGroup,
 			githubCredentials,
+			snykCredentials,
 		);
 
 		addDataAuditLambda(this, {

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -179,7 +179,7 @@ export class ServiceCatalogue extends GuStack {
 			dataType: ParameterDataType.TEXT,
 		});
 
-		const snykCredentials = new Secret(this, 'snyk-credentials', {
+		const snykReadOnlyKey = new Secret(this, 'snyk-credentials', {
 			secretName: `/${stage}/${stack}/${app}/snyk-credentials`,
 		});
 
@@ -188,7 +188,7 @@ export class ServiceCatalogue extends GuStack {
 			db,
 			vpc,
 			dbAccess: applicationToPostgresSecurityGroup,
-			snykCredentials,
+			snykCredentials: snykReadOnlyKey,
 		});
 
 		const anghammaradTopicParameter =
@@ -246,7 +246,7 @@ export class ServiceCatalogue extends GuStack {
 			interactiveMonitor.topic,
 			applicationToPostgresSecurityGroup,
 			githubCredentials,
-			snykCredentials,
+			snykReadOnlyKey,
 		);
 
 		addDataAuditLambda(this, {

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -11,6 +11,7 @@
 	},
 	"dependencies": {
 		"@aws-sdk/client-cloudwatch": "^3.496.0",
+		"@aws-sdk/client-secrets-manager": "^3.496.0",
 		"@aws-sdk/client-sns": "^3.496.0",
 		"octokit-plugin-create-pull-request": "^5.1.1",
 		"ts-markdown": "^1.0.0",

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -68,8 +68,14 @@ export interface Config extends PrismaConfig {
 	 */
 	snykIntegratorTopic: string;
 
-	snykSecretArn: string;
+	/**
+	 * The API key for Snyk.
+	 */
 	snykReadOnlyKey: string;
+
+	/**
+	 * The Snyk group ID.
+	 */
 	snykGroupId: string;
 }
 
@@ -103,7 +109,6 @@ export async function getConfig(): Promise<Config> {
 		snykIntegrationPREnabled:
 			process.env.SNYK_INTEGRATION_PR_ENABLED === 'true',
 		snykIntegratorTopic: getEnvOrThrow('SNYK_INTEGRATOR_INPUT_TOPIC_ARN'),
-		snykSecretArn: getEnvOrThrow('SNYK_API_KEY_ARN'),
 		snykReadOnlyKey: snykSecretValues['api-key'].replaceAll("'", ''),
 		snykGroupId: snykSecretValues['group-id'].replaceAll("'", ''),
 	};

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -50,6 +50,8 @@ async function writeEvaluationTable(
 
 export async function main() {
 	const config: Config = await getConfig();
+
+	console.log('Snyk Group Id:', config.snykGroupId);
 	const prisma = getPrismaClient(config);
 
 	const octokit = await stageAwareOctokit(config.stage);


### PR DESCRIPTION
## What does this change?

Allows repocop to read the contents of the snyk secret so it can retrieve the data that used to populate the `snyk_projects` table. Logs the group ID to the console to demonstrate it was retrieved successfully.

## Why?

So we can retrieve Snyk Projects data using repocop

## How has it been verified?

Local execution works.
Verified group ID is logged on CODE
