### PR TITLE
Opt in service catalogue RDS databases to aws-backups

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -17806,6 +17806,10 @@ spec:
         "StorageType": "gp2",
         "Tags": [
           {
+            "Key": "devx-backup-enabled",
+            "Value": "false",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -17856,6 +17860,10 @@ spec:
         },
         "Tags": [
           {
+            "Key": "devx-backup-enabled",
+            "Value": "false",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
@@ -17895,6 +17903,10 @@ spec:
           "Ref": "PrivateSubnets",
         },
         "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "false",
+          },
           {
             "Key": "gu:cdk:version",
             "Value": "TEST",

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -14,7 +14,7 @@ import {
 } from '@guardian/cdk/lib/constructs/ec2';
 import { GuardianPrivateNetworks } from '@guardian/private-infrastructure-config';
 import type { App } from 'aws-cdk-lib';
-import { Duration } from 'aws-cdk-lib';
+import { Duration, Tags } from 'aws-cdk-lib';
 import {
 	InstanceClass,
 	InstanceSize,
@@ -54,6 +54,7 @@ interface ServiceCatalogueProps extends GuStackProps {
 	 * @default true
 	 */
 	rdsDeletionProtection?: boolean;
+	withBackup: true;
 }
 
 export class ServiceCatalogue extends GuStack {
@@ -109,6 +110,8 @@ export class ServiceCatalogue extends GuStack {
 		};
 
 		const db = new DatabaseInstance(this, 'PostgresInstance1', dbProps);
+
+		Tags.of(db).add("devx-backup-enabled", "false");
 
 		const applicationToPostgresSecurityGroup = new GuSecurityGroup(
 			this,


### PR DESCRIPTION
## What does this change?
This change adds the "devx-backup-enabled":"true" tag to the service catalogue RDS database.

## Why?
This opts the database in to AWS-backup securing it against accidental or malicious deletion of backups of this database.
See the [FAQ's](https://docs.google.com/document/d/1VDCSxYFlWs4R6g0Waa6OmmfytV60AROyHxfIGho7cLA/edit?usp=sharing) for more information.

## How has it been verified?
Deploying change to CODE database and ensuring correct tags are applied and database backups transition correctly.
