### PR TITLE
Run Steampie on ARM

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19728,6 +19728,9 @@ spec:
         "RequiresCompatibilities": [
           "FARGATE",
         ],
+        "RuntimePlatform": {
+          "CpuArchitecture": "ARM64",
+        },
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/packages/cdk/lib/steampipe/service.ts
+++ b/packages/cdk/lib/steampipe/service.ts
@@ -8,7 +8,9 @@ import { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
 import { Duration } from 'aws-cdk-lib';
 import { Port } from 'aws-cdk-lib/aws-ec2';
 import type { ISecurityGroup } from 'aws-cdk-lib/aws-ec2';
+import type { FargateServiceProps } from 'aws-cdk-lib/aws-ecs';
 import {
+	CpuArchitecture,
 	FargateService,
 	FargateTaskDefinition,
 	FireLensLogDriver,
@@ -16,7 +18,6 @@ import {
 	LogDrivers,
 	Secret,
 } from 'aws-cdk-lib/aws-ecs';
-import type { FargateServiceProps } from 'aws-cdk-lib/aws-ecs';
 import {
 	NetworkLoadBalancer,
 	Protocol,
@@ -101,6 +102,9 @@ export class SteampipeService extends FargateService {
 		const task = new FargateTaskDefinition(scope, `${id}TaskDefinition`, {
 			memoryLimitMiB: 512,
 			cpu: 256,
+			runtimePlatform: {
+				cpuArchitecture: CpuArchitecture.ARM64,
+			},
 		});
 
 		const fireLensLogDriver = new FireLensLogDriver({


### PR DESCRIPTION
## What does this change?

Runs Steampipe on ARM

## Why?

Steampipe publishes an ARM image (and so do we). ARM is 20% cheaper and better for the environment!

<img width="770" alt="image" src="https://github.com/guardian/service-catalogue/assets/21217225/99509643-f473-4a8d-86c6-70d12ca9eb2e">


## How has it been verified?

Will run on CODE.
