### PR TITLE
feat: add Swift to the Snyk dependency submission action

### DIFF
--- a/packages/repocop/src/languages.ts
+++ b/packages/repocop/src/languages.ts
@@ -46,6 +46,7 @@ export const actionSupportedLanguages = ignoredLanguages.concat(
 	'Go',
 	'Python',
 	'JavaScript',
+	'Swift',
 );
 
 export const supportedDependabotLanguages = ignoredLanguages.concat(


### PR DESCRIPTION
## What does this change?

Adds the Swift language to those supported by the Snyk [dependency submission action](https://github.com/guardian/.github/blob/main/.github/workflows/sbt-node-snyk.yml). The action works with both Cocoapods and Swift Package Manager files without any modifications required to the action itself.

## Why?

We can check more repos, now that [Snyk supports Swift](https://docs.snyk.io/scan-using-snyk/supported-languages-and-frameworks/swift-and-objective-c).

## How has it been verified?
I tested against the [test-repocop-prs](https://github.com/guardian/test-repocop-prs/actions) repo and a [fork of ios-app](https://github.com/guardian/test-repocop-prs/actions). 