### PR TITLE
Use non-main version of Steampipe Github plugin and trial using Github app authentication

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19768,7 +19768,9 @@ spec:
         "ContainerDefinitions": [
           {
             "Command": [
-              "steampipe service start --foreground",
+              "/bin/sh",
+              "-c",
+              "mkdir -p /home/steampipe/.steampipe/config/github/private-key.pem;echo $GITHUB_PRIVATE_KEY_VALUE > /home/steampipe/.steampipe/config/github/private-key.pem/private-key.pem;steampipe service start --foreground",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -19776,11 +19778,16 @@ spec:
               "Stage": "TEST",
             },
             "EntryPoint": [
-              "/bin/sh",
-              "-c",
+              "",
+            ],
+            "Environment": [
+              {
+                "Name": "GITHUB_PRIVATE_KEY",
+                "Value": "/home/steampipe/.steampipe/config/github/private-key.pem/private-key.pem",
+              },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/steampipe:2",
+            "Image": "ghcr.io/guardian/service-catalogue/steampipe:prerelease-3",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -19825,15 +19832,43 @@ spec:
                 },
               },
               {
-                "Name": "GITHUB_TOKEN",
+                "Name": "GITHUB_PRIVATE_KEY_VALUE",
                 "ValueFrom": {
                   "Fn::Join": [
                     "",
                     [
                       {
-                        "Ref": "steampipecredentials98149F9E",
+                        "Ref": "githubcredentialsAF453741",
                       },
-                      ":github-token::",
+                      ":private-key::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "GITHUB_APP_ID",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "githubcredentialsAF453741",
+                      },
+                      ":app-id::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "GITHUB_INSTALLATION_ID",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "githubcredentialsAF453741",
+                      },
+                      ":installation-id::",
                     ],
                   ],
                 },
@@ -19985,6 +20020,16 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "steampipecredentials98149F9E",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "githubcredentialsAF453741",
               },
             },
             {

--- a/packages/cdk/lib/cloudquery/images.ts
+++ b/packages/cdk/lib/cloudquery/images.ts
@@ -18,6 +18,6 @@ export const Images = {
 		'public.ecr.aws/docker/library/postgres:16-alpine',
 	),
 	steampipe: ContainerImage.fromRegistry(
-		'ghcr.io/guardian/service-catalogue/steampipe:2',
+		'ghcr.io/guardian/service-catalogue/steampipe:prerelease-3',
 	),
 };

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -34,6 +34,7 @@ interface CloudqueryEcsClusterProps {
 	dbAccess: GuSecurityGroup;
 	nonProdSchedule?: Schedule;
 	snykCredentials: SecretsManager;
+	githubCredentials: SecretsManager;
 }
 
 export function addCloudqueryEcsCluster(
@@ -41,7 +42,7 @@ export function addCloudqueryEcsCluster(
 	props: CloudqueryEcsClusterProps,
 ) {
 	const { stage, stack, app = 'service-catalogue' } = scope;
-	const { vpc, db, dbAccess, nonProdSchedule } = props;
+	const { vpc, db, dbAccess, nonProdSchedule, githubCredentials } = props;
 
 	const riffRaffDatabaseAccessSecurityGroupParam =
 		StringParameter.valueForStringParameter(
@@ -267,25 +268,14 @@ export function addCloudqueryEcsCluster(
 		cpu: 1024,
 	};
 
-	const cloudqueryGithubCredentials = new SecretsManager(
-		scope,
-		'github-credentials',
-		{
-			secretName: `/${stage}/${stack}/${app}/github-credentials`,
-		},
-	);
-
 	const githubSecrets: Record<string, Secret> = {
 		GITHUB_PRIVATE_KEY: Secret.fromSecretsManager(
-			cloudqueryGithubCredentials,
+			githubCredentials,
 			'private-key',
 		),
-		GITHUB_APP_ID: Secret.fromSecretsManager(
-			cloudqueryGithubCredentials,
-			'app-id',
-		),
+		GITHUB_APP_ID: Secret.fromSecretsManager(githubCredentials, 'app-id'),
 		GITHUB_INSTALLATION_ID: Secret.fromSecretsManager(
-			cloudqueryGithubCredentials,
+			githubCredentials,
 			'installation-id',
 		),
 	};

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -185,12 +185,17 @@ export class ServiceCatalogue extends GuStack {
 			secretName: `/${stage}/${stack}/${app}/snyk-credentials`,
 		});
 
+		const githubCredentials = new Secret(this, 'github-credentials', {
+			secretName: `/${stage}/${stack}/${app}/github-credentials`,
+		});
+
 		const cluster = addCloudqueryEcsCluster(this, {
 			nonProdSchedule,
 			db,
 			vpc,
 			dbAccess: applicationToPostgresSecurityGroup,
 			snykCredentials: snykReadOnlyKey,
+			githubCredentials,
 		});
 
 		const anghammaradTopicParameter =
@@ -224,7 +229,7 @@ export class ServiceCatalogue extends GuStack {
 			anghammaradTopicParameter.valueAsString,
 		);
 
-		const githubCredentials = new Secret(
+		const repocopGithubCredentials = new Secret(
 			this,
 			`branch-protector-github-app-auth`,
 			{
@@ -247,7 +252,7 @@ export class ServiceCatalogue extends GuStack {
 			vpc,
 			interactiveMonitor.topic,
 			applicationToPostgresSecurityGroup,
-			githubCredentials,
+			repocopGithubCredentials,
 			snykReadOnlyKey,
 		);
 
@@ -266,6 +271,7 @@ export class ServiceCatalogue extends GuStack {
 			secrets: {},
 			accessSecurityGroup: steampipeSecurityGroup,
 			domainName: steampipeDomainName,
+			githubCredentials,
 		});
 	}
 }

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -48,5 +48,9 @@ services:
       - '9193:9193'
     environment:
       STEAMPIPE_DATABASE_PASSWORD: steampipe
-      GITHUB_TOKEN: ${GITHUB_ACCESS_TOKEN}
-    command: ["service", "start", "--foreground"]
+      GITHUB_APP_ID: ${GITHUB_APP_ID}
+      GITHUB_INSTALLATION_ID: ${GITHUB_INSTALLATION_ID}
+      GITHUB_PRIVATE_KEY: /home/.steampipe/config/github/private-key.pem
+    volumes:
+      - ${GITHUB_PRIVATE_KEY_PATH}:/home/.steampipe/config/github/private-key.pem
+    command: ['service', 'start', '--foreground']

--- a/packages/dev-environment/steampipe/Dockerfile
+++ b/packages/dev-environment/steampipe/Dockerfile
@@ -1,3 +1,8 @@
 FROM ghcr.io/turbot/steampipe
-RUN  steampipe plugin install steampipe github@0.39.0 aws@0.129.0
+
+COPY ./github/steampipe-plugin-github.plugin  /home/steampipe/.steampipe/plugins/local/github/steampipe-plugin-github.plugin
+COPY ./github/github.spc  /home/steampipe/.steampipe/config/github.spc
+
+RUN  steampipe plugin install steampipe aws@0.129.0
+
 

--- a/packages/dev-environment/steampipe/github/README.md
+++ b/packages/dev-environment/steampipe/github/README.md
@@ -1,0 +1,3 @@
+Currently we build a version of the Steampipe github plugin ourselves from the [github app token branch](https://github.com/turbot/steampipe-plugin-github/tree/issue-390). The last build was made from commit [a42b89a81ad58bcf55dea2cf1d8c5a2b8d7848fb](https://github.com/turbot/steampipe-plugin-github/commit/a42b89a81ad58bcf55dea2cf1d8c5a2b8d7848fb).
+
+Hopefully this branch will be merged down to main once testing is completed and we can get rid of this folder.

--- a/packages/dev-environment/steampipe/github/github.spc
+++ b/packages/dev-environment/steampipe/github/github.spc
@@ -1,0 +1,3 @@
+connection "github" {
+  plugin          = "local/github"
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -103,17 +103,22 @@ GITHUB_ACCESS_TOKEN=
 "
 
   JSON_STRING=$(aws secretsmanager get-secret-value --secret-id /CODE/deploy/service-catalogue/github-credentials  --profile "$PROFILE" --region "$REGION" --output text | awk '{print $4}')
-echo "$JSON_STRING" | jq -rc '."app-id"' | xargs echo -n > "$local_env_file_dir"/app-id #keys need to be quoted otherwise the hyphen is interpreted as a minus sign
-echo "$JSON_STRING" | jq  -rc '."installation-id"' | xargs echo -n > "$local_env_file_dir"/installation-id
-  GITHUB_PRIVATE_KEY_PATH=$local_env_file_dir/private-key.pem
+  GITHUB_APP_ID=$(echo "$JSON_STRING" | jq -rc '."app-id"')
+  GITHUB_INSTALLATION_ID=$(echo "$JSON_STRING" | jq  -rc '."installation-id"')
 
-echo "$JSON_STRING" | jq -r '."private-key"' | base64 --decode > "$GITHUB_PRIVATE_KEY_PATH"
+  echo "$GITHUB_APP_ID" | xargs echo -n > "$local_env_file_dir"/app-id #keys need to be quoted otherwise the hyphen is interpreted as a minus sign
+  echo "$GITHUB_INSTALLATION_ID" | xargs echo -n > "$local_env_file_dir"/installation-id
+  
+  GITHUB_PRIVATE_KEY_PATH=$local_env_file_dir/private-key.pem
+  echo "$JSON_STRING" | jq -r '."private-key"' | base64 --decode > "$GITHUB_PRIVATE_KEY_PATH"
 
 
   env_var_text="SNYK_TOKEN=${SNYK_TOKEN}
 GALAXIES_BUCKET=${GALAXIES_BUCKET}
 ANGHAMMARAD_SNS_ARN=${ANGHAMMARAD_SNS_ARN}
 INTERACTIVE_MONITOR_TOPIC_ARN=${INTERACTIVE_MONITOR_TOPIC_ARN}
+GITHUB_APP_ID=${GITHUB_APP_ID}
+GITHUB_INSTALLATION_ID=${GITHUB_INSTALLATION_ID}
 GITHUB_PRIVATE_KEY_PATH=${GITHUB_PRIVATE_KEY_PATH}
 CLOUDQUERY_API_KEY=${CLOUDQUERY_API_KEY}
 SNYK_INTEGRATOR_INPUT_TOPIC_ARN=${SNYK_INTEGRATOR_INPUT_TOPIC_ARN}


### PR DESCRIPTION
## What does this change?

- Add `GITHUB_INSTALLATION_ID` and `GITHUB_APP_ID` as environment variables setup by `./scripts/setup`
- Use our own build of the Github steampipe plugin using their [Github app token support branch](https://github.com/turbot/steampipe-plugin-github/tree/issue-390). Based on instructions from [this comment](https://github.com/turbot/steampipe-plugin-github/issues/390#issuecomment-1906162570)
- Update our Dockerfile to use our own build instead of installing Github from Hub
- Hoist github credentials further up in service-catalogue so that both cloudquery and steampipe can use them

## Why?

We ideally don't want to be using our own PAT tokens for Steampipe. Our own accounts don't have as much access as our Github app, and they're prone to expiring / people leaving.

The author of the steampipe plugin has requested people to test the branch, so lets do it!

## How has it been verified?

Shall be ran in CODE
