### PR TITLE
feat: add Kotlin to the Snyk action

### DIFF
--- a/packages/repocop/src/languages.ts
+++ b/packages/repocop/src/languages.ts
@@ -47,6 +47,7 @@ export const actionSupportedLanguages = ignoredLanguages.concat(
 	'Python',
 	'JavaScript',
 	'Swift',
+	'Kotlin',
 );
 
 export const supportedDependabotLanguages = ignoredLanguages.concat(


### PR DESCRIPTION
## What does this change?

Adds the Kotlin language to those supported by the Snyk [dependency submission action](https://github.com/guardian/.github/blob/main/.github/workflows/sbt-node-snyk.yml). The action works with both Maven (pom.xml) and Gradle (build.gradle.kts)  files without any modifications required to the action itself.

## Why?

We can check more repos, now that [Snyk supports Kotlin](https://docs.snyk.io/scan-using-snyk/supported-languages-and-frameworks/java-and-kotlin#open-source-and-licensing).

## How has it been verified?

I tested against a Maven `pom.xml` manifest in [test-repocop-prs](https://github.com/guardian/test-repocop-prs/actions/runs/7628229105/job/20778767374) and the action is already being used for Gradle files by [android-news-app](https://github.com/guardian/android-news-app/blob/main/.github/workflows/snyk.yml), [Snyk dashboard](https://app.snyk.io/org/guardian-mobile/project/c4305fc1-d61b-4f97-82cc-1c62a981abee)
