### PR TITLE
Remove the deregistrationDelay on Steampipes ECS service

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -20252,6 +20252,10 @@ spec:
             "Key": "deregistration_delay.timeout_seconds",
             "Value": "0",
           },
+          {
+            "Key": "deregistration_delay.connection_termination.enabled",
+            "Value": "true",
+          },
         ],
         "TargetType": "ip",
         "VpcId": {

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19768,7 +19768,7 @@ spec:
         "ContainerDefinitions": [
           {
             "Command": [
-              "generate-aws-plugin-config; steampipe service start --foreground",
+              "generate-aws-plugin-config; exec steampipe service start --foreground",
             ],
             "DockerLabels": {
               "App": "service-catalogue",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19716,7 +19716,7 @@ spec:
         "LaunchType": "FARGATE",
         "LoadBalancers": [
           {
-            "ContainerName": "steampipeContainer",
+            "ContainerName": "steampipeContainers",
             "ContainerPort": 9193,
             "TargetGroupArn": {
               "Ref": "steampipenlbsteampipenlblistenersteampipenlbtargetGroup8BBC7369",
@@ -19801,7 +19801,7 @@ spec:
                 "SourceVolume": "steampipe-database",
               },
             ],
-            "Name": "steampipeContainer",
+            "Name": "steampipeContainers",
             "PortMappings": [
               {
                 "ContainerPort": 9193,

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -20247,6 +20247,12 @@ spec:
             "Value": "TEST",
           },
         ],
+        "TargetGroupAttributes": [
+          {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "0",
+          },
+        ],
         "TargetType": "ip",
         "VpcId": {
           "Ref": "VpcId",

--- a/packages/cdk/lib/steampipe/service.ts
+++ b/packages/cdk/lib/steampipe/service.ts
@@ -184,7 +184,7 @@ export class SteampipeService extends FargateService {
 				),
 			},
 			command: [
-				'generate-aws-plugin-config; steampipe service start --foreground',
+				'generate-aws-plugin-config; exec steampipe service start --foreground',
 			],
 			logging: fireLensLogDriver,
 			portMappings: [

--- a/packages/cdk/lib/steampipe/service.ts
+++ b/packages/cdk/lib/steampipe/service.ts
@@ -258,6 +258,15 @@ export class SteampipeService extends FargateService {
 				interval: Duration.seconds(5),
 				timeout: Duration.seconds(2),
 			},
+			// Apps like Grafana will keep a connection to Steampipe alive as long as possible.
+			// When an ECS task is deactivated the NLB tries to be helpful and will keep the task alive
+			// for up to 5 minutes whilst theres still active connections.
+			//
+			// Because we only allow a max of 1 instance of Steampipe this is not particularly useful to us
+			// and we'd prefer for the old instance to stop as quickly as possible so that the new instance
+			// can start. Setting the deregistrationDelay to 0 will cause the NLB to terminate connections
+			// and launch the new instance with 0 delay.
+			deregistrationDelay: Duration.seconds(0),
 		});
 	}
 }

--- a/packages/cdk/lib/steampipe/service.ts
+++ b/packages/cdk/lib/steampipe/service.ts
@@ -165,7 +165,7 @@ export class SteampipeService extends FargateService {
 			},
 		});
 
-		const steampipe = task.addContainer(`${id}Container`, {
+		const steampipe = task.addContainer(`${id}Containers`, {
 			image: Images.steampipe,
 			dockerLabels: {
 				Stack: stack,

--- a/packages/cdk/lib/steampipe/service.ts
+++ b/packages/cdk/lib/steampipe/service.ts
@@ -249,7 +249,7 @@ export class SteampipeService extends FargateService {
 			maxHealthyPercent: 100,
 		});
 
-		nlbListener.addTargets(`steampipe-nlb-target`, {
+		const target = nlbListener.addTargets(`steampipe-nlb-target`, {
 			port: STEAMPIPE_DB_PORT,
 			protocol: Protocol.TCP,
 			targets: [this],
@@ -268,5 +268,10 @@ export class SteampipeService extends FargateService {
 			// and launch the new instance with 0 delay.
 			deregistrationDelay: Duration.seconds(0),
 		});
+
+		target.setAttribute(
+			'deregistration_delay.connection_termination.enabled',
+			'true',
+		);
 	}
 }


### PR DESCRIPTION
## What does this change?

Sets the deregistrationDelay on Steampipes NLB to 0, down from the default of 5 minutes.

## Why?

The deregistration delay controls how long the NLB should wait until terminating connections to a ECS Task thats being removed. Grafana keeps a pool of connections alive, meaning the NLB will wait the maximum delay.

The task is still considered to be active and count towards the desired task total, this means that new tasks can't be started until the current task has been deregistered. For Steampipe where we limit to a maximum of 1 task it means after a deployment is made it takes 5 minutes for the old task to stop before the new task can start.

## How has it been verified?
