### PR TITLE
Declare Svelte, Mako as supported

### DIFF
--- a/packages/repocop/src/languages.ts
+++ b/packages/repocop/src/languages.ts
@@ -22,8 +22,10 @@ const commonSupportedLanguages = [
 	'JavaScript',
 	'Python',
 	'Jinja', // Jinja uses Python dependencies
+	'Mako', // Mako uses Python dependencies
 	'Swift',
 	'TypeScript',
+	'Svelte', // Svelte uses npm etc
 ];
 const snykOnlySupportedLanguages = [
 	'C',


### PR DESCRIPTION
## What does this change?

Declares some more languages as supported
Confirmed Mako with @philmcmahon 

## Why?

They are just extensions of already existing languages
