### PR TITLE
Check author of pull requests created by Snyk Integrator

### DIFF
--- a/packages/snyk-integrator/src/pull-requests.test.ts
+++ b/packages/snyk-integrator/src/pull-requests.test.ts
@@ -1,0 +1,79 @@
+import type { Octokit } from 'octokit';
+import { getPullRequest } from './pull-requests';
+
+/**
+ * Create a mocked version of the Octokit SDK that returns a given array of pull requests
+ */
+function mockOctokit(pulls: unknown[]) {
+	return {
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars -- It's just a mock
+		paginate: (arg0: unknown, arg1: unknown) => Promise.resolve(pulls),
+		rest: {
+			pulls: {
+				list: () => {},
+			},
+		},
+	} as Octokit;
+}
+
+describe('getPullRequest', () => {
+	const featureBranch = {
+		head: {
+			ref: 'feature-branch',
+		},
+		user: {
+			login: 'some-user',
+			type: 'User',
+		},
+	};
+
+	it('should return undefined when no matching branch found', async () => {
+		const pulls = [featureBranch];
+		const foundPull = await getPullRequest(
+			mockOctokit(pulls),
+			'repo',
+			'integrate-snyk-branch',
+		);
+		expect(foundPull).toBeUndefined();
+	});
+
+	it("should return undefined when branch found but author doesn't match", async () => {
+		const pulls = [
+			featureBranch,
+			{
+				head: {
+					ref: 'integrate-snyk-branch',
+				},
+				user: {
+					login: 'some-user',
+					type: 'User',
+				},
+			},
+		];
+		const foundPull = await getPullRequest(
+			mockOctokit(pulls),
+			'repo',
+			'integrate-snyk-branch',
+		);
+		expect(foundPull).toBeUndefined();
+	});
+
+	it('should return pull request when branch found and author matches', async () => {
+		const snykBranch = {
+			head: {
+				ref: 'integrate-snyk-branch',
+			},
+			user: {
+				login: 'gu-snyk-integrator[bot]',
+				type: 'Bot',
+			},
+		};
+		const pulls = [featureBranch, snykBranch];
+		const foundPull = await getPullRequest(
+			mockOctokit(pulls),
+			'repo',
+			'integrate-snyk-branch',
+		);
+		expect(foundPull).toEqual(snykBranch);
+	});
+});

--- a/packages/snyk-integrator/src/pull-requests.ts
+++ b/packages/snyk-integrator/src/pull-requests.ts
@@ -42,6 +42,15 @@ export async function createPullRequest(
 type PullRequestParameters =
 	Endpoints['GET /repos/{owner}/{repo}/pulls']['parameters'];
 
+type PullRequest =
+	Endpoints['GET /repos/{owner}/{repo}/pulls']['response']['data'][number];
+
+const GITHUB_BOT_LOGIN = 'gu-snyk-integrator[bot]';
+
+function isGithubAppAuthor(pull: PullRequest) {
+	return pull.user?.login === GITHUB_BOT_LOGIN && pull.user.type === 'Bot';
+}
+
 export async function getPullRequest(
 	octokit: Octokit,
 	repoName: string,
@@ -52,5 +61,7 @@ export async function getPullRequest(
 		repo: repoName,
 		state: 'open',
 	} satisfies PullRequestParameters);
-	return pulls.find((pull) => pull.head.ref === branchName);
+	return pulls.find(
+		(pull) => pull.head.ref === branchName && isGithubAppAuthor(pull),
+	);
 }


### PR DESCRIPTION
## What does this change?

Adds extra protection on top of #715, by checking the author of the pull request matches what we'd expect in Production.

We check the `login` (that's the username) of the user that created the Pull Request matches a hardcoded value that corresponds to the Snyk Integrator Github App. This matches what we do in [projects-graphql.ts](https://github.com/guardian/service-catalogue/blob/56247587c0a968fa3a9bd15e69cd2cc6b19243cb/packages/snyk-integrator/src/projects-graphql.ts#L75-L76), although in the future we could attempt to retrieve this value via the Github API. Whilst probably not strictly necessary, we additionally check the type of user is `Bot` to ensure a human account didn't create the pull request.

## Why?

Avoids the case where a human account raises a PR with the same name, preventing the Snyk Integrator raising a PR.

## How has it been verified?

Ran `STAGE=PROD npm run -w snyk-integrator start` locally, _TODO_.
