### PR TITLE
Count up number of alerts from Snyk

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -29,18 +29,13 @@ import { sendPotentialInteractives } from './remediations/topics/topic-monitor-i
 import { applyProductionTopicAndMessageTeams } from './remediations/topics/topic-monitor-production';
 import {
 	evaluateRepositories,
-	getAlertsForRepo,
-	hasOldDependabotAlerts,
-	hasOldSnykAlerts,
 	testExperimentalRepocopFeatures,
 } from './rules/repository';
 import type {
 	AwsCloudFormationStack,
 	GuardianSnykTags,
 	ProjectTag,
-	RepoAndAlerts,
 } from './types';
-import { isProduction } from './utils';
 
 async function writeEvaluationTable(
 	evaluatedRepos: repocop_github_repository_rules[],
@@ -108,43 +103,17 @@ export async function main() {
 	const snykProjects = await getSnykProjects(prisma);
 	const latestSnykIssues = await getLatestSnykIssues(prisma);
 
-	const prodRepos = unarchivedRepos.filter((repo) => isProduction(repo));
-
-	prodRepos.map((repo) =>
-		hasOldSnykAlerts(repo, latestSnykIssues, snykProjectsFromRest),
-	);
-
-	const alerts: RepoAndAlerts[] = (
-		await Promise.all(
-			prodRepos.map(async (repo) => {
-				return {
-					shortName: repo.full_name,
-					alerts: await getAlertsForRepo(octokit, repo.name),
-				};
-			}),
-		)
-	).filter((x) => !!x.alerts);
-
-	alerts.forEach((alert) => {
-		if (alert.alerts && alert.alerts.length > 0) {
-			console.log(
-				`Found ${alert.alerts.length} alerts for ${alert.shortName}: `,
-			);
-			hasOldDependabotAlerts(alert.alerts, alert.shortName);
-		}
-	});
-
-	console.log(`Found ${alerts.length} repos with alerts`);
-
 	const evaluatedRepos: repocop_github_repository_rules[] =
-		evaluateRepositories(
-			alerts,
+		await evaluateRepositories(
 			unarchivedRepos,
 			branches,
 			repoTeams,
 			repoLanguages,
 			snykProjects,
 			workflowFiles,
+			latestSnykIssues,
+			snykProjectsFromRest,
+			octokit,
 		);
 
 	const awsConfig = awsClientConfig(config.stage);

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -29,7 +29,7 @@ import { applyProductionTopicAndMessageTeams } from './remediations/topics/topic
 import {
 	evaluateRepositories,
 	getAlertsForRepo,
-	hasOldAlerts,
+	hasOldDependabotAlerts,
 	testExperimentalRepocopFeatures,
 } from './rules/repository';
 import type {
@@ -67,12 +67,13 @@ export async function main() {
 
 	const snykOrgIds = (await getSnykOrgs(config)).orgs.map((org) => org.id);
 
-	const allSnykTags = (
+	const snykProjectsFromRest = (
 		await Promise.all(
 			snykOrgIds.map(async (orgId) => await getProjectsForOrg(orgId, config)),
 		)
-	)
-		.flat()
+	).flat();
+
+	const allSnykTags = snykProjectsFromRest
 		.map((x) => x.attributes.tags)
 		.map(toGuardianSnykTags)
 		.filter((x) => !!x.repo && !!x.branch);
@@ -121,7 +122,7 @@ export async function main() {
 			console.log(
 				`Found ${alert.alerts.length} alerts for ${alert.shortName}: `,
 			);
-			hasOldAlerts(alert.alerts, alert.shortName);
+			hasOldDependabotAlerts(alert.alerts, alert.shortName);
 		}
 	});
 

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -4,6 +4,7 @@ import type {
 	github_workflows,
 	PrismaClient,
 	snyk_projects,
+	snyk_reporting_latest_issues,
 	view_repo_ownership,
 } from '@prisma/client';
 import type { GotBodyOptions } from 'got';
@@ -113,6 +114,12 @@ export async function getSnykProjects(
 	client: PrismaClient,
 ): Promise<snyk_projects[]> {
 	return await client.snyk_projects.findMany({});
+}
+
+export async function getLatestSnykIssues(
+	client: PrismaClient,
+): Promise<snyk_reporting_latest_issues[]> {
+	return await client.snyk_reporting_latest_issues.findMany({});
 }
 
 export async function getRepositoryLanguages(

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -739,8 +739,8 @@ describe('NO RULE - Old snyk issues', () => {
 		isPatchable: false,
 		isUpgradable: true,
 		priorityScore: 999,
-		disclosureTime: '2023-01-14T00:00:00.000Z',
-		publicationTime: '2023-01-14T12:00:00.000Z',
+		disclosureTime: '',
+		publicationTime: '', //'2023-01-14T12:00:00.000Z',
 	};
 
 	const myProject = {
@@ -761,7 +761,7 @@ describe('NO RULE - Old snyk issues', () => {
 		issue: myIssue,
 		projects: [myProject],
 		organization_id: '',
-		introduced_date: null,
+		introduced_date: new Date().toISOString(),
 		project: null,
 		is_fixed: null,
 		patched_date: null,
@@ -785,11 +785,11 @@ describe('NO RULE - Old snyk issues', () => {
 
 	test('Should not be detected if no projects or issues are passed', () => {
 		const x = hasOldSnykAlerts(thePerfectRepo, [], []);
-		expect(x).toEqual([]);
+		expect(x).toEqual(false);
 	});
 	test('Should be detected if a repo, project, and issue match', () => {
 		const x = hasOldSnykAlerts(thePerfectRepo, [myIssueTableRow], [proj]);
-		expect(x.length).toEqual(1);
+		expect(x).toEqual(true);
 	});
 	test('Should not detected if a snyk project has no tags', () => {
 		const x = hasOldSnykAlerts(
@@ -797,6 +797,6 @@ describe('NO RULE - Old snyk issues', () => {
 			[myIssueTableRow],
 			[{ ...proj, attributes: { ...proj.attributes, tags: [] } }],
 		);
-		expect(x.length).toEqual(0);
+		expect(x).toEqual(false);
 	});
 });

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -683,7 +683,6 @@ function createAlert(
 
 describe('NO RULE - Repository alerts', () => {
 	test('should be flagged if there are critical alerts older than one day', () => {
-		console.log(new Date('2021-01-01').toISOString());
 		const alerts: PartialAlert[] = [
 			createAlert('critical', new Date('2021-01-01'), 'open'),
 		];
@@ -740,7 +739,7 @@ describe('NO RULE - Old snyk issues', () => {
 		isUpgradable: true,
 		priorityScore: 999,
 		disclosureTime: '',
-		publicationTime: '', //'2023-01-14T12:00:00.000Z',
+		publicationTime: '',
 	};
 
 	const lowSeverityIssue = {

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -29,6 +29,8 @@ function evaluateRepoTestHelper(
 	snykProjects: snyk_projects[] = [],
 	githubWorkflows: github_workflows[] = [],
 	alerts: PartialAlert[] = [],
+	latestSnykIssues: snyk_reporting_latest_issues[] = [],
+	snykProjectsFromRest: SnykProject[] = [],
 ) {
 	return evaluateOneRepo(
 		alerts,
@@ -38,6 +40,8 @@ function evaluateRepoTestHelper(
 		languages,
 		snykProjects,
 		githubWorkflows,
+		latestSnykIssues,
+		snykProjectsFromRest,
 	);
 }
 
@@ -794,27 +798,35 @@ describe('NO RULE - Old snyk issues', () => {
 	};
 
 	test('Should not be detected if no projects or issues are passed', () => {
-		const x = hasOldSnykAlerts(thePerfectRepo, [], []);
-		expect(x).toEqual(false);
+		const result = hasOldSnykAlerts(thePerfectRepo, [], []);
+		expect(result).toEqual(false);
 	});
 	test('Should be detected if a repo, project, and old issue match', () => {
-		const x = hasOldSnykAlerts(thePerfectRepo, [oldIssueTableRow], [proj]);
-		expect(x).toEqual(true);
+		const result = hasOldSnykAlerts(thePerfectRepo, [oldIssueTableRow], [proj]);
+		expect(result).toEqual(true);
+	});
+	test('Should not be detected if a repo, project, and old issue match, but the repo is not in production', () => {
+		const nonProdRepo = {
+			...thePerfectRepo,
+			topics: [],
+		};
+		const result = hasOldSnykAlerts(nonProdRepo, [oldIssueTableRow], [proj]);
+		expect(result).toEqual(false);
 	});
 	test('Should not be detected if a repo, project, and new issue match', () => {
-		const x = hasOldSnykAlerts(thePerfectRepo, [newIssueTableRow], [proj]);
-		expect(x).toEqual(false);
+		const result = hasOldSnykAlerts(thePerfectRepo, [newIssueTableRow], [proj]);
+		expect(result).toEqual(false);
 	});
 	test('Should not detected if a snyk project has no tags', () => {
-		const x = hasOldSnykAlerts(
+		const result = hasOldSnykAlerts(
 			thePerfectRepo,
 			[oldIssueTableRow],
 			[{ ...proj, attributes: { ...proj.attributes, tags: [] } }],
 		);
-		expect(x).toEqual(false);
+		expect(result).toEqual(false);
 	});
 	test('Should not detect low severity issues', () => {
-		const x = hasOldSnykAlerts(
+		const result = hasOldSnykAlerts(
 			thePerfectRepo,
 			[
 				{
@@ -824,6 +836,6 @@ describe('NO RULE - Old snyk issues', () => {
 			],
 			[proj],
 		);
-		expect(x).toEqual(false);
+		expect(result).toEqual(false);
 	});
 });

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -724,24 +724,15 @@ describe('NO RULE - Dependabot alerts', () => {
 });
 
 describe('NO RULE - Snyk vulnerabilities', () => {
-	const repoName = thePerfectRepo.full_name;
 	const snykProjectId = '1a2b';
 	const highSeverityIssue = {
 		id: '',
-		CVSSv3: '',
-		Semver: { unaffected: '', vulnerable: ['<2.814.0'] },
-		Patches: [],
-		ignored: null,
-		package: '',
-		version: '',
 		severity: 'high',
-		cvssScore: 7.3,
 		isIgnored: false,
 		isPatched: false,
 		isPinnable: false,
 		isPatchable: false,
 		isUpgradable: true,
-		priorityScore: 999,
 		disclosureTime: '',
 		publicationTime: '',
 	};
@@ -749,7 +740,6 @@ describe('NO RULE - Snyk vulnerabilities', () => {
 	const lowSeverityIssue = {
 		...highSeverityIssue,
 		severity: 'low',
-		cvssScore: 1.3,
 	};
 
 	const myProject = {
@@ -791,7 +781,7 @@ describe('NO RULE - Snyk vulnerabilities', () => {
 			tags: [
 				{
 					key: 'repo',
-					value: repoName,
+					value: thePerfectRepo.full_name,
 				},
 			],
 		},

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -691,26 +691,26 @@ describe('NO RULE - Repository alerts', () => {
 			createAlert('critical', new Date('2021-01-01'), 'open'),
 		];
 
-		expect(hasOldDependabotAlerts(alerts, 'test')).toBe(true);
+		expect(hasOldDependabotAlerts(alerts, thePerfectRepo)).toBe(true);
 	});
 	test('should not be flagged if a critical alert was raised today', () => {
 		const alerts: PartialAlert[] = [
 			createAlert('critical', new Date(), 'open'),
 		];
 
-		expect(hasOldDependabotAlerts(alerts, 'test')).toBe(false);
+		expect(hasOldDependabotAlerts(alerts, thePerfectRepo)).toBe(false);
 	});
 	test('should be flagged if there are high alerts older than 14 days', () => {
 		const alerts: PartialAlert[] = [
 			createAlert('high', new Date('2021-01-01'), 'open'),
 		];
 
-		expect(hasOldDependabotAlerts(alerts, 'test')).toBe(true);
+		expect(hasOldDependabotAlerts(alerts, thePerfectRepo)).toBe(true);
 	});
 	test('should not be flagged if a high alert was raised today', () => {
 		const alerts: PartialAlert[] = [createAlert('high', new Date(), 'open')];
 
-		expect(hasOldDependabotAlerts(alerts, 'test')).toBe(false);
+		expect(hasOldDependabotAlerts(alerts, thePerfectRepo)).toBe(false);
 	});
 	test('should not be flagged if a high alert was raised 13 days ago', () => {
 		const thirteenDaysAgo = new Date();
@@ -719,7 +719,7 @@ describe('NO RULE - Repository alerts', () => {
 			createAlert('high', thirteenDaysAgo, 'open'),
 		];
 
-		expect(hasOldDependabotAlerts(alerts, 'test')).toBe(false);
+		expect(hasOldDependabotAlerts(alerts, thePerfectRepo)).toBe(false);
 	});
 });
 

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -362,7 +362,6 @@ export function hasOldSnykAlerts(
 		issue: SnykIssue;
 	}
 
-	//find snyk projects that have a tag value matching the full repo name
 	const snykProjectIdsForRepo = snykProjects
 		.filter((project) => {
 			const tagValues = project.attributes.tags.map((tag) => tag.value);

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -368,9 +368,11 @@ export function hasOldSnykAlerts(
 		.map((projectId) => getProjectIssues(projectId, snykIssues))
 		.flat();
 
-	return repoIssues.map(
+	const finalIssues = repoIssues.map(
 		(i) => JSON.parse(JSON.stringify(i.issue)) as SnykIssue,
 	);
+
+	return finalIssues.length > 0;
 }
 
 export function testExperimentalRepocopFeatures(

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -126,33 +126,16 @@ export interface GuardianSnykTags {
 
 export interface SnykIssue {
 	id: string;
-	url?: string;
 	type?: string;
 	title?: string;
-	//CVSSv3: string;
-	//Semver: { unaffected: ''; vulnerable: ['<2.814.0'] };
-	credit?: string[];
-	//Patches: [];
-	//ignored: boolean | null; -- do we need this alongside isIgnored?
-	//package: 'aws-sdk';
-	version: '2.93.0';
+	version?: string;
 	language?: string;
 	severity: string;
-	cvssScore: number;
-	isIgnored: boolean;
-	isPatched: false;
+	isPatched: boolean;
 	isPinnable: false;
-	Identifiers?: {
-		CVE: string[];
-		CWE: string[];
-		OSVDB: string[];
-	};
 	isPatchable: boolean;
 	isUpgradable: boolean;
-	// jiraIssueUrl: string;
-	priorityScore: number;
 	disclosureTime: string; //or Date?
 	packageManager?: string;
-	exploitMaturity?: string;
 	publicationTime: string; //or Date?
 }

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -123,3 +123,36 @@ export interface GuardianSnykTags {
 	repo: string | undefined;
 	branch: string | undefined;
 }
+
+export interface SnykIssue {
+	id: string;
+	url?: string;
+	type?: string;
+	title?: string;
+	//CVSSv3: string;
+	//Semver: { unaffected: ''; vulnerable: ['<2.814.0'] };
+	credit?: string[];
+	//Patches: [];
+	//ignored: boolean | null; -- do we need this alongside isIgnored?
+	//package: 'aws-sdk';
+	version: '2.93.0';
+	language?: string;
+	severity: string;
+	cvssScore: number;
+	isIgnored: boolean;
+	isPatched: false;
+	isPinnable: false;
+	Identifiers?: {
+		CVE: string[];
+		CWE: string[];
+		OSVDB: string[];
+	};
+	isPatchable: boolean;
+	isUpgradable: boolean;
+	// jiraIssueUrl: string;
+	priorityScore: number;
+	disclosureTime: string; //or Date?
+	packageManager?: string;
+	exploitMaturity?: string;
+	publicationTime: string; //or Date?
+}


### PR DESCRIPTION
## What does this change?

Calculates whether or not a repository has Snyk vulnerabilities older than the cut-off date

## Why?

So teams can be better informed about their vulnerability obligations

## How has it been verified?

Unit tests verify expected behaviour. Deploying to CODE, we can see that it is logging when it finds repos with out of date vulnerabilities.

Example:
```
INFO	Dependabot - <REDACTED>: has 19 alerts that need addressing
INFO	Snyk - <REDACTED>: has 5 issues that need addressing
```

## Next steps

Combine alerts from both formats using a common format