### PR TITLE
feat: add Ruby to Snyk integrator

### DIFF
--- a/packages/repocop/src/languages.ts
+++ b/packages/repocop/src/languages.ts
@@ -50,6 +50,7 @@ export const actionSupportedLanguages = ignoredLanguages.concat(
 	'JavaScript',
 	'Swift',
 	'Kotlin',
+	'Ruby',
 );
 
 export const supportedDependabotLanguages = ignoredLanguages.concat(


### PR DESCRIPTION
## What does this change?

Adds the Ruby language to those supported by the Snyk [dependency submission action](https://github.com/guardian/.github/blob/main/.github/workflows/sbt-node-snyk.yml). 

## Why?

We can check more repos, as [Snyk supports Ruby](https://docs.snyk.io/scan-using-snyk/supported-languages-and-frameworks/ruby).

## How has it been verified?

I tested against [the fork of the ios-app](https://github.com/guardian/snyk-test-ios-live/actions/runs/7641883008/job/20820203079) and the Gemfile was scanned successfully [Snyk results](https://app.snyk.io/org/guardian-test/project/91dcb40c-e94e-4147-94cc-1c0a245f0fd0/history/adf48955-625b-4c4d-8847-21f00c32543f).