### PR TITLE
Don't send ignored languages to the Snyk integrator

### DIFF
--- a/packages/repocop/src/remediations/snyk-integrator/send-to-sns.test.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/send-to-sns.test.ts
@@ -57,6 +57,10 @@ function withGoodAndBadLanguages(fullName: string): github_languages {
 	return repoWithLanguages(fullName, ['Scala', 'TypeScript', 'Rust']);
 }
 
+function withGoodAndIgnoredLanguages(fullName: string): github_languages {
+	return repoWithLanguages(fullName, ['Scala', 'TypeScript', 'Shell', 'HTML']);
+}
+
 describe('When trying to find untracked repos where snyk integration will work', () => {
 	test('return a result if an untracked repo contains only languages our action supports', () => {
 		const actual = findUntrackedReposWhereIntegrationWillWork(
@@ -86,5 +90,18 @@ describe('When trying to find untracked repos where snyk integration will work',
 			[withGoodLanguages('repo4')],
 		);
 		expect(actual.length).toEqual(0);
+	});
+
+	test('return a result that removes languages ignored during snyk integration', () => {
+		const actual = findUntrackedReposWhereIntegrationWillWork(
+			[untrackedRepo('guardian/repo5')],
+			[withGoodAndIgnoredLanguages('guardian/repo5')],
+		);
+		expect(actual).toStrictEqual([
+			{
+				name: 'repo5',
+				languages: ['Scala', 'TypeScript'],
+			},
+		]);
 	});
 });

--- a/packages/repocop/src/remediations/snyk-integrator/send-to-sns.test.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/send-to-sns.test.ts
@@ -61,6 +61,10 @@ function withGoodAndIgnoredLanguages(fullName: string): github_languages {
 	return repoWithLanguages(fullName, ['Scala', 'TypeScript', 'Shell', 'HTML']);
 }
 
+function withIgnoredLanguages(fullName: string): github_languages {
+	return repoWithLanguages(fullName, ['Shell', 'HTML', 'CSS']);
+}
+
 describe('When trying to find untracked repos where snyk integration will work', () => {
 	test('return a result if an untracked repo contains only languages our action supports', () => {
 		const actual = findUntrackedReposWhereIntegrationWillWork(
@@ -103,5 +107,13 @@ describe('When trying to find untracked repos where snyk integration will work',
 				languages: ['Scala', 'TypeScript'],
 			},
 		]);
+	});
+
+	test('do not return a result if repository only contains ignored languages', () => {
+		const actual = findUntrackedReposWhereIntegrationWillWork(
+			[untrackedRepo('guardian/repo6')],
+			[withIgnoredLanguages('guardian/repo6')],
+		);
+		expect(actual.length).toEqual(0);
 	});
 });

--- a/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediations/snyk-integrator/send-to-sns.ts
@@ -54,7 +54,8 @@ export function findUntrackedReposWhereIntegrationWillWork(
 
 	const reposWhereAllLanguagesAreSupported = unprotectedReposWithLanguages
 		.filter((event) => eventContainsOnlyActionSupportedLanguages(event))
-		.map((event) => removeIgnoredLanguages(event));
+		.map((event) => removeIgnoredLanguages(event))
+		.filter((event) => event.languages.length > 0);
 
 	if (reposWhereAllLanguagesAreSupported.length > 0) {
 		console.log(


### PR DESCRIPTION
## What does this change?

Filter out all of the _ignored languages_ before we send an event to the Snyk integrator lambda. If a Snyk integrator event is left with zero languages, it will now also be filtered out.

## Why?

To prevent additional languages being sent to the Snyk integrator which it cannot action. This currently causes confusion on [some PRs](https://github.com/guardian/etag-caching/pull/38) *.

(*) This might not be super important in the future if we refactor the way we name branches.

## How has it been verified?

I've added two test cases, and existing tests pass.
