### PR TITLE
classify coffeescript as a dependabot supported language

### DIFF
--- a/packages/repocop/src/languages.ts
+++ b/packages/repocop/src/languages.ts
@@ -25,7 +25,8 @@ const commonSupportedLanguages = [
 	'Mako', // Mako uses Python dependencies
 	'Swift',
 	'TypeScript',
-	'Svelte', // Svelte uses npm etc
+	'CoffeeScript', // Uses JS/TS dependencies
+	'Svelte', // Uses JS/TS dependencies
 ];
 const snykOnlySupportedLanguages = [
 	'C',


### PR DESCRIPTION
## What does this change?

Classifies coffeescript as a dependabot supported language

## Why?

It uses NPM dependencies.
This will allow us to classify some repos more accurately

## How has it been verified?

CI passes
