### PR TITLE
feat(steampipe): Configure for multi-AWS account

### DIFF
--- a/.github/workflows/ecs-publish.yml
+++ b/.github/workflows/ecs-publish.yml
@@ -52,5 +52,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            GITHUB_PLUGIN_VERSION=${{ env.SP_GITHUB }}
-            AWS_PLUGIN_VERSION=${{ env.SP_AWS }}
+            SP_GITHUB=${{ env.SP_GITHUB }}
+            SP_AWS=${{ env.SP_AWS }}

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19879,7 +19879,7 @@ spec:
             "Name": "steampipeFirelens",
           },
         ],
-        "Cpu": "256",
+        "Cpu": "1024",
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
             "steampipeTaskDefinitionExecutionRole36454CCE",
@@ -19887,7 +19887,7 @@ spec:
           ],
         },
         "Family": "ServiceCataloguesteampipeTaskDefinition7074901D",
-        "Memory": "512",
+        "Memory": "2048",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19768,7 +19768,7 @@ spec:
         "ContainerDefinitions": [
           {
             "Command": [
-              "steampipe service start --foreground",
+              "generate-aws-plugin-config; steampipe service start --foreground",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -19780,7 +19780,7 @@ spec:
               "-c",
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/steampipe:3",
+            "Image": "ghcr.io/guardian/service-catalogue/steampipe:4",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -20026,9 +20026,6 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -20083,6 +20080,16 @@ spec:
                   ],
                 ],
               },
+            },
+            {
+              "Action": "organizations:List*",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": "arn:aws:iam::*:role/cloudquery-access",
             },
           ],
           "Version": "2012-10-17",

--- a/packages/cdk/lib/cloudquery/images.ts
+++ b/packages/cdk/lib/cloudquery/images.ts
@@ -18,6 +18,6 @@ export const Images = {
 		'public.ecr.aws/docker/library/postgres:16-alpine',
 	),
 	steampipe: ContainerImage.fromRegistry(
-		'ghcr.io/guardian/service-catalogue/steampipe:3',
+		'ghcr.io/guardian/service-catalogue/steampipe:4',
 	),
 };

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -38,6 +38,7 @@ import {
 } from 'aws-cdk-lib/aws-ssm';
 import { getCentralElkLink } from 'common/src/logs';
 import { addCloudqueryEcsCluster } from './cloudquery';
+import { cloudqueryAccess, listOrgsPolicy } from './cloudquery/policies';
 import { addDataAuditLambda } from './data-audit';
 import { InteractiveMonitor } from './interactive-monitor';
 import { Repocop } from './repocop';
@@ -262,7 +263,7 @@ export class ServiceCatalogue extends GuStack {
 		new SteampipeService(this, 'steampipe', {
 			app,
 			cluster,
-			policies: [],
+			policies: [listOrgsPolicy, cloudqueryAccess('*')],
 			secrets: {},
 			accessSecurityGroup: steampipeSecurityGroup,
 			domainName: steampipeDomainName,

--- a/packages/cdk/lib/steampipe/service.ts
+++ b/packages/cdk/lib/steampipe/service.ts
@@ -137,8 +137,8 @@ export class SteampipeService extends FargateService {
 		);
 
 		const task = new FargateTaskDefinition(scope, `${id}TaskDefinition`, {
-			memoryLimitMiB: 512,
-			cpu: 256,
+			memoryLimitMiB: 2048,
+			cpu: 1024,
 			runtimePlatform: {
 				cpuArchitecture: CpuArchitecture.ARM64,
 			},

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -52,6 +52,7 @@ services:
     volumes:
       - ~/.aws/credentials:/.aws/credentials
     environment:
+      STAGE: ${STAGE}
       STEAMPIPE_DATABASE_PASSWORD: steampipe
       GITHUB_TOKEN: ${GITHUB_ACCESS_TOKEN}
 

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -45,8 +45,8 @@ services:
       context: steampipe
       dockerfile: Dockerfile
       args:
-        GITHUB_PLUGIN_VERSION: ${SP_GITHUB}
-        AWS_PLUGIN_VERSION: ${SP_AWS}
+        SP_GITHUB: ${SP_GITHUB}
+        SP_AWS: ${SP_AWS}
     ports:
       - '9193:9193'
     environment:

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -49,7 +49,14 @@ services:
         SP_AWS: ${SP_AWS}
     ports:
       - '9193:9193'
+    volumes:
+      - ~/.aws/credentials:/.aws/credentials
     environment:
       STEAMPIPE_DATABASE_PASSWORD: steampipe
       GITHUB_TOKEN: ${GITHUB_ACCESS_TOKEN}
-    command: ["service", "start", "--foreground"]
+
+      # these are permanent credentials, as we'll be using STS Assume Role, which Janus DEV doesn't allow
+      AWS_PROFILE: 'service-catalogue-DEV'
+      AWS_SHARED_CREDENTIALS_FILE: '/.aws/credentials'
+    entrypoint: "/bin/bash -c"
+    command: [ "generate-aws-plugin-config; steampipe service start --foreground" ]

--- a/packages/dev-environment/steampipe/Dockerfile
+++ b/packages/dev-environment/steampipe/Dockerfile
@@ -1,6 +1,6 @@
 FROM ghcr.io/turbot/steampipe
 
-ARG GITHUB_PLUGIN_VERSION
-ARG AWS_PLUGIN_VERSION
+ARG SP_GITHUB
+ARG SP_AWS
 
-RUN steampipe plugin install steampipe github@${GITHUB_PLUGIN_VERSION} aws@${AWS_PLUGIN_VERSION}
+RUN steampipe plugin install steampipe github@${SP_GITHUB} aws@${SP_AWS}

--- a/packages/dev-environment/steampipe/Dockerfile
+++ b/packages/dev-environment/steampipe/Dockerfile
@@ -6,7 +6,7 @@ ARG SP_AWS
 RUN steampipe plugin install steampipe github@${SP_GITHUB} aws@${SP_AWS}
 
 # Install awscli (root user needed)
-USER 0
+USER root
 RUN apt-get update && apt-get install -y awscli
 
 # Set environment variables, for access by scripts at runtime

--- a/packages/dev-environment/steampipe/Dockerfile
+++ b/packages/dev-environment/steampipe/Dockerfile
@@ -4,3 +4,13 @@ ARG SP_GITHUB
 ARG SP_AWS
 
 RUN steampipe plugin install steampipe github@${SP_GITHUB} aws@${SP_AWS}
+
+# Install awscli (root user needed)
+USER 0
+RUN apt-get update && apt-get install -y awscli
+
+# Set environment variables, for access by scripts at runtime
+ENV AWS_VERSION ${SP_AWS}
+
+USER steampipe
+COPY generate-aws-plugin-config /usr/local/bin/generate-aws-plugin-config

--- a/packages/dev-environment/steampipe/generate-aws-plugin-config
+++ b/packages/dev-environment/steampipe/generate-aws-plugin-config
@@ -8,6 +8,10 @@ AWS_CONFIG_FILE=$HOME/.aws/config
 STEAMPIPE_INSTALL_DIR=$HOME/.steampipe/
 STEAMPIPE_CONFIG_FILE=${STEAMPIPE_INSTALL_DIR}/config/aws.spc
 
+# The `cloudquery-access` role has not been provisioned in the Root account,
+# Do not configure Steampipe to use it, as it will always error with `GetCallerIdentity`.
+ROOT_ACCOUNT_NAME="Guardian Web Systems"
+
 mkdir -p $(dirname "$AWS_CONFIG_FILE")
 mkdir -p $(dirname "$STEAMPIPE_CONFIG_FILE")
 
@@ -64,6 +68,6 @@ EOF
 
 done < <(
   aws organizations list-accounts \
-    --query "Accounts[?Status!='SUSPENDED'].[Name,Id,Status]" \
+    --query "Accounts[?Status!='SUSPENDED' && Name!='$ROOT_ACCOUNT_NAME'].[Name,Id,Status]" \
     --output text
 )

--- a/packages/dev-environment/steampipe/generate-aws-plugin-config
+++ b/packages/dev-environment/steampipe/generate-aws-plugin-config
@@ -35,6 +35,7 @@ while read -r line ; do
 
   echo "adding config for account $ACCOUNT_NAME ($ACCOUNT_ID)"
 
+  if [ "$STAGE" == "DEV" ] ; then
 cat << EOF >> "$AWS_CONFIG_FILE"
 [profile sp_${ACCOUNT_NAME}]
 role_arn = arn:aws:iam::${ACCOUNT_ID}:role/cloudquery-access
@@ -42,6 +43,15 @@ source_profile = service-catalogue-DEV
 role_session_name = steampipe
 
 EOF
+  else
+cat << EOF >> "$AWS_CONFIG_FILE"
+[profile sp_${ACCOUNT_NAME}]
+role_arn = arn:aws:iam::${ACCOUNT_ID}:role/cloudquery-access
+credential_source = EcsContainer
+role_session_name = steampipe
+
+EOF
+  fi
 
 cat << EOF >> "$STEAMPIPE_CONFIG_FILE"
 connection "aws_${SP_NAME}" {

--- a/packages/dev-environment/steampipe/generate-aws-plugin-config
+++ b/packages/dev-environment/steampipe/generate-aws-plugin-config
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "starting to generate configuration (stage=$STAGE, aws-version=$AWS_VERSION)"
+
+AWS_CONFIG_FILE=$HOME/.aws/config
+STEAMPIPE_INSTALL_DIR=$HOME/.steampipe/
+STEAMPIPE_CONFIG_FILE=${STEAMPIPE_INSTALL_DIR}/config/aws.spc
+
+mkdir -p $(dirname "$AWS_CONFIG_FILE")
+mkdir -p $(dirname "$STEAMPIPE_CONFIG_FILE")
+
+cat << EOF >> "$AWS_CONFIG_FILE"
+[default]
+region = eu-west-1
+
+EOF
+
+cat << EOF > "$STEAMPIPE_CONFIG_FILE"
+connection "aws" {
+  plugin = "aws@${AWS_VERSION}"
+  type        = "aggregator"
+  connections = ["aws_*"]
+}
+
+EOF
+
+while read -r line ; do
+  ACCOUNT_NAME=$(echo "$line" | awk '{for (i=1; i<NF-1; i++) printf $i " "}' | sed 's/ $//' | sed 's/ /_/g')
+  ACCOUNT_ID=$(echo "$line" | awk '{print $(NF - 1)}')
+
+  # Steampipe doesn't like dashes, so we need to swap for underscores
+  SP_NAME=$(echo "$ACCOUNT_NAME" | sed s/-/_/g)
+
+  echo "adding config for account $ACCOUNT_NAME ($ACCOUNT_ID)"
+
+cat << EOF >> "$AWS_CONFIG_FILE"
+[profile sp_${ACCOUNT_NAME}]
+role_arn = arn:aws:iam::${ACCOUNT_ID}:role/cloudquery-access
+source_profile = service-catalogue-DEV
+role_session_name = steampipe
+
+EOF
+
+cat << EOF >> "$STEAMPIPE_CONFIG_FILE"
+connection "aws_${SP_NAME}" {
+  plugin  = "aws@${AWS_VERSION}"
+  profile = "sp_${ACCOUNT_NAME}"
+  regions = ["*"]
+}
+
+EOF
+
+done < <(
+  aws organizations list-accounts \
+    --query "Accounts[?Status!='SUSPENDED'].[Name,Id,Status]" \
+    --output text
+)


### PR DESCRIPTION
> [!Note]
> Easiest to review [commit by commit](https://github.com/guardian/service-catalogue/pull/759/commits).

## What does this change?
Configure Steampipe to [access all the accounts](https://hub.steampipe.io/plugins/turbot/aws#multi-account-connections) in the AWS organisation by generating a config file with an entry per AWS account returned by:

```bash
aws organizations list-accounts
```

> [!Important]
> This branch requires static (permanent) IAM credentials to run locally.

It's worth noting that to run this locally, AWS credentials vended by Janus DEV is not enough, as it does not allow `sts:AssumeRole`. Therefore, one currently has to create some static credentials for an IAM User. This user should have an inline policy as below, and set to the profile `service-catalogue-DEV`:

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Action": "sts:AssumeRole",
            "Effect": "Allow",
            "Resource": "arn:aws:iam::*:role/cloudquery-access"
        },
        {
            "Effect": "Allow",
            "Action": "organizations:ListAccounts",
            "Resource": "*"
        }
    ]
}
```

I have created a user, and credentials, manually, I'll revoke the credentials in the coming days. In the next PR, I'll update the DEV environment to use only the deployTools account, and Janus DEV credentials, simplifying things.

## How has it been verified?
- Ran locally via `npm -w dev-environment start`
- This has been deployed to CODE, and the following query has been run in Grafana:
   ```sql
   select  arn
           , account_aliases
           , organization_id
           , organization_master_account_email
           , organization_master_account_id
   from aws.aws_account;
   ```

---
Co-authored by: @AshCorr, and @JuliaBrigitte.