### PR TITLE
Assess vulnerability tracker integration using results from snyk API

### DIFF
--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -1,9 +1,7 @@
 import type {
 	github_languages,
 	github_repository_branches,
-	github_workflows,
 	PrismaClient,
-	snyk_projects,
 	snyk_reporting_latest_issues,
 	view_repo_ownership,
 } from '@prisma/client';
@@ -109,13 +107,6 @@ export async function getStacks(
 	return toNonEmptyArray(stacks);
 }
 
-//allow it to return an empty array while getWorkflowFiles exists
-export async function getSnykProjects(
-	client: PrismaClient,
-): Promise<snyk_projects[]> {
-	return await client.snyk_projects.findMany({});
-}
-
 export async function getLatestSnykIssues(
 	client: PrismaClient,
 ): Promise<snyk_reporting_latest_issues[]> {
@@ -126,12 +117,6 @@ export async function getRepositoryLanguages(
 	client: PrismaClient,
 ): Promise<NonEmptyArray<github_languages>> {
 	return toNonEmptyArray(await client.github_languages.findMany({}));
-}
-
-export async function getWorkflowFiles(
-	client: PrismaClient,
-): Promise<NonEmptyArray<github_workflows>> {
-	return toNonEmptyArray(await client.github_workflows.findMany({}));
 }
 
 function projectsURL(orgId: string, snykApiVersion: string): string {


### PR DESCRIPTION
## What does this change?

We are able to pull the tags for each project from the Snyk API, meaning we have a more reliable way of telling whether or not a repo is on snyk or not. This means we don't have to use the proxy signal of whether or not it has a workflow file with a particular name.

## Why?

Better accuracy

## How has it been verified?

CI passes

There's about a 10% difference in the number of untracked repos, which is about what I was expecting to see
