### PR TITLE
refactor: move Ruby and Rust into common supported languages

### DIFF
--- a/packages/repocop/src/languages.ts
+++ b/packages/repocop/src/languages.ts
@@ -23,6 +23,8 @@ const commonSupportedLanguages = [
 	'Python',
 	'Jinja', // Jinja uses Python dependencies
 	'Mako', // Mako uses Python dependencies
+	'Ruby',
+	'Rust',
 	'Swift',
 	'TypeScript',
 	'CoffeeScript', // Uses JS/TS dependencies
@@ -36,8 +38,6 @@ const snykOnlySupportedLanguages = [
 	'Elixir',
 	'Kotlin',
 	'PHP',
-	'Ruby',
-	'Rust',
 	'Scala',
 	'Objective-C',
 	'Visual Basic .NET',


### PR DESCRIPTION
## What does this change?

Moves Ruby and Rust into common supported languages, as they are [now supported by Dependabot](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph) as well as Snyk.

## Why?

To be more accurate!

## How has it been verified?

There is a dependency graph on the [self-assessment tool](https://github.com/guardian/self-assessment/network/dependencies) which lists Rust dependencies, and I enabled dependency graph on [the fork of the ios app](https://github.com/guardian/snyk-test-ios-live/network/dependencies) and this lists the Ruby dependencies.