### PR TITLE
refactor(steampipe): Move plugin versions to `.env` file

### DIFF
--- a/.env
+++ b/.env
@@ -36,6 +36,12 @@ CQ_GITHUB_LANGUAGES=0.0.4
 # See https://github.com/guardian/cq-source-ns1
 CQ_NS1=0.0.3
 
+# See https://hub.steampipe.io/plugins/turbot/github/versions
+SP_GITHUB=0.39.0
+
+# See https://hub.steampipe.io/plugins/turbot/aws/versions
+SP_AWS=0.129.0
+
 # --- FOR LOCAL DEVELOPMENT ONLY ---
 STAGE=DEV
 DATABASE_USER=postgres

--- a/.github/workflows/ecs-publish.yml
+++ b/.github/workflows/ecs-publish.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Read .env file
+        run: cat .env | grep SP_ >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -48,3 +51,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GITHUB_PLUGIN_VERSION=${{ env.SP_GITHUB }}
+            AWS_PLUGIN_VERSION=${{ env.SP_AWS }}

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19780,7 +19780,7 @@ spec:
               "-c",
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/steampipe:2",
+            "Image": "ghcr.io/guardian/service-catalogue/steampipe:3",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {

--- a/packages/cdk/lib/cloudquery/images.ts
+++ b/packages/cdk/lib/cloudquery/images.ts
@@ -18,6 +18,6 @@ export const Images = {
 		'public.ecr.aws/docker/library/postgres:16-alpine',
 	),
 	steampipe: ContainerImage.fromRegistry(
-		'ghcr.io/guardian/service-catalogue/steampipe:2',
+		'ghcr.io/guardian/service-catalogue/steampipe:3',
 	),
 };

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -44,6 +44,9 @@ services:
     build:
       context: steampipe
       dockerfile: Dockerfile
+      args:
+        GITHUB_PLUGIN_VERSION: ${SP_GITHUB}
+        AWS_PLUGIN_VERSION: ${SP_AWS}
     ports:
       - '9193:9193'
     environment:

--- a/packages/dev-environment/steampipe/Dockerfile
+++ b/packages/dev-environment/steampipe/Dockerfile
@@ -1,3 +1,6 @@
 FROM ghcr.io/turbot/steampipe
-RUN  steampipe plugin install steampipe github@0.39.0 aws@0.129.0
 
+ARG GITHUB_PLUGIN_VERSION
+ARG AWS_PLUGIN_VERSION
+
+RUN steampipe plugin install steampipe github@${GITHUB_PLUGIN_VERSION} aws@${AWS_PLUGIN_VERSION}


### PR DESCRIPTION
## What does this change?
Move the Steampipe plugin versions to the `.env` file, for consistency, but also to later make them available as env vars in other contexts.

## How has it been verified?
Ran the workflow to build and push the image to GitHub Packages - https://github.com/guardian/service-catalogue/actions/runs/7742341313.