### PR TITLE
One Snyk pull request per repo

### DIFF
--- a/packages/snyk-integrator/src/index.ts
+++ b/packages/snyk-integrator/src/index.ts
@@ -4,7 +4,7 @@ import type { SnykIntegratorEvent } from 'common/src/types';
 import type { Config } from './config';
 import { getConfig } from './config';
 import { addPrToProject } from './projects-graphql';
-import { getPullRequest } from './pull-requests';
+import { getExistingPullRequest } from './pull-requests';
 import {
 	createSnykPullRequest,
 	createYaml,
@@ -19,11 +19,9 @@ export async function main(event: SnykIntegratorEvent) {
 	const branch = generateBranchName();
 	if (config.stage === 'PROD') {
 		const octokit = await stageAwareOctokit(config.stage);
-
-		const existingPullRequest = await getPullRequest(
+		const existingPullRequest = await getExistingPullRequest(
 			octokit,
 			event.name,
-			branch,
 		);
 
 		if (!existingPullRequest) {

--- a/packages/snyk-integrator/src/index.ts
+++ b/packages/snyk-integrator/src/index.ts
@@ -16,7 +16,7 @@ export async function main(event: SnykIntegratorEvent) {
 	console.log(`Generating Snyk PR for ${event.name}`);
 	const config: Config = getConfig();
 
-	const branch = generateBranchName(event.languages);
+	const branch = generateBranchName();
 	if (config.stage === 'PROD') {
 		const octokit = await stageAwareOctokit(config.stage);
 

--- a/packages/snyk-integrator/src/index.ts
+++ b/packages/snyk-integrator/src/index.ts
@@ -38,7 +38,10 @@ export async function main(event: SnykIntegratorEvent) {
 			await addPrToProject(config.stage, event);
 			console.log('Updated project board');
 		} else {
-			console.log(`Existing pull request found with branch ${branch}`);
+			console.log(
+				`Existing pull request found. Skipping creating a new one.`,
+				existingPullRequest.html_url,
+			);
 		}
 	} else {
 		console.log('Testing snyk.yml generation');

--- a/packages/snyk-integrator/src/pull-requests.test.ts
+++ b/packages/snyk-integrator/src/pull-requests.test.ts
@@ -1,0 +1,62 @@
+import type { Octokit } from 'octokit';
+import { getExistingPullRequest } from './pull-requests';
+
+/**
+ * Create a mocked version of the Octokit SDK that returns a given array of pull requests
+ */
+function mockOctokit(pulls: unknown[]) {
+	return {
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars -- It's just a mock
+		paginate: (arg0: unknown, arg1: unknown) => Promise.resolve(pulls),
+		rest: {
+			pulls: {
+				list: () => {},
+			},
+		},
+	} as Octokit;
+}
+
+describe('getPullRequest', () => {
+	const featureBranch = {
+		head: {
+			ref: 'feature-branch',
+		},
+		user: {
+			login: 'some-user',
+			type: 'User',
+		},
+	};
+
+	const snykBranch = {
+		head: {
+			ref: 'integrate-snyk-branch',
+		},
+		user: {
+			login: 'gu-snyk-integrator[bot]',
+			type: 'Bot',
+		},
+	};
+
+	it('should return undefined when no matching branch found', async () => {
+		const pulls = [featureBranch];
+		const foundPull = await getExistingPullRequest(mockOctokit(pulls), 'repo');
+		expect(foundPull).toBeUndefined();
+	});
+
+	it('should return pull request when author matches', async () => {
+		const pulls = [featureBranch, snykBranch];
+		const foundPull = await getExistingPullRequest(mockOctokit(pulls), 'repo');
+		expect(foundPull).toEqual(snykBranch);
+	});
+
+	it('should return first pull request that matches and log warning', async () => {
+		const warn = jest.spyOn(console, 'warn');
+		const pulls = [featureBranch, snykBranch, snykBranch];
+		const foundPull = await getExistingPullRequest(mockOctokit(pulls), 'repo');
+		expect(foundPull).toEqual(snykBranch);
+		expect(warn).toHaveBeenCalledWith(
+			'More than one Snyk integrator PR found on repository - choosing the first.',
+		);
+		warn.mockRestore();
+	});
+});

--- a/packages/snyk-integrator/src/pull-requests.test.ts
+++ b/packages/snyk-integrator/src/pull-requests.test.ts
@@ -29,11 +29,18 @@ describe('getPullRequest', () => {
 
 	const snykBranch = {
 		head: {
-			ref: 'integrate-snyk-branch',
+			ref: 'integrate-snyk-abcd',
 		},
 		user: {
 			login: 'gu-snyk-integrator[bot]',
 			type: 'Bot',
+		},
+	};
+
+	const snykBranch2 = {
+		...snykBranch,
+		head: {
+			ref: 'integrate-snyk-efgh',
 		},
 	};
 
@@ -51,7 +58,7 @@ describe('getPullRequest', () => {
 
 	it('should return first pull request that matches and log warning', async () => {
 		const warn = jest.spyOn(console, 'warn');
-		const pulls = [featureBranch, snykBranch, snykBranch];
+		const pulls = [featureBranch, snykBranch, snykBranch2];
 		const foundPull = await getExistingPullRequest(mockOctokit(pulls), 'repo');
 		expect(foundPull).toEqual(snykBranch);
 		expect(warn).toHaveBeenCalledWith(

--- a/packages/snyk-integrator/src/pull-requests.ts
+++ b/packages/snyk-integrator/src/pull-requests.ts
@@ -34,7 +34,7 @@ export async function createPullRequest(
 		base: baseBranch,
 		changes: changes.map(({ commitMessage, files }) => ({
 			commit: commitMessage,
-			files: files,
+			files,
 		})),
 	});
 }

--- a/packages/snyk-integrator/src/pull-requests.ts
+++ b/packages/snyk-integrator/src/pull-requests.ts
@@ -42,15 +42,32 @@ export async function createPullRequest(
 type PullRequestParameters =
 	Endpoints['GET /repos/{owner}/{repo}/pulls']['parameters'];
 
-export async function getPullRequest(
+type PullRequest =
+	Endpoints['GET /repos/{owner}/{repo}/pulls']['response']['data'][number];
+
+function isGithubAuthor(pull: PullRequest) {
+	return (
+		pull.user?.login === 'gu-snyk-integrator[bot]' && pull.user.type === 'Bot'
+	);
+}
+
+export async function getExistingPullRequest(
 	octokit: Octokit,
 	repoName: string,
-	branchName: string,
 ) {
 	const pulls = await octokit.paginate(octokit.rest.pulls.list, {
 		owner: 'guardian',
 		repo: repoName,
 		state: 'open',
 	} satisfies PullRequestParameters);
-	return pulls.find((pull) => pull.head.ref === branchName);
+
+	const found = pulls.filter((pull) => isGithubAuthor(pull));
+
+	if (found.length > 1) {
+		console.warn(
+			'More than one Snyk integrator PR found on repository - choosing the first.',
+		);
+	}
+
+	return found[0];
 }

--- a/packages/snyk-integrator/src/snyk-integrator.test.ts
+++ b/packages/snyk-integrator/src/snyk-integrator.test.ts
@@ -65,15 +65,14 @@ describe('A generated PR', () => {
 });
 
 describe('generateBranchName', () => {
-	it('should output same branch name for the same languages', () => {
-		const branch1 = generateBranchName(['TypeScript', 'Scala', 'Python']);
-		const branch2 = generateBranchName(['TypeScript', 'Scala', 'Python']);
-		expect(branch1).toBe(branch2);
+	it('includes a helpful prefix', () => {
+		const branch = generateBranchName();
+		expect(branch).toEqual(expect.stringMatching('integrate-snyk*'));
 	});
 
-	it('should output same branch name for the same languages, regardless of order', () => {
-		const branch1 = generateBranchName(['TypeScript', 'Scala', 'Python']);
-		const branch2 = generateBranchName(['Scala', 'Python', 'TypeScript']);
-		expect(branch1).toBe(branch2);
+	it('does not produce the same branch name twice', () => {
+		const branch1 = generateBranchName();
+		const branch2 = generateBranchName();
+		expect(branch1).not.toEqual(branch2);
 	});
 });

--- a/packages/snyk-integrator/src/snyk-integrator.ts
+++ b/packages/snyk-integrator/src/snyk-integrator.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto';
 import type { Octokit } from 'octokit';
 import { h2, p, tsMarkdown } from 'ts-markdown';
 import { stringify } from 'yaml';
@@ -183,9 +184,6 @@ export async function createSnykPullRequest(
 	});
 }
 
-export function generateBranchName(languages: string[]) {
-	return `integrate-snyk-${languages
-		.sort()
-		.map((language) => language.toLowerCase())
-		.join('-')}`;
+export function generateBranchName() {
+	return `integrate-snyk-${randomBytes(8).toString('hex')}`;
 }


### PR DESCRIPTION
## What does this change?

Simplify how we check for the existence of a Snyk integration PR, by assuming that the **gu-snyk-integrator Github app will only have a single open PR on any repository**.

Making this assumption allows us to revert to the old branch naming scheme (removed in #715), independent of the languages. Choosing a random branch name prevents naming collisions, and we lookup the existence of a PR by its author instead.

## Why?

Simplify the logic for looking up Snyk integration PRs.

Also provides a foundation for longer-term work we may wish to do, such as updating the existing PR.

## How has it been verified?

Tested locally (using the `PROD` stage) by running twice against [test-repocop-prs](https://github.com/guardian/test-repocop-prs). Note the first time the PR is created, and the second time it's skipped as it already exists:

![Screenshot 2024-02-01 at 14 17 25](https://github.com/guardian/service-catalogue/assets/8000415/fcdee278-7446-4e5a-bb08-e2f80c2ad440)

(Note I temporarily disabled adding the PR to the project board to prevent noise there).
