### PR TITLE
fix(steampipe): Use standard Janus credentials in DEV

### DIFF
--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -55,9 +55,6 @@ services:
       STAGE: ${STAGE}
       STEAMPIPE_DATABASE_PASSWORD: steampipe
       GITHUB_TOKEN: ${GITHUB_ACCESS_TOKEN}
-
-      # these are permanent credentials, as we'll be using STS Assume Role, which Janus DEV doesn't allow
-      AWS_PROFILE: 'service-catalogue-DEV'
       AWS_SHARED_CREDENTIALS_FILE: '/.aws/credentials'
     entrypoint: "/bin/bash -c"
     command: [ "generate-aws-plugin-config; steampipe service start --foreground" ]

--- a/packages/dev-environment/steampipe/generate-aws-plugin-config
+++ b/packages/dev-environment/steampipe/generate-aws-plugin-config
@@ -4,16 +4,26 @@ set -e
 
 echo "starting to generate configuration (stage=$STAGE, aws-version=$AWS_VERSION)"
 
-AWS_CONFIG_FILE=$HOME/.aws/config
 STEAMPIPE_INSTALL_DIR=$HOME/.steampipe/
 STEAMPIPE_CONFIG_FILE=${STEAMPIPE_INSTALL_DIR}/config/aws.spc
-
-# The `cloudquery-access` role has not been provisioned in the Root account,
-# Do not configure Steampipe to use it, as it will always error with `GetCallerIdentity`.
-ROOT_ACCOUNT_NAME="Guardian Web Systems"
-
-mkdir -p $(dirname "$AWS_CONFIG_FILE")
 mkdir -p $(dirname "$STEAMPIPE_CONFIG_FILE")
+
+if [ "$STAGE" == "DEV" ] ; then
+cat << EOF > "$STEAMPIPE_CONFIG_FILE"
+connection "aws" {
+  plugin = "aws@${AWS_VERSION}"
+  profile = "deployTools"
+  regions = ["*"]
+}
+
+EOF
+else
+  AWS_CONFIG_FILE=$HOME/.aws/config
+  mkdir -p $(dirname "$AWS_CONFIG_FILE")
+
+  # The `cloudquery-access` role has not been provisioned in the Root account,
+  # Do not configure Steampipe to use it, as it will always error with `GetCallerIdentity`.
+  ROOT_ACCOUNT_NAME="Guardian Web Systems"
 
 cat << EOF >> "$AWS_CONFIG_FILE"
 [default]
@@ -30,24 +40,15 @@ connection "aws" {
 
 EOF
 
-while read -r line ; do
-  ACCOUNT_NAME=$(echo "$line" | awk '{for (i=1; i<NF-1; i++) printf $i " "}' | sed 's/ $//' | sed 's/ /_/g')
-  ACCOUNT_ID=$(echo "$line" | awk '{print $(NF - 1)}')
+  while read -r line ; do
+    ACCOUNT_NAME=$(echo "$line" | awk '{for (i=1; i<NF-1; i++) printf $i " "}' | sed 's/ $//' | sed 's/ /_/g')
+    ACCOUNT_ID=$(echo "$line" | awk '{print $(NF - 1)}')
 
-  # Steampipe doesn't like dashes, so we need to swap for underscores
-  SP_NAME=$(echo "$ACCOUNT_NAME" | sed s/-/_/g)
+    # Steampipe doesn't like dashes, so we need to swap for underscores
+    SP_NAME=$(echo "$ACCOUNT_NAME" | sed s/-/_/g)
 
-  echo "adding config for account $ACCOUNT_NAME ($ACCOUNT_ID)"
+    echo "adding config for account $ACCOUNT_NAME ($ACCOUNT_ID)"
 
-  if [ "$STAGE" == "DEV" ] ; then
-cat << EOF >> "$AWS_CONFIG_FILE"
-[profile sp_${ACCOUNT_NAME}]
-role_arn = arn:aws:iam::${ACCOUNT_ID}:role/cloudquery-access
-source_profile = service-catalogue-DEV
-role_session_name = steampipe
-
-EOF
-  else
 cat << EOF >> "$AWS_CONFIG_FILE"
 [profile sp_${ACCOUNT_NAME}]
 role_arn = arn:aws:iam::${ACCOUNT_ID}:role/cloudquery-access
@@ -55,7 +56,6 @@ credential_source = EcsContainer
 role_session_name = steampipe
 
 EOF
-  fi
 
 cat << EOF >> "$STEAMPIPE_CONFIG_FILE"
 connection "aws_${SP_NAME}" {
@@ -66,8 +66,9 @@ connection "aws_${SP_NAME}" {
 
 EOF
 
-done < <(
-  aws organizations list-accounts \
-    --query "Accounts[?Status!='SUSPENDED' && Name!='$ROOT_ACCOUNT_NAME'].[Name,Id,Status]" \
-    --output text
-)
+  done < <(
+    aws organizations list-accounts \
+      --query "Accounts[?Status!='SUSPENDED' && Name!='$ROOT_ACCOUNT_NAME'].[Name,Id,Status]" \
+      --output text
+  )
+fi


### PR DESCRIPTION
## What does this change?
Follows https://github.com/guardian/service-catalogue/pull/759. To simplify the process of running Steampipe in DEV, use the credentials vended by Janus.

## Why?
Making it easier to develop locally.

## How has it been verified?
Ran `npm -w dev-environment start` locally, and observed Steampipe running correctly with a single AWS account.