### PR TITLE
Gather more information about vulnerabilities, and deduplicate

### DIFF
--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -40,7 +40,7 @@ function evaluateRepoTestHelper(
 		languages,
 		latestSnykIssues,
 		snykProjectsFromRest,
-	);
+	).repocopRules;
 }
 
 const nullBranch: github_repository_branches = {

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -14,7 +14,7 @@ import type {
 } from '../types';
 import {
 	collectAndFormatUrgentSnykAlerts,
-	deduplicateVulnerabilities,
+	deduplicateVulnerabilitiesByCve,
 	dependabotAlertToRepocopVulnerability,
 	evaluateOneRepo,
 	findStacks,
@@ -901,7 +901,7 @@ describe('Deduplication of repocop vulnerabilities', () => {
 		isPatchable: true,
 		CVEs: ['CVE-2018-6188'],
 	};
-	const actual = deduplicateVulnerabilities([vuln1, vuln2]);
+	const actual = deduplicateVulnerabilitiesByCve([vuln1, vuln2]);
 	test('Should happen if two vulnerabilities share the same CVEs', () => {
 		console.log(actual);
 		expect(actual.length).toStrictEqual(1);
@@ -914,7 +914,7 @@ describe('Deduplication of repocop vulnerabilities', () => {
 			...vuln1,
 			CVEs: ['CVE-2018-6189'],
 		};
-		const actual = deduplicateVulnerabilities([vuln1, vuln3]);
+		const actual = deduplicateVulnerabilitiesByCve([vuln1, vuln3]);
 		expect(actual.length).toStrictEqual(2);
 	});
 	test('Should not happen if no CVEs are provided', () => {
@@ -922,7 +922,7 @@ describe('Deduplication of repocop vulnerabilities', () => {
 			...vuln1,
 			CVEs: [],
 		};
-		const actual = deduplicateVulnerabilities([vuln4, vuln4]);
+		const actual = deduplicateVulnerabilitiesByCve([vuln4, vuln4]);
 		expect(actual.length).toStrictEqual(2);
 	});
 });

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -595,6 +595,7 @@ const oldCriticalDependabotVuln: RepocopVulnerability = {
 	urls: [],
 	ecosystem: 'pip',
 	alert_issue_date: '2021-01-01T00:00:00.000Z',
+	isPatchable: true,
 };
 
 const newCriticalDependabotVuln: RepocopVulnerability = {
@@ -651,7 +652,7 @@ const highSeverityIssue = {
 	isPatched: false,
 	isPinnable: false,
 	isPatchable: false,
-	isUpgradable: true,
+	isUpgradable: false,
 	disclosureTime: '',
 	publicationTime: '',
 	package: 'fetch',
@@ -776,6 +777,34 @@ describe('NO RULE - Snyk vulnerabilities', () => {
 		);
 		expect(result.length).toEqual(0);
 	});
+	test('Should not be considered patchable if there is no possible upgrade path', () => {
+		const result = collectAndFormatUrgentSnykAlerts(
+			thePerfectRepo,
+			[snykIssue],
+			[snykProject],
+		);
+		expect(result.map((r) => r.isPatchable)).toEqual([false]);
+	});
+	test('Should be considered patchable if there is a possible upgrade path', () => {
+		const pinnableIssue = {
+			...snykIssue,
+			issue: { ...highSeverityIssue, isPinnable: true },
+		};
+		const patchableIssue = {
+			...snykIssue,
+			issue: { ...highSeverityIssue, isPatchable: true },
+		};
+		const upgradableIssue = {
+			...snykIssue,
+			issue: { ...highSeverityIssue, isUpgradable: true },
+		};
+		const result = collectAndFormatUrgentSnykAlerts(
+			thePerfectRepo,
+			[pinnableIssue, patchableIssue, upgradableIssue],
+			[snykProject],
+		);
+		expect(result.map((r) => r.isPatchable)).toEqual([true, true, true]);
+	});
 });
 
 describe('NO RULE - Vulnerabilities from Dependabot', () => {
@@ -828,7 +857,7 @@ describe('NO RULE - Vulnerabilities from Snyk', () => {
 			urls: ['example.com'],
 			ecosystem: 'npm',
 			alert_issue_date: 'someTZdate',
-			vulnerable_version: undefined,
+			isPatchable: false,
 		});
 	});
 });

--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -596,6 +596,7 @@ const oldCriticalDependabotVuln: RepocopVulnerability = {
 	ecosystem: 'pip',
 	alert_issue_date: '2021-01-01T00:00:00.000Z',
 	isPatchable: true,
+	CVEs: ['CVE-2021-1234'],
 };
 
 const newCriticalDependabotVuln: RepocopVulnerability = {
@@ -653,6 +654,11 @@ const highSeverityIssue = {
 	isPinnable: false,
 	isPatchable: false,
 	isUpgradable: false,
+	Identifiers: {
+		CVE: ['CVE-1234'],
+		CWE: ['CWE-1234'],
+		OSVDB: ['OSVDB-1234'],
+	},
 	disclosureTime: '',
 	publicationTime: '',
 	package: 'fetch',
@@ -812,33 +818,41 @@ describe('NO RULE - Vulnerabilities from Dependabot', () => {
 		const result: RepocopVulnerability[] = example.map(
 			dependabotAlertToRepocopVulnerability,
 		);
-		console.log(result);
-		expect(result.length).toEqual(2);
-		expect(result.map((v) => v.source)).toEqual(['Dependabot', 'Dependabot']);
-		expect(result.map((v) => v.open)).toEqual([false, true]);
-		expect(result.map((v) => v.severity)).toEqual(['high', 'medium']);
-		expect(result.map((v) => v.package)).toEqual(['django', 'ansible']);
-		expect(result.map((v) => v.alert_issue_date)).toEqual([
-			'2022-06-15T07:43:03Z',
-			'2022-06-14T15:21:52Z',
-		]);
-	});
-});
+		const expected1: RepocopVulnerability = {
+			source: 'Dependabot',
+			open: false,
+			severity: 'high',
+			package: 'django',
+			urls: [
+				'https://nvd.nist.gov/vuln/detail/CVE-2018-6188',
+				'https://github.com/advisories/GHSA-rf4j-j272-fj86',
+				'https://usn.ubuntu.com/3559-1/',
+				'https://www.djangoproject.com/weblog/2018/feb/01/security-releases/',
+				'http://www.securitytracker.com/id/1040422',
+			],
+			ecosystem: 'pip',
+			alert_issue_date: '2022-06-15T07:43:03Z',
+			isPatchable: true,
+			CVEs: ['CVE-2018-6188'],
+		};
 
-describe('NO RULE - Vulnerabilities from Dependabot', () => {
-	test('Should be parseable into a common format', () => {
-		const result: RepocopVulnerability[] = example.map(
-			dependabotAlertToRepocopVulnerability,
-		);
-		expect(result.length).toEqual(2);
-		expect(result.map((v) => v.source)).toEqual(['Dependabot', 'Dependabot']);
-		expect(result.map((v) => v.open)).toEqual([false, true]);
-		expect(result.map((v) => v.severity)).toEqual(['high', 'medium']);
-		expect(result.map((v) => v.package)).toEqual(['django', 'ansible']);
-		expect(result.map((v) => v.alert_issue_date)).toEqual([
-			'2022-06-15T07:43:03Z',
-			'2022-06-14T15:21:52Z',
-		]);
+		const expected2: RepocopVulnerability = {
+			source: 'Dependabot',
+			open: true,
+			severity: 'medium',
+			package: 'ansible',
+			urls: [
+				'https://nvd.nist.gov/vuln/detail/CVE-2021-20191',
+				'https://access.redhat.com/security/cve/cve-2021-20191',
+				'https://bugzilla.redhat.com/show_bug.cgi?id=1916813',
+			],
+			ecosystem: 'pip',
+			alert_issue_date: '2022-06-14T15:21:52Z',
+			isPatchable: true,
+			CVEs: ['CVE-2021-20191'],
+		};
+
+		expect(result).toStrictEqual([expected1, expected2]);
 	});
 });
 
@@ -858,6 +872,7 @@ describe('NO RULE - Vulnerabilities from Snyk', () => {
 			ecosystem: 'npm',
 			alert_issue_date: 'someTZdate',
 			isPatchable: false,
+			CVEs: ['CVE-1234'],
 		});
 	});
 });

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -473,6 +473,10 @@ export function evaluateOneRepo(
 export function dependabotAlertToRepocopVulnerability(
 	alert: Alert,
 ): RepocopVulnerability {
+	const CVEs = alert.security_advisory.identifiers
+		.filter((i) => i.type === 'CVE')
+		.map((i) => i.value);
+
 	return {
 		open: alert.state === 'open',
 		source: 'Dependabot',
@@ -482,6 +486,7 @@ export function dependabotAlertToRepocopVulnerability(
 		ecosystem: alert.security_vulnerability.package.ecosystem,
 		alert_issue_date: alert.created_at,
 		isPatchable: !!alert.security_vulnerability.first_patched_version,
+		CVEs,
 	};
 }
 
@@ -500,6 +505,7 @@ export function snykAlertToRepocopVulnerability(
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- this is never null in reality
 		alert_issue_date: alert.introduced_date!,
 		isPatchable: issue.isPatchable || issue.isUpgradable || issue.isPinnable,
+		CVEs: issue.Identifiers.CVE,
 	};
 }
 

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -455,8 +455,7 @@ export function deduplicateVulnerabilities(
 			return acc;
 		}, {});
 
-	const x: RepocopVulnerability[] = Object.values(dedupedWithCVEs);
-	const dedupedVulns = x.concat(withoutCVEs);
+	const dedupedVulns = Object.values(dedupedWithCVEs).concat(withoutCVEs);
 	return dedupedVulns;
 }
 

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -481,7 +481,7 @@ export function dependabotAlertToRepocopVulnerability(
 		urls: alert.security_advisory.references.map((ref) => ref.url),
 		ecosystem: alert.security_vulnerability.package.ecosystem,
 		alert_issue_date: alert.created_at,
-		vulnerable_version: alert.security_vulnerability.vulnerable_version_range,
+		isPatchable: !!alert.security_vulnerability.first_patched_version,
 	};
 }
 
@@ -499,7 +499,7 @@ export function snykAlertToRepocopVulnerability(
 		ecosystem: issue.packageManager,
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- this is never null in reality
 		alert_issue_date: alert.introduced_date!,
-		vulnerable_version: issue.version,
+		isPatchable: issue.isPatchable || issue.isUpgradable || issue.isPinnable,
 	};
 }
 

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -427,7 +427,7 @@ export function testExperimentalRepocopFeatures(
 	);
 }
 
-export function deduplicateVulnerabilities(
+export function deduplicateVulnerabilitiesByCve(
 	vulns: RepocopVulnerability[],
 ): RepocopVulnerability[] {
 	const vulnsWithSortedCVEs = vulns.map((v) => {
@@ -502,7 +502,7 @@ export function evaluateOneRepo(
 	return {
 		fullName: repo.full_name,
 		repocopRules,
-		vulnerabilities: deduplicateVulnerabilities(vulnerabilities),
+		vulnerabilities: deduplicateVulnerabilitiesByCve(vulnerabilities),
 	};
 }
 

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -305,7 +305,10 @@ export async function getAlertsForRepo(
 				direction: 'asc', //retrieve oldest vulnerabilities first
 			});
 
-		return alert.data;
+		const openRuntimeDependencies = alert.data.filter(
+			(a) => a.dependency.scope !== 'development',
+		);
+		return openRuntimeDependencies;
 	} catch (error) {
 		console.info(
 			`Dependabot - ${name}: Could not get alerts. Dependabot may not be enabled.`,

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -4,6 +4,7 @@ import type {
 	github_repositories,
 	github_team_repositories,
 	github_teams,
+	repocop_github_repository_rules,
 } from '@prisma/client';
 
 export type NonEmptyArray<T> = [T, ...T[]];
@@ -150,4 +151,10 @@ export interface RepocopVulnerability {
 	alert_issue_date: string;
 	vulnerable_version?: string;
 	fixed_in_version?: string;
+}
+
+export interface EvaluationResult {
+	fullName: string;
+	repocopRules: repocop_github_repository_rules;
+	vulnerabilities: RepocopVulnerability[];
 }

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -134,9 +134,9 @@ export interface SnykIssue {
 	isPatchable: boolean;
 	isUpgradable: boolean;
 	Identifiers: {
-		CVE: string[];
-		CWE: string[];
-		OSVDB: string[];
+		CVE: string[] | null;
+		CWE: string[] | null;
+		OSVDB: string[] | null;
 	};
 	disclosureTime: string; //or Date?
 	package: string;

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -130,7 +130,7 @@ export interface SnykIssue {
 	severity: string;
 	isPatched: boolean;
 	isIgnored: boolean;
-	isPinnable: false;
+	isPinnable: boolean;
 	isPatchable: boolean;
 	isUpgradable: boolean;
 	disclosureTime: string; //or Date?
@@ -149,8 +149,7 @@ export interface RepocopVulnerability {
 	urls: string[];
 	ecosystem: string;
 	alert_issue_date: string;
-	vulnerable_version?: string;
-	fixed_in_version?: string;
+	isPatchable: boolean;
 }
 
 export interface EvaluationResult {

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -133,6 +133,11 @@ export interface SnykIssue {
 	isPinnable: boolean;
 	isPatchable: boolean;
 	isUpgradable: boolean;
+	Identifiers: {
+		CVE: string[];
+		CWE: string[];
+		OSVDB: string[];
+	};
 	disclosureTime: string; //or Date?
 	package: string;
 	packageManager: string;
@@ -150,6 +155,7 @@ export interface RepocopVulnerability {
 	ecosystem: string;
 	alert_issue_date: string;
 	isPatchable: boolean;
+	CVEs: string[];
 }
 
 export interface EvaluationResult {


### PR DESCRIPTION
## What does this change?

1. Adds an `isPatched` field to tell us if a vulnerability can be resolved through a direct or indirect version bump
2. Deduplicate vulnerabilities based on CVE, keeping whichever alert had the highest severity
3. Return a list of vulnerabilities along with the evaluation results for each repo.
4. Only return runtime dependencies from Dependabot

## Why?

1. To give teams an idea of how much work is involved in mitigating a vulnerability, allowing them to prioritise their remediations
2. Make the vulnerability count more accurate, so we aren't double-counting vulnerabilities across two platforms
3. So we can keep track of vulnerabilities on a departmental level
4. Picking only runtime dependencies brings us in line with our existing Snyk policy. It also makes the number of vulnerabilities less overwhelming, and provides teams with some initial focus.

## How has it been verified?

Added unit tests, verified on CODE.

Output looks something like

```json
{
    "timestamp": "YYYY-MM-DDT09:00:00.000Z",
    "level": "WARN",
    "requestId": "<REDACTED>",
    "message": "Found <REDACTED> out of date critical vulnerabilities, of which <REDACTED> are patchable"
}
```

with a corresponding log entry for high vulnerabilities

## Effect of filtering on vulnerability count

Please see [ELK](https://logs.gutools.co.uk/s/devx/goto/9d66a180-c1be-11ee-b3e0-71dbc9710958) for the actual numbers, which I haven't quoted directly as they are somewhat sensitive information

### CVE-based deduplication

- High vulnerabilities - 19% reduction
- Critical vulnerabilities - 22% reduction

### CVE-based deduplication and exclude dev dependencies

- High vulnerabilities - 36% reduction
- Critical vulnerabilities - 54% reduction

## Next steps

- `repository.ts` is getting a little crowded, so I'd like to break this file up a bit, but that can be done as part of a separate PR
- Repocop outputs a LOT of logs. You can provide a log level in the lambda config so I think this would be a nice to have just `INFO` and above, and then figure out which logs are essential, and which can be relegated to `DEBUG`
- Talk to the wider team about how we communicate these vulnerabilities to teams
- Do we have a clear telling whether or not dependabot is enabled everywhere it's supposed to be? Otherwise we may be undercounting our vulnerabilities. How do we enforce this across the org?

