### PR TITLE
fix(cloudquery): Correct `concurrency` configuration

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -833,8 +833,8 @@ spec:
     - aws_securityhub_*
   destinations:
     - postgresql
-  concurrency: 2000
   spec:
+    concurrency: 2000
     regions:
       - eu-west-1
       - eu-west-2
@@ -2190,8 +2190,8 @@ spec:
     - fastly_account_users
   destinations:
     - postgresql
-  concurrency: 1000
   spec:
+    concurrency: 1000
     fastly_api_key: \${FASTLY_API_KEY}
 ' > /source.yaml;printf 'kind: destination
 spec:
@@ -3771,8 +3771,8 @@ spec:
     - github_issues
   destinations:
     - postgresql
-  concurrency: 1000
   spec:
+    concurrency: 1000
     orgs:
       - guardian
     app_auth:
@@ -4948,8 +4948,8 @@ spec:
     - github_repository_dependabot_secrets
   destinations:
     - postgresql
-  concurrency: 1000
   spec:
+    concurrency: 1000
     orgs:
       - guardian
     app_auth:
@@ -5672,8 +5672,8 @@ spec:
     - github_organization_dependabot_secrets
   destinations:
     - postgresql
-  concurrency: 1000
   spec:
+    concurrency: 1000
     orgs:
       - guardian
     app_auth:
@@ -15365,8 +15365,8 @@ spec:
     - aws_ec2_images
   destinations:
     - postgresql
-  concurrency: 2000
   spec:
+    concurrency: 2000
     regions:
       - eu-west-1
       - eu-west-2

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -99,6 +99,7 @@ spec:
 				'aws_accessanalyzer_analyzer_findings',
 			],
 		});
+		console.log(dump(config));
 		expect(dump(config)).toMatchInlineSnapshot(`
 "kind: source
 spec:
@@ -139,8 +140,8 @@ spec:
 		    - github_repositories
 		  destinations:
 		    - postgresql
-		  concurrency: 1000
 		  spec:
+		    concurrency: 1000
 		    orgs:
 		      - guardian
 		    app_auth:

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -61,8 +61,8 @@ export function awsSourceConfig(
 			tables,
 			skip_tables: skipTables,
 			destinations: ['postgresql'],
-			concurrency,
 			spec: {
+				concurrency,
 				regions: AWS_REGIONS,
 				...extraConfig,
 			},
@@ -130,8 +130,8 @@ export function githubSourceConfig(
 			tables,
 			skip_tables: skipTables,
 			destinations: ['postgresql'],
-			concurrency: 1000, // TODO what's the ideal value here?!
 			spec: {
+				concurrency: 1000, // TODO what's the ideal value here?!
 				orgs: ['guardian'],
 				app_auth: [
 					{
@@ -171,11 +171,11 @@ export function fastlySourceConfig(
 			skip_tables: skipTables,
 			destinations: ['postgresql'],
 
-			// The Fastly API is rate limited to 1000 requests per hour.
-			// See https://docs.fastly.com/en/guides/resource-limits#rate-and-time-limits.
-			// TODO what's the ideal value here?!
-			concurrency: 1000,
 			spec: {
+				// The Fastly API is rate limited to 1000 requests per hour.
+				// See https://docs.fastly.com/en/guides/resource-limits#rate-and-time-limits.
+				// TODO what's the ideal value here?!
+				concurrency: 1000,
 				fastly_api_key: '${FASTLY_API_KEY}',
 			},
 		},


### PR DESCRIPTION
## What does this change?
Since [v5 of the CLI](https://github.com/cloudquery/cloudquery/releases/tag/cli-v5.0.0), `concurrency` defined at the top level unrecognised. Move it to the plugin's `spec` configuration.
