### PR TITLE
Add tags prop and proprogateTags prop to ECS task definition

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -89,6 +89,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceAwsCostExplorerTaskDefinition62DC1A04",
@@ -768,6 +769,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceDelegatedToSecurityAccountTaskDefinitionD407788D",
@@ -1443,6 +1445,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceDeployToolsListOrgsTaskDefinitionDE2A34D9",
@@ -2121,6 +2124,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceFastlyServicesTaskDefinitionDCCD3FD4",
@@ -2809,6 +2813,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceGalaxiesTaskDefinition0777FEFC",
@@ -3517,6 +3522,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceGitHubIssuesTaskDefinitionFA21D536",
@@ -4234,6 +4240,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceGitHubLanguagesTaskDefinitionDA995E2B",
@@ -4907,6 +4914,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceGitHubRepositoriesTaskDefinition921DC1BC",
@@ -5631,6 +5639,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceGitHubTeamsTaskDefinitionB01C9D3C",
@@ -6355,6 +6364,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceGuardianCustomSnykProjectsTaskDefinitionEB2B4EBC",
@@ -7038,6 +7048,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceNS1TaskDefinition56258A70",
@@ -7745,6 +7756,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceOrgWideAutoScalingGroupsTaskDefinition90175FA6",
@@ -8424,6 +8436,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceOrgWideBackupTaskDefinition9BAD0C75",
@@ -9105,6 +9118,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceOrgWideCertificatesTaskDefinition47A214D9",
@@ -9784,6 +9798,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceOrgWideCloudFormationTaskDefinitionDA4F8A51",
@@ -10463,6 +10478,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceOrgWideCloudwatchAlarmsTaskDefinitionF28C916F",
@@ -11142,6 +11158,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceOrgWideDynamoDBTaskDefinition7016173E",
@@ -11821,6 +11838,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceOrgWideEc2TaskDefinition7E4B2AE4",
@@ -12549,6 +12567,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceOrgWideInspectorTaskDefinition25FAB51D",
@@ -13229,6 +13248,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceOrgWideLoadBalancersTaskDefinitionF1D11F23",
@@ -13909,6 +13929,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceOrgWideRDSTaskDefinitionFDF4F4E5",
@@ -14591,6 +14612,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceOrgWideS3TaskDefinition8B6BA52D",
@@ -15270,6 +15292,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceRemainingAwsDataTaskDefinition8790EDD9",
@@ -16014,6 +16037,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceRiffRaffDataTaskDefinitionFF023225",
@@ -16728,6 +16752,7 @@ spec:
                   },
                 },
               },
+              "PropagateTags": "TASK_DEFINITION",
               "TaskCount": 1,
               "TaskDefinitionArn": {
                 "Ref": "CloudquerySourceSnykAllTaskDefinitionC8C1F3EC",

--- a/packages/cdk/lib/cloudquery/task.ts
+++ b/packages/cdk/lib/cloudquery/task.ts
@@ -8,6 +8,7 @@ import {
 	FireLensLogDriver,
 	FirelensLogRouterType,
 	LogDrivers,
+	PropagatedTagSource,
 	Secret,
 } from 'aws-cdk-lib/aws-ecs';
 import type { Cluster, RepositoryImage } from 'aws-cdk-lib/aws-ecs';
@@ -338,6 +339,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			},
 			securityGroups: [dbAccess, ...additionalSecurityGroups],
 			enabled,
+			propagateTags: PropagatedTagSource.TASK_DEFINITION,
 		});
 
 		this.sourceConfig = sourceConfig;

--- a/packages/cli/src/aws.ts
+++ b/packages/cli/src/aws.ts
@@ -246,6 +246,7 @@ const runTaskByArn = async (
 				securityGroups: securityGroups,
 			},
 		},
+		propagateTags: 'TASK_DEFINITION',
 		capacityProviderStrategy: [{ capacityProvider: 'FARGATE' }],
 	});
 


### PR DESCRIPTION
## What does this change?

Adds `propogateTags` to our ECS Task definition

## Why?

This tells EventBridge to add the tags from the task definition to the task instance when it schedules one. This allows us to track costs better.