### PR TITLE
fix: Connect to Riff-Raff's Postgres with full ssl verification

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -13362,7 +13362,7 @@ spec:
   spec:
     connection_string: >-
       user=\${RIFFRAFF_DB_USERNAME} password=\${RIFFRAFF_DB_PASSWORD}
-      host=\${RIFFRAFF_DB_HOST} port=5432 dbname=riffraff sslmode=verify-ca
+      host=\${RIFFRAFF_DB_HOST} port=5432 dbname=riffraff sslmode=verify-full
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -242,10 +242,7 @@ export function riffraffSourcesConfig(): CloudqueryConfig {
 					'host=${RIFFRAFF_DB_HOST}',
 					'port=5432',
 					'dbname=riffraff',
-					// Ideally we'd use sslmode=verify-full however the certificates used by riff-raffs DB are quite old and don't have any SANs set.
-					// In order to upgrade to verify-full we need to change the CA used by the riff-raff DB.
-					// See https://github.com/golang/go/issues/39568
-					'sslmode=verify-ca',
+					'sslmode=verify-full',
 				].join(' '),
 			},
 		},


### PR DESCRIPTION
## What does this change?
The commented issue has been resolved in https://github.com/guardian/deploy-tools-platform/pull/733 [^1].

[^1]: Riff-Raff's RDS is using the [same CA certificate as Service Catalogue](https://github.com/guardian/service-catalogue/blob/59cc777a6daa8927c5b7a83566c2a1904771fd10/packages/cdk/lib/service-catalogue.ts#L111-L127).