### PR TITLE
Configure CloudQuery to ignore the Root account

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -137,6 +137,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -6444,6 +6446,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -6996,6 +7000,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -7546,6 +7552,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -8126,6 +8134,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -8856,6 +8866,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -9196,6 +9208,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -9748,6 +9762,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -10331,6 +10347,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -11092,6 +11110,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -11645,6 +11665,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -11985,6 +12007,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -12597,6 +12621,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -53,6 +53,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 "
 `);
 	});
@@ -87,6 +89,8 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+      skip_member_accounts:
+        - '"000000000014"'
 "
 `);
 	});
@@ -99,7 +103,6 @@ spec:
 				'aws_accessanalyzer_analyzer_findings',
 			],
 		});
-		console.log(dump(config));
 		expect(dump(config)).toMatchInlineSnapshot(`
 "kind: source
 spec:

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -1,4 +1,7 @@
-import { GuardianOrganisationalUnits } from '@guardian/private-infrastructure-config';
+import {
+	GuardianAwsAccounts,
+	GuardianOrganisationalUnits,
+} from '@guardian/private-infrastructure-config';
 import { AWS_REGIONS } from 'common/src/aws';
 import { Versions } from './versions';
 
@@ -84,6 +87,9 @@ export function awsSourceConfigForOrganisation(
 			// See: https://github.com/guardian/aws-account-setup/pull/58
 			member_role_name: 'cloudquery-access',
 			organization_units: [GuardianOrganisationalUnits.Root],
+
+			// We have not provisioned a role in the root account, so skip it to avoid noise in logs.
+			skip_member_accounts: [`"${GuardianAwsAccounts.Root}"`],
 		},
 	});
 }


### PR DESCRIPTION
## What does this change?
We've not provisioned an IAM Role in the Root account for CloudQuery to use.

When CloudQuery attempts to process the account, it fails with:

```log
failed to refresh cached credentials, operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: b7b82b00-cb44-401f-972b-71df87bb765c, api error AccessDenied: User: arn:aws:sts::REDACTED:assumed-role/service-catalogue-CODE-task-OrgWideLoadBalancers is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::REDACTED:role/cloudquery-access
```

Setting `skip_member_accounts` should mean CloudQuery doesn't make this call, thus the logs are less noisy.

## Why?
To make the logs easier to search.

## How has it been verified?
TBD.