### PR TITLE
Send vulnerability messages to teams

### DIFF
--- a/packages/repocop/src/rules/repository.test.ts
+++ b/packages/repocop/src/rules/repository.test.ts
@@ -20,6 +20,7 @@ import {
 	findStacks,
 	hasDependencyTracking,
 	hasOldAlerts,
+	isFirstOrThirdTuesdayOfMonth,
 	parseSnykTags,
 	snykAlertToRepocopVulnerability,
 } from './repository';
@@ -933,5 +934,22 @@ describe('Deduplication of repocop vulnerabilities', () => {
 		};
 		const actual = deduplicateVulnerabilitiesByCve([vuln4, vuln4]);
 		expect(actual.length).toStrictEqual(2);
+	});
+});
+describe('isFirstOrThirdTuesdayOfMonth', () => {
+	test('should return true if the date is the first or third Tuesday of the month', () => {
+		const tuesday = new Date('2024-02-06T00:00:00.000Z'); // First Tuesday
+		const result = isFirstOrThirdTuesdayOfMonth(tuesday);
+		expect(result).toBe(true);
+	});
+	test('should return false if the date is not a Tuesday', () => {
+		const wednesday = new Date('2024-02-07T00:00:00.000Z'); // First Wednesday
+		const result = isFirstOrThirdTuesdayOfMonth(wednesday);
+		expect(result).toBe(false);
+	});
+	test('should return false if the date is the second Tuesday of the month', () => {
+		const tuesday = new Date('2024-02-13T00:00:00.000Z'); // Second Tuesday
+		const result = isFirstOrThirdTuesdayOfMonth(tuesday);
+		expect(result).toBe(false);
 	});
 });

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -1,3 +1,4 @@
+import type { Action } from '@guardian/anghammarad';
 import { Anghammarad, RequestedChannel } from '@guardian/anghammarad';
 import type {
 	github_languages,
@@ -448,6 +449,12 @@ export async function testExperimentalRepocopFeatures(
 	console.log(
 		`Sending ${digests.length} vulnerability digests: ${digests.map((d) => d.teamSlug).join(', ')}`,
 	);
+
+	const action: Action = {
+		cta: "See 'Prioritise the vulnerabilities' section of Security HQ docs for departmental obligations",
+		url: 'https://security-hq.gutools.co.uk/documentation/vulnerability-management',
+	};
+
 	const anghammarad = new Anghammarad();
 	await Promise.all(
 		digests.map(
@@ -455,7 +462,7 @@ export async function testExperimentalRepocopFeatures(
 				await anghammarad.notify({
 					subject: digest.subject,
 					message: digest.message,
-					actions: [],
+					actions: [action],
 					target: { Stack: 'testing-alerts' },
 					channel: RequestedChannel.PreferHangouts,
 					sourceSystem: `${config.app} ${config.stage}`,

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -461,28 +461,25 @@ export async function testExperimentalRepocopFeatures(
 		cta: "See 'Prioritise the vulnerabilities' of these docs for vulnerability obligations",
 		url: 'https://security-hq.gutools.co.uk/documentation/vulnerability-management',
 	};
-
-	if (isFirstOrThirdTuesdayOfMonth(new Date()) && config.stage === 'PROD') {
-		const anghammarad = new Anghammarad();
-		await Promise.all(
-			digests.map(
-				async (digest) =>
-					await anghammarad.notify({
-						subject: digest.subject,
-						message: digest.message,
-						actions: [action],
-						target: { Stack: 'testing-alerts' },
-						channel: RequestedChannel.PreferHangouts,
-						sourceSystem: `${config.app} ${config.stage}`,
-						topicArn: config.anghammaradSnsTopic,
-						threadKey: `vulnerability-digest-${digest.teamSlug}`,
-					}),
-			),
-		);
-	} else {
-		console.log('Not sending vulnerability digests.');
-		digests.forEach((digest) => console.log(JSON.stringify(digest)));
-	}
+	const sendMessage =
+		isFirstOrThirdTuesdayOfMonth(new Date()) && config.stage === 'PROD';
+	console.log(`Is it the first or third Tuesday of the month? ${sendMessage}`);
+	const anghammarad = new Anghammarad();
+	await Promise.all(
+		digests.map(
+			async (digest) =>
+				await anghammarad.notify({
+					subject: digest.subject,
+					message: digest.message,
+					actions: [action],
+					target: { Stack: 'testing-alerts' },
+					channel: RequestedChannel.PreferHangouts,
+					sourceSystem: `${config.app} ${config.stage}`,
+					topicArn: config.anghammaradSnsTopic,
+					threadKey: `vulnerability-digest-${digest.teamSlug}`,
+				}),
+		),
+	);
 }
 
 export function deduplicateVulnerabilitiesByCve(

--- a/packages/repocop/src/vulnerability-digest.test.ts
+++ b/packages/repocop/src/vulnerability-digest.test.ts
@@ -84,7 +84,7 @@ describe('createDigest', () => {
 			package: 'leftpad',
 			urls: ['example.com'],
 			ecosystem: 'pip',
-			alert_issue_date: '',
+			alert_issue_date: '2023-01-01',
 			isPatchable: true,
 			CVEs: ['CVE-123'],
 		};
@@ -102,7 +102,7 @@ Displaying the top 1 most urgent.
 Note: DevX does not aggregate vulnerability information for repositories without a production topic.
 
 **leftpad** contains a [HIGH vulnerability](example.com).
-Introduced to [guardian/repo](https://github.com/guardian/repo) via pip.
+Introduced to [guardian/repo](https://github.com/guardian/repo) on Sun Jan 01 2023 via pip.
 This vulnerability is patchable.`,
 		});
 	});

--- a/packages/repocop/src/vulnerability-digest.ts
+++ b/packages/repocop/src/vulnerability-digest.ts
@@ -32,12 +32,18 @@ export function getTopVulns(vulnerabilities: RepocopVulnerability[]) {
 		.sort((v1, v2) => v1.fullName.localeCompare(v2.fullName));
 }
 
+function dateStringToHumanReadable(dateString: string) {
+	const date = new Date(dateString);
+	return date.toDateString();
+}
+
 function createHumanReadableVulnMessage(vuln: RepocopVulnerability): string {
+	const dateString = dateStringToHumanReadable(vuln.alert_issue_date);
 	const ecosystem =
 		vuln.ecosystem === 'maven' ? 'sbt or maven' : vuln.ecosystem;
 
 	return String.raw`**${vuln.package}** contains a [${vuln.severity.toUpperCase()} vulnerability](${vuln.urls[0]}).
-Introduced to [${vuln.fullName}](https://github.com/${vuln.fullName}) via ${ecosystem}.
+Introduced to [${vuln.fullName}](https://github.com/${vuln.fullName}) on ${dateString} via ${ecosystem}.
 This vulnerability is ${vuln.isPatchable ? '' : '*not* '}patchable.`;
 }
 


### PR DESCRIPTION
## What does this change?

Send messages to teams twice a month letting them know about historic vulnerabilities in their estate.

Give teams an indication of how long a vulnerability has existed in their codebase.

## Why?

Since enabling dependency graphs on our repos, Dependabot has flagged new vulnerabilities against our repos. Teams don't have a clear way of viewing and prioritising this information, so we have created a way for them to see the most urgent vulnerabilities that need addressing.

## How has it been verified?

Unit tests have been added to make sure that the date logic works, and the anghammarad messages have been tested extensively in CODE. The first messages are due to go out next week, but it may be worth deploying a version without a date condition to test the first run.

## Next steps

It's worth noting that this is _not_ intended as a way for teams to recieve real time vulnerability alerts, but as a way for them to clear the _existing_ backlog. Currently we are only processing vulnerabilities older than our obligations permit. We will need to adjust/expand this solution to handle new vulnerabilities as they come up ad hoc.

There may be a few teething problems on initial rollout. Once these have been ironed out, we should move this functionality out of the experimental features section.

