### PR TITLE
Don't run DeployToolsListOrgs every minute at the start of a month

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -1162,7 +1162,7 @@ spec:
     },
     "CloudquerySourceDeployToolsListOrgsScheduledEventRuleDF9BD8AF": {
       "Properties": {
-        "ScheduleExpression": "cron(* 10 1 1 ? *)",
+        "ScheduleExpression": "cron(0 10 1 1 ? *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -1364,82 +1364,6 @@ spec:
                         "Ref": "cloudqueryapikeyCCF82F53",
                       },
                       ":api-key::",
-                    ],
-                  ],
-                },
-              },
-            ],
-          },
-          {
-            "Command": [
-              "/bin/sh",
-              "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_organization%', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
-            ],
-            "DockerLabels": {
-              "App": "service-catalogue",
-              "Name": "DeployToolsListOrgs",
-              "Stack": "deploy",
-              "Stage": "TEST",
-            },
-            "EntryPoint": [
-              "",
-            ],
-            "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:16-alpine",
-            "LogConfiguration": {
-              "LogDriver": "awsfirelens",
-              "Options": {
-                "Name": "kinesis_streams",
-                "region": {
-                  "Ref": "AWS::Region",
-                },
-                "retry_limit": "2",
-                "stream": {
-                  "Ref": "LoggingStreamName",
-                },
-              },
-            },
-            "Name": "CloudquerySource-DeployToolsListOrgsPostgresContainer",
-            "Secrets": [
-              {
-                "Name": "PGUSER",
-                "ValueFrom": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
-                      },
-                      ":username::",
-                    ],
-                  ],
-                },
-              },
-              {
-                "Name": "PGHOST",
-                "ValueFrom": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
-                      },
-                      ":host::",
-                    ],
-                  ],
-                },
-              },
-              {
-                "Name": "PGPASSWORD",
-                "ValueFrom": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      {
-                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
-                      },
-                      ":password::",
                     ],
                   ],
                 },

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -64,7 +64,8 @@ export function addCloudqueryEcsCluster(
 			description:
 				'Data about the AWS Organisation, including accounts and OUs. Uses include mapping account IDs to account names.',
 			schedule:
-				nonProdSchedule ?? Schedule.cron({ month: '1', day: '1', hour: '10' }), // Run on the first of the month at 10am
+				nonProdSchedule ??
+				Schedule.cron({ month: '1', day: '1', hour: '10', minute: '0' }), // Run on the first of the month at 10am
 			config: awsSourceConfigForAccount(GuardianAwsAccounts.DeployTools, {
 				tables: [
 					/*


### PR DESCRIPTION
## What does this change?

Updates the `minute` field to be `0` instead of `*`. This caused:

1. At 10AM the `DeployToolsListOrgs` task would be launched every minute until 11AM
2. Our stale data alerting incorrectly flagged the table as `DAILY` (despite it actually being `MONTHLY`) as the time between 1 invocation and the next was 1 minute.