### PR TITLE
Update actions-riff-raff to version 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Setup AWS credentials to enable uploading to S3 for Riff-Raff.
-      # See https://github.com/aws-actions/configure-aws-credentials
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          aws-region: eu-west-1
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -54,9 +47,10 @@ jobs:
         run: ./scripts/ci.sh
 
       - name: Upload to riff-raff
-        uses: guardian/actions-riff-raff@v3
+        uses: guardian/actions-riff-raff@v4
         with:
           app: service-catalogue
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           buildNumber: ${{ env.GITHUB_RUN_NUMBER }}
           projectName: deploy::service-catalogue


### PR DESCRIPTION
Co-authored-by: @AshCorr

## What does this change?

Upgrade [guardian/actions-riff-raff](https://github.com/guardian/actions-riff-raff) to [v4](https://github.com/guardian/actions-riff-raff/releases/tag/v4).

## Why?

This allows us to remove the [aws-configure-credentials](https://github.com/aws-actions/configure-aws-credentials) step from the earlier part of the workflow.

## How has it been verified?

Builds of the service-catalogue are still picked up by Riff-Raff.
