### PR TITLE
refactor(data-audit): Explicitly name the IAM Role

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -14168,8 +14168,8 @@ spec:
     },
     "DataAudit2FEB3068": {
       "DependsOn": [
-        "DataAuditServiceRoleDefaultPolicyB6C67E52",
-        "DataAuditServiceRole35A15887",
+        "DataAuditRoleDefaultPolicyD0BF34E5",
+        "DataAuditRoleB3B90C40",
       ],
       "Properties": {
         "Code": {
@@ -14196,7 +14196,7 @@ spec:
         "MemorySize": 512,
         "Role": {
           "Fn::GetAtt": [
-            "DataAuditServiceRole35A15887",
+            "DataAuditRoleB3B90C40",
             "Arn",
           ],
         },
@@ -14277,7 +14277,7 @@ spec:
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "DataAuditServiceRole35A15887": {
+    "DataAuditRoleB3B90C40": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -14292,31 +14292,10 @@ spec:
           "Version": "2012-10-17",
         },
         "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
-              ],
-            ],
-          },
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
         ],
+        "RoleName": "service-catalogue-data-audit-TEST",
         "Tags": [
           {
             "Key": "App",
@@ -14342,7 +14321,7 @@ spec:
       },
       "Type": "AWS::IAM::Role",
     },
-    "DataAuditServiceRoleDefaultPolicyB6C67E52": {
+    "DataAuditRoleDefaultPolicyD0BF34E5": {
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -14474,10 +14453,10 @@ spec:
           ],
           "Version": "2012-10-17",
         },
-        "PolicyName": "DataAuditServiceRoleDefaultPolicyB6C67E52",
+        "PolicyName": "DataAuditRoleDefaultPolicyD0BF34E5",
         "Roles": [
           {
-            "Ref": "DataAuditServiceRole35A15887",
+            "Ref": "DataAuditRoleB3B90C40",
           },
         ],
       },

--- a/packages/cdk/lib/data-audit.ts
+++ b/packages/cdk/lib/data-audit.ts
@@ -1,9 +1,10 @@
 import { GuScheduledLambda } from '@guardian/cdk';
 import type { GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
-import { Duration } from 'aws-cdk-lib';
+import { Duration, Tags } from 'aws-cdk-lib';
 import type { IVpc } from 'aws-cdk-lib/aws-ec2';
 import { Schedule } from 'aws-cdk-lib/aws-events';
+import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
 import { cloudqueryAccess, listOrgsPolicy } from './cloudquery/policies';
@@ -18,8 +19,46 @@ export function addDataAuditLambda(scope: GuStack, props: DataAuditProps) {
 	const app = 'data-audit';
 
 	const { vpc, dbAccess, db } = props;
+	const { stage } = scope;
+
+	const role = new Role(scope, 'DataAuditRole', {
+		assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+
+		/*
+		The lambda will be assuming the `cloudquery-access` role.
+		This role's principal has been narrowed to a pattern.
+
+		See https://github.com/guardian/aws-account-setup/pull/166.
+		 */
+		roleName: `service-catalogue-${app}-${stage}`,
+
+		/*
+		These managed policies do not meet AWS FSBP.
+		TODO remove these once GuCDK has improved - https://github.com/guardian/cdk/pull/2212.
+
+		See:
+		  - https://docs.aws.amazon.com/securityhub/latest/userguide/fsbp-standard.html
+		  - https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambdaBasicExecutionRole.html
+		  - https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambdaVPCAccessExecutionRole.html
+		 */
+		managedPolicies: [
+			ManagedPolicy.fromManagedPolicyArn(
+				scope,
+				'AWSLambdaBasicExecutionRole',
+				'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+			),
+			ManagedPolicy.fromManagedPolicyArn(
+				scope,
+				'AWSLambdaVPCAccessExecutionRole',
+				'arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole',
+			),
+		],
+	});
+
+	Tags.of(role).add('App', app);
 
 	const lambda = new GuScheduledLambda(scope, 'DataAudit', {
+		role,
 		app,
 		vpc,
 		securityGroups: [dbAccess],


### PR DESCRIPTION
## What does this change, and why?
The data-audit lambda assumes the `cloudquery-access` role. This role's principal has been narrowed to a pattern. Update the IAM Role used by the lambda to match this pattern, so that it can assume the role.

See https://github.com/guardian/aws-account-setup/pull/166.