### PR TITLE
send notifications more teams, modify wording

### DIFF
--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -480,7 +480,7 @@ export async function testExperimentalRepocopFeatures(
 
 	const someDigests = teams
 		.sort((a, b) => a.slug.localeCompare(b.slug))
-		.slice(0, 15)
+		.slice(0, 30)
 		.map((t) => createDigest(t, repoOwners, evaluationResults))
 		.filter((d): d is VulnerabilityDigest => d !== undefined);
 

--- a/packages/repocop/src/vulnerability-digest.ts
+++ b/packages/repocop/src/vulnerability-digest.ts
@@ -44,7 +44,7 @@ function createHumanReadableVulnMessage(vuln: RepocopVulnerability): string {
 
 	return String.raw`**${vuln.package}** contains a [${vuln.severity.toUpperCase()} vulnerability](${vuln.urls[0]}).
 Introduced to [${vuln.fullName}](https://github.com/${vuln.fullName}) on ${dateString} via ${ecosystem}.
-This vulnerability is ${vuln.isPatchable ? '' : '*not* '}patchable.`;
+This vulnerability ${vuln.isPatchable ? 'is ' : 'may *not* be '}patchable.`;
 }
 
 export function createDigest(


### PR DESCRIPTION
## What does this change?

Sending out 15 messages only results a couple of teams with vulnerable production repos. let's widen our test group a little, especially as we don't know for sure that all those teams have anghammarad mappings. Let's double this number

Snyk API responses sometimes wrongly indicate that a vulnerability is not patchable. This is something we should address with Snyk directly, but for now, let's make the negative case more ambiguous.

## How has it been verified?

Deployed to CODE, confirmed we are now sending twice as many messages as before
