### PR TITLE
Refactor: temporarily remove Dependabot alerts from vulnerability monitoring 

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -79,14 +79,13 @@ export async function main() {
 	const teams = await getTeams(prisma);
 	const repoOwners = await getRepoOwnership(prisma);
 
-	const evaluationResults: EvaluationResult[] = await evaluateRepositories(
+	const evaluationResults: EvaluationResult[] = evaluateRepositories(
 		unarchivedRepos,
 		branches,
 		repoTeams,
 		repoLanguages,
 		latestSnykIssues,
 		snykProjectsFromRest,
-		octokit,
 	);
 
 	const repocopRules = evaluationResults.map((r) => r.repocopRules);

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -611,25 +611,49 @@ export function snykAlertToRepocopVulnerability(
 	};
 }
 
-export async function evaluateRepositories(
+// export async function evaluateRepositories(
+// 	repositories: Repository[],
+// 	branches: github_repository_branches[],
+// 	teams: TeamRepository[],
+// 	repoLanguages: github_languages[],
+// 	latestSnykIssues: snyk_reporting_latest_issues[],
+// 	snykProjectsFromRest: SnykProject[],
+// 	octokit: Octokit,
+// ): Promise<EvaluationResult[]> {
+// 	const evaluatedRepos = repositories.map(async (r) => {
+// 		const dependabotAlerts = isProduction(r)
+// 			? (await getAlertsForRepo(octokit, r.name))
+// 					?.filter((a) => a.state === 'open')
+// 					.map((a) => dependabotAlertToRepocopVulnerability(r.full_name, a))
+// 			: [];
+// 		const teamsForRepo = teams.filter((t) => t.id === r.id);
+// 		const branchesForRepo = branches.filter((b) => b.repository_id === r.id);
+// 		return evaluateOneRepo(
+// 			dependabotAlerts,
+// 			r,
+// 			branchesForRepo,
+// 			teamsForRepo,
+// 			repoLanguages,
+// 			latestSnykIssues,
+// 			snykProjectsFromRest,
+// 		);
+// 	});
+// 	return Promise.all(evaluatedRepos);
+// }
+
+export function evaluateRepositories(
 	repositories: Repository[],
 	branches: github_repository_branches[],
 	teams: TeamRepository[],
 	repoLanguages: github_languages[],
 	latestSnykIssues: snyk_reporting_latest_issues[],
 	snykProjectsFromRest: SnykProject[],
-	octokit: Octokit,
-): Promise<EvaluationResult[]> {
-	const evaluatedRepos = repositories.map(async (r) => {
-		const dependabotAlerts = isProduction(r)
-			? (await getAlertsForRepo(octokit, r.name))
-					?.filter((a) => a.state === 'open')
-					.map((a) => dependabotAlertToRepocopVulnerability(r.full_name, a))
-			: [];
+): EvaluationResult[] {
+	const evaluatedRepos = repositories.map((r) => {
 		const teamsForRepo = teams.filter((t) => t.id === r.id);
 		const branchesForRepo = branches.filter((b) => b.repository_id === r.id);
 		return evaluateOneRepo(
-			dependabotAlerts,
+			undefined,
 			r,
 			branchesForRepo,
 			teamsForRepo,
@@ -638,5 +662,5 @@ export async function evaluateRepositories(
 			snykProjectsFromRest,
 		);
 	});
-	return Promise.all(evaluatedRepos);
+	return evaluatedRepos;
 }


### PR DESCRIPTION
Co-authored-by @NovemberTang 

## What does this change?

Temporarily removes Dependabot alerts from Repocop vulnerability monitoring.

## Why?

Currently we are creating vulnerability digests alerting on critical vulnerabilities from dev dependencies. This will create a lot of unnecessary work for teams that receive the digests. It seems like some vulnerabilities have been mis-classified by Dependabot as 'runtime' when they are not, and transitive (as well as possibly direct) dev dependencies are not being ignored as they should be. 

Once we have resolved these issues then this work can be reverted.

## How has it been verified?

Tested on CODE and the vulnerability digests were created with only Snyk vulnerabilities.