### PR TITLE
Run DeployToolsListOrgs once a month, instead of once a year

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -1162,7 +1162,7 @@ spec:
     },
     "CloudquerySourceDeployToolsListOrgsScheduledEventRuleDF9BD8AF": {
       "Properties": {
-        "ScheduleExpression": "cron(0 10 1 1 ? *)",
+        "ScheduleExpression": "cron(0 10 1 * ? *)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -64,8 +64,7 @@ export function addCloudqueryEcsCluster(
 			description:
 				'Data about the AWS Organisation, including accounts and OUs. Uses include mapping account IDs to account names.',
 			schedule:
-				nonProdSchedule ??
-				Schedule.cron({ month: '1', day: '1', hour: '10', minute: '0' }), // Run on the first of the month at 10am
+				nonProdSchedule ?? Schedule.cron({ day: '1', hour: '10', minute: '0' }), // Run on the first of the month at 10am
 			config: awsSourceConfigForAccount(GuardianAwsAccounts.DeployTools, {
 				tables: [
 					/*


### PR DESCRIPTION
## What does this change?

This job was set to run on the 1st of January every year, Instead of the 1st of every month. This was causing our our table out of sync alarm to trigger.

## How has it been verified?

Before

<img width="834" alt="image" src="https://github.com/guardian/service-catalogue/assets/21217225/ae6d4a44-02fe-4025-99de-2d47f7640f8c">

After

<img width="850" alt="image" src="https://github.com/guardian/service-catalogue/assets/21217225/19df5a56-0964-41b5-b20a-d76920d03f64">
