### PR TITLE
Bump Clouquery Github plugin to v8

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ CQ_POSTGRES_SOURCE=3.0.7
 CQ_AWS=23.6.1
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/github/versions
-CQ_GITHUB=7.6.4
+CQ_GITHUB=8.0.0
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/fastly/versions
 CQ_FASTLY=3.0.7

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -4034,7 +4034,7 @@ spec:
             "Environment": [
               {
                 "Name": "GOMEMLIMIT",
-                "Value": "409MiB",
+                "Value": "819MiB",
               },
             ],
             "Essential": true,
@@ -4277,7 +4277,7 @@ spec:
           ],
         },
         "Family": "ServiceCatalogueCloudquerySourceGitHubRepositoriesTaskDefinition13A7DF48",
-        "Memory": "512",
+        "Memory": "1024",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -3056,7 +3056,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v7.6.4
+  version: v8.0.0
   tables:
     - github_issues
   destinations:
@@ -3988,7 +3988,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v7.6.4
+  version: v8.0.0
   tables:
     - github_repositories
     - github_repository_branches
@@ -4593,7 +4593,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v7.6.4
+  version: v8.0.0
   tables:
     - github_organizations
     - github_organization_members

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -135,7 +135,7 @@ spec:
 		spec:
 		  name: github
 		  path: cloudquery/github
-		  version: v7.6.4
+		  version: v8.0.0
 		  tables:
 		    - github_repositories
 		  destinations:

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -320,6 +320,7 @@ export function addCloudqueryEcsCluster(
 			}),
 			secrets: githubSecrets,
 			additionalCommands: additionalGithubCommands,
+			memoryLimitMiB: 1024,
 		},
 		{
 			name: 'GitHubTeams',


### PR DESCRIPTION
## What does this change?

Bumps the Github plugin to v8.0.0

## Why?

The newest version of the Github plugin [supports syncing SBOM tables](https://github.com/cloudquery/cloudquery/pull/16796) from Github!

## How has it been verified?

Ran locally
