### PR TITLE
Notify all teams about old vulnerabilities

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -26,6 +26,7 @@ import { sendUnprotectedRepo } from './remediations/snyk-integrator/send-to-sns'
 import { sendPotentialInteractives } from './remediations/topics/topic-monitor-interactive';
 import { applyProductionTopicAndMessageTeams } from './remediations/topics/topic-monitor-production';
 import {
+	createAndSendVulnerabilityDigests,
 	evaluateRepositories,
 	testExperimentalRepocopFeatures,
 } from './rules/repository';
@@ -109,14 +110,18 @@ export async function main() {
 	const cloudwatch = new CloudWatchClient(awsConfig);
 	await sendToCloudwatch(repocopRules, cloudwatch, config);
 
-	await testExperimentalRepocopFeatures(
+	testExperimentalRepocopFeatures(
 		evaluationResults,
 		unarchivedRepos,
 		archivedRepos,
 		nonPlaygroundStacks,
-		teams,
+	);
+
+	await createAndSendVulnerabilityDigests(
 		config,
+		teams,
 		repoOwners,
+		evaluationResults,
 	);
 
 	await sendUnprotectedRepo(repocopRules, config, repoLanguages);

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -447,14 +447,29 @@ function sendVulnerabilityDigests(
 	);
 }
 
-export async function testExperimentalRepocopFeatures(
+export async function createAndSendVulnerabilityDigests(
+	config: Config,
+	teams: Team[],
+	repoOwners: view_repo_ownership[],
+	evaluationResults: EvaluationResult[],
+) {
+	const digests = teams
+		.map((t) => createDigest(t, repoOwners, evaluationResults))
+		.filter((d): d is VulnerabilityDigest => d !== undefined);
+
+	if (isFirstOrThirdTuesdayOfMonth(new Date()) && config.stage === 'PROD') {
+		await sendVulnerabilityDigests(digests, config);
+	} else {
+		console.log('Logging vulnerability digests');
+		digests.forEach((digest) => console.log(JSON.stringify(digest)));
+	}
+}
+
+export function testExperimentalRepocopFeatures(
 	evaluationResults: EvaluationResult[],
 	unarchivedRepos: Repository[],
 	archivedRepos: Repository[],
 	nonPlaygroundStacks: AwsCloudFormationStack[],
-	teams: Team[],
-	config: Config,
-	repoOwners: view_repo_ownership[],
 ) {
 	const evaluatedRepos = evaluationResults.map((r) => r.repocopRules);
 	const unmaintinedReposCount = evaluatedRepos.filter(
@@ -477,17 +492,6 @@ export async function testExperimentalRepocopFeatures(
 		'Archived repos with live stacks, first 3 results:',
 		archivedWithStacks.slice(0, 3),
 	);
-
-	const digests = teams
-		.map((t) => createDigest(t, repoOwners, evaluationResults))
-		.filter((d): d is VulnerabilityDigest => d !== undefined);
-
-	if (isFirstOrThirdTuesdayOfMonth(new Date()) && config.stage === 'PROD') {
-		await sendVulnerabilityDigests(digests, config);
-	} else {
-		console.log('Logging vulnerability digests');
-		digests.forEach((digest) => console.log(JSON.stringify(digest)));
-	}
 }
 
 export function deduplicateVulnerabilitiesByCve(

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -478,17 +478,15 @@ export async function testExperimentalRepocopFeatures(
 		archivedWithStacks.slice(0, 3),
 	);
 
-	const someDigests = teams
-		.sort((a, b) => a.slug.localeCompare(b.slug))
-		.slice(0, 30)
+	const digests = teams
 		.map((t) => createDigest(t, repoOwners, evaluationResults))
 		.filter((d): d is VulnerabilityDigest => d !== undefined);
 
 	if (isFirstOrThirdTuesdayOfMonth(new Date()) && config.stage === 'PROD') {
-		await sendVulnerabilityDigests(someDigests, config);
+		await sendVulnerabilityDigests(digests, config);
 	} else {
 		console.log('Logging vulnerability digests');
-		someDigests.forEach((digest) => console.log(JSON.stringify(digest)));
+		digests.forEach((digest) => console.log(JSON.stringify(digest)));
 	}
 }
 

--- a/packages/repocop/src/vulnerability-digest.test.ts
+++ b/packages/repocop/src/vulnerability-digest.test.ts
@@ -99,7 +99,7 @@ describe('createDigest', () => {
 			subject: `Vulnerability Digest for ${teamName}`,
 			message: String.raw`Found 1 vulnerabilities across 1 repositories.
 Displaying the top 1 most urgent.
-Note: DevX does not aggregate vulnerability information for repositories without a production topic.
+Note: DevX only aggregates vulnerability information for repositories with a production topic.
 
 **leftpad** contains a [HIGH vulnerability](example.com).
 Introduced to [guardian/repo](https://github.com/guardian/repo) on Sun Jan 01 2023 via pip.

--- a/packages/repocop/src/vulnerability-digest.ts
+++ b/packages/repocop/src/vulnerability-digest.ts
@@ -65,7 +65,7 @@ export function createDigest(
 	const listedVulnsCount = topVulns.length;
 	const preamble = String.raw`Found ${totalVulnsCount} vulnerabilities across ${resultsForTeam.length} repositories.
 Displaying the top ${listedVulnsCount} most urgent.
-Note: DevX does not aggregate vulnerability information for repositories without a production topic.`;
+Note: DevX only aggregates vulnerability information for repositories with a production topic.`;
 
 	const digestString = topVulns
 		.map((v) => createHumanReadableVulnMessage(v))


### PR DESCRIPTION
## What does this change?

Send all teams with vulnerable repos notifications.

## Why?

No negative feedback received about current message system, so roll out to department, and move it out of the test feature function
