### PR TITLE
refactor: reinstate Dependabot vulnerabilities without yarn v1

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -80,13 +80,14 @@ export async function main() {
 	const teams = await getTeams(prisma);
 	const repoOwners = await getRepoOwnership(prisma);
 
-	const evaluationResults: EvaluationResult[] = evaluateRepositories(
+	const evaluationResults: EvaluationResult[] = await evaluateRepositories(
 		unarchivedRepos,
 		branches,
 		repoTeams,
 		repoLanguages,
 		latestSnykIssues,
 		snykProjectsFromRest,
+		octokit,
 	);
 
 	const repocopRules = evaluationResults.map((r) => r.repocopRules);

--- a/packages/repocop/src/rules/repository.ts
+++ b/packages/repocop/src/rules/repository.ts
@@ -613,49 +613,28 @@ export function snykAlertToRepocopVulnerability(
 	};
 }
 
-// export async function evaluateRepositories(
-// 	repositories: Repository[],
-// 	branches: github_repository_branches[],
-// 	teams: TeamRepository[],
-// 	repoLanguages: github_languages[],
-// 	latestSnykIssues: snyk_reporting_latest_issues[],
-// 	snykProjectsFromRest: SnykProject[],
-// 	octokit: Octokit,
-// ): Promise<EvaluationResult[]> {
-// 	const evaluatedRepos = repositories.map(async (r) => {
-// 		const dependabotAlerts = isProduction(r)
-// 			? (await getAlertsForRepo(octokit, r.name))
-// 					?.filter((a) => a.state === 'open')
-// 					.map((a) => dependabotAlertToRepocopVulnerability(r.full_name, a))
-// 			: [];
-// 		const teamsForRepo = teams.filter((t) => t.id === r.id);
-// 		const branchesForRepo = branches.filter((b) => b.repository_id === r.id);
-// 		return evaluateOneRepo(
-// 			dependabotAlerts,
-// 			r,
-// 			branchesForRepo,
-// 			teamsForRepo,
-// 			repoLanguages,
-// 			latestSnykIssues,
-// 			snykProjectsFromRest,
-// 		);
-// 	});
-// 	return Promise.all(evaluatedRepos);
-// }
-
-export function evaluateRepositories(
+export async function evaluateRepositories(
 	repositories: Repository[],
 	branches: github_repository_branches[],
 	teams: TeamRepository[],
 	repoLanguages: github_languages[],
 	latestSnykIssues: snyk_reporting_latest_issues[],
 	snykProjectsFromRest: SnykProject[],
-): EvaluationResult[] {
-	const evaluatedRepos = repositories.map((r) => {
+	octokit: Octokit,
+): Promise<EvaluationResult[]> {
+	const evaluatedRepos = repositories.map(async (r) => {
+		const dependabotAlerts = isProduction(r)
+			? (await getAlertsForRepo(octokit, r.name))
+					?.filter((a) => a.state === 'open')
+					.filter(
+						(a) => a.security_vulnerability.package.ecosystem !== 'yarn v1',
+					)
+					.map((a) => dependabotAlertToRepocopVulnerability(r.full_name, a))
+			: [];
 		const teamsForRepo = teams.filter((t) => t.id === r.id);
 		const branchesForRepo = branches.filter((b) => b.repository_id === r.id);
 		return evaluateOneRepo(
-			undefined,
+			dependabotAlerts,
 			r,
 			branchesForRepo,
 			teamsForRepo,
@@ -664,5 +643,5 @@ export function evaluateRepositories(
 			snykProjectsFromRest,
 		);
 	});
-	return evaluatedRepos;
+	return Promise.all(evaluatedRepos);
 }


### PR DESCRIPTION
## What does this change?

Reverts the work of #799 which removed Dependabot vulnerabilities from vulnerability monitoring, but filters out alerts with the ecosystem of `yarn v1` as these are always [classified as runtime dependencies by Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-alerts/viewing-and-updating-dependabot-alerts) resulting in false positives whereby dev dependencies are classified as runtime. We saw this example with `prosemirror-invisibles` recently. 

## Why?

We can collect Dependabot vulnerabilities for other ecosystems such as pnpm (not supported by Snyk) and soon, as well as the Scala dependencies submitted through the sbt dependency submission workflow ([example on `janus-app`](https://github.com/guardian/janus-app/blob/main/.github/workflows/dependency-graph.yml)).

## How has it been verified?
