### PR TITLE
Check for branch protection before raising a PR

### DIFF
--- a/packages/common/src/pull-requests.ts
+++ b/packages/common/src/pull-requests.ts
@@ -105,10 +105,12 @@ async function hasBranchProtection(
 
 		console.log(protection.data);
 
-		return (
+		const hasProtection =
 			protection.data.enabled === true &&
-			!!protection.data.required_pull_request_reviews
-		);
+			!!protection.data.required_pull_request_reviews;
+
+		console.log('has branch protection:', hasProtection);
+		return hasProtection;
 	} catch (e) {
 		console.error(e);
 		return false;
@@ -138,7 +140,12 @@ async function productionCustomProperty(
 			property.value === 'production',
 	);
 
-	return !!result;
+	console.log('Found property:', result);
+
+	const hasProductionStatus = !!result;
+	console.log('has production status:', hasProductionStatus);
+
+	return hasProductionStatus;
 }
 
 export async function createPrAndAddToProject(

--- a/packages/common/src/pull-requests.ts
+++ b/packages/common/src/pull-requests.ts
@@ -96,18 +96,23 @@ async function hasBranchProtection(
 	octokit: Octokit,
 	repoName: string,
 ): Promise<boolean> {
-	const protection = await octokit.rest.repos.getBranchProtection({
-		owner: 'guardian',
-		repo: repoName,
-		branch: 'main',
-	});
+	try {
+		const protection = await octokit.rest.repos.getBranchProtection({
+			owner: 'guardian',
+			repo: repoName,
+			branch: 'main',
+		});
 
-	console.log(protection.data);
+		console.log(protection.data);
 
-	return (
-		protection.data.enabled === true &&
-		!!protection.data.required_pull_request_reviews
-	);
+		return (
+			protection.data.enabled === true &&
+			!!protection.data.required_pull_request_reviews
+		);
+	} catch (e) {
+		console.error(e);
+		return false;
+	}
 }
 
 async function productionCustomProperty(

--- a/packages/common/src/pull-requests.ts
+++ b/packages/common/src/pull-requests.ts
@@ -112,7 +112,7 @@ async function hasBranchProtection(
 		console.log('has branch protection:', hasProtection);
 		return hasProtection;
 	} catch (e) {
-		console.error(e);
+		console.warn(e);
 		return false;
 	}
 }
@@ -132,7 +132,7 @@ async function productionCustomProperty(
 		},
 	);
 
-	console.log(allResults.data);
+	console.debug(allResults.data);
 
 	const result = allResults.data.find(
 		(property) =>
@@ -140,10 +140,8 @@ async function productionCustomProperty(
 			property.value === 'production',
 	);
 
-	console.log('Found property:', result);
-
 	const hasProductionStatus = !!result;
-	console.log('has production status:', hasProductionStatus);
+	console.log('has custom property ruleset protection:', hasProductionStatus);
 
 	return hasProductionStatus;
 }
@@ -178,11 +176,9 @@ export async function createPrAndAddToProject(
 	const protection1 = await hasBranchProtection(octokit, repoName);
 	const protection2 = await productionCustomProperty(octokit, repoName);
 
-	console.log('Checking branch protection: ', protection1);
-	console.log('Checking production status: ', protection2);
 	const branchIsProtected = protection1 || protection2;
 
-	console.log('Branch is protected:', branchIsProtected);
+	console.log('Branch is protected by rule or ruleset:', branchIsProtected);
 
 	if (!branchIsProtected) {
 		console.warn(

--- a/packages/common/src/pull-requests.ts
+++ b/packages/common/src/pull-requests.ts
@@ -173,10 +173,10 @@ export async function createPrAndAddToProject(
 		`${author}[bot]`,
 	);
 
-	const protection1 = await hasBranchProtection(octokit, repoName);
-	const protection2 = await productionCustomProperty(octokit, repoName);
+	const usesBranchProtectionRule = await hasBranchProtection(octokit, repoName);
+	const usesCentralRuleset = await productionCustomProperty(octokit, repoName);
 
-	const branchIsProtected = protection1 || protection2;
+	const branchIsProtected = usesBranchProtectionRule || usesCentralRuleset;
 
 	console.log('Branch is protected by rule or ruleset:', branchIsProtected);
 

--- a/packages/common/src/pull-requests.ts
+++ b/packages/common/src/pull-requests.ts
@@ -175,13 +175,16 @@ export async function createPrAndAddToProject(
 		`${author}[bot]`,
 	);
 
-	const branchIsUnprotected = !(await hasBranchProtection(octokit, repoName));
-	const noProductionRuleset = !(await productionCustomProperty(
-		octokit,
-		repoName,
-	));
+	const protection1 = await hasBranchProtection(octokit, repoName);
+	const protection2 = await productionCustomProperty(octokit, repoName);
 
-	if (branchIsUnprotected || noProductionRuleset) {
+	console.log('Checking branch protection: ', protection1);
+	console.log('Checking production status: ', protection2);
+	const branchIsProtected = protection1 || protection2;
+
+	console.log('Branch is protected:', branchIsProtected);
+
+	if (!branchIsProtected) {
 		console.warn(
 			`Branch protection not enabled for ${branch} on ${repoName}. Skipping PR creation.`,
 		);


### PR DESCRIPTION
## What does this change?

Any part of the service catalogue using `createPrAndAddToProject` will now check that the repo has sufficient branch protections before raising a PR.

## Why?

These PRs need to be reviewed by teams as they have been raised by a bot. We make requests to GitHub to get this information. We can't rely on repocop to provide this information for two reasons:
1) Branch protection data could be out of date, especially if the job has failed recently
2) CloudQuery does not collect data about rulesets or custom properties

## How has it been verified?

This has been tested on PROD. #823 was generated as a result, as the repo does not have branch protection, but does have the ruleset applied as a consequence of its `production_status` property
