### PR TITLE
bring back dependabot vulnerabilities

### DIFF
--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -549,49 +549,25 @@ export function snykAlertToRepocopVulnerability(
 	};
 }
 
-// export async function evaluateRepositories(
-// 	repositories: Repository[],
-// 	branches: github_repository_branches[],
-// 	teams: TeamRepository[],
-// 	repoLanguages: github_languages[],
-// 	latestSnykIssues: snyk_reporting_latest_issues[],
-// 	snykProjectsFromRest: SnykProject[],
-// 	octokit: Octokit,
-// ): Promise<EvaluationResult[]> {
-// 	const evaluatedRepos = repositories.map(async (r) => {
-// 		const dependabotAlerts = isProduction(r)
-// 			? (await getAlertsForRepo(octokit, r.name))
-// 					?.filter((a) => a.state === 'open')
-// 					.map((a) => dependabotAlertToRepocopVulnerability(r.full_name, a))
-// 			: [];
-// 		const teamsForRepo = teams.filter((t) => t.id === r.id);
-// 		const branchesForRepo = branches.filter((b) => b.repository_id === r.id);
-// 		return evaluateOneRepo(
-// 			dependabotAlerts,
-// 			r,
-// 			branchesForRepo,
-// 			teamsForRepo,
-// 			repoLanguages,
-// 			latestSnykIssues,
-// 			snykProjectsFromRest,
-// 		);
-// 	});
-// 	return Promise.all(evaluatedRepos);
-// }
-
-export function evaluateRepositories(
+export async function evaluateRepositories(
 	repositories: Repository[],
 	branches: github_repository_branches[],
 	teams: TeamRepository[],
 	repoLanguages: github_languages[],
 	latestSnykIssues: snyk_reporting_latest_issues[],
 	snykProjectsFromRest: SnykProject[],
-): EvaluationResult[] {
-	const evaluatedRepos = repositories.map((r) => {
+	octokit: Octokit,
+): Promise<EvaluationResult[]> {
+	const evaluatedRepos = repositories.map(async (r) => {
+		const dependabotAlerts = isProduction(r)
+			? (await getAlertsForRepo(octokit, r.name))
+					?.filter((a) => a.state === 'open')
+					.map((a) => dependabotAlertToRepocopVulnerability(r.full_name, a))
+			: [];
 		const teamsForRepo = teams.filter((t) => t.id === r.id);
 		const branchesForRepo = branches.filter((b) => b.repository_id === r.id);
 		return evaluateOneRepo(
-			undefined,
+			dependabotAlerts,
 			r,
 			branchesForRepo,
 			teamsForRepo,
@@ -600,5 +576,5 @@ export function evaluateRepositories(
 			snykProjectsFromRest,
 		);
 	});
-	return evaluatedRepos;
+	return Promise.all(evaluatedRepos);
 }

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -80,13 +80,14 @@ export async function main() {
 	const teams = await getTeams(prisma);
 	const repoOwners = await getRepoOwnership(prisma);
 
-	const evaluationResults: EvaluationResult[] = evaluateRepositories(
+	const evaluationResults: EvaluationResult[] = await evaluateRepositories(
 		unarchivedRepos,
 		branches,
 		repoTeams,
 		repoLanguages,
 		latestSnykIssues,
 		snykProjectsFromRest,
+		octokit,
 	);
 
 	const repocopRules = evaluationResults.map((r) => r.repocopRules);


### PR DESCRIPTION
## What does this change?

Bring back dependabot alerts

## Why?

We stopped collecting dependabot alerts while we were deciding what to do about yarn dependencies, as github does not differentiate between development and runtime deps. We decided to take no action, and encourage people to move away from yarn, in line with departmental recommendations.

## How has it been verified?

CI passes.
deploy to CODE and sense check the number of vulnerabilities
