### PR TITLE
refactor: use central dependency submission workflow

### DIFF
--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -14,7 +14,7 @@ jobs:
   dependency-graph:
     steps:
       - uses: actions/checkout@v4
-      - uses: scalacenter/sbt-dependency-submission@v2
+      - uses: guardian/.github/.github/workflows/dependency-graph.yml@main
     permissions:
       contents: write
 `;

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -16,7 +16,9 @@ export function createYaml(prBranch: string): string {
 				// 'runs-on': 'ubuntu-latest', //let's see how we do without this
 				steps: [
 					{ uses: 'actions/checkout@v4' },
-					{ uses: 'scalacenter/sbt-dependency-submission@v2' },
+					{
+						uses: 'guardian/.github/.github/workflows/dependency-graph.yml@main',
+					},
 				],
 				permissions: { contents: 'write' },
 			},


### PR DESCRIPTION
## What does this change?

Following on from #816, this changes the dependency submission workflow from the third party sbt submission one to our new [central workflow](https://github.com/guardian/.github/blob/main/.github/workflows/dependency-graph.yml) in the `dependency-graph-integrator`.

## Why?

This is so that we can add other languages'/build tools' dependency submission workflows to our central one, and update it in one place.

## How has it been verified?
TBC
