### PR TITLE
chore(deps): Update the GitHub plugin for CloudQuery to v8.1.0

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ CQ_POSTGRES_SOURCE=3.0.7
 CQ_AWS=23.6.1
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/github/versions
-CQ_GITHUB=8.0.0
+CQ_GITHUB=8.1.0
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/fastly/versions
 CQ_FASTLY=3.0.7

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -3057,7 +3057,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v8.0.0
+  version: v8.1.0
   tables:
     - github_issues
   destinations:
@@ -3989,7 +3989,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v8.0.0
+  version: v8.1.0
   tables:
     - github_repositories
     - github_repository_branches
@@ -4594,7 +4594,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v8.0.0
+  version: v8.1.0
   tables:
     - github_organizations
     - github_organization_members

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -135,7 +135,7 @@ spec:
 		spec:
 		  name: github
 		  path: cloudquery/github
-		  version: v8.0.0
+		  version: v8.1.0
 		  tables:
 		    - github_repositories
 		  destinations:


### PR DESCRIPTION
## What does this change, and why?
This change includes an update (https://github.com/cloudquery/cloudquery/pull/16846) to the `github_workflows` table, which could allow us to replace the `github_actions_usage` lambda with a SQL statement, as mentioned in https://github.com/guardian/service-catalogue/pull/810.

I'll attempt a refactor of the [`view_github_actions` view](https://github.com/guardian/service-catalogue/blob/794b20d16ba3041d57bacc12684dbd9e1787a6ba/packages/common/prisma/views/public/view_github_actions.sql) in a follow-up PR.