### PR TITLE
log digests no matter what

### DIFF
--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -132,10 +132,12 @@ export async function createAndSendVulnerabilityDigests(
 		.map((t) => createDigest(t, repoOwners, evaluationResults))
 		.filter((d): d is VulnerabilityDigest => d !== undefined);
 
+	console.log('Logging vulnerability digests');
+	digests.forEach((digest) => console.log(JSON.stringify(digest)));
+
 	if (isFirstOrThirdTuesdayOfMonth(new Date()) && config.stage === 'PROD') {
 		await sendVulnerabilityDigests(digests, config);
 	} else {
-		console.log('Logging vulnerability digests');
-		digests.forEach((digest) => console.log(JSON.stringify(digest)));
+		console.log('Not sending vulnerability digests');
 	}
 }


### PR DESCRIPTION
## What does this change?

Always log digests

## Why?

So we can see what messages have been sent to teams on the day digests are sent

## How has it been verified?

CI passes
