### PR TITLE
Add Github team slug to `view_repo_ownership`

### DIFF
--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -26,6 +26,12 @@ Once you have a draft migration, apply it via:
 npm -w cli start migrate -- --stage DEV
 ```
 
+You can then generate a new version of the Prisma Client via:
+
+```bash
+npx -w common prisma generate
+```
+
 ## Applying a migration to CODE or PROD
 Prerequisite:
 1. You have an approved Pull Request

--- a/packages/common/prisma/migrations/20240229142634_add_team_slug_to_view_repo_ownership/migration.sql
+++ b/packages/common/prisma/migrations/20240229142634_add_team_slug_to_view_repo_ownership/migration.sql
@@ -1,0 +1,15 @@
+create or replace view view_repo_ownership as
+select ght.id        as "github_team_id"
+     , ght.name      as "github_team_name"
+     , tr.full_name  as "repo_name" --deprecated. use full_name below for consistency with other tables
+     , tr.full_name  as "full_name"
+     , tr.role_name
+     , tr.archived
+     , gtt.team_name as "galaxies_team"
+     , gtt.team_contact_email
+     , ght.slug      as "github_team_slug"
+     , tr.name       as "name"
+from github_team_repositories tr
+         join github_teams ght on tr.team_id = ght.id
+         left join galaxies_teams_table gtt on ght.slug = gtt.team_primary_github_team
+where tr.role_name = 'admin';

--- a/packages/common/prisma/migrations/20240229142634_add_team_slug_to_view_repo_ownership/migration.sql
+++ b/packages/common/prisma/migrations/20240229142634_add_team_slug_to_view_repo_ownership/migration.sql
@@ -1,14 +1,15 @@
-create or replace view view_repo_ownership as
+drop view if exists view_repo_ownership;
+
+create view view_repo_ownership as
 select ght.id        as "github_team_id"
      , ght.name      as "github_team_name"
-     , tr.full_name  as "repo_name" --deprecated. use full_name below for consistency with other tables
-     , tr.full_name  as "full_name"
+     , ght.slug      as "github_team_slug"
+     , tr.name       as "short_repo_name"
+     , tr.full_name  as "full_repo_name"
      , tr.role_name
      , tr.archived
      , gtt.team_name as "galaxies_team"
      , gtt.team_contact_email
-     , ght.slug      as "github_team_slug"
-     , tr.name       as "name"
 from github_team_repositories tr
          join github_teams ght on tr.team_id = ght.id
          left join galaxies_teams_table gtt on ght.slug = gtt.team_primary_github_team

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -637,6 +637,8 @@ view view_repo_ownership {
   archived           Boolean
   galaxies_team      String?
   team_contact_email String?
+  github_team_slug   String?
+  name               String?
 
   @@unique([github_team_id, full_name])
 }

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -631,16 +631,15 @@ model guardian_github_actions_usage {
 view view_repo_ownership {
   github_team_id     BigInt
   github_team_name   String
-  repo_name          String
-  full_name          String
+  github_team_slug   String
+  short_repo_name    String
+  full_repo_name     String
   role_name          String
   archived           Boolean
   galaxies_team      String?
   team_contact_email String?
-  github_team_slug   String?
-  name               String?
 
-  @@unique([github_team_id, full_name])
+  @@unique([github_team_name, full_repo_name])
 }
 
 view aws_accounts {

--- a/packages/common/prisma/views/public/view_repo_ownership.sql
+++ b/packages/common/prisma/views/public/view_repo_ownership.sql
@@ -6,7 +6,9 @@ SELECT
   tr.role_name,
   tr.archived,
   gtt.team_name AS galaxies_team,
-  gtt.team_contact_email
+  gtt.team_contact_email,
+  ght.slug AS github_team_slug,
+  tr.name
 FROM
   (
     (

--- a/packages/common/prisma/views/public/view_repo_ownership.sql
+++ b/packages/common/prisma/views/public/view_repo_ownership.sql
@@ -1,14 +1,13 @@
 SELECT
   ght.id AS github_team_id,
   ght.name AS github_team_name,
-  tr.full_name AS repo_name,
-  tr.full_name,
+  ght.slug AS github_team_slug,
+  tr.name AS short_repo_name,
+  tr.full_name AS full_repo_name,
   tr.role_name,
   tr.archived,
   gtt.team_name AS galaxies_team,
-  gtt.team_contact_email,
-  ght.slug AS github_team_slug,
-  tr.name
+  gtt.team_contact_email
 FROM
   (
     (

--- a/packages/repocop/src/remediation/branch-protector/branch-protection.test.ts
+++ b/packages/repocop/src/remediation/branch-protector/branch-protection.test.ts
@@ -6,10 +6,11 @@ import type { Team } from '../../types';
 import { createBranchProtectionEvents } from './branch-protection';
 
 const nullOwner: view_repo_ownership = {
-	full_name: '',
+	full_repo_name: '',
 	github_team_id: BigInt(0),
 	github_team_name: '',
-	repo_name: '',
+	github_team_slug: '',
+	short_repo_name: '',
 	role_name: '',
 	archived: false,
 	galaxies_team: null,
@@ -40,9 +41,10 @@ describe('Team slugs should be findable for every team associated with a repo', 
 
 		const teamOneOwner: view_repo_ownership = {
 			...nullOwner,
-			full_name: repo,
+			full_repo_name: repo,
 			github_team_id: BigInt(1),
 			github_team_name: 'Team One',
+			github_team_slug: teamOne.slug,
 		};
 
 		const actual = createBranchProtectionEvents(

--- a/packages/repocop/src/remediation/shared-utilities.ts
+++ b/packages/repocop/src/remediation/shared-utilities.ts
@@ -11,7 +11,7 @@ export function findContactableOwners(
 	allRepoOwners: view_repo_ownership[],
 	teams: Team[],
 ): string[] {
-	const owners = allRepoOwners.filter((owner) => owner.full_name === repo);
+	const owners = allRepoOwners.filter((owner) => owner.full_repo_name === repo);
 	const teamSlugs = owners
 		.map((owner) => findTeamSlugFromId(owner.github_team_id, teams))
 		.filter((slug): slug is string => !!slug);

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -27,8 +27,9 @@ const date = new Date('2021-01-01');
 const ownershipRecord: view_repo_ownership = {
 	github_team_name: teamName,
 	github_team_id: teamId,
-	repo_name: removeRepoOwner(fullName),
-	full_name: fullName,
+	github_team_slug: teamSlug,
+	short_repo_name: removeRepoOwner(fullName),
+	full_repo_name: fullName,
 	role_name: '',
 	archived: false,
 	galaxies_team: null,
@@ -52,7 +53,7 @@ const anotherOwnershipRecord: view_repo_ownership = {
 	...ownershipRecord,
 	github_team_name: anotherTeam.name,
 	github_team_id: anotherTeam.id,
-	full_name: anotherFullName,
+	full_repo_name: anotherFullName,
 };
 
 const anotherRepocopRuleEvaluation: repocop_github_repository_rules = {

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -21,7 +21,7 @@ function getOwningRepos(
 
 	const resultsOwnedByTeam = reposOwnedByTeam
 		.map((repo) => {
-			return results.find((result) => result.fullName === repo.full_name);
+			return results.find((result) => result.fullName === repo.full_repo_name);
 		})
 		.filter((result): result is EvaluationResult => result !== undefined);
 


### PR DESCRIPTION
## What does this change?

This PR adds a new Prisma migration that drops and recreates the `view_repo_ownership` view.

The migration contains some breaking schema changes:
- Add column `github_team_slug`.
- Add column `short_repo_name`.
- Drop column `repo_name`.
- Renamed the `full_name` column to `full_repo_name`.

As some of these changes are breaking, this required changes in the Recocop application code, which are included as part of this PR.

> [!NOTE]
> Applying the migration without deploying the new Repocop application will break Repocop (as field names have changed). This shouldn't be a problem in reality, as Repocop runs on a schedule such that we should be able to migrate the database and deploy the new application between invocations.

## Why?

Making the team slug available in this view should ease sending notifications to Anghammarad, as we previously had to join this data with another table to retrieve team slugs.

## How has it been verified?

The dev migration was successfully applied locally. On approval, we'll also test this migration on CODE.
