### PR TITLE
chore(deps): Update Galaxies to v1.1.1

### DIFF
--- a/.env
+++ b/.env
@@ -21,7 +21,7 @@ CQ_GITHUB=8.0.0
 CQ_FASTLY=3.0.7
 
 # See https://github.com/guardian/cq-source-galaxies
-CQ_GUARDIAN_GALAXIES=1.1.0
+CQ_GUARDIAN_GALAXIES=1.1.1
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/snyk/versions
 CQ_SNYK=4.0.6

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -2268,7 +2268,7 @@ spec:
   name: galaxies
   path: guardian/galaxies
   registry: github
-  version: v1.1.0
+  version: v1.1.1
   destinations:
     - postgresql
   tables:


### PR DESCRIPTION
## What does this change?
Update the Galaxies CloudQuery plugin to v1.1.1. This version includes some dependency updates. See https://github.com/guardian/cq-source-galaxies/releases/tag/v1.1.1.