### PR TITLE
fix: add Snyk API key ARN to setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -82,6 +82,8 @@ setup_environment() {
 
   SNYK_TOKEN=$(aws secretsmanager get-secret-value --secret-id /CODE/deploy/service-catalogue/snyk-credentials  --profile "$PROFILE" --region "$REGION" | jq -r '.SecretString' | jq -r '."api-key"' | tr -d "'")
 
+  SNYK_API_KEY_ARN=$(aws secretsmanager list-secrets --profile "$PROFILE" --region "$REGION" --query 'SecretList[*]['ARN']' --output text | grep /CODE/deploy/service-catalogue/snyk-credentials)
+  
   GALAXIES_BUCKET=$(aws ssm get-parameter --name /INFRA/deploy/cloudquery/actions-static-site-bucket-arn --profile "$PROFILE" --region "$REGION" | jq -r '.Parameter.Value | sub("arn:aws:s3:::"; "")')
 
   ANGHAMMARAD_SNS_ARN=$(aws ssm get-parameter --name /account/services/anghammarad.topic.arn --profile "$PROFILE" --region "$REGION" | jq '.Parameter.Value' | tr -d '"')
@@ -111,6 +113,7 @@ echo "$JSON_STRING" | jq -r '."private-key"' | base64 --decode > "$GITHUB_PRIVAT
 
 
   env_var_text="SNYK_TOKEN=${SNYK_TOKEN}
+SNYK_API_KEY_ARN=${SNYK_API_KEY_ARN}
 GALAXIES_BUCKET=${GALAXIES_BUCKET}
 ANGHAMMARAD_SNS_ARN=${ANGHAMMARAD_SNS_ARN}
 INTERACTIVE_MONITOR_TOPIC_ARN=${INTERACTIVE_MONITOR_TOPIC_ARN}


### PR DESCRIPTION
Co-authored-by: @NovemberTang 

## What does this change?

Adds a step to fetch the Snyk API key ARN and add this as an environment variable in the setup script.

## Why?

This is required to successfuly run  Repocop locally, since the environment variable was added to Repocop in #733.

## How has it been verified?

Ran the setup script after this change and observed repocop running without error.

## Note: 
A future piece of work is required to use only one SNYK env var.