### PR TITLE
Provision infra for the Dependency Graph Integrator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
               - packages/data-audit/dist/data-audit.zip
             snyk-integrator:
               - packages/snyk-integrator/dist/snyk-integrator.zip
+            dependency-graph-integrator:
+                - packages/dependency-graph-integrator/dist/dependency-graph-integrator.zip
             github-actions-usage:
               - packages/github-actions-usage/dist/github-actions-usage.zip
     env:

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -16,6 +16,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuScheduledLambda",
       "GuLambdaFunction",
+      "GuLambdaFunction",
       "GuScheduledLambda",
       "GuLambdaFunction",
       "GuSecurityGroup",
@@ -15398,6 +15399,371 @@ spec:
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
     },
+    "dependencygraphintegrator508B46FC": {
+      "DependsOn": [
+        "dependencygraphintegratorServiceRoleDefaultPolicy6EBFEC55",
+        "dependencygraphintegratorServiceRole5200A556",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "deploy/TEST/dependency-graph-integrator/dependency-graph-integrator.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "dependency-graph-integrator",
+            "GITHUB_APP_SECRET": {
+              "Ref": "dependencygraphintegratorgithubappauthB8B9DE78",
+            },
+            "STACK": "deploy",
+            "STAGE": "TEST",
+          },
+        },
+        "Handler": "index.handler",
+        "MemorySize": 1024,
+        "Role": {
+          "Fn::GetAtt": [
+            "dependencygraphintegratorServiceRole5200A556",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "dependency-graph-integrator",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 300,
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "dependencygraphintegratorSecurityGroupC8A882C0",
+                "GroupId",
+              ],
+            },
+          ],
+          "SubnetIds": {
+            "Ref": "PrivateSubnets",
+          },
+        },
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "dependencygraphintegratorAllowInvokeServiceCataloguedependencygraphintegratorinputtopicTESTC360D94D8B8A768E": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "dependencygraphintegrator508B46FC",
+            "Arn",
+          ],
+        },
+        "Principal": "sns.amazonaws.com",
+        "SourceArn": {
+          "Ref": "dependencygraphintegratorinputtopicTESTDAA73A88",
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "dependencygraphintegratorSecurityGroupC8A882C0": {
+      "Properties": {
+        "GroupDescription": "Automatic security group for Lambda Function ServiceCataloguedependencygraphintegrator6DE43587",
+        "SecurityGroupEgress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound traffic by default",
+            "IpProtocol": "-1",
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "dependency-graph-integrator",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VpcId": {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "dependencygraphintegratorServiceRole5200A556": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "dependency-graph-integrator",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "dependencygraphintegratorServiceRoleDefaultPolicy6EBFEC55": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/deploy/TEST/dependency-graph-integrator/dependency-graph-integrator.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/dependency-graph-integrator",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/dependency-graph-integrator/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "dependencygraphintegratorgithubappauthB8B9DE78",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "dependencygraphintegratorServiceRoleDefaultPolicy6EBFEC55",
+        "Roles": [
+          {
+            "Ref": "dependencygraphintegratorServiceRole5200A556",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "dependencygraphintegratordependencygraphintegratorinputtopicTEST621C9371": {
+      "Properties": {
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "dependencygraphintegrator508B46FC",
+            "Arn",
+          ],
+        },
+        "Protocol": "lambda",
+        "TopicArn": {
+          "Ref": "dependencygraphintegratorinputtopicTESTDAA73A88",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
+    "dependencygraphintegratorgithubappauthB8B9DE78": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "GenerateSecretString": {},
+        "Name": "/TEST/deploy/service-catalogue/dependency-graph-integrator-github-app-secret",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "dependencygraphintegratorinputtopicTESTDAA73A88": {
+      "Properties": {
+        "DisplayName": "Dependency Graph Integrator Input Topic",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
     "fastlycredentialsF42D3C80": {
       "DeletionPolicy": "Delete",
       "Properties": {
@@ -16012,6 +16378,9 @@ spec:
                 "Endpoint.Address",
               ],
             },
+            "DEPENDENCY_GRAPH_INPUT_TOPIC_ARN": {
+              "Ref": "dependencygraphintegratorinputtopicTESTDAA73A88",
+            },
             "GITHUB_APP_SECRET": {
               "Ref": "branchprotectorgithubappauth4E91892E",
             },
@@ -16294,6 +16663,13 @@ spec:
               "Effect": "Allow",
               "Resource": {
                 "Ref": "snykintegratorinputtopicTEST6BCA9CE1",
+              },
+            },
+            {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "dependencygraphintegratorinputtopicTESTDAA73A88",
               },
             },
             {

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -88,7 +88,11 @@ export class Repocop {
 		repocopLambda.addToRolePolicy(policyStatement);
 		snykCredentialsSecret.grantRead(repocopLambda);
 
-		const snykIntegatorLambda = stageAwareSnykIntegrator(guStack, vpc);
+		const snykIntegatorLambda = stageAwareIntegratorLambda(
+			guStack,
+			vpc,
+			'snyk-integrator',
+		);
 
 		snykIntegratorInputTopic.addSubscription(
 			new LambdaSubscription(snykIntegatorLambda, {}),
@@ -96,11 +100,11 @@ export class Repocop {
 	}
 }
 
-function stageAwareSnykIntegrator(
+function stageAwareIntegratorLambda(
 	guStack: GuStack,
 	vpc: IVpc,
+	app: `${string}-integrator`,
 ): GuLambdaFunction {
-	const app: string = 'snyk-integrator';
 	const nonProdLambdaProps = {
 		app,
 		fileName: `${app}.zip`,

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -116,18 +116,18 @@ function stageAwareIntegratorLambda(
 	};
 
 	if (guStack.stage === 'PROD' || guStack.stage === 'TEST') {
-		const snykIntegratorSecret = new Secret(guStack, `${app}-github-app-auth`, {
+		const githubAppSecret = new Secret(guStack, `${app}-github-app-auth`, {
 			secretName: `/${guStack.stage}/${guStack.stack}/service-catalogue/${app}-github-app-secret`,
 		});
 
 		const lambda = new GuLambdaFunction(guStack, app, {
 			...nonProdLambdaProps,
 			environment: {
-				GITHUB_APP_SECRET: snykIntegratorSecret.secretArn,
+				GITHUB_APP_SECRET: githubAppSecret.secretArn,
 			},
 		});
 
-		snykIntegratorSecret.grantRead(lambda);
+		githubAppSecret.grantRead(lambda);
 
 		return lambda;
 	} else {

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -54,6 +54,7 @@ npx npm-run-all --print-label --parallel typecheck lint synth build
 verifyMarkdown
 createZip "interactive-monitor"
 createZip "snyk-integrator"
+createZip "dependency-graph-integrator"
 createLambdaWithPrisma "repocop"
 createLambdaWithPrisma "data-audit"
 createLambdaWithPrisma "github-actions-usage"


### PR DESCRIPTION
## What does this change?

This change adds additional CDK to create some new resources:
- A lambda that will run the dependency-graph-integrator script.
- A SNS topic from which Repocop can publish messages, and a lambda subscription so the dependency graph integrator lambda is triggered with these messages.
- In `PROD`/`TEST`, a secret for Github app credentials.

It also modifies our CI script and Riff Raff content directories to add a new lambda artifact, which we're already producing.

## Why?

So that we can begin running the `dependency-graph-integrator` in CODE and PROD stages, as opposed to just locally.

## How has it been verified?

CI passes and the snapshot appears to match what I'd roughly expect. I've also deployed the CFN and lambda changes to CODE, which passed successfully and created the new resources in AWS.

I tested the new CODE SNS topic and lambda by publishing messages via this command (using a suitable `$TOPIC_ARN`), and observing the lambda being invoked and logging to Cloudwatch as expected .

```bash
MESSAGE='{ "name": "test-repocop-prs" }'
aws sns publish \
    --topic-arn "$TOPIC_ARN" \
    --region eu-west-1 \
    --profile deployTools \
    --message "$MESSAGE" | jq .
```

The one thing I haven't been able to test, due to the lambda being stage-aware, is that the secret is successfully created and made available to the lambda. It should be okay to test this in prod, as the lambda doesn't consume it yet.
