### PR TITLE
Add `noEmit` option to the root TypeScript config

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "npm run test --workspaces --if-present",
     "test-update": "jest -u",
     "synth": "npm run synth --workspace=cdk",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc",
     "build": "npm run build --workspaces --if-present",
     "lint": "eslint packages/** --ext .ts --no-error-on-unmatched-pattern"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@guardian/tsconfig/tsconfig.json",
   "compilerOptions": {
+    "noEmit": true,
     "module": "commonjs",
     "esModuleInterop": true,
     "baseUrl": ".",


### PR DESCRIPTION
## What does this change?

Specify the `noEmit` TypeScript compiler option in the root tsconfig. This means we can also remove it from the `typecheck` package script.

## Why?

If I mistakenly run `npm run tsc` it won't emit JS files across the entire repository.

## How has it been verified?

CI passes, and running `npm run typecheck` doesn't emit JS locally.
