### PR TITLE
wip: Generate infrastructure diagram using `@aws/pdk`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,20 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@aws-cdk/aws-cognito-identitypool-alpha": {
+      "version": "2.104.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito-identitypool-alpha/-/aws-cognito-identitypool-alpha-2.104.0-alpha.0.tgz",
+      "integrity": "sha512-a1SdwZE1vdzkWjmULD9kt16nUHgg6Iz2WtHD8XZYw8nW4IKweIX0IgvO+Ie8JvGOfKrdZjTBpcwWgNTkA1aG9Q==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.104.0",
+        "constructs": "^10.0.0"
+      }
+    },
     "node_modules/@aws-crypto/crc32": {
       "version": "3.0.0",
       "license": "Apache-2.0",
@@ -1392,6 +1406,1941 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws/pdk": {
+      "version": "0.23.14",
+      "resolved": "https://registry.npmjs.org/@aws/pdk/-/pdk-0.23.14.tgz",
+      "integrity": "sha512-EmDCve+UQ7quzUryVNJW7S3iQ3z77UwQIJM9EgoHsV1gDYofQL1s6HoVchJNDikfBlMUpLnQkXTXlmlIBput6g==",
+      "bundleDependencies": [
+        "@pnpm/reviewing.dependencies-hierarchy",
+        "chalk",
+        "execa",
+        "find-up",
+        "findup",
+        "fs-extra",
+        "he",
+        "lodash",
+        "lodash.clonedeep",
+        "lodash.isempty",
+        "lodash.memoize",
+        "lodash.merge",
+        "lodash.omit",
+        "lodash.startcase",
+        "lodash.uniq",
+        "lodash.uniqby",
+        "lodash.words",
+        "log4js",
+        "mustache",
+        "openapi-types",
+        "read-pkg-up",
+        "semver",
+        "shorthash2",
+        "svgson",
+        "to-px",
+        "traverse",
+        "ts-graphviz",
+        "ts-node",
+        "word-wrap"
+      ],
+      "dev": true,
+      "dependencies": {
+        "@pnpm/reviewing.dependencies-hierarchy": "^2.1.3",
+        "chalk": "^4.x",
+        "execa": "5.1.1",
+        "find-up": "^4.x",
+        "findup": "^0.1.5",
+        "fs-extra": "^11.1.1",
+        "he": "^1.2.0",
+        "lodash": "^4.17.21",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.memoize": "^4.1.2",
+        "lodash.merge": "^4.6.2",
+        "lodash.omit": "^4.5.0",
+        "lodash.startcase": "^4.4.0",
+        "lodash.uniq": "^4.5.0",
+        "lodash.uniqby": "^4.7.0",
+        "lodash.words": "^4.2.0",
+        "log4js": "^6.9.1",
+        "mustache": "^4.2.0",
+        "openapi-types": "^12.1.3",
+        "read-pkg-up": "^7.0.1",
+        "semver": "^7.5.4",
+        "shorthash2": "^1.0.3",
+        "svgson": "^5.3.1",
+        "to-px": "^1.1.0",
+        "traverse": "^0.6.7",
+        "ts-graphviz": "^1.8.1",
+        "ts-node": "^10.9.1",
+        "word-wrap": "^1.2.5"
+      },
+      "bin": {
+        "monorepo.nx-dir-hasher": "scripts/monorepo/nx-dir-hasher.js",
+        "monorepo.pnpm-link-bundled-transitive-deps": "scripts/monorepo/pnpm/link-bundled-transitive-deps.js",
+        "pdk": "_scripts/pdk.sh",
+        "type-safe-api.clean-openapi-generated-code": "scripts/type-safe-api/custom/clean-openapi-generated-code/clean-openapi-generated-code",
+        "type-safe-api.copy-gradle-wrapper": "scripts/type-safe-api/custom/gradle-wrapper/copy-gradle-wrapper",
+        "type-safe-api.generate": "scripts/type-safe-api/generators/generate",
+        "type-safe-api.generate-html-redoc-docs": "scripts/type-safe-api/custom/docs/html-redoc",
+        "type-safe-api.generate-mock-data": "scripts/type-safe-api/custom/mock-data/generate-mock-data",
+        "type-safe-api.parse-openapi-spec": "scripts/type-safe-api/parser/parse-openapi-spec"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-cognito-identitypool-alpha": "^2.104.0-alpha.0",
+        "aws-cdk-lib": "^2.104.0",
+        "cdk-nag": "^2.28.2",
+        "constructs": "^10.3.0",
+        "projen": "^0.79.24"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@babel/code-frame": {
+      "version": "7.22.13",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@babel/helper-validator-identifier": {
+      "version": "7.22.20",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@babel/highlight": {
+      "version": "7.22.20",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/constants": {
+      "version": "7.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/crypto.base32-hash": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfc4648": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/dependency-path": {
+      "version": "2.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/crypto.base32-hash": "2.0.0",
+        "@pnpm/types": "9.4.0",
+        "encode-registry": "^3.0.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/error": {
+      "version": "5.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/constants": "7.1.1"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/git-utils": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "npm:safe-execa@0.1.2"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/lockfile-file": {
+      "version": "8.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/constants": "7.1.1",
+        "@pnpm/dependency-path": "2.1.5",
+        "@pnpm/error": "5.0.2",
+        "@pnpm/git-utils": "1.0.0",
+        "@pnpm/lockfile-types": "5.1.3",
+        "@pnpm/merge-lockfile-changes": "5.0.5",
+        "@pnpm/types": "9.4.0",
+        "@pnpm/util.lex-comparator": "1.0.0",
+        "@zkochan/rimraf": "^2.1.3",
+        "comver-to-semver": "^1.0.0",
+        "js-yaml": "npm:@zkochan/js-yaml@0.0.6",
+        "normalize-path": "^3.0.0",
+        "ramda": "npm:@pnpm/ramda@0.28.1",
+        "semver": "^7.5.4",
+        "sort-keys": "^4.2.0",
+        "strip-bom": "^4.0.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      },
+      "peerDependencies": {
+        "@pnpm/logger": "^5.0.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/lockfile-types": {
+      "version": "5.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/types": "9.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/lockfile-utils": {
+      "version": "9.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/dependency-path": "2.1.5",
+        "@pnpm/lockfile-types": "5.1.3",
+        "@pnpm/pick-fetcher": "2.0.1",
+        "@pnpm/resolver-base": "11.0.0",
+        "@pnpm/types": "9.4.0",
+        "get-npm-tarball-url": "^2.0.3",
+        "ramda": "npm:@pnpm/ramda@0.28.1"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/matcher": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/merge-lockfile-changes": {
+      "version": "5.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/lockfile-types": "5.1.3",
+        "comver-to-semver": "^1.0.0",
+        "ramda": "npm:@pnpm/ramda@0.28.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/modules-yaml": {
+      "version": "12.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/types": "9.4.0",
+        "is-windows": "^1.0.2",
+        "ramda": "npm:@pnpm/ramda@0.28.1",
+        "read-yaml-file": "^2.1.0",
+        "write-yaml-file": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/normalize-registries": {
+      "version": "5.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/types": "9.4.0",
+        "normalize-registry-url": "2.0.0",
+        "ramda": "npm:@pnpm/ramda@0.28.1"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/npm-package-arg": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/pick-fetcher": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/read-modules-dir": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.11"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/read-package-json": {
+      "version": "8.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/error": "5.0.2",
+        "@pnpm/types": "9.4.0",
+        "load-json-file": "^6.2.0",
+        "normalize-package-data": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/resolver-base": {
+      "version": "11.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/types": "9.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/reviewing.dependencies-hierarchy": {
+      "version": "2.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/dependency-path": "2.1.5",
+        "@pnpm/lockfile-file": "8.1.4",
+        "@pnpm/lockfile-utils": "9.0.0",
+        "@pnpm/matcher": "5.0.0",
+        "@pnpm/modules-yaml": "12.1.4",
+        "@pnpm/normalize-registries": "5.0.4",
+        "@pnpm/npm-package-arg": "^1.0.0",
+        "@pnpm/read-modules-dir": "6.0.1",
+        "@pnpm/read-package-json": "8.0.5",
+        "@pnpm/types": "9.4.0",
+        "normalize-path": "^3.0.0",
+        "realpath-missing": "^1.1.0",
+        "resolve-link-target": "^2.0.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/types": {
+      "version": "9.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.14"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pnpm"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@pnpm/util.lex-comparator": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/@tsconfig/node16": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/@types/normalize-package-data": {
+      "version": "2.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/@zkochan/rimraf": {
+      "version": "2.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=12.10"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/acorn": {
+      "version": "8.8.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/arg": {
+      "version": "4.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/argparse": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@aws/pdk/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/builtins": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/colors": {
+      "version": "0.6.2",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/commander": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "engines": {
+        "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/comver-to-semver": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/create-require": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/date-format": {
+      "version": "4.0.14",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/debug": {
+      "version": "4.3.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/deep-rename-keys": {
+      "version": "0.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^3.0.2",
+        "rename-keys": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/diff": {
+      "version": "4.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/encode-registry": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mem": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/error-ex": {
+      "version": "1.3.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/eventemitter3": {
+      "version": "2.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/execa": {
+      "version": "5.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/find-up": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/findup": {
+      "version": "0.1.5",
+      "dev": true,
+      "inBundle": true,
+      "dependencies": {
+        "colors": "~0.6.0-1",
+        "commander": "~2.1.0"
+      },
+      "bin": {
+        "findup": "bin/findup.js"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/flatted": {
+      "version": "3.2.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws/pdk/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws/pdk/node_modules/function-bind": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/get-npm-tarball-url": {
+      "version": "2.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/get-stream": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws/pdk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/hasown": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/he": {
+      "version": "1.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/human-signals": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/inherits": {
+      "version": "2.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws/pdk/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/is-buffer": {
+      "version": "1.1.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/is-core-module": {
+      "version": "2.13.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/is-stream": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/is-windows": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/isexe": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws/pdk/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/js-yaml": {
+      "name": "@zkochan/js-yaml",
+      "version": "0.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/kind-of": {
+      "version": "3.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/load-json-file": {
+      "version": "6.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.15",
+        "parse-json": "^5.0.0",
+        "strip-bom": "^4.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/locate-path": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/lodash": {
+      "version": "4.17.21",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/lodash.isempty": {
+      "version": "4.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/lodash.omit": {
+      "version": "4.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/lodash.uniqby": {
+      "version": "4.7.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/lodash.words": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/log4js": {
+      "version": "6.9.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "date-format": "^4.0.14",
+        "debug": "^4.3.4",
+        "flatted": "^3.2.7",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.1.5"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/make-error": {
+      "version": "1.3.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws/pdk/node_modules/map-age-cleaner": {
+      "version": "0.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-defer": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/mem": {
+      "version": "8.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "map-age-cleaner": "^0.1.3",
+        "mimic-fn": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/mem?sponsor=1"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/merge-stream": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/ms": {
+      "version": "2.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/mustache": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/normalize-package-data": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^6.0.0",
+        "is-core-module": "^2.8.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/normalize-path": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/normalize-registry-url": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/onetime": {
+      "version": "5.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/openapi-types": {
+      "version": "12.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/p-defer": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/p-limit": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/p-locate": {
+      "version": "4.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/p-try": {
+      "version": "2.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/parse-json": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/parse-unit": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/path-exists": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/path-key": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/ramda": {
+      "name": "@pnpm/ramda",
+      "version": "0.28.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/read-yaml-file": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10.13"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/realpath-missing": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/rename-keys": {
+      "version": "1.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/resolve-link-target": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/rfc4648": {
+      "version": "1.5.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/rfdc": {
+      "version": "1.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/rimraf": {
+      "version": "3.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/semver": {
+      "version": "7.5.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/shorthash2": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws/pdk/node_modules/sort-keys": {
+      "version": "4.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/@aws/pdk/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/spdx-license-ids": {
+      "version": "3.0.13",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@aws/pdk/node_modules/streamroller": {
+      "version": "3.1.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "date-format": "^4.0.14",
+        "debug": "^4.3.4",
+        "fs-extra": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/svgson": {
+      "version": "5.3.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-rename-keys": "^0.2.1",
+        "xml-reader": "2.4.3"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/to-px": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-unit": "^1.0.1"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/traverse": {
+      "version": "0.6.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/ts-graphviz": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ts-graphviz"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/ts-node": {
+      "version": "10.9.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/type-fest": {
+      "version": "0.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/universalify": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/@aws/pdk/node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/validate-npm-package-name": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "builtins": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/word-wrap": {
+      "version": "1.2.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws/pdk/node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/write-yaml-file": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.1.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/xml-lexer": {
+      "version": "0.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^2.0.0"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/xml-reader": {
+      "version": "2.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^2.0.0",
+        "xml-lexer": "^0.2.2"
+      }
+    },
+    "node_modules/@aws/pdk/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/@aws/pdk/node_modules/yn": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",
       "dev": true,
@@ -2022,8 +3971,6 @@
       "version": "0.8.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -2035,8 +3982,6 @@
       "version": "0.3.9",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -3896,30 +5841,22 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.134",
@@ -4322,8 +6259,6 @@
       "version": "8.3.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4429,9 +6364,7 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5443,6 +7376,17 @@
       "resolved": "packages/cdk",
       "link": true
     },
+    "node_modules/cdk-nag": {
+      "version": "2.28.65",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.28.65.tgz",
+      "integrity": "sha512-DBD0jfl0i2F7EeFHDwDQ6tGho5VIUKOEzIMQw+5Y4QnZOUnz9ULYVW3k2N4zWXpbZOMIHcz9p8XkEquJil/biA==",
+      "dev": true,
+      "peer": true,
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.116.0",
+        "constructs": "^10.0.5"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -5734,9 +7678,7 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cronstrue": {
       "version": "2.48.0",
@@ -5927,8 +7869,6 @@
       "version": "4.0.2",
       "dev": true,
       "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -9037,9 +10977,7 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -10066,6 +12004,832 @@
       },
       "engines": {
         "node": ">=16.13"
+      }
+    },
+    "node_modules/projen": {
+      "version": "0.79.27",
+      "resolved": "https://registry.npmjs.org/projen/-/projen-0.79.27.tgz",
+      "integrity": "sha512-NPA0lcifqMO+YOK7IPQO4jLxHi2/1CkE0x3Pv9WnSjmvGNabLZ43J1260T8kwYyNQhoVdCFQo1ieAz221cBntA==",
+      "bundleDependencies": [
+        "@iarna/toml",
+        "case",
+        "chalk",
+        "comment-json",
+        "conventional-changelog-config-spec",
+        "fast-json-patch",
+        "glob",
+        "ini",
+        "semver",
+        "shx",
+        "xmlbuilder2",
+        "yaml",
+        "yargs"
+      ],
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "case": "^1.6.3",
+        "chalk": "^4.1.2",
+        "comment-json": "4.2.2",
+        "constructs": "^10.0.0",
+        "conventional-changelog-config-spec": "^2.1.0",
+        "fast-json-patch": "^3.1.1",
+        "glob": "^8",
+        "ini": "^2.0.0",
+        "semver": "^7.6.0",
+        "shx": "^0.3.4",
+        "xmlbuilder2": "^3.1.1",
+        "yaml": "^2.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "projen": "bin/projen"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/projen/node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/@oozcitak/dom": {
+      "version": "1.15.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/url": "1.0.4",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/projen/node_modules/@oozcitak/infra": {
+      "version": "1.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/projen/node_modules/@oozcitak/url": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/projen/node_modules/@oozcitak/util": {
+      "version": "8.3.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/projen/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/projen/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/projen/node_modules/argparse": {
+      "version": "1.0.10",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/projen/node_modules/array-timsort": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/projen/node_modules/case": {
+      "version": "1.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/projen/node_modules/chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/projen/node_modules/cliui": {
+      "version": "8.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/projen/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/projen/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/comment-json": {
+      "version": "4.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "array-timsort": "^1.0.3",
+        "core-util-is": "^1.0.3",
+        "esprima": "^4.0.1",
+        "has-own-prop": "^2.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/projen/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/conventional-changelog-config-spec": {
+      "version": "2.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/core-util-is": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/escalade": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/projen/node_modules/esprima": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/projen/node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/function-bind": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/projen/node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/projen/node_modules/glob": {
+      "version": "8.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/projen/node_modules/glob/node_modules/minimatch": {
+      "version": "5.1.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/projen/node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/projen/node_modules/has-own-prop": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/projen/node_modules/hasown": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/projen/node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/projen/node_modules/inherits": {
+      "version": "2.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/ini": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/projen/node_modules/interpret": {
+      "version": "1.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/projen/node_modules/is-core-module": {
+      "version": "2.13.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "hasown": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/projen/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/projen/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/projen/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/projen/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/projen/node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/projen/node_modules/minimist": {
+      "version": "1.2.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/projen/node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/projen/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/projen/node_modules/path-parse": {
+      "version": "1.0.7",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/rechoir": {
+      "version": "0.6.2",
+      "dev": true,
+      "inBundle": true,
+      "peer": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/projen/node_modules/repeat-string": {
+      "version": "1.6.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/projen/node_modules/require-directory": {
+      "version": "2.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/projen/node_modules/resolve": {
+      "version": "1.22.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/projen/node_modules/semver": {
+      "version": "7.6.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/projen/node_modules/shelljs": {
+      "version": "0.8.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/projen/node_modules/shelljs/node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/projen/node_modules/shx": {
+      "version": "0.3.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.3",
+        "shelljs": "^0.8.5"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/projen/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/projen/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/projen/node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/projen/node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/projen/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/projen/node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/xmlbuilder2": {
+      "version": "3.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oozcitak/dom": "1.15.10",
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8",
+        "js-yaml": "3.14.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/projen/node_modules/y18n": {
+      "version": "5.0.8",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/projen/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/projen/node_modules/yaml": {
+      "version": "2.3.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/projen/node_modules/yargs": {
+      "version": "17.7.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/projen/node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/prompts": {
@@ -11565,8 +14329,6 @@
       "version": "10.9.2",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -12014,9 +14776,7 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -12229,8 +14989,6 @@
       "version": "3.1.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -12255,6 +15013,7 @@
     "packages/cdk": {
       "version": "1.0.0",
       "devDependencies": {
+        "@aws/pdk": "^0.23.14",
         "@guardian/cdk": "56.0.0",
         "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
         "@types/js-yaml": "^4.0.9",

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -1,6 +1,8 @@
 import 'source-map-support/register';
+import { CdkGraph } from '@aws/pdk/cdk-graph';
+import { CdkGraphDiagramPlugin } from '@aws/pdk/cdk-graph-plugin-diagram';
 import { GuRoot } from '@guardian/cdk/lib/constructs/root';
-import { Duration } from 'aws-cdk-lib';
+import { App, Duration } from 'aws-cdk-lib';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import { ServiceCatalogue } from '../lib/service-catalogue';
 
@@ -21,3 +23,34 @@ new ServiceCatalogue(app, 'ServiceCatalogue-CODE', {
 	rdsDeletionProtection: false,
 	cloudFormationStackName: 'deploy-CODE-service-catalogue',
 });
+
+/*
+Uses `aws/pdk` to generate a graph of the CDK application.
+The diagram plugin must be wrapped in an async IFEE.
+
+`CdkGraph` creates a diagram for each node attached to `App`.
+In the `GuRoot` above, there are two nodes, differing only by `stage`.
+This creates a rather busy diagram, with duplicated information.
+As a workaround, we create a new `App` and attach only one `ServiceCatalogue` instance to it.
+To avoid it causing issues with the rest of the application, we set the `outdir` to a different directory.
+
+See https://aws.github.io/aws-pdk/developer_guides/cdk-graph-plugin-diagram/index.html.
+ */
+void (async () => {
+	const appForGraphing = new App({ outdir: 'cdk.out/graph' });
+	new ServiceCatalogue(
+		appForGraphing,
+		'ServiceCatalogue-PROD-for-diagramming',
+		{
+			stack: 'deploy',
+			stage: 'PROD',
+			env: { region: 'eu-west-1' },
+			cloudFormationStackName: 'deploy-PROD-service-catalogue',
+		},
+	);
+	const graph = new CdkGraph(appForGraphing, {
+		plugins: [new CdkGraphDiagramPlugin()],
+	});
+	appForGraphing.synth();
+	await graph.report();
+})();

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -7,6 +7,7 @@
     "diff:code": "cdk diff --path-metadata false --version-reporting false --profile deployTools ServiceCatalogue-CODE"
   },
   "devDependencies": {
+    "@aws/pdk": "^0.23.14",
     "@guardian/cdk": "56.0.0",
     "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.3.0",
     "@types/js-yaml": "^4.0.9",


### PR DESCRIPTION
## What does this change?
Use [@aws/pdk](https://aws.github.io/aws-pdk/developer_guides/cdk-graph-plugin-diagram/index.html) to generate an infrastructure diagram.

> [!NOTE]
> To create a PNG, [graphviz](https://graphviz.org/download/) needs to be installed

## Why?
Automated diagramming!

## How has it been verified?
When ran locally, the following diagram is produced:

![diagram](https://github.com/guardian/service-catalogue/assets/836140/e3349978-04e1-4886-a00d-28776ba40e17)

It's not hugely accessible, I think this is due to every construct being a direct child of `GuStack`.