### PR TITLE
Upload Prisma migrations to S3 bucket on deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
                 - packages/dependency-graph-integrator/dist/dependency-graph-integrator.zip
             github-actions-usage:
               - packages/github-actions-usage/dist/github-actions-usage.zip
+            prisma:
+              - packages/common/prisma.zip
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
 

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -36,7 +36,7 @@ deployments.set('service-catalogue-prisma-migrations', {
 	contentDirectory: 'prisma',
 	app: 'prisma-migrate-task',
 	parameters: {
-		cacheControl: 'max-age=0',
+		cacheControl: 'no-store',
 		publicReadAcl: false,
 	},
 	regions: new Set([region]),

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -31,18 +31,10 @@ const riffRaff = new RiffRaffYamlFile(app);
 
 const deployments = riffRaff.riffRaffYaml.deployments;
 
-/**
- * All cfn-based dependencies should be applied before this s3 deployment
- */
-const dependencies = [...deployments.entries()]
-	.filter(([, { type }]) => type === 'cloud-formation')
-	.map(([key]) => key);
-
 deployments.set('service-catalogue-prisma-migrations', {
 	type: 'aws-s3',
 	contentDirectory: 'prisma',
 	app: 'prisma-migrate-task',
-	dependencies,
 	parameters: {
 		cacheControl: 'max-age=0',
 		publicReadAcl: false,

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -1,23 +1,54 @@
 import 'source-map-support/register';
-import { GuRoot } from '@guardian/cdk/lib/constructs/root';
-import { Duration } from 'aws-cdk-lib';
+import { RiffRaffYamlFile } from '@guardian/cdk/lib/riff-raff-yaml-file';
+import { App, Duration } from 'aws-cdk-lib';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import { ServiceCatalogue } from '../lib/service-catalogue';
 
-const app = new GuRoot();
+const app = new App();
+
+const stack = 'deploy';
+const region = 'eu-west-1';
 
 new ServiceCatalogue(app, 'ServiceCatalogue-PROD', {
-	stack: 'deploy',
+	stack,
 	stage: 'PROD',
-	env: { region: 'eu-west-1' },
+	env: { region },
 	cloudFormationStackName: 'deploy-PROD-service-catalogue',
 });
 
 new ServiceCatalogue(app, 'ServiceCatalogue-CODE', {
-	stack: 'deploy',
+	stack,
 	stage: 'CODE',
-	env: { region: 'eu-west-1' },
+	env: { region },
 	schedule: Schedule.rate(Duration.days(30)),
 	rdsDeletionProtection: false,
 	cloudFormationStackName: 'deploy-CODE-service-catalogue',
 });
+
+// --- Add an additional S3 deployment type and synth riff-raff.yml ---
+
+const riffRaff = new RiffRaffYamlFile(app);
+
+const deployments = riffRaff.riffRaffYaml.deployments;
+
+/**
+ * All cfn-based dependencies should be applied before this s3 deployment
+ */
+const dependencies = [...deployments.entries()]
+	.filter(([, { type }]) => type === 'cloud-formation')
+	.map(([key]) => key);
+
+deployments.set('service-catalogue-prisma-migrations', {
+	type: 'aws-s3',
+	contentDirectory: 'prisma',
+	app: 'prisma-migrate-task',
+	dependencies,
+	parameters: {
+		cacheControl: 'max-age=0',
+		publicReadAcl: false,
+	},
+	regions: new Set([region]),
+	stacks: new Set([stack]),
+});
+
+riffRaff.synth();

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -34,6 +34,14 @@ createZip() {
   )
 }
 
+createPrismaZip() {
+  echo "Creating zip of Prisma files"
+  (
+    cd "$ROOT_DIR/packages/common"  
+    zip -qr prisma.zip ./prisma
+  )
+}
+
 verifyMarkdown() {
   npm run generate -w best-practices
 
@@ -55,6 +63,7 @@ verifyMarkdown
 createZip "interactive-monitor"
 createZip "snyk-integrator"
 createZip "dependency-graph-integrator"
+createPrismaZip
 createLambdaWithPrisma "repocop"
 createLambdaWithPrisma "data-audit"
 createLambdaWithPrisma "github-actions-usage"


### PR DESCRIPTION
## What does this change?

This PR adds a new artifact to the RiffRaff deployment, which gets directly copied into the account dist bucket. To achieve this, a change is made to the Riff Raff file (synthed in the CDK, requiring a change to `bin/cdk.ts`).

The steps are:
1. The CI script produces an additional `prisma.zip` file containing the contents of the Prisma directory.
2. This is added as a content directory to Riff-Raff, so it gets synced to the Riff Raff artifacts bucket.
3. When a deploy is triggered, this `prisma.zip` file is copied from the RiffRaff artifacts bucket to account dist bucket.
  
Subsequent work will then focus on running a migration within a task, triggered by a `prisma.zip` being PUT into the bucket.

## Why?

This is the first PR for a series of steps that will allow us to run automated Prisma migrations every time we deploy the service-catalogue, preventing the need for manual connections to RDS from a laptop for this purpose.

## How has it been verified?

Testing by deploying to CODE and verifying that the prisma.zip file was successfully uploaded to the account dist bucket by RiffRaff.