### PR TITLE
Run service catalogue in Multi-AZ on prod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13801,11 +13801,6 @@
         "@types/got": "^9.6.12"
       }
     },
-    "packages/reservations-checker": {
-      "name": "reservation-checker",
-      "version": "1.0.0",
-      "extraneous": true
-    },
     "packages/snyk-integrator": {
       "version": "1.0.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11143,10 +11143,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/reservation-checker": {
-      "resolved": "packages/reservations-checker",
-      "link": true
-    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "dev": true,
@@ -13807,7 +13803,8 @@
     },
     "packages/reservations-checker": {
       "name": "reservation-checker",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "extraneous": true
     },
     "packages/snyk-integrator": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11143,6 +11143,10 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reservation-checker": {
+      "resolved": "packages/reservations-checker",
+      "link": true
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "dev": true,
@@ -13800,6 +13804,10 @@
         "@types/aws-lambda": "^8.10.136",
         "@types/got": "^9.6.12"
       }
+    },
+    "packages/reservations-checker": {
+      "name": "reservation-checker",
+      "version": "1.0.0"
     },
     "packages/snyk-integrator": {
       "version": "1.0.0",

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -13,6 +13,7 @@ new ServiceCatalogue(app, 'ServiceCatalogue-PROD', {
 	stack,
 	stage: 'PROD',
 	env: { region },
+	multiAz: true,
 	cloudFormationStackName: 'deploy-PROD-service-catalogue',
 });
 

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -14823,6 +14823,7 @@ spec:
             ],
           ],
         },
+        "MultiAZ": false,
         "Port": "5432",
         "PubliclyAccessible": false,
         "StorageEncrypted": true,

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -106,6 +106,10 @@ export class ServiceCatalogue extends GuStack {
 			securityGroups: [dbSecurityGroup],
 			deletionProtection: rdsDeletionProtection,
 			multiAz: multiAz,
+			/*
+			This certificate supports automatic rotation.
+			See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.RegionCertificateAuthorities
+			 */
 			caCertificate: CaCertificate.RDS_CA_RDS2048_G1,
 		};
 

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -58,6 +58,7 @@ interface ServiceCatalogueProps extends GuStackProps {
 	 * @default true
 	 */
 	rdsDeletionProtection?: boolean;
+	multiAz?: boolean;
 }
 
 export class ServiceCatalogue extends GuStack {
@@ -67,7 +68,7 @@ export class ServiceCatalogue extends GuStack {
 		const { stage, stack } = this;
 		const app = props.app ?? 'service-catalogue';
 
-		const { rdsDeletionProtection = true } = props;
+		const { rdsDeletionProtection = true, multiAz = false } = props;
 
 		const nonProdSchedule = props.schedule;
 
@@ -104,11 +105,7 @@ export class ServiceCatalogue extends GuStack {
 			storageEncrypted: true,
 			securityGroups: [dbSecurityGroup],
 			deletionProtection: rdsDeletionProtection,
-
-			/*
-			This certificate supports automatic rotation.
-			See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.RegionCertificateAuthorities
-			 */
+			multiAz: multiAz,
 			caCertificate: CaCertificate.RDS_CA_RDS2048_G1,
 		};
 


### PR DESCRIPTION
## What does this change?
Run the service catalogue db as a Multi-AZ on prod

## Why?
This is the standard approach for PROD and we saw we did not at the moment when doing the reservations. So we reserved a Multi-AZ db instance now.
