### PR TITLE
change ordering of information in vulnerability digests

### DIFF
--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -106,8 +106,8 @@ describe('createDigest', () => {
 Displaying the top 1 most urgent.
 Note: DevX only aggregates vulnerability information for repositories with a production topic.
 
-**leftpad** contains a [HIGH vulnerability](example.com).
-Introduced to [guardian/repo](https://github.com/guardian/repo) on Sun Jan 01 2023 via pip.
+[guardian/repo](https://github.com/guardian/repo) contains a [HIGH vulnerability](example.com).
+Introduced via **leftpad** on Sun Jan 01 2023, from pip.
 This vulnerability is patchable.`,
 		});
 	});

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -45,8 +45,8 @@ function createHumanReadableVulnMessage(vuln: RepocopVulnerability): string {
 	const ecosystem =
 		vuln.ecosystem === 'maven' ? 'sbt or maven' : vuln.ecosystem;
 
-	return String.raw`**${vuln.package}** contains a [${vuln.severity.toUpperCase()} vulnerability](${vuln.urls[0]}).
-Introduced to [${vuln.fullName}](https://github.com/${vuln.fullName}) on ${dateString} via ${ecosystem}.
+	return String.raw`[${vuln.fullName}](https://github.com/${vuln.fullName}) contains a [${vuln.severity.toUpperCase()} vulnerability](${vuln.urls[0]}).
+Introduced via **${vuln.package}** on ${dateString}, from ${ecosystem}.
 This vulnerability ${vuln.isPatchable ? 'is ' : 'may *not* be '}patchable.`;
 }
 


### PR DESCRIPTION
## What does this change?

Swaps package name and repo name

## Why?

Feedback has indicated that people would find it more useful to have the repo name first, then severity, then package name

## How has it been verified?

Unit tests have been updated to reflect the change
