### PR TITLE
Build an image to perform Prisma migrations

### DIFF
--- a/.github/workflows/prisma-migrate-image.yml
+++ b/.github/workflows/prisma-migrate-image.yml
@@ -1,0 +1,65 @@
+# Find full documentation here https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
+name: prisma-migrate image
+
+on:
+  pull_request:
+    paths:
+      - 'containers/prisma-migrate/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'containers/prisma-migrate/**'
+
+  # Manual invocation.
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/prisma-migrate
+
+# Ensure we only ever have one build running at a time.
+# If we push twice in quick succession, the first build will be stopped once the second starts.
+# This avoids any race conditions.
+concurrency:
+  group: ${{ github.ref }}/prisma-migrate
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,format=long
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./
+          file: containers/prisma-migrate/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/containers/prisma-migrate/Dockerfile
+++ b/containers/prisma-migrate/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:18-alpine
+
+WORKDIR /usr/src/app
+
+# Install the AWS CLI
+# This is used to fetch the prisma directory from S3
+RUN apk --no-cache add aws-cli
+
+# Install the Prisma NPM package
+# This will allow us to use the prisma migrate deploy command
+RUN npm init -y
+RUN npm install prisma
+
+COPY ./containers/prisma-migrate/run-prisma-migrate.sh ./run-prisma-migrate.sh
+RUN chmod +x ./run-prisma-migrate.sh
+
+# The default entrypoint for the node image is `node ...`
+# Switch it back here so we can run a .sh script
+ENTRYPOINT [ "sh" ]
+
+CMD ["./run-prisma-migrate.sh"]

--- a/containers/prisma-migrate/run-prisma-migrate.sh
+++ b/containers/prisma-migrate/run-prisma-migrate.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+echo 'Retrieving Prisma artifact from S3'
+aws s3 cp "s3://$ARTIFACT_BUCKET/$PRISMA_ARTIFACT_KEY" ./
+
+echo 'Unzipping Prisma artifact'
+unzip -q prisma.zip
+
+DB_PORT=5432
+export DATABASE_URL=postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/postgres
+
+echo 'Running prisma migrate deploy'
+node_modules/.bin/prisma migrate deploy


### PR DESCRIPTION
## What does this change?

This PR adds a `Dockerfile` (*) for building an image that can perform Prisma migrations. This image uses a `run-prisma-migrate.sh` script to fetch the Prisma directory from S3, which will be placed there by a successful deploy on Riff-Raff (see https://github.com/guardian/service-catalogue/pull/852), before performing the `prisma migrate deploy` command against the database specified by the environment variables set.

At the moment, each image gets pushed to GHCR tagged with the full commit sha, e.g.
```
ghcr.io/guardian/service-catalogue/prisma-migrate:sha-42771e43c3130daa7476d9e5b77455001533c557
```

This will be manually referenced within the CDK, when the task definition that uses this image is defined.

(*) Heavily inspired by the Steampipe CI step that used to be part of this repo.

## Why?

This image will be used by an ECS task that runs whenever new Prisma migrations are added to the deploy tools artifact bucket.

## How has it been verified?

Run the following two commands locally to verify the image can perform a migration as expected (for a suitable substitution of the environment variables below):

```
docker build -t prisma-migrate -f ./containers/prisma-migrate/Dockerfile .
docker run \
    --net=host \
    -e DB_USERNAME="..." \
    -e DB_PASSWORD="..." \
    -e DB_HOST="..." \
    -e AWS_ACCESS_KEY_ID="..." \
    -e AWS_SECRET_ACCESS_KEY="..." \
    -e AWS_REGION="..." \
    -e AWS_SESSION_TOKEN="..." \
    -e ARTIFACT_BUCKET="..." \
    -e PRISMA_ARTIFACT_KEY="..." \
    -t prisma-migrate
```
