### PR TITLE
clj/test automated prisma migrate

### DIFF
--- a/packages/common/prisma/migrations/20240326150235_add_simple_model_for_testing/migration.sql
+++ b/packages/common/prisma/migrations/20240326150235_add_simple_model_for_testing/migration.sql
@@ -1,0 +1,6 @@
+-- CreateTable
+CREATE TABLE "test_model" (
+    "id" TEXT NOT NULL,
+
+    CONSTRAINT "test_model_pkey" PRIMARY KEY ("id")
+);

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -642,6 +642,10 @@ model repocop_vulnerabilities {
   id               String   @id @default(uuid())
 }
 
+model test_model {
+  id String @id
+}
+
 view view_repo_ownership {
   github_team_id     BigInt
   github_team_name   String


### PR DESCRIPTION
- Add task definition for performing Prisma migrations
- Use SHA from latest prisma migrate image
- Restrict to just prisma key in artifact bucket
- Add a table to test Prisma migrate

## What does this change?

## Why?

## How has it been verified?
