### PR TITLE
Add Table Options to AWS Source to only ingest ACTIVE SecurityHub findings

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -742,7 +742,11 @@ spec:
         role_arn: arn:aws:iam::000000000015:role/cloudquery-access
     table_options:
       aws_securityhub_findings:
-        record_state: ACTIVE
+        get_findings:
+          - filters:
+              record_state:
+                - comparison: EQUALS
+                  value: ACTIVE
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -740,6 +740,9 @@ spec:
     accounts:
       - id: cq-for-000000000015
         role_arn: arn:aws:iam::000000000015:role/cloudquery-access
+    table_options:
+      aws_securityhub_findings:
+        record_state: ACTIVE
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -128,6 +128,50 @@ spec:
 `);
 	});
 
+	it('Should create an AWS source configuration for a single account with table options', () => {
+		const config = awsSourceConfigForAccount(
+			GuardianAwsAccounts.Security,
+			{
+				tables: ['aws_securityhub_findings'],
+			},
+			{
+				table_options: {
+					securityhub_findings: {
+						record_state: 'ACTIVE',
+					},
+				},
+			},
+		);
+		console.log(dump(config));
+		expect(dump(config)).toMatchInlineSnapshot(`
+"kind: source
+spec:
+  name: aws
+  path: cloudquery/aws
+  version: v23.6.1
+  tables:
+    - aws_securityhub_findings
+  destinations:
+    - postgresql
+  spec:
+    regions:
+      - eu-west-1
+      - eu-west-2
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - ap-southeast-2
+      - ca-central-1
+    accounts:
+      - id: cq-for-000000000015
+        role_arn: arn:aws:iam::000000000015:role/cloudquery-access
+    table_options:
+      securityhub_findings:
+        record_state: ACTIVE
+"
+`);
+	});
+
 	it('Should create a GitHub source configuration', () => {
 		const config = githubSourceConfig({ tables: ['github_repositories'] });
 		expect(dump(config)).toMatchInlineSnapshot(`

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -65,11 +65,6 @@ export function awsSourceConfig(
 				concurrency,
 				regions: AWS_REGIONS,
 				...extraConfig,
-				table_options: {
-					securityhub_findings: {
-						record_state: 'ACTIVE',
-					},
-				},
 			},
 		},
 	};
@@ -106,6 +101,7 @@ export function awsSourceConfigForOrganisation(
 export function awsSourceConfigForAccount(
 	accountNumber: string,
 	tableConfig: CloudqueryTableConfig,
+	extraConfig: Record<string, unknown> = {},
 ): CloudqueryConfig {
 	return awsSourceConfig(tableConfig, {
 		accounts: [
@@ -114,6 +110,7 @@ export function awsSourceConfigForAccount(
 				role_arn: `arn:aws:iam::${accountNumber}:role/cloudquery-access`,
 			},
 		],
+		...extraConfig,
 	});
 }
 

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -65,6 +65,11 @@ export function awsSourceConfig(
 				concurrency,
 				regions: AWS_REGIONS,
 				...extraConfig,
+				table_options: {
+					securityhub_findings: {
+						record_state: 'ACTIVE',
+					},
+				},
 			},
 		},
 	};

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -102,7 +102,18 @@ export function addCloudqueryEcsCluster(
 				{
 					table_options: {
 						aws_securityhub_findings: {
-							record_state: 'ACTIVE',
+							get_findings: [
+								{
+									filters: {
+										record_state: [
+											{
+												comparison: 'EQUALS',
+												value: 'ACTIVE',
+											},
+										],
+									},
+								},
+							],
 						},
 					},
 				},

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -93,10 +93,20 @@ export function addCloudqueryEcsCluster(
 			description:
 				'Organisation wide security data, from access analyzer and security hub. Uses include identifying lambdas using deprecated runtimes.',
 			schedule: nonProdSchedule ?? Schedule.cron({ minute: '0', hour: '22' }),
-			config: awsSourceConfigForAccount(GuardianAwsAccounts.Security, {
-				tables: ['aws_accessanalyzer_*', 'aws_securityhub_*'],
-				concurrency: 2000,
-			}),
+			config: awsSourceConfigForAccount(
+				GuardianAwsAccounts.Security,
+				{
+					tables: ['aws_accessanalyzer_*', 'aws_securityhub_*'],
+					concurrency: 2000,
+				},
+				{
+					table_options: {
+						aws_securityhub_findings: {
+							record_state: 'ACTIVE',
+						},
+					},
+				},
+			),
 			policies: [cloudqueryAccess(GuardianAwsAccounts.Security)],
 			memoryLimitMiB: 2048,
 			cpu: 1024,

--- a/packages/dev-environment/dev-config/cloudquery.yaml
+++ b/packages/dev-environment/dev-config/cloudquery.yaml
@@ -19,7 +19,11 @@ spec:
         local_profile: 'deployTools'
     table_options:
       aws_securityhub_findings:
-        record_state: 'ACTIVE'
+        get_findings:
+          - filters:
+              record_state: 
+                - comparison: 'EQUALS'
+                  value: 'ACTIVE'
 ---
 kind: destination
 spec:

--- a/packages/dev-environment/dev-config/cloudquery.yaml
+++ b/packages/dev-environment/dev-config/cloudquery.yaml
@@ -6,6 +6,7 @@ spec:
   destinations: ['postgresql']
   tables:
     - aws_lambda_functions
+    - aws_securityhub_findings
     - aws_s3_buckets
     - aws_ec2_images
   skip_dependent_tables: true
@@ -16,6 +17,9 @@ spec:
     accounts:
       - id: 'deployTools'
         local_profile: 'deployTools'
+    table_options:
+      aws_securityhub_findings:
+        record_state: 'ACTIVE'
 ---
 kind: destination
 spec:


### PR DESCRIPTION
## What does this change?

This change adds table_options to the AWS source to ingest only the records which are ACTIVE. 

## Why?

Right now aws_securityhub_findings has 51000 active records and 914000 archived records. This is extremely slow to query, taking about 19.5 seconds. This number is also unlikely to decrease over time. The 914050 archived records (representing a little under 95% of entries aren't particularly interesting, as there will be a more up to date ACTIVE record, if the resource(s) in question still exist.

## Cost saving estimates
This table runs once a day. Ignoring the free rows quota, using the price of $15 per million rows, and the row counts stated above, this change will save us  about $14 a day, which over the course of a month, represents a saving of over $400 a month, or 27.5 million rows ($5000 over the course of a year).

NB these numbers only apply to `PROD`, but we expect to see similar results on a smaller scale across `DEV` and `CODE` environments
Its possible there are other tables where similar efficiency savings can be made.

## How has this been verified

CODE row count before: 968,157
CODE row count after: 51,732 (95% reduction)

Time to query before: 19.5 seconds
Time to query after: 2.5 seconds

Co-authored-by: @akash1810 @louishather @NovemberTang 