### PR TITLE
copy github data directly from DB

### DIFF
--- a/packages/dev-environment/dev-config/cloudquery.yaml
+++ b/packages/dev-environment/dev-config/cloudquery.yaml
@@ -1,53 +1,3 @@
----
-kind: source
-spec:
-  # Source spec section
-  name: 'github'
-  path: 'cloudquery/github'
-  version: v${CQ_GITHUB}
-  skip_dependent_tables: true
-  tables:
-    - github_repositories
-    - github_repository_branches
-    - github_workflows
-  destinations: ['postgresql']
-  spec:
-    app_auth:
-      - org: guardian
-        private_key_path: /private-key.pem
-        app_id: '${file:/app-id}'
-        installation_id: '${file:/installation-id}'
-    repos: [
-        # example devX owned repos
-        'guardian/cdk',
-        'guardian/service-catalogue',
-
-        # example non-devX repo
-        'guardian/dotcom-rendering',
-
-        # example private repo
-        'guardian/tracker',
-      ]
----
-kind: source
-spec:
-  name: 'github-teams'
-  path: 'cloudquery/github'
-  version: v${CQ_GITHUB}
-  skip_dependent_tables: true
-  tables:
-    - github_teams
-    - github_team_repositories
-  destinations: ['postgresql']
-  spec:
-    app_auth:
-      - org: guardian
-        private_key_path: /private-key.pem
-        app_id: '${file:/app-id}'
-        installation_id: '${file:/installation-id}'
-    orgs:
-      - guardian
----
 kind: source
 spec:
   name: 'aws'
@@ -71,16 +21,6 @@ spec:
     accounts:
       - id: 'deployTools'
         local_profile: 'deployTools'
----
-kind: source
-spec:
-  name: 'github-languages'
-  # https://github.com/guardian/cq-source-github-languages
-  path: 'guardian/github-languages'
-  registry: 'github'
-  version: v0.0.4
-  tables: ['*']
-  destinations: ['postgresql']
 ---
 kind: destination
 spec:

--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -49,10 +49,10 @@ copy(){
     step "Copying $1 data to local database"
     PGPASSWORD=${CODE_DB_PASSWORD} pg_dump \
     -U postgres -h "${CODE_HOST}" -p 5432 -d "${DATABASE_NAME}" -t "$1*" -f "$1.sql" \
-    --no-owner --no-privileges --verbose --inserts
+    --no-owner --no-privileges --inserts
 
     PGPASSWORD=${DATABASE_PASSWORD}  psql \
-    -U postgres -h "${DATABASE_HOSTNAME}" -p 5432 -d "${DATABASE_NAME}" -f "$1.sql"
+    -U postgres -h "${DATABASE_HOSTNAME}" -p 5432 -d "${DATABASE_NAME}" -f "$1.sql" -q
     rm "$1.sql"
 }
 
@@ -83,6 +83,9 @@ source "$MAIN_ENV_FILE"
 
 copy "snyk"
 copy "galaxies"
-
+copy "github_team"
+copy "github_repo"
+copy "github_workflows"
+copy "github_languages"
 unset CODE_DB_PASSWORD
 unset CODE_HOST


### PR DESCRIPTION
## What does this change?

Copy github data directly from the cloudquery DB.
The copy function uses wildcarding, meaning we're collecting a couple more tables than we were before, but only about 5 or 6. Until we're more specific about which tables we want, we should be careful when introspecting the database.

For now, the only data we are not gathering is AWS data. These tables tend to me much larger, and theres like 600 of them. This means we need to be really careful about what data we pull, and the wildcarding approach used so far might be a bit too greedy, and will be refined in the next PR

## Why?

- Save money on CQ rows
- Faster startup times

## How has it been verified?

Tables show up in DEV environment
