### PR TITLE
Sync some AWS tables using pg_dump

### DIFF
--- a/packages/dev-environment/dev-config/cloudquery.yaml
+++ b/packages/dev-environment/dev-config/cloudquery.yaml
@@ -7,10 +7,6 @@ spec:
   tables:
     - aws_lambda_functions
     - aws_s3_buckets
-    - aws_cloudformation_stacks
-    - aws_organizations_accounts
-    - aws_organizations_account_parents
-    - aws_organizations_organizational_units
     - aws_ec2_instances
     - aws_ec2_images
   skip_dependent_tables: true

--- a/packages/dev-environment/dev-config/cloudquery.yaml
+++ b/packages/dev-environment/dev-config/cloudquery.yaml
@@ -7,7 +7,6 @@ spec:
   tables:
     - aws_lambda_functions
     - aws_s3_buckets
-    - aws_ec2_instances
     - aws_ec2_images
   skip_dependent_tables: true
   spec:

--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -107,8 +107,6 @@ fi
 
 step "Baselining DB"
 echo -e "${yellow}Please note that this will drop all tables in the local database${clear}"
-echo "Waiting 10 seconds before proceeding..." # Give the user a chance to cancel.
-sleep 10
 npm -w cli start migrate -- --stage DEV --confirm
 
 step "Copying data from CODE DB to local DB"

--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -81,6 +81,9 @@ get_db_password
 
 source "$MAIN_ENV_FILE"
 
+step "Baselining DB"
+npm -w cli start migrate -- --stage DEV --confirm
+
 copy "snyk"
 copy "galaxies"
 copy "github_team"

--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -9,10 +9,20 @@ MAIN_ENV_FILE=$ROOT_DIR/.env
 LOCAL_ENV_FILE=$HOME/.gu/service_catalogue/.env.local
 clear='\033[0m'
 cyan='\033[0;36m'
+yellow="\033[1;33m"
 
 step(){
   ((STEP_COUNT++))
   echo -e "\n${cyan}Step ${STEP_COUNT}${clear}: $1"
+}
+
+install_brew_formula() {
+    if ! brew list "$1" &>/dev/null; then
+        step "Installing $1"
+        brew install "$1"
+    else
+        echo "$1 is already installed"
+    fi
 }
 
 add_to_path ()
@@ -27,12 +37,12 @@ add_to_path ()
 
 setup_libpq() {
     step "Setting up libpq"
-    brew install libpq
+    install_brew_formula "libpq"
     add_to_path "/opt/homebrew/opt/libpq/bin"
 }
 
 get_db_password() {
-    step "Getting DB password"
+    step "Getting DB credentials"
     SECRET_NAME=$(aws secretsmanager list-secrets \
     --profile deployTools --region eu-west-1 \
     --filters Key=tag-value,Values=CODE  | jq '.SecretList[].Name' | grep Postgres | tr -d '"')
@@ -45,15 +55,30 @@ get_db_password() {
     unset SECRET_NAME
 }
 
-copy(){
-    step "Copying $1 data to local database"
+insert_into_db() {
+      PGPASSWORD=${DATABASE_PASSWORD}  psql \
+    -U postgres -h "${DATABASE_HOSTNAME}" -p 5432 -d "${DATABASE_NAME}" -f "$1.sql" -q
+    rm "$1.sql"
+
+    echo "Transfer of $1 data complete ✅"
+}
+
+wildcard_copy(){
+    echo "Copying tables prefixed with $1 to local database"
     PGPASSWORD=${CODE_DB_PASSWORD} pg_dump \
     -U postgres -h "${CODE_HOST}" -p 5432 -d "${DATABASE_NAME}" -t "$1*" -f "$1.sql" \
     --no-owner --no-privileges --inserts
 
-    PGPASSWORD=${DATABASE_PASSWORD}  psql \
-    -U postgres -h "${DATABASE_HOSTNAME}" -p 5432 -d "${DATABASE_NAME}" -f "$1.sql" -q
-    rm "$1.sql"
+    insert_into_db "$1"
+}
+
+copy(){
+    echo "Copying table $1 to local database"
+    PGPASSWORD=${CODE_DB_PASSWORD} pg_dump \
+    -U postgres -h "${CODE_HOST}" -p 5432 -d "${DATABASE_NAME}" -t "$1" -f "$1.sql" \
+    --no-owner --no-privileges --inserts
+
+    insert_into_db "$1"
 }
 
 step "Checking AWS credentials"
@@ -68,6 +93,10 @@ else
   echo "AWS credentials are valid"
 fi
 
+setup_libpq
+get_db_password
+source "$MAIN_ENV_FILE"
+
 step "Launching Docker containers"
 if (docker info) 2>&1 >/dev/null; then
   docker-compose -f "${DIR}/../docker-compose.yaml" --env-file "$MAIN_ENV_FILE" --env-file "$LOCAL_ENV_FILE" up -d
@@ -76,19 +105,27 @@ else
   exit 1
 fi
 
-setup_libpq
-get_db_password
-
-source "$MAIN_ENV_FILE"
-
 step "Baselining DB"
+echo -e "${yellow}Please note that this will drop all tables in the local database${clear}"
+echo "Waiting 10 seconds before proceeding..." # Give the user a chance to cancel.
+sleep 10
 npm -w cli start migrate -- --stage DEV --confirm
 
-copy "snyk"
-copy "galaxies"
-copy "github_team"
-copy "github_repo"
-copy "github_workflows"
-copy "github_languages"
+step "Copying data from CODE DB to local DB"
+wildcard_copy "snyk" & \
+wildcard_copy "galaxies" & \
+wildcard_copy "github_team" & \
+wildcard_copy "github_repo" & \
+copy "github_workflows" & \
+copy "github_languages" & \
+copy "aws_cloudformation_stacks" & \
+copy "aws_organizations_accounts" & \
+copy "aws_organizations_account_parents" & \
+copy "aws_organizations_organizational_units" & \
+copy "aws_ec2_instances"
+
+wait
+
+step "Cleaning up"
 unset CODE_DB_PASSWORD
 unset CODE_HOST

--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -16,15 +16,6 @@ step(){
   echo -e "\n${cyan}Step ${STEP_COUNT}${clear}: $1"
 }
 
-install_brew_formula() {
-    if ! brew list "$1" &>/dev/null; then
-        step "Installing $1"
-        brew install "$1"
-    else
-        echo "$1 is already installed"
-    fi
-}
-
 step "Setting up libpq"
 if ! brew list "libpq" &>/dev/null; then
     brew install "libpq"
@@ -84,7 +75,6 @@ else
   echo "AWS credentials are valid"
 fi
 
-setup_libpq
 get_db_password
 source "$MAIN_ENV_FILE"
 

--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -25,21 +25,12 @@ install_brew_formula() {
     fi
 }
 
-add_to_path ()
-{
-    if [[ "$PATH" =~ (^|:)"${1}"(:|$) ]]
-    then
-        echo "Path already contains ${1}"
-        return 0
-    fi
-    export PATH=${1}:$PATH
-}
-
-setup_libpq() {
-    step "Setting up libpq"
-    install_brew_formula "libpq"
-    add_to_path "/opt/homebrew/opt/libpq/bin"
-}
+step "Setting up libpq"
+if ! brew list "libpq" &>/dev/null; then
+    brew install "libpq"
+else
+    echo "libpq is already installed"
+fi
 
 get_db_password() {
     step "Getting DB credentials"


### PR DESCRIPTION
### Note
This PR is more easily digestible in [split mode](https://github.com/guardian/service-catalogue/pull/876/files?diff=split&w=1)

## What does this change?

- Check for the `libpq` package before attempting to install it. Less noisy output, quicker execution if `libpq` is already installed
- Split up `copy` into two methods. One for wildcarding, one for pulling single tables. Better performance.
- Perform db migration before copying data over, so views show up from the beginning. Improves QOL - there is no need to pull data twice.
- Parallelise `copy` operations. Improves setup performance
- Copy some AWS tables over via `copy`. Much faster than waiting for cloudquery, grabs data from multiple accounts, no sync fees.

This script runs in about a minute: `npm run start -w dev-environment  7.59s user 5.29s system 21% cpu 1:00.08 total`

It pulls all the data required for repocop to run without needing to wait to collect the remaining CQ tables. I'm not sure what we're using them for, but I've left them in for now.

## What does this not change

Some amazon tables have been left for the cloudquery container to collect. This is because they throw errors when we try to transfer the data from the database directly. More investigation is required to work out the root cause, but this shouldn't stop us from moving forward with the ones that work, as this PR still provides a significant performance benefit compared to before. 


## How has it been verified?

- Ran locally, verified the tables look how we expect.
- Ran repocop locally, produced expected (though much richer) output