### PR TITLE
Stop hand-rolling RepocopVulnerability type

### DIFF
--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -569,14 +569,14 @@ const oldCriticalDependabotVuln: RepocopVulnerability = {
 	package: 'ansible',
 	urls: [],
 	ecosystem: 'pip',
-	alert_issue_date: '2021-01-01T00:00:00.000Z',
+	alert_issue_date: new Date('2021-01-01T00:00:00.000Z'),
 	is_patchable: true,
 	cves: ['CVE-2021-1234'],
 };
 
 const newCriticalDependabotVuln: RepocopVulnerability = {
 	...oldCriticalDependabotVuln,
-	alert_issue_date: new Date().toISOString(),
+	alert_issue_date: new Date(),
 };
 
 const oldHighDependabotVuln: RepocopVulnerability = {
@@ -586,7 +586,7 @@ const oldHighDependabotVuln: RepocopVulnerability = {
 
 const newHighDependabotVuln: RepocopVulnerability = {
 	...oldHighDependabotVuln,
-	alert_issue_date: new Date().toISOString(),
+	alert_issue_date: new Date(),
 };
 
 describe('NO RULE - Dependabot alerts', () => {
@@ -612,7 +612,7 @@ describe('NO RULE - Dependabot alerts', () => {
 
 		const thirteenDayOldHigh: RepocopVulnerability = {
 			...oldHighDependabotVuln,
-			alert_issue_date: thirteenDaysAgo.toISOString(),
+			alert_issue_date: thirteenDaysAgo,
 		};
 
 		expect(hasOldAlerts([thirteenDayOldHigh], thePerfectRepo)).toBe(false);
@@ -636,7 +636,7 @@ const snykIssue: SnykIssue = {
 				discovered_at: '', //or Date?
 			},
 		],
-		created_at: 'someTZdate', //or Date?
+		created_at: '2020-01-01', //or Date?
 		updated_at: '', //or Date?
 		coordinates: [
 			{
@@ -864,7 +864,7 @@ describe('NO RULE - Vulnerabilities from Dependabot', () => {
 				'http://www.securitytracker.com/id/1040422',
 			],
 			ecosystem: 'pip',
-			alert_issue_date: '2022-06-15T07:43:03Z',
+			alert_issue_date: new Date('2022-06-15T07:43:03Z'),
 			is_patchable: true,
 			cves: ['CVE-2018-6188'],
 		};
@@ -881,7 +881,7 @@ describe('NO RULE - Vulnerabilities from Dependabot', () => {
 				'https://bugzilla.redhat.com/show_bug.cgi?id=1916813',
 			],
 			ecosystem: 'pip',
-			alert_issue_date: '2022-06-14T15:21:52Z',
+			alert_issue_date: new Date('2022-06-14T15:21:52Z'),
 			is_patchable: true,
 			cves: ['CVE-2021-20191'],
 		};
@@ -907,7 +907,7 @@ describe('NO RULE - Vulnerabilities from Snyk', () => {
 			package: 'fetch',
 			urls: ['example.com'],
 			ecosystem: 'npm',
-			alert_issue_date: 'someTZdate',
+			alert_issue_date: new Date('2020-01-01'),
 			is_patchable: true,
 			cves: ['CVE-1234'],
 		});
@@ -932,7 +932,7 @@ describe('Deduplication of repocop vulnerabilities', () => {
 		package: 'django',
 		urls: ['https://nvd.nist.gov/vuln/detail/CVE-2018-6188'],
 		ecosystem: 'pip',
-		alert_issue_date: '2022-06-15T07:43:03Z',
+		alert_issue_date: new Date('2022-06-15T07:43:03Z'),
 		is_patchable: true,
 		cves: ['CVE-2018-6188'],
 	};
@@ -944,7 +944,7 @@ describe('Deduplication of repocop vulnerabilities', () => {
 		package: 'django',
 		urls: ['https://nvd.nist.gov/vuln/detail/CVE-2018-6188'],
 		ecosystem: 'pip',
-		alert_issue_date: '2022-06-15T07:43:03Z',
+		alert_issue_date: new Date('2022-06-15T07:43:03Z'),
 		is_patchable: true,
 		cves: ['CVE-2018-6188'],
 	};

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -457,7 +457,7 @@ export function dependabotAlertToRepocopVulnerability(
 		package: alert.security_vulnerability.package.name,
 		urls: alert.security_advisory.references.map((ref) => ref.url),
 		ecosystem: alert.security_vulnerability.package.ecosystem,
-		alert_issue_date: alert.created_at,
+		alert_issue_date: new Date(alert.created_at),
 		is_patchable: !!alert.security_vulnerability.first_patched_version,
 		cves: CVEs,
 	};
@@ -493,7 +493,7 @@ export function snykAlertToRepocopVulnerability(
 		package: packageName,
 		urls: issue.attributes.problems.map((p) => p.url).filter((u) => !!u),
 		ecosystem: ecosystem ?? 'unknown ecosystem',
-		alert_issue_date: issue.attributes.created_at,
+		alert_issue_date: new Date(issue.attributes.created_at),
 		is_patchable: isPatchable,
 		cves: issue.attributes.problems.map((p) => p.id),
 	};

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -89,7 +89,7 @@ describe('createDigest', () => {
 			package: 'leftpad',
 			urls: ['example.com'],
 			ecosystem: 'pip',
-			alert_issue_date: '2023-01-01',
+			alert_issue_date: date,
 			is_patchable: true,
 			cves: ['CVE-123'],
 		};
@@ -107,7 +107,7 @@ Displaying the top 1 most urgent.
 Note: DevX only aggregates vulnerability information for repositories with a production topic.
 
 [guardian/repo](https://github.com/guardian/repo) contains a [HIGH vulnerability](example.com).
-Introduced via **leftpad** on Sun Jan 01 2023, from pip.
+Introduced via **leftpad** on Fri Jan 01 2021, from pip.
 This vulnerability is patchable.`,
 		});
 	});
@@ -121,7 +121,7 @@ This vulnerability is patchable.`,
 			package: 'jackson',
 			urls: ['example.com'],
 			ecosystem: 'maven',
-			alert_issue_date: '',
+			alert_issue_date: date,
 			is_patchable: true,
 			cves: ['CVE-123'],
 		};
@@ -143,7 +143,7 @@ This vulnerability is patchable.`,
 			package: 'leftpad',
 			urls: ['example.com'],
 			ecosystem: 'pip',
-			alert_issue_date: '',
+			alert_issue_date: date,
 			is_patchable: true,
 			cves: ['CVE-123'],
 		};
@@ -159,7 +159,7 @@ This vulnerability is patchable.`,
 			package: 'rightpad',
 			urls: ['example.com'],
 			ecosystem: 'pip',
-			alert_issue_date: '',
+			alert_issue_date: date,
 			is_patchable: true,
 			cves: ['CVE-123'],
 		};

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -35,13 +35,8 @@ export function getTopVulns(vulnerabilities: RepocopVulnerability[]) {
 		.sort((v1, v2) => v1.full_name.localeCompare(v2.full_name));
 }
 
-function dateStringToHumanReadable(dateString: string) {
-	const date = new Date(dateString);
-	return date.toDateString();
-}
-
 function createHumanReadableVulnMessage(vuln: RepocopVulnerability): string {
-	const dateString = dateStringToHumanReadable(vuln.alert_issue_date);
+	const dateString = new Date(vuln.alert_issue_date).toDateString();
 	const ecosystem =
 		vuln.ecosystem === 'maven' ? 'sbt or maven' : vuln.ecosystem;
 

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -4,6 +4,7 @@ import type {
 	github_repositories,
 	github_teams,
 	repocop_github_repository_rules,
+	repocop_vulnerabilities,
 } from '@prisma/client';
 
 export type NonEmptyArray<T> = [T, ...T[]];
@@ -161,18 +162,10 @@ export interface SnykProject {
 
 export type Severity = 'critical' | 'high' | 'medium' | 'low' | 'unknown';
 
-export type RepocopVulnerability = {
-	source: 'Dependabot' | 'Snyk';
-	full_name: string;
-	open: boolean;
-	severity: Severity;
-	package: string;
-	urls: string[];
-	ecosystem: string;
-	alert_issue_date: string;
-	is_patchable: boolean;
-	cves: string[];
-};
+export type RepocopVulnerability = Omit<
+	repocop_vulnerabilities,
+	'id' | 'repo_owner'
+>;
 
 export interface EvaluationResult {
 	fullName: string;

--- a/packages/repocop/src/utils.test.ts
+++ b/packages/repocop/src/utils.test.ts
@@ -65,7 +65,7 @@ describe('vulnSortingPredicate', () => {
 			urls: [],
 			open: true,
 			source: 'Dependabot',
-			alert_issue_date: '',
+			alert_issue_date: new Date(),
 			cves: [],
 		};
 		const criticalNotPatchable: RepocopVulnerability = {


### PR DESCRIPTION
## What does this change?

Remove the need to hand-roll a `RepocopVulnerability` type. Derive one from the `repocop_vulnerabilities` interface provided by prisma

## Why?

Maintainability. This is part of a larger piece of work to simplify vulnerability calculations in repocop

## How has it been verified?

All unit tests still pass, local execution of repocop produces the same output as CODE
