### PR TITLE
pull all dependabot vulnerabilities up front

### DIFF
--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -150,6 +150,8 @@ async function getAlertsForRepo(
 			`Dependabot - ${name}: Could not get alerts. Dependabot may not be enabled.`,
 		);
 		console.debug(error);
+		// Return undefined if dependabot is not enabled, to distinguish from
+		// the scenario where it is enabled, but there are no alerts
 		return undefined;
 	}
 }

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -165,11 +165,9 @@ export async function getDependabotVulnerabilities(
 			repos.map(async (repo) => {
 				const alerts = await getAlertsForRepo(octokit, repo.name);
 				if (alerts) {
-					return alerts
-						.filter((a) => a.state === 'open')
-						.map((a) =>
-							dependabotAlertToRepocopVulnerability(repo.full_name, a),
-						);
+					return alerts.map((a) =>
+						dependabotAlertToRepocopVulnerability(repo.full_name, a),
+					);
 				}
 				return [];
 			}),

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -4,9 +4,14 @@ import type {
 	PrismaClient,
 	view_repo_ownership,
 } from '@prisma/client';
+import type { Octokit } from 'octokit';
+import { dependabotAlertToRepocopVulnerability } from './evaluation/repository';
 import type {
+	Alert,
 	AwsCloudFormationStack,
+	DependabotVulnResponse,
 	NonEmptyArray,
+	RepocopVulnerability,
 	Repository,
 	SnykIssue,
 	SnykProject,
@@ -112,4 +117,66 @@ export async function getRepositoryLanguages(
 	client: PrismaClient,
 ): Promise<NonEmptyArray<github_languages>> {
 	return toNonEmptyArray(await client.github_languages.findMany({}));
+}
+
+//Octokit Queries
+
+async function getAlertsForRepo(
+	octokit: Octokit,
+	name: string,
+): Promise<Alert[] | undefined> {
+	if (name.startsWith('guardian/')) {
+		name = name.replace('guardian/', '');
+	}
+
+	try {
+		const alert: DependabotVulnResponse =
+			await octokit.rest.dependabot.listAlertsForRepo({
+				owner: 'guardian',
+				repo: name,
+				per_page: 100,
+				severity: 'critical,high',
+				state: 'open',
+				sort: 'created',
+				direction: 'asc', //retrieve oldest vulnerabilities first
+			});
+
+		const openRuntimeDependencies = alert.data.filter(
+			(a) => a.dependency.scope !== 'development',
+		);
+		return openRuntimeDependencies;
+	} catch (error) {
+		console.debug(
+			`Dependabot - ${name}: Could not get alerts. Dependabot may not be enabled.`,
+		);
+		console.debug(error);
+		return undefined;
+	}
+}
+
+export async function getDependabotVulnerabilities(
+	repos: Repository[],
+	octokit: Octokit,
+) {
+	const dependabotVulnerabilities: RepocopVulnerability[] = (
+		await Promise.all(
+			repos.map(async (repo) => {
+				const alerts = await getAlertsForRepo(octokit, repo.name);
+				if (alerts) {
+					return alerts
+						.filter((a) => a.state === 'open')
+						.map((a) =>
+							dependabotAlertToRepocopVulnerability(repo.full_name, a),
+						);
+				}
+				return [];
+			}),
+		)
+	).flat();
+
+	console.log(
+		`Found ${dependabotVulnerabilities.length} dependabot vulnerabilities across ${repos.length} repos`,
+	);
+
+	return dependabotVulnerabilities;
 }


### PR DESCRIPTION
## What does this change?

Pull dependabot alerts for production repos up front.

## Why?

This brings data loading behaviour for dependabot in line with the rest of repocop. We've generally preferred loading all our data up front, and failing fast if there are any issues. This also pushes `await` statements to the edge of the lambda, making repocop more testable overall.

The function to pull dependabot alerts has been moved to `query.ts`, as to an outside observer, it's behaviour isn't really that different to if we were pulling this information from the CloudQuery database.

## How has it been verified?

Repocop runs as expected. The number of vulnerabilites detected has remained constant.
