### PR TITLE
allow snyk integrator to support kotlin and ruby

### DIFF
--- a/packages/snyk-integrator/src/snyk-integrator.test.ts
+++ b/packages/snyk-integrator/src/snyk-integrator.test.ts
@@ -50,7 +50,6 @@ describe('A generated PR', () => {
 			'Scala',
 			'TypeScript',
 			'Rust', //unsupported by the action
-			'Kotlin', //unsupported by the action
 			'Go',
 		])[0];
 

--- a/packages/snyk-integrator/src/snyk-integrator.test.ts
+++ b/packages/snyk-integrator/src/snyk-integrator.test.ts
@@ -58,7 +58,7 @@ describe('A generated PR', () => {
 		);
 	});
 	it('should throw if no supported languages are provided', () => {
-		expect(() => generateServiceCataloguePr(['Rust', 'Kotlin'])).toThrow();
+		expect(() => generateServiceCataloguePr(['Rust'])).toThrow();
 		expect(() => generateServiceCataloguePr([])).toThrow();
 	});
 });

--- a/packages/snyk-integrator/src/snyk-integrator.ts
+++ b/packages/snyk-integrator/src/snyk-integrator.ts
@@ -136,6 +136,8 @@ export function generatePr(
 		'TypeScript',
 		'JavaScript',
 		'Python',
+		'Kotlin',
+		'Ruby',
 		'Go',
 	];
 


### PR DESCRIPTION
## What does this change?

Allows PRs to be raised for repos that contain Kotlin or Ruby

## Why?

Our action supports these languages
