### PR TITLE
Move to Arm64 lambdas 

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -14161,6 +14161,9 @@ spec:
         "DataAuditRoleB3B90C40",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "DistributionBucketName",
@@ -14457,6 +14460,9 @@ spec:
         "GithubActionsUsageServiceRole782ABC41",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "DistributionBucketName",
@@ -15218,6 +15224,9 @@ spec:
         "dependencygraphintegratorServiceRole5200A556",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "DistributionBucketName",
@@ -15740,6 +15749,9 @@ spec:
         "interactivemonitorServiceRoleC210EED3",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "DistributionBucketName",
@@ -16700,6 +16712,9 @@ spec:
         "repocopServiceRole757D74E8",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "DistributionBucketName",
@@ -20120,6 +20135,9 @@ spec:
         "snykintegratorServiceRole8B7567EF",
       ],
       "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
         "Code": {
           "S3Bucket": {
             "Ref": "DistributionBucketName",

--- a/packages/cdk/lib/data-audit.ts
+++ b/packages/cdk/lib/data-audit.ts
@@ -5,7 +5,7 @@ import { Duration, Tags } from 'aws-cdk-lib';
 import type { IVpc } from 'aws-cdk-lib/aws-ec2';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
 import { cloudqueryAccess, listOrgsPolicy } from './cloudquery/policies';
 
@@ -61,6 +61,7 @@ export function addDataAuditLambda(scope: GuStack, props: DataAuditProps) {
 		role,
 		app,
 		vpc,
+		architecture: Architecture.ARM_64,
 		securityGroups: [dbAccess],
 		fileName: `${app}.zip`,
 		handler: 'index.main',

--- a/packages/cdk/lib/github-actions-usage.ts
+++ b/packages/cdk/lib/github-actions-usage.ts
@@ -6,7 +6,7 @@ import type { IVpc } from 'aws-cdk-lib/aws-ec2';
 import { ScheduledFargateTask } from 'aws-cdk-lib/aws-ecs-patterns';
 import { Rule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
 
 interface GithubActionsUsageProps {
@@ -26,6 +26,7 @@ export function addGithubActionsUsageLambda(
 	const lambda = new GuLambdaFunction(scope, 'GithubActionsUsage', {
 		app,
 		vpc,
+		architecture: Architecture.ARM_64,
 		securityGroups: [dbAccess],
 		fileName: `${app}.zip`,
 		handler: 'index.main',

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -1,7 +1,7 @@
 import { type GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { LambdaSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
@@ -22,6 +22,7 @@ export class InteractiveMonitor {
 
 		const lambda = new GuLambdaFunction(guStack, service, {
 			app: service,
+			architecture: Architecture.ARM_64,
 			fileName: `${service}.zip`,
 			handler: 'index.handler',
 			runtime: Runtime.NODEJS_20_X,

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -9,7 +9,7 @@ import { Duration } from 'aws-cdk-lib';
 import type { IVpc, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import type { Schedule } from 'aws-cdk-lib/aws-events';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { Topic } from 'aws-cdk-lib/aws-sns';
@@ -48,6 +48,7 @@ export class Repocop {
 
 		const repocopLampdaProps: GuScheduledLambdaProps = {
 			app: 'repocop',
+			architecture: Architecture.ARM_64,
 			fileName: 'repocop.zip',
 			handler: 'index.main',
 			memorySize: 1024,
@@ -125,6 +126,7 @@ function stageAwareIntegratorLambda(
 ): GuLambdaFunction {
 	const nonProdLambdaProps = {
 		app,
+		architecture: Architecture.ARM_64,
 		fileName: `${app}.zip`,
 		handler: 'index.handler',
 		memorySize: 1024,

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -1,7 +1,7 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["views"]
-  binaryTargets   = ["native", "rhel-openssl-3.0.x"]
+  binaryTargets   = ["native", "linux-arm64-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## What does this change?
Change the architecture of each lambda to Arm64.

## Why?
Arm based lambdas are cheaper and more performant. See https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/.

## How has it been verified?
- [Deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/8df7ce4d-c5bf-42af-941e-e86d88a1bfd2)
- Successfully ran each lambda

## Statistics
Here are some statistics after invoking the x86_64 and arm64 versions of each lambda once with the same input.

Lambda | Architecture | Duration (ms) | Init Duration (ms) | Max Memory Used (MB)
-- | -- | -- | -- | --
data-audit | arm64 | 43,625.24 | 544.92 | 226
data-audit | x86_64 | 40,958.23 | 471.65 | 217
dependency-graph-integrator | arm64 | 11.61 | 404.20 | 91
dependency-graph-integrator | x86_64 | 15.16 | 386.19 | 87
github-actions-usage | arm64 | 15,342.05 | 294.96 | 188
github-actions-usage | x86_64 | 12,884.00 | 293.36 | 190
interactive-monitor | arm64 | 2,022.39 | 56.95 | 201
interactive-monitor | x86_64 | 1,970.55 | 833.22 | 191
repocop | arm64 | 27,607.03 | 909.56 | 683
repocop | x86_64 | 24,273.92 | 950.93 | 640
snyk-integrator | arm64 | 16.76 | 397.81 | 91
snyk-integrator | x86_64 | 14.90 | 359.59 | 87

As mentioned in the linked post:

> For functions using the Arm/Graviton2 architecture, duration charges are 20 percent lower than the current pricing for x86.

In [this estimate](https://calculator.aws/#/estimate?id=d904ec352da22ae5f7e0d70a665589b3367b3b5a)[^1] of 100,000 requests per month, of 50,000ms duration, and 1,024MB memory, Arm64 costs $61.33 and x86_64 $76.67.

That is, whilst the statistics do not suggest a dramatic change in performance, we will see a reduction in the bill.

[^1]: URL will expire in 1 year.