### PR TITLE
Don't pull DB schemas

### DIFF
--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -82,20 +82,15 @@ echo -e "${yellow}Please note that this will drop all tables in the local databa
 npm -w cli start migrate -- --stage DEV --confirm
 
 step "Copying data from CODE DB to local DB"
-copy "snyk_issues" & \
-copy "snyk_projects" & \
-copy "galaxies_teams_table" & \
-copy "github_team_repositories" & \
-copy "github_teams" & \
-copy "github_repositories" & \
-copy "github_repository_branches" & \
-copy "github_workflows" & \
-copy "github_languages" & \
-copy "aws_cloudformation_stacks" & \
-copy "aws_organizations_accounts" & \
-copy "aws_organizations_account_parents" & \
-copy "aws_organizations_organizational_units" & \
-copy "aws_ec2_instances"
+for table in "snyk_issues" "snyk_projects" \
+"galaxies_teams_table" \
+"github_team_repositories" "github_teams" \
+"github_repositories" "github_repository_branches" \
+"github_workflows" "github_languages" \
+"aws_organizations_accounts" "aws_organizations_account_parents" "aws_organizations_organizational_units"\
+"aws_ec2_instances" "aws_cloudformation_stacks" \ ; do
+  copy "$table" &
+done
 
 wait
 

--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -81,14 +81,24 @@ step "Baselining DB"
 echo -e "${yellow}Please note that this will drop all tables in the local database${clear}"
 npm -w cli start migrate -- --stage DEV --confirm
 
-step "Copying data from CODE DB to local DB"
-for table in "snyk_issues" "snyk_projects" \
-"galaxies_teams_table" \
-"github_team_repositories" "github_teams" \
-"github_repositories" "github_repository_branches" \
-"github_workflows" "github_languages" \
-"aws_organizations_accounts" "aws_organizations_account_parents" "aws_organizations_organizational_units"\
-"aws_ec2_instances" "aws_cloudformation_stacks" \ ; do
+tables_to_copy=(
+  "snyk_issues"
+  "snyk_projects"
+  "galaxies_teams_table"
+  "github_team_repositories"
+  "github_teams"
+  "github_repositories"
+  "github_repository_branches"
+  "github_workflows"
+  "github_languages"
+  "aws_organizations_accounts"
+  "aws_organizations_account_parents"
+  "aws_organizations_organizational_units"
+  "aws_ec2_instances"
+  "aws_cloudformation_stacks"
+)
+
+for table in "${tables_to_copy[@]}"; do
   copy "$table" &
 done
 

--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -45,20 +45,11 @@ insert_into_db() {
     echo "Transfer of $1 data complete ✅"
 }
 
-wildcard_copy(){
-    echo "Copying tables prefixed with $1 to local database"
-    PGPASSWORD=${CODE_DB_PASSWORD} pg_dump \
-    -U postgres -h "${CODE_HOST}" -p 5432 -d "${DATABASE_NAME}" -t "$1*" -f "$1.sql" \
-    --no-owner --no-privileges --inserts
-
-    insert_into_db "$1"
-}
-
 copy(){
     echo "Copying table $1 to local database"
     PGPASSWORD=${CODE_DB_PASSWORD} pg_dump \
     -U postgres -h "${CODE_HOST}" -p 5432 -d "${DATABASE_NAME}" -t "$1" -f "$1.sql" \
-    --no-owner --no-privileges --inserts
+    --no-owner --no-privileges --inserts --data-only
 
     insert_into_db "$1"
 }
@@ -91,10 +82,13 @@ echo -e "${yellow}Please note that this will drop all tables in the local databa
 npm -w cli start migrate -- --stage DEV --confirm
 
 step "Copying data from CODE DB to local DB"
-wildcard_copy "snyk" & \
-wildcard_copy "galaxies" & \
-wildcard_copy "github_team" & \
-wildcard_copy "github_repo" & \
+copy "snyk_issues" & \
+copy "snyk_projects" & \
+copy "galaxies_teams_table" & \
+copy "github_team_repositories" & \
+copy "github_teams" & \
+copy "github_repositories" & \
+copy "github_repository_branches" & \
 copy "github_workflows" & \
 copy "github_languages" & \
 copy "aws_cloudformation_stacks" & \


### PR DESCRIPTION
## What does this change?

Reduces the error messages we see from the dev environment start script as we are not setting up redundant schemas. ty to @akash1810 for the tip!

This means getting rid of wildcard_copy and being explicit about exactly which tables we want, because if the wildcard causes us to dump a table we don't have a schema for, it will fail.

Also, we are now using a parallel for loop instead of calling `copy` a million times.

## How has it been verified?

No more misleading errors when running `npm run start -w dev-environment`.
Repocop still runs correctly.
