### PR TITLE
chore: Update CloudQuery GitHub source to v8.2.1

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ CQ_POSTGRES_SOURCE=3.0.7
 CQ_AWS=23.6.1
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/github/versions
-CQ_GITHUB=8.1.3
+CQ_GITHUB=8.2.1
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/fastly/versions
 CQ_FASTLY=3.0.7

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -3254,7 +3254,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v8.1.3
+  version: v8.2.1
   tables:
     - github_issues
   destinations:
@@ -4206,7 +4206,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v8.1.3
+  version: v8.2.1
   tables:
     - github_repositories
     - github_repository_branches
@@ -4831,7 +4831,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v8.1.3
+  version: v8.2.1
   tables:
     - github_organizations
     - github_organization_members

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -135,7 +135,7 @@ spec:
 		spec:
 		  name: github
 		  path: cloudquery/github
-		  version: v8.1.3
+		  version: v8.2.1
 		  tables:
 		    - github_repositories
 		  destinations:


### PR DESCRIPTION
## What does this change?
Update the [GitHub source plugin](https://hub.cloudquery.io/plugins/source/cloudquery/github/latest/versions) to v8.2.1.

## Why?
The GitHub tasks are failing to parse the configuration correctly. This has happened a few times in the past, and a version upgrade was one solution.

Example of the error, as seen in the logs:

> Error: failed to sync v3 source github: rpc error: code = Internal desc = failed to init plugin: failed to initialize client: failed to parse AppID 000000\n: strconv.ParseInt: parsing "000000\\n": invalid syntax

## How has it been verified?
TBD.