### PR TITLE
fix(cloudquery): Remove newline from GitHub config files

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -3250,7 +3250,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;wget -O /usr/local/share/ca-certificates/global-bundle.crt -q https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem && update-ca-certificates;printf 'kind: source
+              "echo -n $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo -n $GITHUB_APP_ID > /github-app-id;echo -n $GITHUB_INSTALLATION_ID > /github-installation-id;wget -O /usr/local/share/ca-certificates/global-bundle.crt -q https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem && update-ca-certificates;printf 'kind: source
 spec:
   name: github
   path: cloudquery/github
@@ -4202,7 +4202,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;wget -O /usr/local/share/ca-certificates/global-bundle.crt -q https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem && update-ca-certificates;printf 'kind: source
+              "echo -n $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo -n $GITHUB_APP_ID > /github-app-id;echo -n $GITHUB_INSTALLATION_ID > /github-installation-id;wget -O /usr/local/share/ca-certificates/global-bundle.crt -q https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem && update-ca-certificates;printf 'kind: source
 spec:
   name: github
   path: cloudquery/github
@@ -4827,7 +4827,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo $GITHUB_APP_ID > /github-app-id;echo $GITHUB_INSTALLATION_ID > /github-installation-id;wget -O /usr/local/share/ca-certificates/global-bundle.crt -q https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem && update-ca-certificates;printf 'kind: source
+              "echo -n $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key;echo -n $GITHUB_APP_ID > /github-app-id;echo -n $GITHUB_INSTALLATION_ID > /github-installation-id;wget -O /usr/local/share/ca-certificates/global-bundle.crt -q https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem && update-ca-certificates;printf 'kind: source
 spec:
   name: github
   path: cloudquery/github

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -299,9 +299,9 @@ export function addCloudqueryEcsCluster(
 	};
 
 	const additionalGithubCommands = [
-		'echo $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key',
-		'echo $GITHUB_APP_ID > /github-app-id',
-		'echo $GITHUB_INSTALLATION_ID > /github-installation-id',
+		'echo -n $GITHUB_PRIVATE_KEY | base64 -d > /github-private-key',
+		'echo -n $GITHUB_APP_ID > /github-app-id',
+		'echo -n $GITHUB_INSTALLATION_ID > /github-installation-id',
 	];
 
 	const githubSources: CloudquerySource[] = [


### PR DESCRIPTION
## What does this change?
Do not write trailing newline from GitHub configuration files to improve CloudQuery's parsing.

This should solve the CloudQuery error:

> Error: failed to sync v3 source github: rpc error: code = Internal desc = failed to init plugin: failed to initialize client: failed to parse AppID 000000\n: strconv.ParseInt: parsing "000000\n": invalid syntax

## How has it been verified?
[Deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/b7d9637b-2190-44e1-a65c-18e81a988740), and successfully ran the `GitHubRepositories` task.