### PR TITLE
fix(cloudquery): Remove erroneous configuration

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -13636,9 +13636,6 @@ spec:
     - postgresql
   spec:
     api_key: \${SNYK_API_KEY}
-    table_options:
-      snyk_reporting_issues:
-        period: 30d
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -269,11 +269,6 @@ export function snykSourceConfig(
 			destinations: ['postgresql'],
 			spec: {
 				api_key: '${SNYK_API_KEY}',
-				table_options: {
-					snyk_reporting_issues: {
-						period: '30d',
-					},
-				},
 			},
 		},
 	};

--- a/packages/common/prisma/migrations/20240329083925_snyk_frequency/migration.sql
+++ b/packages/common/prisma/migrations/20240329083925_snyk_frequency/migration.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+-- CloudQuery no longer collects data for these Snyk tables, so remove the frequency data for them else alarms will trip
+DELETE FROM cloudquery_table_frequency
+WHERE table_name IN (
+    'snyk_dependencies'
+    , 'snyk_groups'
+    , 'snyk_group_members'
+    , 'snyk_integrations'
+    , 'snyk_organization_members'
+    , 'snyk_reporting_issues'
+    , 'snyk_reporting_latest_issues'
+);
+
+-- Remove tables that are no longer collected to avoid querying against stale data
+DROP TABLE IF EXISTS snyk_dependencies;
+DROP TABLE IF EXISTS snyk_groups;
+DROP TABLE IF EXISTS snyk_group_members;
+DROP TABLE IF EXISTS snyk_integrations;
+DROP TABLE IF EXISTS snyk_organization_members;
+DROP TABLE IF EXISTS snyk_reporting_issues;
+DROP TABLE IF EXISTS snyk_reporting_latest_issues;
+
+COMMIT;


### PR DESCRIPTION
## What does this change?
Since the version update in https://github.com/guardian/service-catalogue/pull/809, the `snyk_reporting_issues` property is not valid, as observed in the logs:

> jsonschema: '/table_options' does not validate with https://github.com/cloudquery/cloudquery/plugins/source/snyk/client/spec/spec#/$ref/properties/table_options/$ref/additionalProperties: additionalProperties 'snyk_reporting_issues' not allowed

It has been replaced with [`created_after`](https://hub.cloudquery.io/plugins/source/cloudquery/snyk/latest/docs?search=sny#overview-snyk-table-options-spec) which takes an ISO 8601 date string.

Achieving the same "only collect issues from 30 days ago" with the new configuration options is tricky, as the ISO 8601 string will be set at build time, not runtime...

Additionally, to avoid alarms, and querying of stale data, remove the tables that are no longer [collected by CloudQuery](https://hub.cloudquery.io/plugins/source/cloudquery/snyk/latest/tables).

## How has it been verified?
[Deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/6a0a87c8-6b1e-4982-a92d-850757f85520), ran the `SnykAll` task, and observed the absence of the above log.