### PR TITLE
ci: Add test reporter

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ const transform = {
 module.exports = {
 	verbose: true,
 	testEnvironment: 'node',
+	reporters: [['github-actions', { silent: false }], 'summary'],
 	projects: [
 		{
 			displayName: 'cdk',


### PR DESCRIPTION
## What does this change?
Improve the DX of a failing test using https://jestjs.io/docs/configuration#github-actions-reporter to annotate a pull request with details of a failing test.

### Examples
#### When a unit test fails
<img width="568" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/ac427283-7bf9-4081-ba95-1f11139d37ff">

#### When the CDK snapshots have not been updated
<img width="543" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/ef50b5dd-dfc5-47f4-aa09-3d044e1c7288">

## Why?
The build log is fairly busy, and can be difficult to isolate which test is failing. Annotating the failing test(s) improves the DX.