### PR TITLE
chore: Configure octokit Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,11 @@ updates:
           - "@guardian/prettier"
           - "eslint"
           - "eslint-plugin-prettier"
+      octokit:
+        patterns:
+          - "@octokit/*"
+          - "octokit"
+          - "octokit-plugin-create-pull-request"
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
## What does this change?
These libraries are related, so update them in unison.

## Why?
https://github.com/guardian/service-catalogue/pull/895 is failing the build, for no fault of our code. Updating the octokit libraries in unison (hopefully) improves this.

This change will also result in fewer PRs. For example the changes in https://github.com/guardian/service-catalogue/pull/900, https://github.com/guardian/service-catalogue/pull/899, and https://github.com/guardian/service-catalogue/pull/895 will be made in a single PR.