### PR TITLE
Add `aws-otel-collector` cloudquery sidecar to collect OTLP traces and forward them to XRay

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -126,7 +126,7 @@ spec:
     - aws_costexplorer_*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -771,7 +771,7 @@ spec:
     - aws_securityhub_*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     concurrency: 2000
@@ -1400,7 +1400,7 @@ spec:
     - aws_organization*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -6508,7 +6508,7 @@ spec:
     - aws_autoscaling_groups
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -7124,7 +7124,7 @@ spec:
     - aws_backup_vault_recovery_points
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -7738,7 +7738,7 @@ spec:
     - aws_acm*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -8382,7 +8382,7 @@ spec:
     - aws_cloudformation_*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -9196,7 +9196,7 @@ spec:
     - aws_cloudwatch_alarms
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -9580,7 +9580,7 @@ spec:
     - aws_dynamodb*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -10196,7 +10196,7 @@ spec:
     - aws_ec2_images
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -10841,7 +10841,7 @@ spec:
     - aws_inspector2_findings
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -11686,7 +11686,7 @@ spec:
     - aws_elbv2_*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -12303,7 +12303,7 @@ spec:
     - aws_rds_cluster_snapshots
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -12687,7 +12687,7 @@ spec:
     - aws_s3*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -13362,7 +13362,7 @@ spec:
     - aws_ec2_images
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     concurrency: 2000

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -126,6 +126,8 @@ spec:
     - aws_costexplorer_*
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -151,6 +153,12 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-AwsCostExplorerAWSOTELCollector",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -239,6 +247,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-AwsCostExplorerAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -727,6 +771,8 @@ spec:
     - aws_securityhub_*
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     concurrency: 2000
     regions:
@@ -767,6 +813,12 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-DelegatedToSecurityAccountAWSOTELCollector",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -855,6 +907,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-DelegatedToSecurityAccountAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -1312,6 +1400,8 @@ spec:
     - aws_organization*
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -1336,6 +1426,12 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-DeployToolsListOrgsAWSOTELCollector",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -1424,6 +1520,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-DeployToolsListOrgsAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -1902,6 +2034,12 @@ spec:
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
             ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-FastlyServicesAWSOTELCollector",
+              },
+            ],
             "DockerLabels": {
               "App": "service-catalogue",
               "Name": "FastlyServices",
@@ -2003,6 +2141,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-FastlyServicesAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -2490,6 +2664,12 @@ spec:
                 ],
               },
             ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-GalaxiesAWSOTELCollector",
+              },
+            ],
             "DockerLabels": {
               "App": "service-catalogue",
               "Name": "Galaxies",
@@ -2577,6 +2757,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-GalaxiesAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -3296,6 +3512,12 @@ spec:
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
             ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-GitHubIssuesAWSOTELCollector",
+              },
+            ],
             "DockerLabels": {
               "App": "service-catalogue",
               "Name": "GitHubIssues",
@@ -3425,6 +3647,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-GitHubIssuesAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -3696,6 +3954,12 @@ spec:
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
             ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-GitHubLanguagesAWSOTELCollector",
+              },
+            ],
             "DockerLabels": {
               "App": "service-catalogue",
               "Name": "GitHubLanguages",
@@ -3789,6 +4053,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-GitHubLanguagesAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -4255,6 +4555,12 @@ spec:
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
             ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-GitHubRepositoriesAWSOTELCollector",
+              },
+            ],
             "DockerLabels": {
               "App": "service-catalogue",
               "Name": "GitHubRepositories",
@@ -4384,6 +4690,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-GitHubRepositoriesAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -4880,6 +5222,12 @@ spec:
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
             ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-GitHubTeamsAWSOTELCollector",
+              },
+            ],
             "DockerLabels": {
               "App": "service-catalogue",
               "Name": "GitHubTeams",
@@ -5009,6 +5357,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-GitHubTeamsAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -5494,6 +5878,10 @@ spec:
             ],
             "DependsOn": [
               {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-NS1AWSOTELCollector",
+              },
+              {
                 "Condition": "START",
                 "ContainerName": "CloudquerySource-NS1PluginContainer",
               },
@@ -5599,6 +5987,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-NS1AWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -6084,6 +6508,8 @@ spec:
     - aws_autoscaling_groups
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -6109,6 +6535,12 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-OrgWideAutoScalingGroupsAWSOTELCollector",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -6197,6 +6629,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-OrgWideAutoScalingGroupsAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -6656,6 +7124,8 @@ spec:
     - aws_backup_vault_recovery_points
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -6681,6 +7151,12 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-OrgWideBackupAWSOTELCollector",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -6769,6 +7245,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-OrgWideBackupAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -7226,6 +7738,8 @@ spec:
     - aws_acm*
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -7251,6 +7765,12 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-OrgWideCertificatesAWSOTELCollector",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -7339,6 +7859,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-OrgWideCertificatesAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -7826,6 +8382,8 @@ spec:
     - aws_cloudformation_*
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -7851,6 +8409,12 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-OrgWideCloudFormationAWSOTELCollector",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -7939,6 +8503,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-OrgWideCloudFormationAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -8596,6 +9196,8 @@ spec:
     - aws_cloudwatch_alarms
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -8621,6 +9223,12 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-OrgWideCloudwatchAlarmsAWSOTELCollector",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -8709,6 +9317,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-OrgWideCloudwatchAlarmsAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -8936,6 +9580,8 @@ spec:
     - aws_dynamodb*
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -8961,6 +9607,12 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-OrgWideDynamoDBAWSOTELCollector",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -9049,6 +9701,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-OrgWideDynamoDBAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -9508,6 +10196,8 @@ spec:
     - aws_ec2_images
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -9535,6 +10225,10 @@ spec:
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
             ],
             "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-OrgWideEc2AWSOTELCollector",
+              },
               {
                 "Condition": "SUCCESS",
                 "ContainerName": "CloudquerySource-OrgWideEc2AwsCli",
@@ -9627,6 +10321,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-OrgWideEc2AWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -10111,6 +10841,8 @@ spec:
     - aws_inspector2_findings
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -10136,6 +10868,12 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-OrgWideInspectorAWSOTELCollector",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -10224,6 +10962,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-OrgWideInspectorAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -10912,6 +11686,8 @@ spec:
     - aws_elbv2_*
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -10937,6 +11713,12 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-OrgWideLoadBalancersAWSOTELCollector",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -11025,6 +11807,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-OrgWideLoadBalancersAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -11485,6 +12303,8 @@ spec:
     - aws_rds_cluster_snapshots
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -11510,6 +12330,12 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-OrgWideRDSAWSOTELCollector",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -11598,6 +12424,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-OrgWideRDSAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -11825,6 +12687,8 @@ spec:
     - aws_s3*
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -11850,6 +12714,12 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-OrgWideS3AWSOTELCollector",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -11938,6 +12808,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-OrgWideS3AWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -12456,6 +13362,8 @@ spec:
     - aws_ec2_images
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     concurrency: 2000
     regions:
@@ -12482,6 +13390,12 @@ spec:
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-RemainingAwsDataAWSOTELCollector",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -12570,6 +13484,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-RemainingAwsDataAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -13289,6 +14239,12 @@ spec:
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
             ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-RiffRaffDataAWSOTELCollector",
+              },
+            ],
             "DockerLabels": {
               "App": "service-catalogue",
               "Name": "RiffRaffData",
@@ -13418,6 +14374,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-RiffRaffDataAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -13664,6 +14656,12 @@ spec:
       dbname=postgres sslmode=verify-full
 ' > /destination.yaml;/app/cloudquery sync /source.yaml /destination.yaml --log-format json --log-console",
             ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-SnykAllAWSOTELCollector",
+              },
+            ],
             "DockerLabels": {
               "App": "service-catalogue",
               "Name": "SnykAll",
@@ -13765,6 +14763,42 @@ spec:
                     ],
                   ],
                 },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "./healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": {
+                  "Ref": "AWS::Region",
+                },
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-SnykAllAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
               },
             ],
           },
@@ -17146,6 +18180,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-AwsCostExplorer",
         "Tags": [
           {
@@ -17273,6 +18321,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-DelegatedToSecurityAccount",
         "Tags": [
           {
@@ -17395,6 +18457,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-DeployToolsListOrgs",
         "Tags": [
           {
@@ -17522,6 +18598,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-FastlyServices",
         "Tags": [
           {
@@ -17639,6 +18729,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-Galaxies",
         "Tags": [
           {
@@ -17771,6 +18875,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-GitHubIssues",
         "Tags": [
           {
@@ -17969,6 +19087,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-GitHubLanguages",
         "Tags": [
           {
@@ -18005,6 +19137,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-GitHubRepositories",
         "Tags": [
           {
@@ -18122,6 +19268,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-GitHubTeams",
         "Tags": [
           {
@@ -18239,6 +19399,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-NS1",
         "Tags": [
           {
@@ -18356,6 +19530,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-OrgWideAutoScalingGroups",
         "Tags": [
           {
@@ -18483,6 +19671,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-OrgWideBackup",
         "Tags": [
           {
@@ -18610,6 +19812,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-OrgWideCertificates",
         "Tags": [
           {
@@ -18828,6 +20044,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-OrgWideCloudFormation",
         "Tags": [
           {
@@ -18864,6 +20094,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-OrgWideCloudwatchAlarms",
         "Tags": [
           {
@@ -18991,6 +20235,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-OrgWideDynamoDB",
         "Tags": [
           {
@@ -19118,6 +20376,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-OrgWideEc2",
         "Tags": [
           {
@@ -19260,6 +20532,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-OrgWideInspector",
         "Tags": [
           {
@@ -19387,6 +20673,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-OrgWideLoadBalancers",
         "Tags": [
           {
@@ -19514,6 +20814,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-OrgWideRDS",
         "Tags": [
           {
@@ -19641,6 +20955,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-OrgWideS3",
         "Tags": [
           {
@@ -19768,6 +21096,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-RemainingAwsData",
         "Tags": [
           {
@@ -19895,6 +21237,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-RiffRaffData",
         "Tags": [
           {
@@ -20093,6 +21449,20 @@ spec:
           ],
           "Version": "2012-10-17",
         },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
         "RoleName": "service-catalogue-TEST-task-SnykAll",
         "Tags": [
           {

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -126,7 +126,7 @@ spec:
     - aws_costexplorer_*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -258,7 +258,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -771,7 +771,7 @@ spec:
     - aws_securityhub_*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     concurrency: 2000
@@ -918,7 +918,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -1400,7 +1400,7 @@ spec:
     - aws_organization*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -1531,7 +1531,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -2152,7 +2152,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -2768,7 +2768,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -3658,7 +3658,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -4064,7 +4064,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -4701,7 +4701,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -5368,7 +5368,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -5998,7 +5998,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -6508,7 +6508,7 @@ spec:
     - aws_autoscaling_groups
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -6640,7 +6640,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -7124,7 +7124,7 @@ spec:
     - aws_backup_vault_recovery_points
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -7256,7 +7256,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -7738,7 +7738,7 @@ spec:
     - aws_acm*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -7870,7 +7870,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -8382,7 +8382,7 @@ spec:
     - aws_cloudformation_*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -8514,7 +8514,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -9196,7 +9196,7 @@ spec:
     - aws_cloudwatch_alarms
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -9328,7 +9328,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -9580,7 +9580,7 @@ spec:
     - aws_dynamodb*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -9712,7 +9712,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -10196,7 +10196,7 @@ spec:
     - aws_ec2_images
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -10332,7 +10332,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -10841,7 +10841,7 @@ spec:
     - aws_inspector2_findings
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -10973,7 +10973,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -11686,7 +11686,7 @@ spec:
     - aws_elbv2_*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -11818,7 +11818,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -12303,7 +12303,7 @@ spec:
     - aws_rds_cluster_snapshots
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -12435,7 +12435,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -12687,7 +12687,7 @@ spec:
     - aws_s3*
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -12819,7 +12819,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -13362,7 +13362,7 @@ spec:
     - aws_ec2_images
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     concurrency: 2000
@@ -13495,7 +13495,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -14385,7 +14385,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,
@@ -14774,7 +14774,7 @@ spec:
             "HealthCheck": {
               "Command": [
                 "CMD",
-                "./healthcheck",
+                "/healthcheck",
               ],
               "Interval": 5,
               "Retries": 3,

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -40,7 +40,7 @@ spec:
     - aws_s3_buckets
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -76,7 +76,7 @@ spec:
     - aws_s3_buckets
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -115,7 +115,7 @@ spec:
     - aws_accessanalyzer_analyzer_findings
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -157,7 +157,7 @@ spec:
     - aws_securityhub_findings
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint: 127.0.0.1:4323
   otel_endpoint_insecure: true
   spec:
     regions:

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -40,6 +40,8 @@ spec:
     - aws_s3_buckets
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -74,6 +76,8 @@ spec:
     - aws_s3_buckets
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -99,7 +103,6 @@ spec:
 				'aws_accessanalyzer_analyzer_findings',
 			],
 		});
-		console.log(dump(config));
 		expect(dump(config)).toMatchInlineSnapshot(`
 "kind: source
 spec:
@@ -112,6 +115,8 @@ spec:
     - aws_accessanalyzer_analyzer_findings
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1
@@ -142,7 +147,6 @@ spec:
 				},
 			},
 		);
-		console.log(dump(config));
 		expect(dump(config)).toMatchInlineSnapshot(`
 "kind: source
 spec:
@@ -153,6 +157,8 @@ spec:
     - aws_securityhub_findings
   destinations:
     - postgresql
+  otel_endpoint: 127.0.0.1:4318
+  otel_endpoint_insecure: true
   spec:
     regions:
       - eu-west-1

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -40,7 +40,7 @@ spec:
     - aws_s3_buckets
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -76,7 +76,7 @@ spec:
     - aws_s3_buckets
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -115,7 +115,7 @@ spec:
     - aws_accessanalyzer_analyzer_findings
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:
@@ -157,7 +157,7 @@ spec:
     - aws_securityhub_findings
   destinations:
     - postgresql
-  otel_endpoint: 127.0.0.1:4323
+  otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
     regions:

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -61,6 +61,8 @@ export function awsSourceConfig(
 			tables,
 			skip_tables: skipTables,
 			destinations: ['postgresql'],
+			otel_endpoint: '127.0.0.1:4318',
+			otel_endpoint_insecure: true,
 			spec: {
 				concurrency,
 				regions: AWS_REGIONS,

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -61,7 +61,7 @@ export function awsSourceConfig(
 			tables,
 			skip_tables: skipTables,
 			destinations: ['postgresql'],
-			otel_endpoint: '127.0.0.1:4323',
+			otel_endpoint: '0.0.0.0:4318',
 			otel_endpoint_insecure: true,
 			spec: {
 				concurrency,

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -61,7 +61,7 @@ export function awsSourceConfig(
 			tables,
 			skip_tables: skipTables,
 			destinations: ['postgresql'],
-			otel_endpoint: '127.0.0.1:4318',
+			otel_endpoint: '127.0.0.1:4323',
 			otel_endpoint_insecure: true,
 			spec: {
 				concurrency,

--- a/packages/cdk/lib/cloudquery/images.ts
+++ b/packages/cdk/lib/cloudquery/images.ts
@@ -27,4 +27,7 @@ export const Images = {
 	prismaMigrate: ContainerImage.fromRegistry(
 		'ghcr.io/guardian/service-catalogue/prisma-migrate:sha-cdd0348904373d72dcbbdd3bc943e6b5dc232d3c',
 	),
+	otelCollector: ContainerImage.fromRegistry(
+		'public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0',
+	),
 };

--- a/packages/cdk/lib/cloudquery/task.ts
+++ b/packages/cdk/lib/cloudquery/task.ts
@@ -1,6 +1,6 @@
 import type { AppIdentity, GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
-import { Tags } from 'aws-cdk-lib';
+import { Duration, Tags } from 'aws-cdk-lib';
 import type { ISecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import {
 	ContainerDependencyCondition,
@@ -15,7 +15,7 @@ import type { Cluster, RepositoryImage } from 'aws-cdk-lib/aws-ecs';
 import type { ScheduledFargateTaskProps } from 'aws-cdk-lib/aws-ecs-patterns';
 import { ScheduledFargateTask } from 'aws-cdk-lib/aws-ecs-patterns';
 import type { IManagedPolicy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
 import { dump } from 'js-yaml';
@@ -151,6 +151,10 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 			roleName,
 		});
 
+		const xrayPolicy = ManagedPolicy.fromAwsManagedPolicyName(
+			'AWSXrayWriteOnlyAccess',
+		);
+
 		const task = new FargateTaskDefinition(scope, `${id}TaskDefinition`, {
 			memoryLimitMiB,
 			cpu,
@@ -222,6 +226,33 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 				].join(';'),
 			],
 			logging: fireLensLogDriver,
+		});
+
+		const otel = task.addContainer(`${id}AWSOTELCollector`, {
+			image: Images.otelCollector,
+			command: ['--config=/etc/ecs/ecs-xray.yaml'],
+			logging: new FireLensLogDriver({
+				options: {
+					Name: `kinesis_streams`,
+					region,
+					stream: loggingStreamName,
+					retry_limit: '2',
+				},
+			}),
+			healthCheck: {
+				command: ['CMD', './healthcheck'],
+				interval: Duration.seconds(5),
+			},
+			portMappings: [
+				{
+					containerPort: 4318,
+				},
+			],
+		});
+
+		cloudqueryTask.addContainerDependencies({
+			container: otel,
+			condition: ContainerDependencyCondition.HEALTHY,
 		});
 
 		if (dockerDistributedPluginImage) {
@@ -334,6 +365,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 
 		managedPolicies.forEach((policy) => task.taskRole.addManagedPolicy(policy));
 		policies.forEach((policy) => task.addToTaskRolePolicy(policy));
+		task.taskRole.addManagedPolicy(xrayPolicy);
 
 		db.grantConnect(task.taskRole);
 

--- a/packages/cdk/lib/cloudquery/task.ts
+++ b/packages/cdk/lib/cloudquery/task.ts
@@ -231,16 +231,9 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 		const otel = task.addContainer(`${id}AWSOTELCollector`, {
 			image: Images.otelCollector,
 			command: ['--config=/etc/ecs/ecs-xray.yaml'],
-			logging: new FireLensLogDriver({
-				options: {
-					Name: `kinesis_streams`,
-					region,
-					stream: loggingStreamName,
-					retry_limit: '2',
-				},
-			}),
+			logging: fireLensLogDriver,
 			healthCheck: {
-				command: ['CMD', './healthcheck'],
+				command: ['CMD', '/healthcheck'],
 				interval: Duration.seconds(5),
 			},
 			portMappings: [


### PR DESCRIPTION
## What does this change?
Adds a new sidecar container to all our tasks. This sidecar runs [`aws-otel-collector`](https://github.com/aws-observability/aws-otel-collector) which collects Telemetry traces from CloudQuery and forwards them to AWS XRay[^1].

The `aws-otel-collector` sidecar also supports collecting container metrics such as CPU usage and Memory usage, but @NovemberTang found that its possible to enable `Container Insights` at a cluster level and AWS will collect roughly this information for us. So for now I've disabled the `aws-otel-collectors` ability to collect metrics.

## Why?
Cloudquery is capable of [generating traces](https://docs.cloudquery.io/docs/advanced-topics/monitoring) to let developers understand whats happening under the hood. This is good for debugging and fine tuning job resources.

This also lets us explore XRay a bit and understand how much it might cost for us to roll out tracing across the department and whether we need to explore other alternative tracing providers.

## How has it been verified?
[Deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/81a93c5e-93a1-4cf3-a105-d8d92145766b), and after the `DeployToolsListOrgs` is been manually run, we can see traces in the AWS console:

![image](https://github.com/guardian/service-catalogue/assets/836140/09d40e94-9324-4c5d-97d6-e5888808850e)

And logs in Central ELK:

![image](https://github.com/guardian/service-catalogue/assets/836140/36b2715b-c769-49ea-bf55-18eccacd439c)

[^1]: See https://github.com/aws-observability/aws-otel-collector/blob/main/deployment-template/ecs/aws-otel-ec2-sidecar-deployment-cfn.yaml.