### PR TITLE
Enable Container Insights

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -18132,6 +18132,12 @@ spec:
     },
     "servicecatalogueCluster5FC34DC5": {
       "Properties": {
+        "ClusterSettings": [
+          {
+            "Name": "containerInsights",
+            "Value": "disabled",
+          },
+        ],
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -18135,7 +18135,7 @@ spec:
         "ClusterSettings": [
           {
             "Name": "containerInsights",
-            "Value": "disabled",
+            "Value": "enabled",
           },
         ],
         "Tags": [

--- a/packages/cdk/lib/cloudquery/cluster.ts
+++ b/packages/cdk/lib/cloudquery/cluster.ts
@@ -129,6 +129,7 @@ export class CloudqueryCluster extends Cluster {
 		super(scope, id, {
 			vpc: props.vpc,
 			enableFargateCapacityProviders: true,
+			containerInsights: scope.stage === 'PROD',
 		});
 
 		const { stack, stage } = scope;

--- a/packages/cdk/lib/cloudquery/cluster.ts
+++ b/packages/cdk/lib/cloudquery/cluster.ts
@@ -129,7 +129,7 @@ export class CloudqueryCluster extends Cluster {
 		super(scope, id, {
 			vpc: props.vpc,
 			enableFargateCapacityProviders: true,
-			containerInsights: scope.stage === 'PROD',
+			containerInsights: true,
 		});
 
 		const { stack, stage } = scope;


### PR DESCRIPTION
## What does this change?

Enables Container Insights for ECS.

## Why?

Container Insights tracks container metrics such as CPU Utilization & Memory Utilization in Cloudwatch allowing us to more easily identify jobs that have too many or too few resources assigned to them.

A slight concern with this PR is how expensive custom metrics are in Cloudwatch, with each custom metric costing 0.30$ per month it can be quite scary to have ~10 custom metrics per task. However, as I understand metrics are charged by the hour and only if they're actively being pushed to, this means for most tasks that are run daily the metric will only be "active" 1 hour every day, therefore costing 0.30/24 = 0.0125$ per month per metric.

We have 26 tasks, so it roughly works out at 3.25$ per month for these metrics assuming my above understanding is correct.

## How has it been verified?

Tested in CODE.