### PR TITLE
New view view_aws_resources for tagging OKR baseline

### DIFF
--- a/packages/common/prisma/migrations/20240408141500_view_aws_resources/migration.sql
+++ b/packages/common/prisma/migrations/20240408141500_view_aws_resources/migration.sql
@@ -1,0 +1,57 @@
+/*
+ The view view_aws_resources
+ */
+DROP VIEW IF EXISTS view_aws_resources;
+
+DO $$
+    DECLARE
+        tbl TEXT;
+        strSQL TEXT = '';
+    BEGIN
+        -- iterate over every table in our information_schema that has an `arn` column available
+        FOR tbl IN
+            SELECT DISTINCT table_name
+            FROM information_schema.columns
+            WHERE table_name LIKE 'aws_%s' and COLUMN_NAME IN ('account_id', 'request_account_id')
+            INTERSECT
+            SELECT table_name
+            FROM information_schema.columns
+            WHERE table_name LIKE 'aws_%s' and COLUMN_NAME = 'arn'
+            LOOP
+                -- UNION each table query to create one view
+                IF NOT (strSQL = ''::TEXT) THEN
+                    strSQL = strSQL || ' UNION ALL ';
+                END IF;
+                -- create an SQL query to select from table and transform it into our resources view schema
+                strSQL = strSQL || FORMAT(E'
+        SELECT _cq_id,
+            _cq_source_name,
+            _cq_sync_time,
+            %L AS _cq_table,
+            COALESCE(%s, SPLIT_PART(arn, \':\', 5)) AS account_id,
+            COALESCE(%s, %s, SPLIT_PART(arn, \':\', 5)) AS request_account_id,
+            %s AS region,
+            SPLIT_PART(arn, \':\', 2) AS PARTITION,
+            SPLIT_PART(arn, \':\', 3) AS service,
+            CASE
+            WHEN SPLIT_PART(SPLIT_PART(ARN, \':\', 6), \'/\', 2) = \'\' AND SPLIT_PART(arn, \':\', 7) = \'\' THEN NULL
+                ELSE SPLIT_PART(SPLIT_PART(arn, \':\', 6), \'/\', 1)
+            END AS TYPE,
+            arn, %s AS tags
+        FROM %s',
+                                          tbl,
+                                          CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='account_id' AND table_name=tbl) THEN 'account_id' ELSE 'NULL' END,
+                                          CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='request_account_id' AND table_name=tbl) THEN 'request_account_id' ELSE 'NULL' END,
+                                          CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='account_id' AND table_name=tbl) THEN 'account_id' ELSE 'NULL' END,
+                                          CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='region' AND table_name=tbl) THEN 'region' ELSE E'\'unavailable\'' END,
+                                          CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='tags' AND table_name=tbl) THEN 'tags' ELSE '''{}''::jsonb' END,
+                                          tbl);
+            END LOOP;
+
+        IF strSQL = ''::TEXT THEN
+            RAISE EXCEPTION 'No tables found with ARN and ACCOUNT_ID columns. Run a sync first and try again.';
+        ELSE
+            EXECUTE FORMAT('CREATE VIEW view_aws_resources AS (%s)', strSQL);
+        END IF;
+
+    END $$;

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -708,3 +708,21 @@ view view_github_actions {
 
   @@ignore
 }
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view view_aws_resources {
+  cq_id              String?   @map("_cq_id") @db.Uuid
+  cq_source_name     String?   @map("_cq_source_name")
+  cq_sync_time       DateTime? @map("_cq_sync_time") @db.Timestamp(6)
+  cq_table           String?   @map("_cq_table")
+  account_id         String?
+  request_account_id String?
+  region             String?
+  partition          String?
+  service            String?
+  type               String?
+  arn                String?
+  tags               Json?
+
+  @@ignore
+}

--- a/packages/common/prisma/views/public/view_aws_resources.sql
+++ b/packages/common/prisma/views/public/view_aws_resources.sql
@@ -1,0 +1,320 @@
+SELECT
+  aws_ec2_instances._cq_id,
+  aws_ec2_instances._cq_source_name,
+  aws_ec2_instances._cq_sync_time,
+  'aws_ec2_instances' :: text AS _cq_table,
+  COALESCE(
+    aws_ec2_instances.account_id,
+    split_part(aws_ec2_instances.arn, ':' :: text, 5)
+  ) AS account_id,
+  COALESCE(
+    NULL :: text,
+    aws_ec2_instances.account_id,
+    split_part(aws_ec2_instances.arn, ':' :: text, 5)
+  ) AS request_account_id,
+  aws_ec2_instances.region,
+  split_part(aws_ec2_instances.arn, ':' :: text, 2) AS PARTITION,
+  split_part(aws_ec2_instances.arn, ':' :: text, 3) AS service,
+  CASE
+    WHEN (
+      (
+        split_part(
+          split_part(aws_ec2_instances.arn, ':' :: text, 6),
+          '/' :: text,
+          2
+        ) = '' :: text
+      )
+      AND (
+        split_part(aws_ec2_instances.arn, ':' :: text, 7) = '' :: text
+      )
+    ) THEN NULL :: text
+    ELSE split_part(
+      split_part(aws_ec2_instances.arn, ':' :: text, 6),
+      '/' :: text,
+      1
+    )
+  END AS TYPE,
+  aws_ec2_instances.arn,
+  aws_ec2_instances.tags
+FROM
+  aws_ec2_instances
+UNION
+ALL
+SELECT
+  aws_ec2_images._cq_id,
+  aws_ec2_images._cq_source_name,
+  aws_ec2_images._cq_sync_time,
+  'aws_ec2_images' :: text AS _cq_table,
+  COALESCE(
+    aws_ec2_images.account_id,
+    split_part(aws_ec2_images.arn, ':' :: text, 5)
+  ) AS account_id,
+  COALESCE(
+    NULL :: text,
+    aws_ec2_images.account_id,
+    split_part(aws_ec2_images.arn, ':' :: text, 5)
+  ) AS request_account_id,
+  aws_ec2_images.region,
+  split_part(aws_ec2_images.arn, ':' :: text, 2) AS PARTITION,
+  split_part(aws_ec2_images.arn, ':' :: text, 3) AS service,
+  CASE
+    WHEN (
+      (
+        split_part(
+          split_part(aws_ec2_images.arn, ':' :: text, 6),
+          '/' :: text,
+          2
+        ) = '' :: text
+      )
+      AND (
+        split_part(aws_ec2_images.arn, ':' :: text, 7) = '' :: text
+      )
+    ) THEN NULL :: text
+    ELSE split_part(
+      split_part(aws_ec2_images.arn, ':' :: text, 6),
+      '/' :: text,
+      1
+    )
+  END AS TYPE,
+  aws_ec2_images.arn,
+  aws_ec2_images.tags
+FROM
+  aws_ec2_images
+UNION
+ALL
+SELECT
+  aws_cloudformation_stacks._cq_id,
+  aws_cloudformation_stacks._cq_source_name,
+  aws_cloudformation_stacks._cq_sync_time,
+  'aws_cloudformation_stacks' :: text AS _cq_table,
+  COALESCE(
+    aws_cloudformation_stacks.account_id,
+    split_part(aws_cloudformation_stacks.arn, ':' :: text, 5)
+  ) AS account_id,
+  COALESCE(
+    NULL :: text,
+    aws_cloudformation_stacks.account_id,
+    split_part(aws_cloudformation_stacks.arn, ':' :: text, 5)
+  ) AS request_account_id,
+  aws_cloudformation_stacks.region,
+  split_part(aws_cloudformation_stacks.arn, ':' :: text, 2) AS PARTITION,
+  split_part(aws_cloudformation_stacks.arn, ':' :: text, 3) AS service,
+  CASE
+    WHEN (
+      (
+        split_part(
+          split_part(aws_cloudformation_stacks.arn, ':' :: text, 6),
+          '/' :: text,
+          2
+        ) = '' :: text
+      )
+      AND (
+        split_part(aws_cloudformation_stacks.arn, ':' :: text, 7) = '' :: text
+      )
+    ) THEN NULL :: text
+    ELSE split_part(
+      split_part(aws_cloudformation_stacks.arn, ':' :: text, 6),
+      '/' :: text,
+      1
+    )
+  END AS TYPE,
+  aws_cloudformation_stacks.arn,
+  aws_cloudformation_stacks.tags
+FROM
+  aws_cloudformation_stacks
+UNION
+ALL
+SELECT
+  aws_organizations_accounts._cq_id,
+  aws_organizations_accounts._cq_source_name,
+  aws_organizations_accounts._cq_sync_time,
+  'aws_organizations_accounts' :: text AS _cq_table,
+  COALESCE(
+    NULL :: text,
+    split_part(aws_organizations_accounts.arn, ':' :: text, 5)
+  ) AS account_id,
+  COALESCE(
+    aws_organizations_accounts.request_account_id,
+    NULL :: text,
+    split_part(aws_organizations_accounts.arn, ':' :: text, 5)
+  ) AS request_account_id,
+  'unavailable' :: text AS region,
+  split_part(aws_organizations_accounts.arn, ':' :: text, 2) AS PARTITION,
+  split_part(aws_organizations_accounts.arn, ':' :: text, 3) AS service,
+  CASE
+    WHEN (
+      (
+        split_part(
+          split_part(aws_organizations_accounts.arn, ':' :: text, 6),
+          '/' :: text,
+          2
+        ) = '' :: text
+      )
+      AND (
+        split_part(aws_organizations_accounts.arn, ':' :: text, 7) = '' :: text
+      )
+    ) THEN NULL :: text
+    ELSE split_part(
+      split_part(aws_organizations_accounts.arn, ':' :: text, 6),
+      '/' :: text,
+      1
+    )
+  END AS TYPE,
+  aws_organizations_accounts.arn,
+  aws_organizations_accounts.tags
+FROM
+  aws_organizations_accounts
+UNION
+ALL
+SELECT
+  aws_organizations_organizational_units._cq_id,
+  aws_organizations_organizational_units._cq_source_name,
+  aws_organizations_organizational_units._cq_sync_time,
+  'aws_organizations_organizational_units' :: text AS _cq_table,
+  COALESCE(
+    NULL :: text,
+    split_part(
+      aws_organizations_organizational_units.arn,
+      ':' :: text,
+      5
+    )
+  ) AS account_id,
+  COALESCE(
+    aws_organizations_organizational_units.request_account_id,
+    NULL :: text,
+    split_part(
+      aws_organizations_organizational_units.arn,
+      ':' :: text,
+      5
+    )
+  ) AS request_account_id,
+  'unavailable' :: text AS region,
+  split_part(
+    aws_organizations_organizational_units.arn,
+    ':' :: text,
+    2
+  ) AS PARTITION,
+  split_part(
+    aws_organizations_organizational_units.arn,
+    ':' :: text,
+    3
+  ) AS service,
+  CASE
+    WHEN (
+      (
+        split_part(
+          split_part(
+            aws_organizations_organizational_units.arn,
+            ':' :: text,
+            6
+          ),
+          '/' :: text,
+          2
+        ) = '' :: text
+      )
+      AND (
+        split_part(
+          aws_organizations_organizational_units.arn,
+          ':' :: text,
+          7
+        ) = '' :: text
+      )
+    ) THEN NULL :: text
+    ELSE split_part(
+      split_part(
+        aws_organizations_organizational_units.arn,
+        ':' :: text,
+        6
+      ),
+      '/' :: text,
+      1
+    )
+  END AS TYPE,
+  aws_organizations_organizational_units.arn,
+  '{}' :: jsonb AS tags
+FROM
+  aws_organizations_organizational_units
+UNION
+ALL
+SELECT
+  aws_lambda_functions._cq_id,
+  aws_lambda_functions._cq_source_name,
+  aws_lambda_functions._cq_sync_time,
+  'aws_lambda_functions' :: text AS _cq_table,
+  COALESCE(
+    aws_lambda_functions.account_id,
+    split_part(aws_lambda_functions.arn, ':' :: text, 5)
+  ) AS account_id,
+  COALESCE(
+    NULL :: text,
+    aws_lambda_functions.account_id,
+    split_part(aws_lambda_functions.arn, ':' :: text, 5)
+  ) AS request_account_id,
+  aws_lambda_functions.region,
+  split_part(aws_lambda_functions.arn, ':' :: text, 2) AS PARTITION,
+  split_part(aws_lambda_functions.arn, ':' :: text, 3) AS service,
+  CASE
+    WHEN (
+      (
+        split_part(
+          split_part(aws_lambda_functions.arn, ':' :: text, 6),
+          '/' :: text,
+          2
+        ) = '' :: text
+      )
+      AND (
+        split_part(aws_lambda_functions.arn, ':' :: text, 7) = '' :: text
+      )
+    ) THEN NULL :: text
+    ELSE split_part(
+      split_part(aws_lambda_functions.arn, ':' :: text, 6),
+      '/' :: text,
+      1
+    )
+  END AS TYPE,
+  aws_lambda_functions.arn,
+  aws_lambda_functions.tags
+FROM
+  aws_lambda_functions
+UNION
+ALL
+SELECT
+  aws_s3_buckets._cq_id,
+  aws_s3_buckets._cq_source_name,
+  aws_s3_buckets._cq_sync_time,
+  'aws_s3_buckets' :: text AS _cq_table,
+  COALESCE(
+    aws_s3_buckets.account_id,
+    split_part(aws_s3_buckets.arn, ':' :: text, 5)
+  ) AS account_id,
+  COALESCE(
+    NULL :: text,
+    aws_s3_buckets.account_id,
+    split_part(aws_s3_buckets.arn, ':' :: text, 5)
+  ) AS request_account_id,
+  aws_s3_buckets.region,
+  split_part(aws_s3_buckets.arn, ':' :: text, 2) AS PARTITION,
+  split_part(aws_s3_buckets.arn, ':' :: text, 3) AS service,
+  CASE
+    WHEN (
+      (
+        split_part(
+          split_part(aws_s3_buckets.arn, ':' :: text, 6),
+          '/' :: text,
+          2
+        ) = '' :: text
+      )
+      AND (
+        split_part(aws_s3_buckets.arn, ':' :: text, 7) = '' :: text
+      )
+    ) THEN NULL :: text
+    ELSE split_part(
+      split_part(aws_s3_buckets.arn, ':' :: text, 6),
+      '/' :: text,
+      1
+    )
+  END AS TYPE,
+  aws_s3_buckets.arn,
+  aws_s3_buckets.tags
+FROM
+  aws_s3_buckets;


### PR DESCRIPTION
## What does this change?
Add a view to service-catalogue for easier querying of resources and their tags

## Why?
We want more visibility on tagged resources

## How has it been verified?
Tried locally
