### PR TITLE
Reduce the number of rows we collect form security hub

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -747,6 +747,14 @@ spec:
               record_state:
                 - comparison: EQUALS
                   value: ACTIVE
+              compliance_status:
+                - comparison: NOT_EQUALS
+                  value: PASSED
+              workflow_status:
+                - comparison: NOT_EQUALS
+                  value: RESOLVED
+              severity_normalized:
+                - Gte: 50
 ' > /source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -101,6 +101,10 @@ export function addCloudqueryEcsCluster(
 				},
 				{
 					table_options: {
+						// For more information on how security hub filtering works, see the following links:
+						// # https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_AwsSecurityFindingFilters.html
+						// # https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_StringFilter.html
+						//https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_NumberFilter.html
 						aws_securityhub_findings: {
 							get_findings: [
 								{

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -111,6 +111,23 @@ export function addCloudqueryEcsCluster(
 												value: 'ACTIVE',
 											},
 										],
+										compliance_status: [
+											{
+												comparison: 'NOT_EQUALS',
+												value: 'PASSED',
+											},
+										],
+										workflow_status: [
+											{
+												comparison: 'NOT_EQUALS',
+												value: 'RESOLVED',
+											},
+										],
+										severity_normalized: [
+											{
+												Gte: 50,
+											},
+										],
 									},
 								},
 							],

--- a/packages/dev-environment/dev-config/cloudquery.yaml
+++ b/packages/dev-environment/dev-config/cloudquery.yaml
@@ -27,6 +27,9 @@ spec:
               compliance_status:
                 - comparison: 'NOT_EQUALS'
                   value: 'PASSED'
+              workflow_status:
+                - comparison: 'NOT_EQUALS'
+                  value: 'RESOLVED'
 ---
 kind: destination
 spec:

--- a/packages/dev-environment/dev-config/cloudquery.yaml
+++ b/packages/dev-environment/dev-config/cloudquery.yaml
@@ -19,8 +19,8 @@ spec:
         local_profile: 'deployTools'
     table_options:
       aws_securityhub_findings:
-        get_findings:
-          - filters:
+        get_findings: # https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_AwsSecurityFindingFilters.html
+          - filters: # https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_StringFilter.html
               record_state:
                 - comparison: 'EQUALS'
                   value: 'ACTIVE'
@@ -30,6 +30,8 @@ spec:
               workflow_status:
                 - comparison: 'NOT_EQUALS'
                   value: 'RESOLVED'
+              severity_normalized:
+                - Gte: 50 # https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_NumberFilter.html
 ---
 kind: destination
 spec:

--- a/packages/dev-environment/dev-config/cloudquery.yaml
+++ b/packages/dev-environment/dev-config/cloudquery.yaml
@@ -21,9 +21,12 @@ spec:
       aws_securityhub_findings:
         get_findings:
           - filters:
-              record_state: 
+              record_state:
                 - comparison: 'EQUALS'
                   value: 'ACTIVE'
+              compliance_status:
+                - comparison: 'NOT_EQUALS'
+                  value: 'PASSED'
 ---
 kind: destination
 spec:


### PR DESCRIPTION
## What does this change?

By limiting ourselves to only open, sufficiently severe issues, the number of rows in this table has reduced from ~50k to about 1.5k, a reduction of 98.5%.

Prior to #874 , we were ingesting about a million rows a day, so the combination of these PRs mean we are ingesting 99.85% less data

## Why?

Queries against this table take a long time to execute. By limiting ourselves only to information that is relevant, the table is now about 700x smaller than it was last week, and we should see a correlating increase in performance. 

### Why don't you use a view?

A view is a thin query wrapper around the original table. It provides no performance benefit, and is more useful as a tool of convenience rather than performance

### Why don't you use a materialized view?

Prisma doesn't have great support for materialized views. Also, this would require more work to be done to make sure the view updates regularly, either via a new scheduled job, or some quite complicated and not-very-maintainable SQL magic.

### Why don't you set up a job that takes this table and creates a second, smaller table?

We considered doing this, but  reducing the size of the table has additional cost-saving benefits, as CloudQuery charges us per million rows. This step would require a lot of additional work, and a prisma migration. I also think having two tables with basically exactly the same schema, with a relationship that isn't immediately clear could cause confusion, even with extensive documentation. If we do end up needing this, it's relatively simple to remove some of the existing filters and set it up at a later date, but currently, it's scope creep.

## How has it been verified?

Verified by running the task on CODE
