### PR TITLE
Add new `aws_resources()` function which returns a dedupped list of AWS Resources tracked by cloudquery

### DIFF
--- a/packages/common/prisma/migrations/20240409101800_function_aws_resource/migration.sql
+++ b/packages/common/prisma/migrations/20240409101800_function_aws_resource/migration.sql
@@ -1,3 +1,6 @@
+-- Cloudquery cant update the schema of tables referenced by views. 
+-- As this view references any Cloudquery table containing an ARN column It can make Cloudquery behave strangely.
+-- This migration replaces this view with a function which doesn't have the same restriction.
 DROP VIEW view_aws_resources;
 
 -- Custom aggregate function that combines two JSONB objects together. Uses the inbuilt `jsonb_concat` function.
@@ -66,7 +69,7 @@ BEGIN
                                                      AND table_name = cloudquery_table.table_name)
                                           THEN 'request_account_id'
                                       ELSE 'NULL' END;
-            -- Check if table has an region column, or default to NULL
+            -- Check if table has an region column, or default to unavailable
             region := CASE
                           WHEN EXISTS (SELECT 1
                                        FROM information_schema.columns

--- a/packages/common/prisma/migrations/20240409101800_function_aws_resource/migration.sql
+++ b/packages/common/prisma/migrations/20240409101800_function_aws_resource/migration.sql
@@ -1,0 +1,138 @@
+DROP VIEW view_aws_resources;
+
+-- Custom aggregate function that combines two JSONB objects together. Uses the inbuilt `jsonb_concat` function.
+-- Useful for when grouping many rows together that share a JSONB column
+CREATE AGGREGATE jsonb_aggregate (jsonb)(
+    SFUNC = jsonb_concat,
+    STYPE = jsonb
+);
+
+-- Aggregate rows from all AWS Cloudquery tables
+CREATE FUNCTION aws_resources()
+    RETURNS TABLE
+            (
+                account_id         text,
+                request_account_id text,
+                region             text,
+                partition          text,
+                service            text,
+                type               text,
+                arn                text,
+                taggable           boolean,
+                tags               jsonb
+            )
+AS
+$$
+DECLARE
+    cloudquery_table   record;
+    str_sql            text;
+    account_id         text;
+    request_account_id text;
+    region             text;
+    tags               text;
+    taggable           text;
+BEGIN
+    FOR cloudquery_table IN
+        -- Find all base tables (no views allowed)
+        SELECT DISTINCT table_name
+        FROM information_schema.tables
+        WHERE table_type = 'BASE TABLE'
+        -- find the intersection of tables that have an account_id or request_account_id column
+        INTERSECT
+        SELECT DISTINCT table_name
+        FROM information_schema.columns
+        WHERE table_name LIKE 'aws_%s'
+          and COLUMN_NAME IN ('account_id', 'request_account_id')
+        -- find the intersection of tables that have an arn column
+        INTERSECT
+        SELECT table_name
+        FROM information_schema.columns
+        WHERE table_name LIKE 'aws_%s'
+          and COLUMN_NAME = 'arn'
+
+        LOOP
+            -- Check if table has an account_id column, or default to NULL
+            account_id := CASE
+                              WHEN EXISTS (SELECT 1
+                                           FROM information_schema.columns
+                                           WHERE column_name = 'account_id'
+                                             AND table_name = cloudquery_table.table_name) THEN 'account_id'
+                              ELSE 'NULL' END;
+            -- Check if table has an request_account_id column, or default to NULL
+            request_account_id := CASE
+                                      WHEN EXISTS (SELECT 1
+                                                   FROM information_schema.columns
+                                                   WHERE column_name = 'request_account_id'
+                                                     AND table_name = cloudquery_table.table_name)
+                                          THEN 'request_account_id'
+                                      ELSE 'NULL' END;
+            -- Check if table has an region column, or default to NULL
+            region := CASE
+                          WHEN EXISTS (SELECT 1
+                                       FROM information_schema.columns
+                                       WHERE column_name = 'region'
+                                         AND table_name = cloudquery_table.table_name)
+                              THEN 'region'
+                          ELSE E'\'unavailable\'' END;
+            -- Check if table has an tags column, or default to an empty object
+            tags := CASE
+                        WHEN EXISTS (SELECT 1
+                                     FROM information_schema.columns
+                                     WHERE column_name = 'tags'
+                                       AND table_name = cloudquery_table.table_name)
+                            THEN 'tags'
+                        ELSE '''{}''::jsonb' END;
+            -- Does the table have a tags column
+            taggable := CASE
+                            WHEN EXISTS (SELECT 1
+                                         FROM information_schema.columns
+                                         WHERE column_name = 'tags'
+                                           AND table_name = cloudquery_table.table_name)
+                                THEN 'true'
+                            ELSE 'false' END;
+
+            IF NOT (str_sql = ''::TEXT) THEN
+                str_sql = str_sql || ' UNION ALL ';
+            END IF;
+
+            -- Fetch rows of table and append to function output
+            str_sql = str_sql || FORMAT(E'
+                    SELECT
+                        %L as cq_table,
+                        COALESCE(%s, SPLIT_PART(arn, \':\', 5)) AS account_id,
+                        COALESCE(%s, %s, SPLIT_PART(arn, \':\', 5)) AS request_account_id,
+                        %s AS region,
+                        SPLIT_PART(arn, \':\', 2) AS partition,
+                        SPLIT_PART(arn, \':\', 3) AS service,
+                        CASE
+                        WHEN SPLIT_PART(SPLIT_PART(ARN, \':\', 6), \'/\', 2) = \'\' AND SPLIT_PART(arn, \':\', 7) = \'\' THEN NULL
+                            ELSE SPLIT_PART(SPLIT_PART(arn, \':\', 6), \'/\', 1)
+                        END AS type,
+                        arn,
+                        %s as taggable,
+                        %s as tags
+                    FROM %s',
+                                        cloudquery_table.table_name, account_id, request_account_id, account_id, region,
+                                        taggable, tags, cloudquery_table.table_name);
+        END LOOP;
+
+    RETURN QUERY EXECUTE FORMAT(
+            E'SELECT account_id,
+                     request_account_id,
+                     region,
+                     partition,
+                     service,
+                     type,
+                     arn,
+                     bool_or(taggable) as taggable,
+                     jsonb_agg(tags) as tags
+                FROM (%s) 
+            GROUP BY account_id,
+                     request_account_id,
+                     region,
+                     partition,
+                     service,
+                     type',
+            str_sql);
+END
+$$ LANGUAGE plpgsql;

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -708,21 +708,3 @@ view view_github_actions {
 
   @@ignore
 }
-
-/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
-view view_aws_resources {
-  cq_id              String?   @map("_cq_id") @db.Uuid
-  cq_source_name     String?   @map("_cq_source_name")
-  cq_sync_time       DateTime? @map("_cq_sync_time") @db.Timestamp(6)
-  cq_table           String?   @map("_cq_table")
-  account_id         String?
-  request_account_id String?
-  region             String?
-  partition          String?
-  service            String?
-  type               String?
-  arn                String?
-  tags               Json?
-
-  @@ignore
-}


### PR DESCRIPTION
## What does this change?

 - **Drops the `view_aws_resources` view in favour of a function.**

Views can be a bit problematic for CloudQuery and Postgres. The structure of any tables a view depends on cannot be changed, this means that you have to delete the view before you can change the underlying tables.

Since our view references most AWS Cloudquery tables this means that we won't be able to update any of our tables without deleting our view. This can also cause CloudQuery to behave unpredictably as it will try to update table schemas whenever a plugin is updated.

Functions on the other hand don't have this limitation. Due to how much custom code a function can contain its impossible for Postgres to do integrity checks on tables used by a function.

Using a function in a query is pretty straight forward. The only change users need to do is append `()` to the function name in a query, for example

```
SELECT * FROM aws_resources()
```
instead of
```
SELECT * FROM aws_resources
```

- **Track all resources, not just taggable ones**

The previous view ignored tables that didn't have a `tags` column, this meant that untaggable resources couldn't be found in the view. This was a quirk of how we tried to dedupe rows.

This function improves on that by introducing a `taggable` column. If a given resource has no tables with a `tags` column, this column is set to false, otherwise its set to true.

 - **This function looks for any table that has an Account ID and ARN column and aggregates all its rows with similar tables.**

ARNs are deduplicated so that each resource only has 1 row in the output. This is important as an AWS resource can be described over multiple different tables, for example S3 buckets have `aws_s3_buckets`, `aws_s3_bucket_policies`, and `aws_s3_bucket_lifecycles` all of which can contain a record for the same ARN.


## How has it been verified?

Tested in DEV and CODE
