### PR TITLE
Add aws_securityhub_findings table to prisma schema, and make more performant

### DIFF
--- a/packages/common/prisma/migrations/20240410101502_aws_securityhub_findings/migration.sql
+++ b/packages/common/prisma/migrations/20240410101502_aws_securityhub_findings/migration.sql
@@ -54,8 +54,8 @@ CREATE TABLE IF NOT EXISTS "aws_securityhub_findings" (
     CONSTRAINT "aws_securityhub_findings_cqpk" PRIMARY KEY ("request_account_id","request_region","aws_account_id","created_at","description","generator_id","id","product_arn","schema_version","title","updated_at","region")
 );
 -- CreateIndex
-CREATE UNIQUE INDEX "aws_securityhub_findings__cq_id_key" ON "aws_securityhub_findings"("_cq_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "aws_securityhub_findings__cq_id_key" ON "aws_securityhub_findings"("_cq_id");
 
-CREATE INDEX idx_aws_account_name ON aws_securityhub_findings (aws_account_name);
-CREATE INDEX idx_severity_normalized ON aws_securityhub_findings (severity->>'Normalized');
-CREATE INDEX idx_workflow_status ON aws_securityhub_findings (workflow->>'Status');
+CREATE INDEX IF NOT EXISTS idx_aws_account_name ON aws_securityhub_findings ((aws_account_name));
+CREATE INDEX IF NOT EXISTS idx_severity_normalized ON aws_securityhub_findings ((severity->>'Normalized'));
+CREATE INDEX IF NOT EXISTS idx_workflow_status ON aws_securityhub_findings ((workflow->>'Status'));

--- a/packages/common/prisma/migrations/20240410101502_aws_securityhub_findings/migration.sql
+++ b/packages/common/prisma/migrations/20240410101502_aws_securityhub_findings/migration.sql
@@ -1,0 +1,61 @@
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "aws_securityhub_findings" (
+    "_cq_sync_time" TIMESTAMP(6),
+    "_cq_source_name" TEXT,
+    "_cq_id" UUID NOT NULL,
+    "_cq_parent_id" UUID,
+    "request_account_id" TEXT NOT NULL,
+    "request_region" TEXT NOT NULL,
+    "aws_account_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(6) NOT NULL,
+    "description" TEXT NOT NULL,
+    "generator_id" TEXT NOT NULL,
+    "id" TEXT NOT NULL,
+    "product_arn" TEXT NOT NULL,
+    "resources" JSONB,
+    "schema_version" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "updated_at" TIMESTAMP(6) NOT NULL,
+    "action" JSONB,
+    "aws_account_name" TEXT,
+    "company_name" TEXT,
+    "compliance" JSONB,
+    "confidence" BIGINT,
+    "criticality" BIGINT,
+    "finding_provider_fields" JSONB,
+    "first_observed_at" TIMESTAMP(6),
+    "generator_details" JSONB,
+    "last_observed_at" TIMESTAMP(6),
+    "malware" JSONB,
+    "network" JSONB,
+    "network_path" JSONB,
+    "note" JSONB,
+    "patch_summary" JSONB,
+    "process" JSONB,
+    "processed_at" TIMESTAMP(6),
+    "product_fields" JSONB,
+    "product_name" TEXT,
+    "record_state" TEXT,
+    "region" TEXT NOT NULL,
+    "related_findings" JSONB,
+    "remediation" JSONB,
+    "sample" BOOLEAN,
+    "severity" JSONB,
+    "source_url" TEXT,
+    "threat_intel_indicators" JSONB,
+    "threats" JSONB,
+    "types" TEXT[],
+    "user_defined_fields" JSONB,
+    "verification_state" TEXT,
+    "vulnerabilities" JSONB,
+    "workflow" JSONB,
+    "workflow_state" TEXT,
+
+    CONSTRAINT "aws_securityhub_findings_cqpk" PRIMARY KEY ("request_account_id","request_region","aws_account_id","created_at","description","generator_id","id","product_arn","schema_version","title","updated_at","region")
+);
+-- CreateIndex
+CREATE UNIQUE INDEX "aws_securityhub_findings__cq_id_key" ON "aws_securityhub_findings"("_cq_id");
+
+CREATE INDEX idx_aws_account_name ON aws_securityhub_findings (aws_account_name);
+CREATE INDEX idx_severity_normalized ON aws_securityhub_findings (severity->>'Normalized');
+CREATE INDEX idx_workflow_status ON aws_securityhub_findings (workflow->>'Status');

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -642,6 +642,7 @@ model repocop_vulnerabilities {
   id               String   @id @default(uuid())
 }
 
+/// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.
 model aws_securityhub_findings {
   cq_sync_time            DateTime? @map("_cq_sync_time") @db.Timestamp(6)
   cq_source_name          String?   @map("_cq_source_name")
@@ -695,6 +696,7 @@ model aws_securityhub_findings {
   workflow_state          String?
 
   @@id([request_account_id, request_region, aws_account_id, created_at, description, generator_id, id, product_arn, schema_version, title, updated_at, region], map: "aws_securityhub_findings_cqpk")
+  @@index([aws_account_name], map: "idx_aws_account_name")
 }
 
 view view_repo_ownership {

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -642,6 +642,61 @@ model repocop_vulnerabilities {
   id               String   @id @default(uuid())
 }
 
+model aws_securityhub_findings {
+  cq_sync_time            DateTime? @map("_cq_sync_time") @db.Timestamp(6)
+  cq_source_name          String?   @map("_cq_source_name")
+  cq_id                   String    @unique @map("_cq_id") @db.Uuid
+  cq_parent_id            String?   @map("_cq_parent_id") @db.Uuid
+  request_account_id      String
+  request_region          String
+  aws_account_id          String
+  created_at              DateTime  @db.Timestamp(6)
+  description             String
+  generator_id            String
+  id                      String
+  product_arn             String
+  resources               Json?
+  schema_version          String
+  title                   String
+  updated_at              DateTime  @db.Timestamp(6)
+  action                  Json?
+  aws_account_name        String?
+  company_name            String?
+  compliance              Json?
+  confidence              BigInt?
+  criticality             BigInt?
+  finding_provider_fields Json?
+  first_observed_at       DateTime? @db.Timestamp(6)
+  generator_details       Json?
+  last_observed_at        DateTime? @db.Timestamp(6)
+  malware                 Json?
+  network                 Json?
+  network_path            Json?
+  note                    Json?
+  patch_summary           Json?
+  process                 Json?
+  processed_at            DateTime? @db.Timestamp(6)
+  product_fields          Json?
+  product_name            String?
+  record_state            String?
+  region                  String
+  related_findings        Json?
+  remediation             Json?
+  sample                  Boolean?
+  severity                Json?
+  source_url              String?
+  threat_intel_indicators Json?
+  threats                 Json?
+  types                   String[]
+  user_defined_fields     Json?
+  verification_state      String?
+  vulnerabilities         Json?
+  workflow                Json?
+  workflow_state          String?
+
+  @@id([request_account_id, request_region, aws_account_id, created_at, description, generator_id, id, product_arn, schema_version, title, updated_at, region], map: "aws_securityhub_findings_cqpk")
+}
+
 view view_repo_ownership {
   github_team_id     BigInt
   github_team_name   String


### PR DESCRIPTION
## What does this change?

Adds aws_securityhub_findings to the prisma schema
Creates indexes for the table, for faster searching

## Why?

Running this query

```sql
SELECT title
     , resources
     , aws_account_name
     , severity
     , workflow
FROM aws_securityhub_findings
WHERE aws_account_name = '<MY_ACCOUNT>'
  AND workflow ->> 'Status' != 'SUPPRESSED'
ORDER BY severity ->> 'Normalized' DESC
                LIMIT 50
```

previously took 22 seconds. When using this table as a source for grafana, this results in intolerable waiting times when graphs are loading. By creating a migration that includes adding indexes, we can see the query time reduced to 220 ms, a 100x improvement

## How has it been verified?

The migration has already been applied to CODE, and the query benchmarked
