### PR TITLE
Create cloudbuster project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6082,6 +6082,10 @@
         "node": ">=12"
       }
     },
+    "node_modules/cloudbuster": {
+      "resolved": "packages/cloudbuster",
+      "link": true
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "dev": true,
@@ -13647,6 +13651,9 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "packages/cloudbuster": {
+      "version": "1.0.0"
     },
     "packages/common": {
       "version": "0.0.0",

--- a/packages/cloudbuster/.gitignore
+++ b/packages/cloudbuster/.gitignore
@@ -1,0 +1,4 @@
+index.js
+
+# Generated files
+dist

--- a/packages/cloudbuster/README.md
+++ b/packages/cloudbuster/README.md
@@ -1,0 +1,23 @@
+## Cloudbuster
+
+Yes, it is a Kate Bush reference.
+
+### What does it do?
+
+The cloudbuster evaluates AWS FSBP violations, collected via CloudQuery, and sends alerts to the relevant teams.
+
+### Why?
+
+Security best practice in the cloud is constantly evolving, and it's difficult to keep up. By using a framework like FSBP, we can ensure that we are largely following best practices, and teams have less security work to worry about.
+
+### Running on non-production environments
+
+???
+
+#### CODE
+
+???
+
+#### DEV
+
+???

--- a/packages/cloudbuster/README.md
+++ b/packages/cloudbuster/README.md
@@ -10,14 +10,8 @@ The cloudbuster evaluates AWS FSBP violations, collected via CloudQuery, and sen
 
 Security best practice in the cloud is constantly evolving, and it's difficult to keep up. By using a framework like FSBP, we can ensure that we are largely following best practices, and teams have less security work to worry about.
 
-### Running on non-production environments
+### How do I run it?
 
-???
+Retrieve deployTools credentials from Janus. Run: `npm run start -w dev-environment` to set up a local CloudQuery DB.
 
-#### CODE
-
-???
-
-#### DEV
-
-???
+Wait a minute or two for the DB sync to complete, then run: `npm run start -w cloudbuster`

--- a/packages/cloudbuster/package.json
+++ b/packages/cloudbuster/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "cloudbuster",
+	"version": "1.0.0",
+	"devDependencies": {
+		"@types/aws-lambda": "^8.10.137"
+	},
+	"scripts": {
+		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@aws-sdk",
+		"start": "APP=cloudbuster tsx src/run-locally.ts",
+		"test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects snyk-integrator"
+	},
+	"dependencies": {}
+}

--- a/packages/cloudbuster/package.json
+++ b/packages/cloudbuster/package.json
@@ -1,13 +1,7 @@
 {
 	"name": "cloudbuster",
 	"version": "1.0.0",
-	"devDependencies": {
-		"@types/aws-lambda": "^8.10.137"
-	},
 	"scripts": {
-		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@aws-sdk",
-		"start": "APP=cloudbuster tsx src/run-locally.ts",
-		"test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects snyk-integrator"
-	},
-	"dependencies": {}
+		"start": "APP=cloudbuster tsx src/run-locally.ts"
+	}
 }

--- a/packages/cloudbuster/src/config.ts
+++ b/packages/cloudbuster/src/config.ts
@@ -1,0 +1,14 @@
+import { getEnvOrThrow } from 'common/functions';
+
+export interface Config {
+	/**
+	 * The stage of the application, e.g. DEV, CODE, PROD.
+	 */
+	stage: string;
+}
+
+export function getConfig(): Config {
+	return {
+		stage: getEnvOrThrow('STAGE'),
+	};
+}

--- a/packages/cloudbuster/src/config.ts
+++ b/packages/cloudbuster/src/config.ts
@@ -1,14 +1,27 @@
+import type { PrismaConfig } from 'common/database';
+import {
+	getDatabaseConfig,
+	getDatabaseConnectionString,
+	getDevDatabaseConfig,
+} from 'common/database';
 import { getEnvOrThrow } from 'common/functions';
 
-export interface Config {
+export interface Config extends PrismaConfig {
 	/**
 	 * The stage of the application, e.g. DEV, CODE, PROD.
 	 */
 	stage: string;
 }
 
-export function getConfig(): Config {
+export async function getConfig(): Promise<Config> {
+	const stage = getEnvOrThrow('STAGE');
+	const databaseConfig =
+		stage === 'DEV'
+			? await getDevDatabaseConfig()
+			: await getDatabaseConfig(stage, 'repocop');
 	return {
-		stage: getEnvOrThrow('STAGE'),
+		stage,
+		databaseConnectionString: getDatabaseConnectionString(databaseConfig),
+		withQueryLogging: stage === 'DEV',
 	};
 }

--- a/packages/cloudbuster/src/config.ts
+++ b/packages/cloudbuster/src/config.ts
@@ -18,7 +18,7 @@ export async function getConfig(): Promise<Config> {
 	const databaseConfig =
 		stage === 'DEV'
 			? await getDevDatabaseConfig()
-			: await getDatabaseConfig(stage, 'repocop');
+			: await getDatabaseConfig(stage, 'repocop'); //TODO create a new db user for cloudbuster before deploying.
 	return {
 		stage,
 		databaseConnectionString: getDatabaseConnectionString(databaseConfig),

--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -1,0 +1,3 @@
+export function main() {
+	console.log('Hello, world!');
+}

--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -1,3 +1,14 @@
-export function main() {
-	console.log('Hello, world!');
+import type { aws_securityhub_findings, PrismaClient } from '@prisma/client';
+import { getPrismaClient } from 'common/database';
+import { config } from 'dotenv';
+import { getConfig } from './config';
+
+config({ path: `../../.env` }); // Load `.env` file at the root of the repository
+
+export async function main() {
+	const config = await getConfig();
+	const prisma: PrismaClient = getPrismaClient(config);
+	const findings: aws_securityhub_findings[] =
+		await prisma.aws_securityhub_findings.findMany();
+	console.log(findings.slice(0, 5));
 }

--- a/packages/cloudbuster/src/run-locally.ts
+++ b/packages/cloudbuster/src/run-locally.ts
@@ -1,0 +1,5 @@
+import { main } from './index';
+
+if (require.main === module) {
+	void main();
+}

--- a/packages/cloudbuster/tsconfig.json
+++ b/packages/cloudbuster/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}


### PR DESCRIPTION
## What does this change?

Get in loser, we're going [cloudbusting](https://www.youtube.com/watch?v=pllRW9wETzw)!

Since #922 , the `aws_securityhub_findings` table has been availabe to the Prisma client. This PR sets up a skeleton project that will eventually send FSBP alerts to teams.

## Why?

We currently have an FSPB dashboard, where teams/managers can examine their open vulnerabilities, as well as in SecurityHub itself, but there is currently no standardised way of getting these alerts to teams. In the same vein as repocop, cloudbuster is a lambda that will collect this information, process and prioritise it, and tell teams what the most urgent vulnerabilities are.

## How has it been verified?

Local execution works.
