### PR TITLE
Skip `aws_wellarchitected` tables

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -13417,6 +13417,7 @@ spec:
     - aws_xray_sampling_rules
     - aws_xray_resource_policies
     - aws_xray_groups
+    - aws_wellarchitected_*
     - aws_stepfunctions_map_runs
     - aws_stepfunctions_map_run_executions
     - aws_stepfunctions_executions

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -327,6 +327,9 @@ export const skipTables = [
 	'aws_xray_sampling_rules',
 	'aws_xray_resource_policies',
 	'aws_xray_groups',
+	// We don't really use Wellarchictected and it confuses our Tagging obligation
+	// due to it having many resources managed by AWS without tags
+	'aws_wellarchitected_*',
 
 	// These appear to be heavily rate limited, and not too interesting (yet).
 	// Don't collect them to reduce execution time.


### PR DESCRIPTION
## What does this change?

Skips the `aws_wellarchitected` tables.

## Why?

We don't use wellarchitected so the data from these tables is not very useful. They also contain a lot of AWS managed resources that are untagged which throws off our tagging baseline.
