### PR TITLE
feat: Remove Snyk vulnerability IDs where possible in favour of CVEs.

### DIFF
--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -21,6 +21,7 @@ import {
 	hasDependencyTracking,
 	hasOldAlerts,
 	snykAlertToRepocopVulnerability,
+	snykVulnIdFilter,
 } from './repository';
 
 function evaluateRepoTestHelper(
@@ -971,5 +972,25 @@ describe('Deduplication of repocop vulnerabilities', () => {
 		};
 		const actual = deduplicateVulnerabilitiesByCve([vuln4, vuln4]);
 		expect(actual.length).toStrictEqual(2);
+	});
+});
+
+describe('NO RULE - Snyk vulnerability ID filter', () => {
+	test('Should not remove any IDs if no CVE id is present', () => {
+		const ids = ['SNYK-1234', 'SNYK-1235'];
+		const actual = snykVulnIdFilter(ids);
+		expect(actual).toStrictEqual(ids);
+	});
+
+	test('Should remove vulnerability IDs that start with Snyk, if a CVE id is present', () => {
+		const ids = ['SNYK-1234', 'CVE-1234'];
+		const actual = snykVulnIdFilter(ids);
+		expect(actual).toStrictEqual(['CVE-1234']);
+	});
+
+	test('Should return the original list if only CVEs are present', () => {
+		const ids = ['CVE-1234', 'CVE-1235'];
+		const actual = snykVulnIdFilter(ids);
+		expect(actual).toStrictEqual(ids);
 	});
 });

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -428,6 +428,15 @@ export function dependabotAlertToRepocopVulnerability(
 	};
 }
 
+export function snykVulnIdFilter(ids: string[]): string[] {
+	const hasCvePrefixedIssue = !!ids.find((cve) => cve.startsWith('CVE-'));
+	if (hasCvePrefixedIssue) {
+		return ids.filter((cve) => cve.startsWith('CVE-'));
+	} else {
+		return ids;
+	}
+}
+
 export function snykAlertToRepocopVulnerability(
 	fullName: string,
 	issue: SnykIssue,
@@ -460,7 +469,7 @@ export function snykAlertToRepocopVulnerability(
 		ecosystem: ecosystem ?? 'unknown ecosystem',
 		alert_issue_date: new Date(issue.attributes.created_at),
 		is_patchable: isPatchable,
-		cves: issue.attributes.problems.map((p) => p.id),
+		cves: snykVulnIdFilter(issue.attributes.problems.map((p) => p.id)),
 	};
 }
 


### PR DESCRIPTION
Co-authored-by: @tjsilver 


## What does this change?

If a CVE-based vulnerability ID is available, pass only that to the `cves` field of the `RepocopVulnerability` interface. Otherwise, fall back to the original list of IDs.

## Why?

Snyk usually gives a vulnerability an internal Snyk ID, regardless of whether or not there is already a CVE.
This means there are lots of scenarios where a dependabot issue looks like this `[CVE-1234]`, and its corresponding Snyk issue could look like this `[CVE-1234, SNYK-5678]`, meaning that it does not get deduplicated.
Now that we are filtering out the Snyk ID wherever possible, we are able to deduplicate CVEs more accurately


## How has it been verified?

- Unit tests have been added to verify the correct behaviour.
- Repocop has been run on CODE, where we saw the number of vulnerabilities drop by 11%
