### PR TITLE
feat: add action to link to team vuln dashboard

### DIFF
--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -100,7 +100,6 @@ describe('createDigest', () => {
 		expect(
 			createDigest(team, [ownershipRecord], [resultWithVuln]),
 		).toStrictEqual({
-			teamName,
 			teamSlug,
 			subject: `Vulnerability Digest for ${teamName}`,
 			message: String.raw`Found 1 vulnerabilities across 1 repositories.
@@ -110,6 +109,16 @@ Note: DevX only aggregates vulnerability information for repositories with a pro
 [guardian/repo](https://github.com/guardian/repo) contains a [HIGH vulnerability](example.com).
 Introduced via **leftpad** on Fri Jan 01 2021, from pip.
 This vulnerability is patchable.`,
+			actions: [
+				{
+					cta: `View vulnerability dashboard for ${teamName} on Grafana`,
+					url: `https://metrics.gutools.co.uk/d/fdib3p8l85jwgd?var-repo_owner=${teamSlug}`,
+				},
+				{
+					cta: "See 'Prioritise the vulnerabilities' in these docs for obligations",
+					url: 'https://security-hq.gutools.co.uk/documentation/vulnerability-management',
+				},
+			],
 		});
 	});
 
@@ -173,7 +182,6 @@ This vulnerability is patchable.`,
 			[ownershipRecord, anotherOwnershipRecord],
 			[resultWithVuln, anotherResultWithVuln],
 		);
-		expect(digest?.teamName).toBe(team.name);
 		expect(digest?.teamSlug).toBe(team.slug);
 		expect(digest?.message).toContain('leftpad');
 
@@ -182,7 +190,6 @@ This vulnerability is patchable.`,
 			[ownershipRecord, anotherOwnershipRecord],
 			[resultWithVuln, anotherResultWithVuln],
 		);
-		expect(anotherDigest?.teamName).toBe(anotherTeam.name);
 		expect(anotherDigest?.teamSlug).toBe(anotherTeam.slug);
 		expect(anotherDigest?.message).toContain('rightpad');
 	});

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -173,6 +173,7 @@ This vulnerability is patchable.`,
 			[ownershipRecord, anotherOwnershipRecord],
 			[resultWithVuln, anotherResultWithVuln],
 		);
+		expect(digest?.teamName).toBe(team.name);
 		expect(digest?.teamSlug).toBe(team.slug);
 		expect(digest?.message).toContain('leftpad');
 
@@ -181,6 +182,7 @@ This vulnerability is patchable.`,
 			[ownershipRecord, anotherOwnershipRecord],
 			[resultWithVuln, anotherResultWithVuln],
 		);
+		expect(anotherDigest?.teamName).toBe(anotherTeam.name);
 		expect(anotherDigest?.teamSlug).toBe(anotherTeam.slug);
 		expect(anotherDigest?.message).toContain('rightpad');
 	});

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -100,6 +100,7 @@ describe('createDigest', () => {
 		expect(
 			createDigest(team, [ownershipRecord], [resultWithVuln]),
 		).toStrictEqual({
+			teamName,
 			teamSlug,
 			subject: `Vulnerability Digest for ${teamName}`,
 			message: String.raw`Found 1 vulnerabilities across 1 repositories.

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -45,6 +45,13 @@ Introduced via **${vuln.package}** on ${dateString}, from ${ecosystem}.
 This vulnerability ${vuln.is_patchable ? 'is ' : 'may *not* be '}patchable.`;
 }
 
+function createTeamDashboardLinkAction(team: Team) {
+	return {
+		cta: `View vulnerability dashboard for ${team.name} on Grafana`,
+		url: `https://metrics.gutools.co.uk/d/fdib3p8l85jwgd?var-repo_owner=${team.slug}`,
+	};
+}
+
 export function createDigest(
 	team: Team,
 	repoOwners: view_repo_ownership[],
@@ -71,11 +78,18 @@ Note: DevX only aggregates vulnerability information for repositories with a pro
 
 	const message = `${preamble}\n\n${digestString}`;
 
+	const actionObligations: Action = {
+		cta: "See 'Prioritise the vulnerabilities' in these docs for obligations",
+		url: 'https://security-hq.gutools.co.uk/documentation/vulnerability-management',
+	};
+
+	const actions = [createTeamDashboardLinkAction(team), actionObligations];
+
 	return {
-		teamName: team.name,
 		teamSlug: team.slug,
 		subject: `Vulnerability Digest for ${team.name}`,
 		message,
+		actions,
 	};
 }
 
@@ -84,13 +98,6 @@ export function isFirstOrThirdTuesdayOfMonth(date: Date) {
 	const inFirstWeek = date.getDate() <= 7;
 	const inThirdWeek = date.getDate() >= 15 && date.getDate() <= 21;
 	return isTuesday && (inFirstWeek || inThirdWeek);
-}
-
-function createTeamDashboardLinkAction(digest: VulnerabilityDigest) {
-	return {
-		cta: `View Vulnerability dashboard for ${digest.teamName} on Grafana`,
-		url: `https://metrics.gutools.co.uk/d/fdib3p8l85jwgd/dependency-vulnerabilities?orgId=1&var-repo_owner=${digest.teamSlug}`,
-	};
 }
 
 async function sendVulnerabilityDigests(
@@ -104,18 +111,13 @@ async function sendVulnerabilityDigests(
 			.join(', ')}`,
 	);
 
-	const actionObligations: Action = {
-		cta: "See 'Prioritise the vulnerabilities' of these docs for vulnerability obligations",
-		url: 'https://security-hq.gutools.co.uk/documentation/vulnerability-management',
-	};
-
 	return Promise.all(
 		digests.map(
 			async (digest) =>
 				await anghammarad.notify({
 					subject: digest.subject,
 					message: digest.message,
-					actions: [actionObligations, createTeamDashboardLinkAction(digest)],
+					actions: digest.actions,
 					target: { GithubTeamSlug: digest.teamSlug },
 					channel: RequestedChannel.PreferHangouts,
 					sourceSystem: `${config.app} ${config.stage}`,

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -174,6 +174,7 @@ export interface EvaluationResult {
 }
 
 export interface VulnerabilityDigest {
+	teamName: string;
 	teamSlug: string;
 	subject: string;
 	message: string;

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -1,3 +1,4 @@
+import type { Action } from '@guardian/anghammarad';
 import type { Endpoints } from '@octokit/types';
 import type {
 	aws_cloudformation_stacks,
@@ -174,8 +175,8 @@ export interface EvaluationResult {
 }
 
 export interface VulnerabilityDigest {
-	teamName: string;
 	teamSlug: string;
 	subject: string;
 	message: string;
+	actions: Action[];
 }


### PR DESCRIPTION
## What does this change?

- Adds a new action to the vulnerability digest Anghammarad notification which links to the Grafana dashboard filtered to the team slug.
- Moves the action creation into the `createDigest`  function
- Adds an `actions` field to the VulnerabilityDigest type.

## Why?

Teams will be able to view all their Critical and High vulnerabilities in one place.

## How has it been verified?

All unit tests pass and the shape of the digest produced is as expected.