### PR TITLE
Revert "ci: Add test reporter"

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,6 @@ const transform = {
 module.exports = {
 	verbose: true,
 	testEnvironment: 'node',
-	reporters: [['github-actions', { silent: false }], 'summary'],
 	projects: [
 		{
 			displayName: 'cdk',


### PR DESCRIPTION
Reverts guardian/service-catalogue#896

## Why

The change in the original PR had some unintended consequences. Individual tests are no longer visible in the console when running `npm run test` locally. This makes it almost impossible to debug test failures without pushing to GitHub or raising a PR. As a result, CI has "shifted right", and debugging tests takes much longer than it needs to, as it requires an interaction with GitHub.

I think that having GitHub annotate PRs with test failures is valuable, but this shouldn't come at the expense of elongating the feedback loop.