### PR TITLE
Bump AWS Source plugin to v26.0.0

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ CQ_POSTGRES_DESTINATION=7.2.0
 CQ_POSTGRES_SOURCE=3.0.7
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/aws/versions
-CQ_AWS=23.6.1
+CQ_AWS=26.0.0
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/github/versions
 CQ_GITHUB=8.1.3

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -121,7 +121,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_costexplorer_*
   destinations:
@@ -769,7 +769,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_accessanalyzer_*
     - aws_securityhub_*
@@ -1403,7 +1403,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_organization*
   destinations:
@@ -6543,7 +6543,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_autoscaling_groups
   destinations:
@@ -7161,7 +7161,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_backup_protected_resources
     - aws_backup_vaults
@@ -7781,7 +7781,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_acm*
   destinations:
@@ -8429,7 +8429,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_cloudformation_*
   destinations:
@@ -9251,7 +9251,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_cloudwatch_alarms
   destinations:
@@ -9635,7 +9635,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_dynamodb*
   destinations:
@@ -10253,7 +10253,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_ec2_instances
     - aws_ec2_security_groups
@@ -10903,7 +10903,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_inspector_findings
     - aws_inspector2_findings
@@ -11756,7 +11756,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_elbv1_*
     - aws_elbv2_*
@@ -12375,7 +12375,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_rds_instances
     - aws_rds_clusters
@@ -12762,7 +12762,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_s3*
   destinations:
@@ -13380,7 +13380,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_*
   skip_tables:

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -35,7 +35,7 @@ describe('Config generation, and converting to YAML', () => {
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_s3_buckets
   destinations:
@@ -69,7 +69,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - '*'
   skip_tables:
@@ -108,7 +108,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_accessanalyzer_analyzers
     - aws_accessanalyzer_analyzer_archive_rules
@@ -152,7 +152,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v23.6.1
+  version: v26.0.0
   tables:
     - aws_securityhub_findings
   destinations:


### PR DESCRIPTION
## What does this change?

Bumps AWS Source plugin to v26.0.0

## Why?

This version includes a bug fix to various tables where the `tags` column was not in the correct format.

- Change tag column to a map {} rather than an array of objects [{}] for tables aws_directoryservice_directories, aws_ec2_traffic_mirror_filters, aws_ec2_traffic_mirror_sessions, aws_ec2_traffic_mirror_targets, aws_emr_notebook_executions, aws_emr_studios, aws_transfer_agreements, aws_transfer_users, aws_transfer_certificates, aws_transfer_connectors, aws_transfer_profiles, aws_transfer_workflows

In v25.0.0 a number of AWS tables were moved to premium. We should keep an eye on our row usage to make sure it doesn't increase drastically.
