### PR TITLE
refactor: remove obligations action and replace with text

### DIFF
--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -104,6 +104,7 @@ describe('createDigest', () => {
 			subject: `Vulnerability Digest for ${teamName}`,
 			message: String.raw`Found 1 vulnerabilities across 1 repositories.
 Displaying the top 1 most urgent.
+Obligations to resolve: Critical - 1 day; High - 2 weeks.
 Note: DevX only aggregates vulnerability information for repositories with a production topic.
 
 [guardian/repo](https://github.com/guardian/repo) contains a [HIGH vulnerability](example.com).
@@ -113,10 +114,6 @@ This vulnerability is patchable.`,
 				{
 					cta: `View vulnerability dashboard for ${teamName} on Grafana`,
 					url: `https://metrics.gutools.co.uk/d/fdib3p8l85jwgd?var-repo_owner=${teamSlug}`,
-				},
-				{
-					cta: "See 'Prioritise the vulnerabilities' in these docs for obligations",
-					url: 'https://security-hq.gutools.co.uk/documentation/vulnerability-management',
 				},
 			],
 		});

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -1,4 +1,3 @@
-import type { Action } from '@guardian/anghammarad';
 import { Anghammarad, RequestedChannel } from '@guardian/anghammarad';
 import type { view_repo_ownership } from '@prisma/client';
 import type { Config } from '../../config';

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -70,6 +70,7 @@ export function createDigest(
 	const listedVulnsCount = topVulns.length;
 	const preamble = String.raw`Found ${totalVulnsCount} vulnerabilities across ${resultsForTeam.length} repositories.
 Displaying the top ${listedVulnsCount} most urgent.
+Obligations to resolve: Critical - 1 day; High - 2 weeks.
 Note: DevX only aggregates vulnerability information for repositories with a production topic.`;
 
 	const digestString = topVulns
@@ -77,13 +78,7 @@ Note: DevX only aggregates vulnerability information for repositories with a pro
 		.join('\n\n');
 
 	const message = `${preamble}\n\n${digestString}`;
-
-	const actionObligations: Action = {
-		cta: "See 'Prioritise the vulnerabilities' in these docs for obligations",
-		url: 'https://security-hq.gutools.co.uk/documentation/vulnerability-management',
-	};
-
-	const actions = [createTeamDashboardLinkAction(team), actionObligations];
+	const actions = [createTeamDashboardLinkAction(team)];
 
 	return {
 		teamSlug: team.slug,


### PR DESCRIPTION
## What does this change?

Removes the action that links to the SLA obligations and replaces it with text in the digest itself.

## Why?

Saves users at least one click and provides the information there and then.

## How has it been verified?

Local tests ran successfully.