### PR TITLE
chore(deps): Update Galaxies plugin to v1.1.3

### DIFF
--- a/.env
+++ b/.env
@@ -21,7 +21,7 @@ CQ_GITHUB=8.1.3
 CQ_FASTLY=3.0.7
 
 # See https://github.com/guardian/cq-source-galaxies
-CQ_GUARDIAN_GALAXIES=1.1.1
+CQ_GUARDIAN_GALAXIES=1.1.3
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/snyk/versions
 CQ_SNYK=5.3.0

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -2746,7 +2746,7 @@ spec:
   name: galaxies
   path: guardian/galaxies
   registry: github
-  version: v1.1.1
+  version: v1.1.3
   destinations:
     - postgresql
   tables:


### PR DESCRIPTION
## What does this change, and why?
Update the version of the [Galaxies plugin](https://github.com/guardian/cq-source-galaxies/releases). This version includes dependency updates, some of which patch vulnerabilities. For example https://github.com/guardian/cq-source-galaxies/security/dependabot/7.

## How has it been verified?
N/A.