### PR TITLE
ci: Add test reporter... take 2

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,10 +8,22 @@ const transform = {
 	'^.+\\.tsx?$': ['esbuild-jest', { target: 'esnext' }],
 };
 
+/*
+When running in CI (GitHub Actions), use the GitHub Actions reporter to annotate the PR with any test failures.
+Locally, use the default reporter.
+
+See:
+  - https://jestjs.io/docs/configuration#github-actions-reporter
+  - https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+ */
+const reporters = process.env.GITHUB_ACTIONS
+	? [['github-actions', { silent: false }], 'summary']
+	: ['default'];
+
 module.exports = {
 	verbose: true,
 	testEnvironment: 'node',
-	reporters: [['github-actions', { silent: false }], 'summary'],
+	reporters,
 	projects: [
 		{
 			displayName: 'cdk',

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,7 @@ const transform = {
 module.exports = {
 	verbose: true,
 	testEnvironment: 'node',
+	reporters: [['github-actions', { silent: false }], 'summary'],
 	projects: [
 		{
 			displayName: 'cdk',


### PR DESCRIPTION
## What does this change?
Attempt https://github.com/guardian/service-catalogue/pull/896 again, following the reversion in https://github.com/guardian/service-catalogue/pull/933.

In this version, we observe the [`GITHUB_ACTIONS` environment variable](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) which:

> Always set to `true` when GitHub Actions is running the workflow. You can use this variable to differentiate when tests are being run locally or by GitHub Actions.

Locally, test outputs look the same. In CI, test failures are annotated on the PR.

## Why?
As noted in https://github.com/guardian/service-catalogue/pull/896, the build log is pretty noisy. Seeing where https://github.com/guardian/service-catalogue/pull/941 is failing will be easier with PR annotations.

## How has it been verified?
Ran the tests locally, and observed the same output as on `main`.