### PR TITLE
use the main branch of release-image instead of a tagged version

### DIFF
--- a/.github/workflows/cq-image.yml
+++ b/.github/workflows/cq-image.yml
@@ -44,7 +44,7 @@ jobs:
 
   build-and-push:
     needs: CQ_CLI
-    uses: guardian/service-catalogue/.github/workflows/release-image.yml@v0.0.1
+    uses: guardian/service-catalogue/.github/workflows/release-image.yml@main
     with:
       IMAGE_NAME: cloudquery
       BUILD_ARGS: CQ_CLI=${{ needs.CQ_CLI.outputs.CQ_CLI }}

--- a/.github/workflows/cq-image.yml
+++ b/.github/workflows/cq-image.yml
@@ -44,7 +44,7 @@ jobs:
 
   build-and-push:
     needs: CQ_CLI
-    uses: guardian/service-catalogue/.github/workflows/release-image.yml@main
+    uses: ./.github/workflows/release-image.yml
     with:
       IMAGE_NAME: cloudquery
       BUILD_ARGS: CQ_CLI=${{ needs.CQ_CLI.outputs.CQ_CLI }}

--- a/.github/workflows/prisma-migrate-image.yml
+++ b/.github/workflows/prisma-migrate-image.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    uses: guardian/service-catalogue/.github/workflows/release-image.yml@release-image.yml@v0.0.1
+    uses: guardian/service-catalogue/.github/workflows/release-image.yml@main
     with:
       IMAGE_NAME: prisma-migrate
     permissions:

--- a/.github/workflows/prisma-migrate-image.yml
+++ b/.github/workflows/prisma-migrate-image.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    uses: guardian/service-catalogue/.github/workflows/release-image.yml@main
+    uses: ./.github/workflows/release-image.yml
     with:
       IMAGE_NAME: prisma-migrate
     permissions:

--- a/.github/workflows/singleton.yml
+++ b/.github/workflows/singleton.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    uses: guardian/service-catalogue/.github/workflows/release-image.yml@v0.0.1
+    uses: guardian/service-catalogue/.github/workflows/release-image.yml@main
     with:
       IMAGE_NAME: singleton
     permissions:

--- a/.github/workflows/singleton.yml
+++ b/.github/workflows/singleton.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    uses: guardian/service-catalogue/.github/workflows/release-image.yml@main
+    uses: ./.github/workflows/release-image.yml
     with:
       IMAGE_NAME: singleton
     permissions:


### PR DESCRIPTION
## What does this change?

Switches from a named release to a branch

## Why?

I think versioned releases make sense if we are using a workflow from another repo. However, as this action is only used by the service catalogue, I think that doing this would create unnecessary complication, in exchange for very little security benefit. In order to update a versioned workflow, the steps would be

1. Create a branch with the desired change,
2. Test the change referencing `branch-name` instead of `vX.Y.Z`
3. Remember to put it back at the end
4. Create a PR, and merge it to main
5. Create a new version via the CLI or GitHub UI
6. Create a second PR, advancing the version referenced in the action to the new release.

Using the relative workflow path, the steps are
1. Create a branch with the desired change
2. Test it
3. Create a PR, and merge it to main.
