### PR TITLE
chore(deps): Update Snyk plugin to 5.4.0

### DIFF
--- a/.env
+++ b/.env
@@ -24,7 +24,7 @@ CQ_FASTLY=3.0.7
 CQ_GUARDIAN_GALAXIES=1.1.3
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/snyk/versions
-CQ_SNYK=5.3.0
+CQ_SNYK=5.4.0
 
 # See https://github.com/guardian/cq-source-github-languages
 CQ_GITHUB_LANGUAGES=0.0.4

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -15393,7 +15393,7 @@ spec:
 spec:
   name: snyk
   path: cloudquery/snyk
-  version: v5.3.0
+  version: v5.4.0
   tables:
     - snyk_issues
     - snyk_organizations


### PR DESCRIPTION
## What does this change, and why?
This includes a fix to the `snyk_sbom` table. See https://github.com/cloudquery/cloudquery/issues/17767.

## How has it been verified?
Successfully ran CloudQuery locally with this version.