### PR TITLE
refactor: add SHAs to action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,29 +12,29 @@ updates:
     ignore:
       # The version of AWS CDK libraries must match those from @guardian/cdk.
       # We'd never be able to update them here independently, so just ignore them.
-      - dependency-name: "aws-cdk"
-      - dependency-name: "aws-cdk-lib"
-      - dependency-name: "constructs"
+      - dependency-name: 'aws-cdk'
+      - dependency-name: 'aws-cdk-lib'
+      - dependency-name: 'constructs'
 
     groups:
       aws-sdk:
         patterns:
-          - "@aws-sdk/*"
+          - '@aws-sdk/*'
       prisma:
         patterns:
-          - "prisma"
-          - "@prisma/client"
+          - 'prisma'
+          - '@prisma/client'
       code-quality:
         patterns:
-          - "@guardian/eslint-config-typescript"
-          - "@guardian/prettier"
-          - "eslint"
-          - "eslint-plugin-prettier"
+          - '@guardian/eslint-config-typescript'
+          - '@guardian/prettier'
+          - 'eslint'
+          - 'eslint-plugin-prettier'
       octokit:
         patterns:
-          - "@octokit/*"
-          - "octokit"
-          - "octokit-plugin-create-pull-request"
+          - '@octokit/*'
+          - 'octokit'
+          - 'octokit-plugin-create-pull-request'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,15 @@ jobs:
       contents: read
       pull-requests: write # required by guardian/actions-riff-raff
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - uses: guardian/actions-read-private-repos@v0.1.1
+      - uses: guardian/actions-read-private-repos@8792b5279dc2e6dfb6b9aa6ba2f26b6226be444c # v0.1.1
         with:
           private-ssh-keys: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
 
@@ -47,7 +47,7 @@ jobs:
         run: ./scripts/ci.sh
 
       - name: Upload to riff-raff
-        uses: guardian/actions-riff-raff@v4
+        uses: guardian/actions-riff-raff@8bedd7cded86fd7b374259d5959f9b729af5bdcb # v4.0.1
         with:
           app: service-catalogue
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
@@ -106,15 +106,15 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - uses: guardian/actions-read-private-repos@v0.1.1
+      - uses: guardian/actions-read-private-repos@8792b5279dc2e6dfb6b9aa6ba2f26b6226be444c # v0.1.1
         with:
           private-ssh-keys: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,12 +1,12 @@
 # Automatically mark any pull requests that have been inactive for 30 days as "Stale"
 # then close them 3 days later if there is still no activity.
-name: "Stale PR Handler"
+name: 'Stale PR Handler'
 
 on:
   schedule:
     # Check for Stale PRs every Monday to Thursday morning
     # Don't check on Fridays as it wouldn't be very nice to have a bot mark your PR as Stale on Friday and then close it on Monday morning!
-    - cron: "0 6 * * MON-THU"
+    - cron: '0 6 * * MON-THU'
 
 permissions:
   pull-requests: write
@@ -15,7 +15,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         id: stale
         # Read about options here: https://github.com/actions/stale#all-options
         with:
@@ -33,4 +33,4 @@ jobs:
           close-pr-message: This PR was closed because it has been stalled for 3 days with no activity.
 
           # Ignore PR's raised by Dependabot
-          exempt-pr-labels: "dependencies"
+          exempt-pr-labels: 'dependencies'


### PR DESCRIPTION
## What does this change?

This PR versions any remaining actions by SHA, where applicable.

## Why?

This is more secure, as per our [recommendations](https://github.com/guardian/recommendations/blob/main/github-actions.md).

