### PR TITLE
Add more languages that do not pull depencies for repocop to ignore

### DIFF
--- a/packages/repocop/src/languages.ts
+++ b/packages/repocop/src/languages.ts
@@ -15,6 +15,10 @@ export const ignoredLanguages = [
 	'MDX',
 	'Procfile',
 	'Mermaid',
+        'Apex',
+        'SaltStack',
+        'Cypher',
+        'Awk',
 ];
 
 const commonSupportedLanguages = [


### PR DESCRIPTION
Adding more languages that are not used to pull in dependencies into repocop ignore list so that these repositories are not falsely flagged as not being covered by vulnerability scanning. 