### PR TITLE
Only include recent vulnerabilities in digests

### DIFF
--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -8,7 +8,6 @@ import {
 	createDigestForSeverity,
 	daysLeftToFix,
 	getTopVulns,
-	isFirstOrThirdTuesdayOfMonth,
 } from './vuln-digest';
 
 const fullName = 'guardian/repo';
@@ -267,24 +266,6 @@ describe('getTopVulns', () => {
 
 		expect(criticalCount).toBe(8);
 		expect(highCount).toBe(2);
-	});
-});
-
-describe('isFirstOrThirdTuesdayOfMonth', () => {
-	test('should return true if the date is the first or third Tuesday of the month', () => {
-		const tuesday = new Date('2024-02-06T00:00:00.000Z'); // First Tuesday
-		const result = isFirstOrThirdTuesdayOfMonth(tuesday);
-		expect(result).toBe(true);
-	});
-	test('should return false if the date is not a Tuesday', () => {
-		const wednesday = new Date('2024-02-07T00:00:00.000Z'); // First Wednesday
-		const result = isFirstOrThirdTuesdayOfMonth(wednesday);
-		expect(result).toBe(false);
-	});
-	test('should return false if the date is the second Tuesday of the month', () => {
-		const tuesday = new Date('2024-02-13T00:00:00.000Z'); // Second Tuesday
-		const result = isFirstOrThirdTuesdayOfMonth(tuesday);
-		expect(result).toBe(false);
 	});
 });
 

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -65,20 +65,20 @@ export function createDigest(
 		(v) => !vulnerabilityExceedsSla(v.alert_issue_date, v.severity),
 	);
 
-	const totalVulnsCount = recentVulns.length;
+	const totalNewVulnsCount = recentVulns.length;
 
-	if (totalVulnsCount === 0) {
+	const totalOldVulnsCount = vulns.length - totalNewVulnsCount;
+
+	if (totalNewVulnsCount === 0) {
 		return undefined;
 	}
 
-	const topVulns = getTopVulns(recentVulns);
-	const listedVulnsCount = topVulns.length;
-	const preamble = String.raw`Found ${totalVulnsCount} recently introduced vulnerabilities across ${resultsForTeam.length} repositories.
-Displaying the top ${listedVulnsCount} most urgent.
+	const preamble = String.raw`Found ${totalNewVulnsCount} recently introduced vulnerabilities across ${resultsForTeam.length} repositories.
 Obligations to resolve: Critical - ${SLAs.critical} days; High - ${SLAs.high} days.
+There are ${totalOldVulnsCount} vulnerabilities exceeding this obligation, please see the dashboard linked for more information.
 Note: DevX only aggregates vulnerability information for repositories with a production topic.`;
 
-	const digestString = topVulns
+	const digestString = recentVulns
 		.map((v) => createHumanReadableVulnMessage(v))
 		.join('\n\n');
 

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -60,13 +60,9 @@ function createHumanReadableVulnMessage(vuln: RepocopVulnerability): string {
 There are ${daysToFix} days left to fix this vulnerability. It ${vuln.is_patchable ? 'is ' : 'might not be '}patchable.`;
 }
 
-function createTeamDashboardLinkAction(
-	team: Team,
-	vulnCount: number,
-	severity: Severity,
-) {
+function createTeamDashboardLinkAction(team: Team, vulnCount: number) {
 	return {
-		cta: `View all ${vulnCount} ${severity} vulnerabilities on Grafana`,
+		cta: `View all ${vulnCount} vulnerabilities on Grafana`,
 		url: `https://metrics.gutools.co.uk/d/fdib3p8l85jwgd?var-repo_owner=${team.slug}`,
 	};
 }
@@ -116,7 +112,7 @@ Note: DevX only aggregates vulnerability information for repositories with a pro
 		.join('\n\n');
 
 	const message = `${preamble}\n\n${digestString}`;
-	const actions = [createTeamDashboardLinkAction(team, vulns.length, severity)];
+	const actions = [createTeamDashboardLinkAction(team, vulns.length)];
 
 	return {
 		teamSlug: team.slug,

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -4,7 +4,6 @@ import type { Config } from '../../config';
 import type {
 	EvaluationResult,
 	RepocopVulnerability,
-	Severity,
 	Team,
 	VulnerabilityDigest,
 } from '../../types';

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -104,7 +104,7 @@ export function createDigestForSeverity(
 	}
 
 	const preamble = String.raw`Found ${totalNewVulnsCount} ${severity} vulnerabilities introduced since ${startDate.toDateString()}. Teams have ${SLAs[severity]} days to fix these.
-Note: DevX only aggregates vulnerability information for repositories with a production topic.`;
+Note: DevX only aggregates vulnerability information for runtime dependencies in repositories with a production topic.`;
 
 	const digestString = vulnsSinceImplementationDate
 		.map((v) => createHumanReadableVulnMessage(v))

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -99,7 +99,7 @@ export function createDigestForSeverity(
 
 	const preamble = String.raw`Found ${totalNewVulnsCount} ${severity} vulnerabilities introduced since ${startDate.toDateString()}.
 Teams have ${SLAs[severity]} days to fix ${severity} vulnerabilities.
-There are ${vulnsOlderThanSLA} vulnerabilities exceeding this obligation, please see the dashboard linked for more information.
+There are ${vulnsOlderThanSLA.length} vulnerabilities exceeding this obligation, please see the dashboard linked for more information.
 Note: DevX only aggregates vulnerability information for repositories with a production topic.`;
 
 	const digestString = vulnsSinceImplementationDate
@@ -158,7 +158,9 @@ export async function createAndSendVulnDigestsForSeverity(
 
 	console.log(`Logging ${severity} vulnerability digests`);
 	digests.forEach((digest) => console.log(JSON.stringify(digest)));
-	await sendVulnerabilityDigests(digests, config);
+	if (config.stage === 'PROD') {
+		await sendVulnerabilityDigests(digests, config);
+	}
 }
 
 export async function createAndSendVulnerabilityDigests(

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -94,7 +94,7 @@ setup_environment() {
 
   github_info_url="https://github.com/settings/tokens?type=beta"
 
-  token_text="# Required permissions are Metadata: Read and Administration: Read. See $github_info_url
+  token_text="# Required permissions are Metadata: Read, Administration: Read, Dependabot alerts: Read. See $github_info_url
 GITHUB_ACCESS_TOKEN=
 "
 


### PR DESCRIPTION
> [!CAUTION]
> This PR should not be merged until comms have been sent to the department.

## What does this change?

The main changes are:

- Only display extended information about vulnerabilities not in the historic backlog
- Create separate digests based on severity
- Send alerts for critical vulnerabilities every day, and high vulnerabilities once a week.

## Why?

Teams are now aware of their vulnerability backlogs, and don't need reminding biweekly. Let's switch to a more alert-based model, displaying only alerts raised after a certain cut-off, so teams can prioritise newer alerts over historic vulnerabilities. We also want the messaging to reflect the urgency with which they should be dealt with. Critical alerts are sent daily, meaning developers should drop feature work to triage or resolve them. High severity vulnerabilities should be factored into the next sprint.

## How has it been verified?

<img width="721" alt="Example of a message a team might receive" src="https://github.com/guardian/service-catalogue/assets/67543397/06e050bc-202d-472d-a270-63039bafabc0">

NB the date was changed for testing in order to generate a meaningful output


- Added/modified unit tests to confirm behaviour
- Tested on CODE
- Sent messages to the test channel to verify the formatting works correctly
