### PR TITLE
QOL: sort vulnerability URLs to show more useful ones first

### DIFF
--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -846,11 +846,12 @@ describe('NO RULE - Snyk vulnerabilities', () => {
 });
 
 describe('NO RULE - Vulnerabilities from Dependabot', () => {
+	const fullName = 'guardian/myrepo';
+	const result: RepocopVulnerability[] = example.map((alert) =>
+		dependabotAlertToRepocopVulnerability(fullName, alert),
+	);
+
 	test('Should be parseable into a common format', () => {
-		const fullName = 'guardian/myrepo';
-		const result: RepocopVulnerability[] = example.map((alert) =>
-			dependabotAlertToRepocopVulnerability(fullName, alert),
-		);
 		const expected1: RepocopVulnerability = {
 			full_name: fullName,
 			source: 'Dependabot',
@@ -858,10 +859,10 @@ describe('NO RULE - Vulnerabilities from Dependabot', () => {
 			severity: 'high',
 			package: 'django',
 			urls: [
-				'https://nvd.nist.gov/vuln/detail/CVE-2018-6188',
+				'https://snyk.io/vuln/some-fake-vuln-id',
 				'https://github.com/advisories/GHSA-rf4j-j272-fj86',
+				'https://nvd.nist.gov/vuln/detail/CVE-2018-6188',
 				'https://usn.ubuntu.com/3559-1/',
-				'https://www.djangoproject.com/weblog/2018/feb/01/security-releases/',
 				'http://www.securitytracker.com/id/1040422',
 			],
 			ecosystem: 'pip',
@@ -888,6 +889,10 @@ describe('NO RULE - Vulnerabilities from Dependabot', () => {
 		};
 
 		expect(result).toStrictEqual([expected1, expected2]);
+	});
+	test('Should display the most useful URLs first', () => {
+		expect(result[0]?.urls[0]).toContain('snyk.io');
+		expect(result[0]?.urls[1]).toContain('github.com');
 	});
 });
 

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -891,8 +891,12 @@ describe('NO RULE - Vulnerabilities from Dependabot', () => {
 		expect(result).toStrictEqual([expected1, expected2]);
 	});
 	test('Should display the most useful URLs first', () => {
-		expect(result[0]?.urls[0]).toContain('snyk.io');
-		expect(result[0]?.urls[1]).toContain('github.com');
+		const actual = result.map((r) => r.urls)[0];
+		const expected = [
+			'https://snyk.io/vuln/some-fake-vuln-id',
+			'https://github.com/advisories/GHSA-rf4j-j272-fj86',
+		];
+		expect(actual?.slice(0, 2)).toEqual(expected);
 	});
 });
 

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -399,6 +399,16 @@ export function evaluateOneRepo(
 	};
 }
 
+//create a predicate that orders a list of urls by whether they contain snyk.io first, and then github.com second
+const urlSortPredicate = (url: string) => {
+	if (url.includes('snyk.io')) {
+		return -2;
+	} else if (url.includes('github.com') && url.includes('advisories')) {
+		return -1;
+	}
+	return 0;
+};
+
 export function dependabotAlertToRepocopVulnerability(
 	fullName: string,
 	alert: Alert,
@@ -413,7 +423,9 @@ export function dependabotAlertToRepocopVulnerability(
 		source: 'Dependabot',
 		severity: alert.security_advisory.severity,
 		package: alert.security_vulnerability.package.name,
-		urls: alert.security_advisory.references.map((ref) => ref.url),
+		urls: alert.security_advisory.references
+			.map((ref) => ref.url)
+			.sort(urlSortPredicate),
 		ecosystem: alert.security_vulnerability.package.ecosystem,
 		alert_issue_date: new Date(alert.created_at),
 		is_patchable: !!alert.security_vulnerability.first_patched_version,
@@ -462,7 +474,9 @@ export function snykAlertToRepocopVulnerability(
 		ecosystem: ecosystem ?? 'unknown ecosystem',
 		alert_issue_date: new Date(issue.attributes.created_at),
 		is_patchable: isPatchable,
-		cves: snykVulnIdFilter(issue.attributes.problems.map((p) => p.id)),
+		cves: snykVulnIdFilter(issue.attributes.problems.map((p) => p.id)).sort(
+			urlSortPredicate,
+		),
 	};
 }
 

--- a/packages/repocop/src/test-data/example-dependabot-alerts.ts
+++ b/packages/repocop/src/test-data/example-dependabot-alerts.ts
@@ -77,10 +77,10 @@ export const example: Alert[] = [
 					url: 'https://usn.ubuntu.com/3559-1/',
 				},
 				{
-					url: 'https://www.djangoproject.com/weblog/2018/feb/01/security-releases/',
+					url: 'http://www.securitytracker.com/id/1040422',
 				},
 				{
-					url: 'http://www.securitytracker.com/id/1040422',
+					url: 'https://snyk.io/vuln/some-fake-vuln-id',
 				},
 			],
 			published_at: '2018-10-03T21:13:54Z',


### PR DESCRIPTION
## What does this change?

Prefer snyk or github advisories, if they exist. Vulnerability digests only link out to the first URL in the list, so lets make it one that's the most likely to be helpful

## Why?

The URLs we prioritise are aimed at developers rather than security researchers, and are generally a bit easier to understand.

## How has it been verified?

Added unit tests
