### PR TITLE
Make prisma container readonly

### DIFF
--- a/containers/prisma-migrate/run-prisma-migrate.sh
+++ b/containers/prisma-migrate/run-prisma-migrate.sh
@@ -3,13 +3,13 @@
 set -e
 
 echo 'Retrieving Prisma artifact from S3'
-aws s3 cp "s3://$ARTIFACT_BUCKET/$PRISMA_ARTIFACT_KEY" ./
+aws s3 cp "s3://$ARTIFACT_BUCKET/$PRISMA_ARTIFACT_KEY" ./prisma/
 
 echo 'Unzipping Prisma artifact'
-unzip -q prisma.zip
+unzip -q prisma/prisma.zip
 
 DB_PORT=5432
 export DATABASE_URL=postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/postgres
 
 echo 'Running prisma migrate deploy'
-node_modules/.bin/prisma migrate deploy
+prisma/node_modules/.bin/prisma migrate deploy

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -18580,7 +18580,15 @@ spec:
                 },
               },
             },
+            "MountPoints": [
+              {
+                "ContainerPath": "/prisma",
+                "ReadOnly": false,
+                "SourceVolume": "prisma-volume",
+              },
+            ],
             "Name": "prisma-migrate-taskContainer",
+            "ReadonlyRootFilesystem": true,
             "Secrets": [
               {
                 "Name": "DB_USERNAME",
@@ -18664,6 +18672,11 @@ spec:
             "Arn",
           ],
         },
+        "Volumes": [
+          {
+            "Name": "prisma-volume",
+          },
+        ],
       },
       "Type": "AWS::ECS::TaskDefinition",
     },

--- a/packages/cdk/lib/prisma-migrate-task.ts
+++ b/packages/cdk/lib/prisma-migrate-task.ts
@@ -1,10 +1,6 @@
 import type { GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
-import type {
-	ContainerDefinition,
-	ICluster,
-	Volume,
-} from 'aws-cdk-lib/aws-ecs';
+import type { ICluster, Volume } from 'aws-cdk-lib/aws-ecs';
 import {
 	FargateTaskDefinition,
 	FireLensLogDriver,


### PR DESCRIPTION
## What does this change?

Makes all parts of the prisma container readonly, except for the ./prisma directory, where all files are now loaded

## Why?

Security!

## How has it been verified?

The change has been deployed to CODE and tested to make sure no errors occur while the script is being run
