### PR TITLE
Apply migrations to Dev environment

### DIFF
--- a/containers/db-copy/entrypoint.sh
+++ b/containers/db-copy/entrypoint.sh
@@ -36,5 +36,7 @@ REMOTE_URL=$(getCodeDatabaseUrl)
 tables_to_copy=$(echo "$TABLES" | tr "-" "\n")
 for tbl in $tables_to_copy; do
   echo "Dumping table $tbl to /sql/$tbl.sql"
-  pg_dump "$REMOTE_URL" -t "$tbl" -f "/sql/$tbl.sql" --no-owner --no-privileges --inserts
+  # We use --data-only here as unfortunately pg_dump does not have a --create-if-not-exists to stop it from
+  # erroring when it tries to dump a table that prisma has already created.
+  pg_dump "$REMOTE_URL" -t "$tbl" -f "/sql/$tbl.sql" --no-owner --no-privileges --inserts --data-only
 done

--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -15,6 +15,20 @@ step() {
   echo -e "\n${cyan}Step ${STEP_COUNT}${clear}: $1"
 }
 
+create_sql_migrations() {
+  step "Copying Prisma Migrations"
+
+  SQL_DIR=$ROOT_DIR/packages/dev-environment/sql
+
+  rm -r $SQL_DIR
+  mkdir -p $SQL_DIR
+
+  MIGRATIONS=$(ls -d $ROOT_DIR/packages/common/prisma/migrations/*/)
+  for MIGRATION in $MIGRATIONS; do
+    cp $MIGRATION/migration.sql $SQL_DIR/$(basename $MIGRATION).sql;
+  done
+}
+
 check_aws_credentials() {
   step "Checking AWS credentials"
 
@@ -53,6 +67,7 @@ check_vpn_connection() {
 }
 
 main() {
+  create_sql_migrations
   check_aws_credentials
   check_vpn_connection
   start_containers


### PR DESCRIPTION
## What does this change?

Apply Prisma migrations to dev environment when running the `start` script.

## Why?

We want to be able to use the functions contained in our prisma migrations for developing new things locally!

## How has it been verified?

Ran locally.
