### PR TITLE
aws_resources materialised view correct taggable flad for iam policies

### DIFF
--- a/packages/common/prisma/migrations/20240508195000_refresh_aws_resources/migration.sql
+++ b/packages/common/prisma/migrations/20240508195000_refresh_aws_resources/migration.sql
@@ -5,7 +5,7 @@
 -- This migration replaces this view with a function which doesn't have the same restriction.
 -- But will need a cron job to keep the materialized view up to date.
 
--- Decide if the resource is taggable when taggable column is present
+-- Check for aws managed iam policies and return false for taggable in that case
 CREATE OR REPLACE FUNCTION is_resource_taggable(arn text, taggable bool) RETURNS boolean AS $$
 BEGIN
     RETURN CASE WHEN arn LIKE '%arn:aws:iam::aws:policy%' THEN 'false'

--- a/packages/common/prisma/migrations/20240508195000_refresh_aws_resources/migration.sql
+++ b/packages/common/prisma/migrations/20240508195000_refresh_aws_resources/migration.sql
@@ -1,0 +1,120 @@
+-- Update materialized view aws_resources creation to correct ARN taggable column for iam policies
+
+-- Cloudquery can't update the schema of tables referenced by views.
+-- As the view aws_resources references any Cloudquery table containing an ARN column it can make Cloudquery behave strangely.
+-- This migration replaces this view with a function which doesn't have the same restriction.
+-- But will need a cron job to keep the materialized view up to date.
+
+-- Decide if taggable when taggable column is present
+CREATE OR REPLACE FUNCTION arn_taggable(arn text, taggable bool) RETURNS boolean AS $$
+BEGIN
+    RETURN CASE WHEN arn LIKE '%arn:aws:iam::aws:policy%' THEN 'false'
+                ELSE taggable END;
+END
+$$ LANGUAGE plpgsql;
+
+-- Function to refresh the materialized view aws_resources
+CREATE OR REPLACE FUNCTION refresh_aws_resources()
+    RETURNS TEXT AS
+$$
+BEGIN
+    REFRESH MATERIALIZED VIEW aws_resources WITH DATA;
+    RETURN 'Triggered refresh of materialized view aws_resources';
+END;
+$$
+    LANGUAGE plpgsql;
+
+-- Aggregate rows from all AWS Cloudquery tables
+CREATE OR REPLACE FUNCTION aws_resources_raw()
+    RETURNS TABLE
+            (
+                cq_table      text,
+                partition     text,
+                service       text,
+                region        text,
+                account_id    text,
+                resource_type text,
+                arn           text,
+                taggable      boolean,
+                tags          jsonb
+            )
+AS
+$$
+DECLARE
+    cloudquery_table   record;
+    account_id         text;
+    request_account_id text;
+    owner_id           text;
+    region             text;
+    tags               text;
+    taggable           text;
+BEGIN
+    FOR cloudquery_table IN
+        -- Find all base tables (no views allowed)
+        SELECT DISTINCT table_name
+        FROM information_schema.tables
+        WHERE table_type = 'BASE TABLE'
+        -- find the intersection of tables that have an ARN column
+        INTERSECT
+        SELECT DISTINCT table_name
+        FROM information_schema.columns
+        WHERE table_name LIKE 'aws_%s'
+          and COLUMN_NAME IN ('arn')
+        LOOP
+            -- Check if table has an account_id column, or default to NULL
+            account_id := CASE WHEN table_has_column(cloudquery_table.table_name, 'account_id') THEN 'account_id' ELSE 'NULL' END;
+            -- Check if table has an owner_id column, or default to NULL
+            owner_id := CASE WHEN table_has_column(cloudquery_table.table_name, 'owner_id') THEN 'owner_id' ELSE 'NULL' END;
+            -- Check if table has an request_account_id column, or default to NULL
+            request_account_id := CASE WHEN table_has_column(cloudquery_table.table_name, 'request_account_id') THEN 'request_account_id' ELSE 'NULL' END;
+            -- Check if table has an region column, or default to NULL
+            region := CASE WHEN table_has_column(cloudquery_table.table_name, 'region') THEN 'region' ELSE 'NULL' END;
+            -- Check if table has an tags column, or default to an empty object
+            taggable := CASE WHEN table_has_column(cloudquery_table.table_name, 'tags') THEN 'true' ELSE 'false' END;
+            tags := CASE WHEN taggable = 'true' THEN 'tags' ELSE '''{}''::jsonb' END;
+
+            -- Fetch rows of table and append to function output
+            RETURN QUERY EXECUTE FORMAT(E'
+                    SELECT
+                        %L as cq_table,
+                        arn_to_partition(arn) as partition,
+                        arn_to_service(arn) as service,
+                        COALESCE(%s, arn_to_region(arn)) AS region,
+                        COALESCE(%s, %s, %s, arn_to_account_id(arn)) AS account_id,
+                        arn_to_resource_type(arn) as resource_type,
+                        arn,
+                        arn_taggable(arn, %s) as taggable,
+                        %s as tags
+                    FROM %s',
+                                        cloudquery_table.table_name, region, account_id, owner_id, request_account_id,
+                                        taggable, tags, cloudquery_table.table_name);
+        END LOOP;
+END
+$$ LANGUAGE plpgsql;
+
+-- Create the materialized view aws_resources without data
+DROP INDEX IF EXISTS idx_aws_resources_account_id;
+DROP INDEX IF EXISTS idx_aws_resources_arn;
+DROP MATERIALIZED VIEW IF EXISTS aws_resources;
+CREATE MATERIALIZED VIEW aws_resources AS
+SELECT
+    partition,
+    service,
+    region,
+    account_id,
+    resource_type,
+    arn,
+    bool_or(taggable) as taggable,
+    jsonb_aggregate(tags) as tags
+FROM aws_resources_raw()
+GROUP BY
+    partition,
+    service,
+    region,
+    account_id,
+    resource_type,
+    arn
+WITH NO DATA;
+
+CREATE INDEX idx_aws_resources_account_id ON aws_resources (account_id);
+CREATE INDEX idx_aws_resources_arn ON aws_resources (arn);

--- a/packages/common/prisma/migrations/20240508195000_refresh_aws_resources/migrations.sql
+++ b/packages/common/prisma/migrations/20240508195000_refresh_aws_resources/migrations.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION refresh_aws_resources()
+    RETURNS TEXT AS
+$$
+BEGIN
+    REFRESH MATERIALIZED VIEW aws_resources WITH DATA;
+    RETURN 'Triggered refresh of materialized view aws_resources';
+END;
+$$
+    LANGUAGE plpgsql;

--- a/packages/common/prisma/migrations/20240508195000_refresh_aws_resources/migrations.sql
+++ b/packages/common/prisma/migrations/20240508195000_refresh_aws_resources/migrations.sql
@@ -1,9 +1,0 @@
-CREATE OR REPLACE FUNCTION refresh_aws_resources()
-    RETURNS TEXT AS
-$$
-BEGIN
-    REFRESH MATERIALIZED VIEW aws_resources WITH DATA;
-    RETURN 'Triggered refresh of materialized view aws_resources';
-END;
-$$
-    LANGUAGE plpgsql;


### PR DESCRIPTION
## What does this change?
The materialised view aws_resources showed iam policies as tageable even though they are not, this migration corrects this.

This migration changes the view aws_resources but without populating it.
This can not be done after the migration was applied with
select refresh_aws_resources()

## SQL Changes
Changes to the sql of the previous migration:
function arn_taggable to return false for aws managed iam policies
aws_resources_raw uses arn_taggable (sadly I had to include the whole function not just the change)
I also added refresh_aws_resources() with I had planned to use in a lamda a db trigger, but kept.
I now create the materialised view without data in case I will add further migrations during the quarter since I feel data dumping should not happen in the migrations

## Why?
The aws_resources view powers our [OKR Dashboard DevX Ops OKRs Q1 2024](https://metrics.gutools.co.uk/d/adig3ssv1yio0c/8c14ffdd-c03a-51ad-90fc-1acb28ab7836?orgId=1) for this quarter.

We will move to repocop style lambda powered tables but need the view for this quarter.

## How has it been verified?
Ran the sql locally
