### PR TITLE
Create "obligatron" lambda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
                 - packages/dependency-graph-integrator/dist/dependency-graph-integrator.zip
             github-actions-usage:
               - packages/github-actions-usage/dist/github-actions-usage.zip
+            obligatron:
+              - packages/obligatron/dist/obligatron.zip
             prisma:
               - packages/common/prisma.zip
             theguardian-servicecatalogue-app:

--- a/jest.config.js
+++ b/jest.config.js
@@ -64,5 +64,10 @@ module.exports = {
 			transform,
 			testMatch: ['<rootDir>/packages/snyk-integrator/**/*.test.ts'],
 		},
+		{
+			displayName: 'obligatron',
+			transform,
+			testMatch: ['<rootDir>/packages/obligatron/**/*.test.ts'],
+		},
 	],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17536,6 +17536,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obligatron": {
+      "resolved": "packages/obligatron",
+      "link": true
+    },
     "node_modules/octokit": {
       "version": "3.2.0",
       "license": "MIT",
@@ -23076,6 +23080,9 @@
       "devDependencies": {
         "@octokit/types": "^13.4.1"
       }
+    },
+    "packages/obligatron": {
+      "version": "1.0.0"
     },
     "packages/repocop": {
       "version": "1.0.0",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -18,6 +18,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuScheduledLambda",
       "GuLambdaFunction",
+      "GuLambdaFunction",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -18347,6 +18348,282 @@ spec:
       },
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
+    },
+    "obligatronA58CFCF1": {
+      "DependsOn": [
+        "obligatronServiceRoleDefaultPolicyC8AE10A2",
+        "obligatronServiceRole1E85277A",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "deploy/TEST/obligatron/obligatron.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "obligatron",
+            "DATABASE_HOSTNAME": {
+              "Fn::GetAtt": [
+                "PostgresInstance16DE4286E",
+                "Endpoint.Address",
+              ],
+            },
+            "QUERY_LOGGING": "false",
+            "STACK": "deploy",
+            "STAGE": "TEST",
+          },
+        },
+        "Handler": "index.main",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 4096,
+        "Role": {
+          "Fn::GetAtt": [
+            "obligatronServiceRole1E85277A",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "obligatron",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 300,
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "PostgresAccessSecurityGroupServicecatalogue03C78F14",
+                "GroupId",
+              ],
+            },
+          ],
+          "SubnetIds": {
+            "Ref": "PrivateSubnets",
+          },
+        },
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "obligatronServiceRole1E85277A": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "obligatron",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "obligatronServiceRoleDefaultPolicyC8AE10A2": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/deploy/TEST/obligatron/obligatron.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/obligatron",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/obligatron/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/obligatron",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "obligatronServiceRoleDefaultPolicyC8AE10A2",
+        "Roles": [
+          {
+            "Ref": "obligatronServiceRole1E85277A",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "prismamigratetaskTEST59D4C0E8": {
       "Properties": {

--- a/packages/cdk/lib/obligatron.ts
+++ b/packages/cdk/lib/obligatron.ts
@@ -30,6 +30,8 @@ export class Obligatron {
 				QUERY_LOGGING: 'false', // Set this to 'true' to enable SQL query logging
 			},
 			timeout: Duration.minutes(5),
+			// Unfortunately Prisma doesn't support streaming data from Postgres at the moment https://github.com/prisma/prisma/issues/5055
+			// This means that all rows need to be loaded into memory at the same time whenever a query is ran hence the high memory requirement.
 			memorySize: 4096,
 		});
 

--- a/packages/cdk/lib/obligatron.ts
+++ b/packages/cdk/lib/obligatron.ts
@@ -1,0 +1,38 @@
+import type { GuStack } from '@guardian/cdk/lib/constructs/core';
+import type { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
+import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
+import { Duration } from 'aws-cdk-lib';
+import type { IVpc } from 'aws-cdk-lib/aws-ec2';
+import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
+import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
+
+type ObligatronProps = {
+	vpc: IVpc;
+	dbAccess: GuSecurityGroup;
+	db: DatabaseInstance;
+};
+
+export class Obligatron {
+	constructor(stack: GuStack, props: ObligatronProps) {
+		const { vpc, dbAccess, db } = props;
+		const app = 'obligatron';
+
+		const lambda = new GuLambdaFunction(stack, 'obligatron', {
+			app,
+			vpc,
+			architecture: Architecture.ARM_64,
+			runtime: Runtime.NODEJS_20_X,
+			securityGroups: [dbAccess],
+			fileName: `${app}.zip`,
+			handler: 'index.main',
+			environment: {
+				DATABASE_HOSTNAME: db.dbInstanceEndpointAddress,
+				QUERY_LOGGING: 'false', // Set this to 'true' to enable SQL query logging
+			},
+			timeout: Duration.minutes(5),
+			memorySize: 4096,
+		});
+
+		db.grantConnect(lambda, 'obligatron');
+	}
+}

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -43,6 +43,7 @@ import { addCloudqueryEcsCluster } from './cloudquery';
 import { addDataAuditLambda } from './data-audit';
 import { addGithubActionsUsageLambda } from './github-actions-usage';
 import { InteractiveMonitor } from './interactive-monitor';
+import { Obligatron } from './obligatron';
 import { addPrismaMigrateTask } from './prisma-migrate-task';
 import { Repocop } from './repocop';
 
@@ -255,6 +256,12 @@ export class ServiceCatalogue extends GuStack {
 			db,
 			dbAccess: applicationToPostgresSecurityGroup,
 			cluster: cloudqueryCluster,
+		});
+
+		new Obligatron(this, {
+			vpc,
+			db,
+			dbAccess: applicationToPostgresSecurityGroup,
 		});
 	}
 }

--- a/packages/obligatron/.gitignore
+++ b/packages/obligatron/.gitignore
@@ -1,0 +1,4 @@
+index.js
+
+# Generated files
+dist

--- a/packages/obligatron/README.md
+++ b/packages/obligatron/README.md
@@ -1,0 +1,9 @@
+# Obligatron
+
+A lambda which evaluates data from Service Catalogue and generates an Obligation report.
+
+## Running Locally
+
+1. Start the Dev database with `npm -w dev-environment run start`
+2. Run the Lambda and specific an obligation with `npm -w obligatron run start -- (Obligation Name)`
+   - For example to run the tagging obligation you would run  `npm -w obligatron run start -- TAGGING`. You can find a list of obligations [here](./src/index.ts)

--- a/packages/obligatron/package.json
+++ b/packages/obligatron/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"start": "APP=obligatron tsx src/run-locally.ts",
 		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@prisma/client --external:prisma",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsc --noEmit",
+		"test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects obligatron"
 	}
 }

--- a/packages/obligatron/package.json
+++ b/packages/obligatron/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "obligatron",
+	"version": "1.0.0",
+	"type": "module",
+	"scripts": {
+		"start": "APP=obligatron tsx src/run-locally.ts",
+		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@prisma/client --external:prisma",
+		"typecheck": "tsc --noEmit"
+	}
+}

--- a/packages/obligatron/src/config.ts
+++ b/packages/obligatron/src/config.ts
@@ -1,0 +1,27 @@
+import type { PrismaConfig } from 'common/database';
+import {
+	getDatabaseConfig,
+	getDatabaseConnectionString,
+	getDevDatabaseConfig,
+} from 'common/database';
+import { getEnvOrThrow } from 'common/functions';
+
+export interface Config extends PrismaConfig {
+	/**
+	 * The stage of the application, e.g. DEV, CODE, PROD.
+	 */
+	stage: string;
+}
+
+export async function getConfig(): Promise<Config> {
+	const stage = getEnvOrThrow('STAGE');
+	const databaseConfig =
+		stage === 'DEV'
+			? await getDevDatabaseConfig()
+			: await getDatabaseConfig(stage, 'obligatron');
+	return {
+		stage,
+		databaseConnectionString: getDatabaseConnectionString(databaseConfig),
+		withQueryLogging: stage === 'DEV',
+	};
+}

--- a/packages/obligatron/src/index.ts
+++ b/packages/obligatron/src/index.ts
@@ -1,0 +1,44 @@
+import { getPrismaClient } from 'common/database';
+import { config } from 'dotenv';
+import { getConfig } from './config';
+import type { ObligationResult } from './obligations';
+import { evaluateTaggingObligation } from './obligations/tagging';
+
+config({ path: `../../.env` }); // Load `.env` file at the root of the repository
+
+const Obligations = ['TAGGING'] as const;
+export type Obligation = (typeof Obligations)[number];
+const stringIsObligation = (input: string): input is Obligation => {
+	return Obligations.filter((v) => v === input).length > 0;
+};
+
+export async function main(obligation: string) {
+	if (!stringIsObligation(obligation)) {
+		throw new Error(
+			`unknown obligation ${obligation}. Valid ones are: ${Obligations.join(
+				', ',
+			)}`,
+		);
+	}
+
+	const config = await getConfig();
+	const db = getPrismaClient(config);
+
+	let results: ObligationResult[];
+
+	switch (obligation) {
+		case 'TAGGING': {
+			results = await evaluateTaggingObligation(db);
+		}
+	}
+
+	// TODO: Save results to DB
+	// log compliance for whole department
+	const compliant = results.filter((r) => r.result).length;
+	const nonCompliant = results.filter((r) => !r.result).length;
+	const total = compliant + nonCompliant;
+
+	console.log(`Total Compliant: ${compliant}`);
+	console.log(`Total Un-compliant: ${nonCompliant}`);
+	console.log(`Compliance rate: ${(compliant / total) * 100}%`);
+}

--- a/packages/obligatron/src/obligations/index.ts
+++ b/packages/obligatron/src/obligations/index.ts
@@ -1,0 +1,33 @@
+export type ObligationResult = {
+	/**
+	 * Resource identifier. Varies depending on resource platform.
+	 *   - Github -> Slug
+	 *   - AWS -> ARN
+	 */
+	resource: string;
+
+	/**
+	 * Did this resource meet the obligation check?
+	 */
+	result: boolean;
+
+	/**
+	 * Explanation for the assessment failing.
+	 */
+	reasons: string[];
+
+	/**
+	 * Link to where the user can see more details on the resource.
+	 */
+	deep_link?: string;
+
+	/**
+	 * Associated AWS account ID (if any)
+	 */
+	aws_account_id?: string;
+
+	/**
+	 * Associated Github teams (if any)
+	 */
+	github_teams?: string[];
+};

--- a/packages/obligatron/src/obligations/tagging.test.ts
+++ b/packages/obligatron/src/obligations/tagging.test.ts
@@ -1,22 +1,176 @@
-import { PrismaClient } from '@prisma/client';
+import type { PrismaClient } from '@prisma/client';
+import type { AwsResource } from './tagging';
 import { evaluateTaggingObligation } from './tagging';
 
-const Mck = typeof jest.MockedClass;
+const createPrismaClientWithMockedResponse = (response: AwsResource[]) => {
+	const test = {
+		$queryRaw: () => Promise.resolve(response),
+	} as unknown as PrismaClient;
 
-jest.mock('@prisma/client');
-
-const ABD = PrismaClient as jest.MockedClass<typeof PrismaClient>;
-
-beforeEach(() => {
-	ABD.mockClear();
-});
+	return test;
+};
 
 describe('The tagging obligation', () => {
+	it('passes correct resource', async () => {
+		const client = createPrismaClientWithMockedResponse([
+			{
+				account_id: '123456789012',
+				arn: 'arn:aws:s3:::mybucket',
+				service: 's3',
+				resource_type: 'bucket',
+				taggable: 'true',
+				tags: {
+					Stack: 'my-stack',
+					Stage: 'prod',
+					App: 'myapp',
+					'gu:repo': 'myrepo',
+				},
+			},
+		]);
+
+		const results = await evaluateTaggingObligation(client);
+
+		expect(results.filter((r) => !r.result)).toHaveLength(0);
+		expect(results[0]).toMatchObject({
+			resource: 'arn:aws:s3:::mybucket',
+			result: true,
+			reasons: [],
+		});
+	});
+
 	it('catches missing Stack tags', async () => {
-		const test = new ABD();
+		const client = createPrismaClientWithMockedResponse([
+			{
+				account_id: '123456789012',
+				arn: 'arn:aws:s3:::mybucket',
+				service: 's3',
+				resource_type: 'bucket',
+				taggable: 'true',
+				tags: {
+					Stage: 'prod',
+					App: 'myapp',
+					'gu:repo': 'myrepo',
+				},
+			},
+		]);
 
-		const results = await evaluateTaggingObligation(test);
+		const results = await evaluateTaggingObligation(client);
 
-		console.log(results);
+		expect(results.filter((r) => !r.result)).toHaveLength(1);
+		expect(results[0]).toMatchObject({
+			resource: 'arn:aws:s3:::mybucket',
+			result: false,
+			reasons: ["Resource missing 'Stack' tag."],
+		});
+	});
+
+	it('catches missing Stage tags', async () => {
+		const client = createPrismaClientWithMockedResponse([
+			{
+				account_id: '123456789012',
+				arn: 'arn:aws:s3:::mybucket',
+				service: 's3',
+				resource_type: 'bucket',
+				taggable: 'true',
+				tags: {
+					Stack: 'my-stack',
+					App: 'myapp',
+					'gu:repo': 'myrepo',
+				},
+			},
+		]);
+
+		const results = await evaluateTaggingObligation(client);
+
+		expect(results.filter((r) => !r.result)).toHaveLength(1);
+		expect(results[0]).toMatchObject({
+			resource: 'arn:aws:s3:::mybucket',
+			result: false,
+			reasons: ["Resource missing 'Stage' tag."],
+		});
+	});
+
+	it('catches missing App tags', async () => {
+		const client = createPrismaClientWithMockedResponse([
+			{
+				account_id: '123456789012',
+				arn: 'arn:aws:s3:::mybucket',
+				service: 's3',
+				resource_type: 'bucket',
+				taggable: 'true',
+				tags: {
+					Stack: 'my-stack',
+					Stage: 'prod',
+					'gu:repo': 'myrepo',
+				},
+			},
+		]);
+
+		const results = await evaluateTaggingObligation(client);
+
+		expect(results.filter((r) => !r.result)).toHaveLength(1);
+		expect(results[0]).toMatchObject({
+			resource: 'arn:aws:s3:::mybucket',
+			result: false,
+			reasons: ["Resource missing 'App' tag."],
+		});
+	});
+
+	it('catches missing Repo tags', async () => {
+		const client = createPrismaClientWithMockedResponse([
+			{
+				account_id: '123456789012',
+				arn: 'arn:aws:s3:::mybucket',
+				service: 's3',
+				resource_type: 'bucket',
+				taggable: 'true',
+				tags: {
+					Stack: 'my-stack',
+					Stage: 'prod',
+					App: 'myapp',
+				},
+			},
+		]);
+
+		const results = await evaluateTaggingObligation(client);
+
+		expect(results.filter((r) => !r.result)).toHaveLength(1);
+		expect(results[0]).toMatchObject({
+			resource: 'arn:aws:s3:::mybucket',
+			result: false,
+			reasons: ["Resource missing 'gu:repo' tag."],
+		});
+	});
+
+	it('catches empty tags', async () => {
+		const client = createPrismaClientWithMockedResponse([
+			{
+				account_id: '123456789012',
+				arn: 'arn:aws:s3:::mybucket',
+				service: 's3',
+				resource_type: 'bucket',
+				taggable: 'true',
+				tags: {
+					Stack: '',
+					Stage: '',
+					App: '',
+					'gu:repo': '',
+				},
+			},
+		]);
+
+		const results = await evaluateTaggingObligation(client);
+
+		expect(results.filter((r) => !r.result)).toHaveLength(1);
+		expect(results[0]).toMatchObject({
+			resource: 'arn:aws:s3:::mybucket',
+			result: false,
+			reasons: [
+				"Resource missing 'Stack' tag.",
+				"Resource missing 'Stage' tag.",
+				"Resource missing 'App' tag.",
+				"Resource missing 'gu:repo' tag.",
+			],
+		});
 	});
 });

--- a/packages/obligatron/src/obligations/tagging.test.ts
+++ b/packages/obligatron/src/obligations/tagging.test.ts
@@ -1,0 +1,22 @@
+import { PrismaClient } from '@prisma/client';
+import { evaluateTaggingObligation } from './tagging';
+
+const Mck = typeof jest.MockedClass;
+
+jest.mock('@prisma/client');
+
+const ABD = PrismaClient as jest.MockedClass<typeof PrismaClient>;
+
+beforeEach(() => {
+	ABD.mockClear();
+});
+
+describe('The tagging obligation', () => {
+	it('catches missing Stack tags', async () => {
+		const test = new ABD();
+
+		const results = await evaluateTaggingObligation(test);
+
+		console.log(results);
+	});
+});

--- a/packages/obligatron/src/obligations/tagging.ts
+++ b/packages/obligatron/src/obligations/tagging.ts
@@ -1,14 +1,14 @@
 import type { PrismaClient } from '@prisma/client';
 import type { ObligationResult } from '.';
 
-interface AwsResource {
+export type AwsResource = {
 	account_id: string;
 	arn: string;
 	service: string;
 	resource_type: string;
 	taggable: string;
 	tags?: Record<string, string> | null;
-}
+};
 
 const REQUIRED_TAGS = ['Stack', 'Stage', 'App', 'gu:repo'] as const;
 
@@ -44,8 +44,7 @@ export async function evaluateTaggingObligation(
 					(tag) =>
 						typeof resource.tags === 'object' &&
 						resource.tags !== null &&
-						resource.tags[tag] === undefined &&
-						resource.tags[tag] === '',
+						(resource.tags[tag] === undefined || resource.tags[tag] === ''),
 				).map((tag) => `Resource missing '${tag}' tag.`)
 			: [];
 

--- a/packages/obligatron/src/obligations/tagging.ts
+++ b/packages/obligatron/src/obligations/tagging.ts
@@ -25,7 +25,6 @@ const isExemptResource = (resource: AwsResource): boolean => {
 export async function evaluateTaggingObligation(
 	db: PrismaClient,
 ): Promise<ObligationResult[]> {
-	// TODO add `where taggable = true`?
 	const awsResources = await db.$queryRaw<AwsResource[]>`
 		SELECT
 			account_id,
@@ -45,7 +44,8 @@ export async function evaluateTaggingObligation(
 					(tag) =>
 						typeof resource.tags === 'object' &&
 						resource.tags !== null &&
-						resource.tags[tag] === undefined,
+						resource.tags[tag] === undefined &&
+						resource.tags[tag] === '',
 				).map((tag) => `Resource missing '${tag}' tag.`)
 			: [];
 

--- a/packages/obligatron/src/obligations/tagging.ts
+++ b/packages/obligatron/src/obligations/tagging.ts
@@ -1,0 +1,60 @@
+import type { PrismaClient } from '@prisma/client';
+import type { ObligationResult } from '.';
+
+interface AwsResource {
+	account_id: string;
+	arn: string;
+	service: string;
+	resource_type: string;
+	taggable: string;
+	tags?: Record<string, string> | null;
+}
+
+const REQUIRED_TAGS = ['Stack', 'Stage', 'App', 'gu:repo'] as const;
+
+const isExemptResource = (resource: AwsResource): boolean => {
+	if (resource.resource_type === 'role') {
+		// AWS Creates roles for various services when onboarding them.
+		// Technically we can tag these but they wouldn't belong to a specific App, Stage, or Stack.
+		return resource.arn.includes('/aws-service-role/');
+	}
+
+	return false;
+};
+
+export async function evaluateTaggingObligation(
+	db: PrismaClient,
+): Promise<ObligationResult[]> {
+	// TODO add `where taggable = true`?
+	const awsResources = await db.$queryRaw<AwsResource[]>`
+		SELECT
+			account_id,
+			arn,
+			service,
+			resource_type,
+			bool_or(taggable) as taggable,
+			jsonb_aggregate(tags) as tags
+		FROM aws_resources_raw()
+		WHERE taggable = true
+		GROUP BY account_id, arn, service, resource_type;
+  `;
+
+	const result: ObligationResult[] = awsResources.map((resource) => {
+		const reasons = !isExemptResource(resource)
+			? REQUIRED_TAGS.filter(
+					(tag) =>
+						typeof resource.tags === 'object' &&
+						resource.tags !== null &&
+						resource.tags[tag] === undefined,
+				).map((tag) => `Resource missing '${tag}' tag.`)
+			: [];
+
+		return {
+			resource: resource.arn,
+			result: reasons.length === 0,
+			reasons,
+		};
+	});
+
+	return result;
+}

--- a/packages/obligatron/src/run-locally.ts
+++ b/packages/obligatron/src/run-locally.ts
@@ -1,0 +1,5 @@
+import { main } from './index';
+
+const [, , obligation] = process.argv;
+
+void main(obligation ?? 'TAGGING');

--- a/packages/obligatron/tsconfig.json
+++ b/packages/obligatron/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -75,6 +75,7 @@ createPrismaZip
 createLambdaWithPrisma "repocop"
 createLambdaWithPrisma "data-audit"
 createLambdaWithPrisma "github-actions-usage"
+createLambdaWithPrisma "obligatron"
 
 # Package the dashboard...
 createZip "dashboard"


### PR DESCRIPTION
## What does this change?

Creates a new "obligatron" lambda which evaluates service-catalogue data and decides if its compliant with obligations.

## Why?

This lays some of the groundwork for writing the business logic for some of the obligations the Ops team is working on (and maybe Security and Reliability too?).

Eventually this lambda should provide a framework for fetching data from Service Catalogue and saving it to a results table in a generic way so that when writing a new obligation the developer only has to worry about parsing the data, and not establish a DB connection or saving the results to a table.

In the short term this lambda will evaluate the Ops TAGGING obligation by fetching data from the aws_resources view, filtering out AWS managed resources, and validating them against our tagging schema.

## How has it been verified?

Ran locally.
