### PR TITLE
fix(prisma): Correct volume permissions

### DIFF
--- a/containers/prisma-migrate/Dockerfile
+++ b/containers/prisma-migrate/Dockerfile
@@ -10,13 +10,13 @@ RUN apk --no-cache add aws-cli
 # This will allow us to use the prisma migrate deploy command
 RUN npm init -y
 # TODO: Keep the version automatically in sync with common/package.json
-RUN npm install prisma@5.11.0 
+RUN npm install prisma@5.11.0
 
-COPY ./containers/prisma-migrate/run-prisma-migrate.sh ./run-prisma-migrate.sh
-RUN chmod +x ./run-prisma-migrate.sh
+COPY ./containers/prisma-migrate/run-prisma-migrate.sh /usr/src/app/run-prisma-migrate.sh
+RUN chmod +x /usr/src/app/run-prisma-migrate.sh
 
 # The default entrypoint for the node image is `node ...`
 # Switch it back here so we can run a .sh script
 ENTRYPOINT [ "sh" ]
 
-CMD ["./run-prisma-migrate.sh"]
+CMD ["/usr/src/app/run-prisma-migrate.sh"]

--- a/containers/prisma-migrate/run-prisma-migrate.sh
+++ b/containers/prisma-migrate/run-prisma-migrate.sh
@@ -2,14 +2,17 @@
 
 set -e
 
+# This must match the WORKDIR in the Dockerfile
+ROOT_DIR=/usr/src/app
+
 echo 'Retrieving Prisma artifact from S3'
-aws s3 cp "s3://$ARTIFACT_BUCKET/$PRISMA_ARTIFACT_KEY" ./prisma/
+aws s3 cp "s3://$ARTIFACT_BUCKET/$PRISMA_ARTIFACT_KEY" "${ROOT_DIR}/prisma/"
 
 echo 'Unzipping Prisma artifact'
-unzip -q prisma/prisma.zip
+unzip -q "${ROOT_DIR}/prisma/prisma.zip"
 
 DB_PORT=5432
 export DATABASE_URL=postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/postgres
 
 echo 'Running prisma migrate deploy'
-prisma/node_modules/.bin/prisma migrate deploy
+"${ROOT_DIR}/node_modules/.bin/prisma" migrate deploy

--- a/containers/prisma-migrate/run-prisma-migrate.sh
+++ b/containers/prisma-migrate/run-prisma-migrate.sh
@@ -2,14 +2,16 @@
 
 set -e
 
-# This must match the WORKDIR in the Dockerfile
 ROOT_DIR=/usr/src/app
 
+# This path needs to be writable
+ARTIFACT_FILE="${ROOT_DIR}/prisma/prisma.zip"
+
 echo 'Retrieving Prisma artifact from S3'
-aws s3 cp "s3://$ARTIFACT_BUCKET/$PRISMA_ARTIFACT_KEY" "${ROOT_DIR}/prisma/"
+aws s3 cp "s3://$ARTIFACT_BUCKET/$PRISMA_ARTIFACT_KEY" "${ARTIFACT_FILE}"
 
 echo 'Unzipping Prisma artifact'
-unzip -q "${ROOT_DIR}/prisma/prisma.zip"
+unzip -q "${ARTIFACT_FILE}"
 
 DB_PORT=5432
 export DATABASE_URL=postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/postgres

--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -42,6 +42,18 @@ deployments.set('service-catalogue-prisma-migrations', {
 	},
 	regions: new Set([region]),
 	stacks: new Set([stack]),
+
+	/*
+	The prisma-migrate ECS task is:
+			- Updated via a CloudFormation deployment
+			- Triggered by a file landing in S3
+
+	This deployment uploads the file to S3,
+	and only runs once the CloudFormation deployment succeeds.
+
+	This ensures the correct versions are used.
+	*/
+	dependencies: ['cfn-eu-west-1-deploy-service-catalogue'],
 });
 
 deployments.set('theguardian-servicecatalogue-app', {

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -18582,9 +18582,9 @@ spec:
             },
             "MountPoints": [
               {
-                "ContainerPath": "/usr/src/app",
+                "ContainerPath": "/usr/src/app/prisma",
                 "ReadOnly": false,
-                "SourceVolume": "prisma-volume",
+                "SourceVolume": "artifact-volume",
               },
             ],
             "Name": "prisma-migrate-taskContainer",
@@ -18674,7 +18674,7 @@ spec:
         },
         "Volumes": [
           {
-            "Name": "prisma-volume",
+            "Name": "artifact-volume",
           },
         ],
       },

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -18582,7 +18582,7 @@ spec:
             },
             "MountPoints": [
               {
-                "ContainerPath": "/prisma",
+                "ContainerPath": "/usr/src/app",
                 "ReadOnly": false,
                 "SourceVolume": "prisma-volume",
               },

--- a/packages/cdk/lib/prisma-migrate-task.ts
+++ b/packages/cdk/lib/prisma-migrate-task.ts
@@ -133,16 +133,16 @@ export function addPrismaMigrateTask(
 	db.grantConnect(taskDefinition.taskRole);
 	artifactBucket.grantRead(taskDefinition.taskRole, prismaArtifactKey);
 
-	const prismaVolume: Volume = {
-		name: 'prisma-volume',
+	const prismaArtifactVolume: Volume = {
+		name: 'artifact-volume',
 	};
 
-	taskDefinition.addVolume(prismaVolume);
+	taskDefinition.addVolume(prismaArtifactVolume);
 
 	prismaTask.addMountPoints({
 		// So that we can download the prisma.zip from the artifact bucket
-		containerPath: '/usr/src/app',
-		sourceVolume: prismaVolume.name,
+		containerPath: '/usr/src/app/prisma',
+		sourceVolume: prismaArtifactVolume.name,
 		readOnly: false,
 	});
 

--- a/packages/cdk/lib/prisma-migrate-task.ts
+++ b/packages/cdk/lib/prisma-migrate-task.ts
@@ -141,7 +141,7 @@ export function addPrismaMigrateTask(
 
 	prismaTask.addMountPoints({
 		// So that we can download the prisma.zip from the artifact bucket
-		containerPath: '/prisma',
+		containerPath: '/usr/src/app',
 		sourceVolume: prismaVolume.name,
 		readOnly: false,
 	});


### PR DESCRIPTION
Since https://github.com/guardian/service-catalogue/pull/986 the Prisma migration task has been failing with:

```log
download failed: s3://<REDACTED>/deploy/CODE/service-catalogue-prisma-migrations/prisma.zip to prisma/prisma.zip Could not create directory /usr/src/app/prisma: [Errno 30] Read-only file system: '/usr/src/app/prisma'
```

That is, we're unable to download a file from S3 to a read-only path.

## What does this change, and why?
This change:
- Mounts the `/usr/src/app/prisma` volume in the container, as a writable location
- Updates the container's entry point to download the artifact to this location

This results in the above error being resolved, and the migrations completing. Indeed the logs show this:

![image](https://github.com/guardian/service-catalogue/assets/836140/afa99bd6-69ac-44e6-9578-670d249023d2)

An additional change was made to better orchestrate the deployment order. See the inline comment for more detail.

## How has it been verified?
The updated container was deployed to, and ran on, CODE. See the above screenshot for the logs.

---
Co-authored-by: @JuliaBrigitte
Co-authored-by: @NovemberTang 