### PR TITLE
chore(deps): Update Galaxies plugin to v1.1.5

### DIFF
--- a/.env
+++ b/.env
@@ -21,7 +21,7 @@ CQ_GITHUB=10.0.1
 CQ_FASTLY=3.0.7
 
 # See https://github.com/guardian/cq-source-galaxies
-CQ_GUARDIAN_GALAXIES=1.1.3
+CQ_GUARDIAN_GALAXIES=1.1.5
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/snyk/versions
 CQ_SNYK=5.4.0

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -2798,7 +2798,7 @@ spec:
   name: galaxies
   path: guardian/galaxies
   registry: github
-  version: v1.1.3
+  version: v1.1.5
   destinations:
     - postgresql
   tables:


### PR DESCRIPTION
## What does this change?
Since https://github.com/guardian/service-catalogue/pull/942, the Galaxies tables are failing to sync with the following error:

```log
failed to sync v1 source galaxies: rpc error: code = Unknown desc = failed to sync resources: failed to create execution client for source plugin guardian-galaxies: unable to load AWS config, failed to get shared config profile, deployTools
```

The only changes to https://github.com/guardian/cq-source-galaxies are dependency updates, so presumably an AWS SDK update in [v1.1.3](https://github.com/guardian/cq-source-galaxies/releases/tag/v1.1.3) included a bug. [v1.1.5](https://github.com/guardian/cq-source-galaxies/releases/tag/v1.1.5) includes a further update to the AWS SDK, resolving the bug?!

## How has it been verified?
