### PR TITLE
dev-environment setup shouldn't fail if SQL_DIR does not exist

### DIFF
--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -20,8 +20,8 @@ create_sql_migrations() {
 
   SQL_DIR=$ROOT_DIR/packages/dev-environment/sql
 
-  rm -r $SQL_DIR
-  mkdir -p $SQL_DIR
+  rm -rf "$SQL_DIR"
+  mkdir -p "$SQL_DIR"
 
   MIGRATIONS=$(ls -d $ROOT_DIR/packages/common/prisma/migrations/*/)
   for MIGRATION in $MIGRATIONS; do


### PR DESCRIPTION
## What does this change?

Adds -f as a flag to the line that removes `SQL_DIR`

From `man rm`

```
-f      Attempt to remove the files without prompting for confirmation, regardless of the file's permissions.  If the file does not exist, do not display a diagnostic
             message or modify the exit status to reflect an error.
```

## Why?

This was causing `npm run start -w dev-environment` to fail if `SQL_DIR` didn't exist in the first place

## How has it been verified?

Script now runs correctly
