### PR TITLE
chore(deps): Update Galaxies plugin to v1.1.6

### DIFF
--- a/.env
+++ b/.env
@@ -21,7 +21,7 @@ CQ_GITHUB=10.0.1
 CQ_FASTLY=3.0.7
 
 # See https://github.com/guardian/cq-source-galaxies
-CQ_GUARDIAN_GALAXIES=1.1.3
+CQ_GUARDIAN_GALAXIES=1.1.6
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/snyk/versions
 CQ_SNYK=5.4.0

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -2798,7 +2798,7 @@ spec:
   name: galaxies
   path: guardian/galaxies
   registry: github
-  version: v1.1.3
+  version: v1.1.6
   destinations:
     - postgresql
   tables:


### PR DESCRIPTION
## What does this change?
Since https://github.com/guardian/service-catalogue/pull/942, the Galaxies tables are failing to sync with the following error:

```log
failed to sync v1 source galaxies: rpc error: code = Unknown desc = failed to sync resources: failed to create execution client for source plugin guardian-galaxies: unable to load AWS config, failed to get shared config profile, deployTools
```

This is fixed in [v1.1.6](https://github.com/guardian/cq-source-galaxies/releases/tag/v1.1.6). See https://github.com/guardian/cq-source-galaxies/pull/20.

## How has it been verified?
See https://github.com/guardian/service-catalogue/pull/1006.