### PR TITLE
Bump Cloudquery to 5.19 and enable Sync Summary

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@
 # Environment variables shared between ci and DEV.
 
 # See https://github.com/cloudquery/cloudquery/releases?q=cli
-CQ_CLI=5.2.0
+CQ_CLI=5.19.0
 
 # See https://hub.cloudquery.io/plugins/destination/cloudquery/postgresql/versions
 CQ_POSTGRES_DESTINATION=7.2.0

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -149,6 +149,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -855,6 +856,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -1514,6 +1516,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -2167,6 +2170,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -2840,6 +2844,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -3742,6 +3747,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -4226,6 +4232,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -4875,6 +4882,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -5589,6 +5597,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -6289,6 +6298,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -6995,6 +7005,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -7657,6 +7668,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -8317,6 +8329,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -9007,6 +9020,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -9871,6 +9885,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -10297,6 +10312,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -10959,6 +10975,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -11651,6 +11668,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -12546,6 +12564,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -13209,6 +13228,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -13635,6 +13655,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -14358,6 +14379,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -15256,6 +15278,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
@@ -15715,6 +15738,7 @@ spec:
   path: cloudquery/postgresql
   version: v7.2.0
   migrate_mode: forced
+  send_sync_summary: true
   spec:
     connection_string: >-
       user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -178,7 +178,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -885,7 +885,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -1545,7 +1545,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -2199,7 +2199,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -2876,7 +2876,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -3776,7 +3776,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -4261,7 +4261,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -4911,7 +4911,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -5626,7 +5626,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -6331,7 +6331,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -7034,7 +7034,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -7697,7 +7697,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -8358,7 +8358,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -9049,7 +9049,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -9914,7 +9914,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -10341,7 +10341,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -11008,7 +11008,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -11697,7 +11697,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -12593,7 +12593,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -13257,7 +13257,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -13684,7 +13684,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -14408,7 +14408,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -15307,7 +15307,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -15767,7 +15767,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -18,6 +18,7 @@ describe('Config generation, and converting to YAML', () => {
 		  path: cloudquery/postgresql
 		  version: v7.2.0
 		  migrate_mode: forced
+		  send_sync_summary: true
 		  spec:
 		    connection_string: >-
 		      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -28,6 +28,7 @@ export function postgresDestinationConfig(): CloudqueryConfig {
 			path: 'cloudquery/postgresql',
 			version: `v${Versions.CloudqueryPostgresDestination}`,
 			migrate_mode: 'forced',
+			send_sync_summary: true,
 			spec: {
 				connection_string: [
 					'user=${DB_USERNAME}',

--- a/packages/cdk/lib/cloudquery/images.ts
+++ b/packages/cdk/lib/cloudquery/images.ts
@@ -3,7 +3,7 @@ import { Versions } from './versions';
 
 export const Images = {
 	cloudquery: ContainerImage.fromRegistry(
-		`ghcr.io/guardian/service-catalogue/cloudquery:stable`,
+		`ghcr.io/guardian/service-catalogue/cloudquery:sha-2d6c95ee216c4fa9723aa3d0f8dc4e2a4636080b`,
 	),
 	devxLogs: ContainerImage.fromRegistry('ghcr.io/guardian/devx-logs:2'),
 	singletonImage: ContainerImage.fromRegistry(


### PR DESCRIPTION
## What does this change?

Bumps Cloudquery to 5.19 and enable Sync Summary for all jobs.

## Why?

Cloudquery 5.19 just [released the ability to enable sync summaries](https://github.com/cloudquery/cloudquery/issues/8690#issuecomment-2120716012). This feature sends a summary of the sync to the destination plugin in the form of a `cloudquery_sync_summary` table.

We can possibly simplify our Cloudquery job by removing the initial postgres step. This also lets us generate a reliability report for our Cloudquery tasks.

## How has it been verified?

Deployed to CODE.