### PR TITLE
fix(dev-environment): Wait for Postgres to initialise before running CloudQuery

### DIFF
--- a/.env
+++ b/.env
@@ -41,6 +41,10 @@ DATABASE_NAME=postgres
 DATABASE_PORT=5432
 DATABASE_URL=postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOSTNAME}:${DATABASE_PORT}/${DATABASE_NAME}
 
+# Locally, CloudQuery and Postgres run within Docker.
+# Hard-code the database hostname to 'postgres' (the Postgres container name), configuring CloudQuery to connect to Postgres via the Docker network.
+CQ_DATABASE_URL=postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@postgres:${DATABASE_PORT}/${DATABASE_NAME}
+
 # Set this to 'false' to disable SQL query logging
 QUERY_LOGGING=true
 

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -70,7 +70,7 @@ services:
       SNYK_TOKEN: ${SNYK_TOKEN}
       GALAXIES_BUCKET: ${GALAXIES_BUCKET}
       CLOUDQUERY_API_KEY: ${CLOUDQUERY_API_KEY}
-      DATABASE_URL: ${DATABASE_URL}
+      DATABASE_URL: ${CQ_DATABASE_URL}
     command: sync /cloudquery.yaml --log-console --log-level info
   grafana:
     user: root

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -46,6 +46,12 @@ services:
     depends_on:
       db-copy:
         condition: service_completed_successfully
+    healthcheck:
+      # Ensures the initialisation scripts have completed, before accepting connections from CloudQuery, Grafana, etc.
+      test: [ "CMD-SHELL", "pg_isready --host 127.0.0.1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   cloudquery:
     build:
       context: ../../containers/cloudquery
@@ -53,7 +59,8 @@ services:
         CQ_CLI: ${CQ_CLI}
     platform: linux/amd64
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     volumes:
       - ~/.aws/credentials:/.aws/credentials
       - ./config/cloudquery.yaml:/cloudquery.yaml
@@ -82,7 +89,8 @@ services:
         grafana_version: ${GRAFANA_VERSION:-10.3.3}
         development: ${DEVELOPMENT:-true}
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     ports:
       - '3000:3000'
     volumes:


### PR DESCRIPTION
## What does this change?
In the DEV environment, CloudQuery fails to connect to the Postgres database, logging:

```log
failed to init destination postgresql: rpc error: code = Internal desc = failed to init plugin: failed to initialize client: failed to get current database: failed to connect to `host=postgres user=postgres database=postgres`: dial error (dial tcp 172.26.0.2:5432: connect: connection refused)
```

This is because Postgres is still initialising when the connection is attempted. This initialisation includes creating the tables, and inserting rows copied from CODE.

In this change, a healthcheck is added to the Postgres container, passing only once the initialisation has completed. CloudQuery (and Grafana) starts afterwards.

Additionally, the configuration is updated, getting the CloudQuery container to connect to the Postgres container via the Docker network, as opposed to going via the host.

## How has it been verified?
- Start the dev-environment on `main`, observe the above error from the CloudQuery container
- Start the dev-environment on this branch, observe the CloudQuery container running