### PR TITLE
feat(cloudquery): Collect more Security Hub findings

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -830,8 +830,6 @@ spec:
               workflow_status:
                 - comparison: NOT_EQUALS
                   value: RESOLVED
-              severity_normalized:
-                - Gte: 50
 ' > /usr/share/cloudquery/source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -128,11 +128,6 @@ export function addCloudqueryEcsCluster(
 												value: 'RESOLVED',
 											},
 										],
-										severity_normalized: [
-											{
-												Gte: 50,
-											},
-										],
 									},
 								},
 							],

--- a/packages/dev-environment/config/cloudquery.yaml
+++ b/packages/dev-environment/config/cloudquery.yaml
@@ -30,8 +30,6 @@ spec:
               workflow_status:
                 - comparison: 'NOT_EQUALS'
                   value: 'RESOLVED'
-              severity_normalized:
-                - Gte: 50 # https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_NumberFilter.html
 ---
 kind: destination
 spec:


### PR DESCRIPTION
## What does this change, and why?
Remove the `severity_normalized` filter when collecting AWS Security Hub findings. We're using the Tagging Standard for the tagging obligation. These findings are reported with a severity of 0; removing the filter allows them to be collected in Service Catalogue.

The `severity_normalized` filter is also [deprecated](https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_Severity.html).

## How has it been verified?
Ran locally; it does not take significantly longer to collect this data either.