### PR TITLE
feat: Automatically refresh `aws_resources` materialized view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
               - packages/github-actions-usage/dist/github-actions-usage.zip
             obligatron:
               - packages/obligatron/dist/obligatron.zip
+            refresh-materialized-view:
+              - packages/refresh-materialized-view/dist/refresh-materialized-view.zip
             prisma:
               - packages/common/prisma.zip
             theguardian-servicecatalogue-app:

--- a/package-lock.json
+++ b/package-lock.json
@@ -19038,6 +19038,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/refresh-materialized-view": {
+      "resolved": "packages/refresh-materialized-view",
+      "link": true
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "license": "MIT"
@@ -22707,6 +22711,9 @@
     },
     "packages/obligatron": {
       "version": "1.0.0"
+    },
+    "packages/refresh-materialized-view": {
+      "version": "0.0.0"
     },
     "packages/repocop": {
       "version": "1.0.0",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19,6 +19,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuScheduledLambda",
       "GuLambdaFunction",
       "GuLambdaFunction",
+      "GuLambdaFunction",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -17155,6 +17156,282 @@ spec:
       },
       "Type": "AWS::Events::Rule",
     },
+    "RefreshMaterializedViewF0E38938": {
+      "DependsOn": [
+        "RefreshMaterializedViewServiceRoleDefaultPolicyCF61664F",
+        "RefreshMaterializedViewServiceRole8A87DE10",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "deploy/TEST/refresh-materialized-view/refresh-materialized-view.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "refresh-materialized-view",
+            "DATABASE_HOSTNAME": {
+              "Fn::GetAtt": [
+                "PostgresInstance16DE4286E",
+                "Endpoint.Address",
+              ],
+            },
+            "QUERY_LOGGING": "false",
+            "STACK": "deploy",
+            "STAGE": "TEST",
+          },
+        },
+        "Handler": "index.main",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 512,
+        "Role": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewServiceRole8A87DE10",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "refresh-materialized-view",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 600,
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            {
+              "Fn::GetAtt": [
+                "PostgresAccessSecurityGroupServicecatalogue03C78F14",
+                "GroupId",
+              ],
+            },
+          ],
+          "SubnetIds": {
+            "Ref": "PrivateSubnets",
+          },
+        },
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "RefreshMaterializedViewServiceRole8A87DE10": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "refresh-materialized-view",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "RefreshMaterializedViewServiceRoleDefaultPolicyCF61664F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/deploy/TEST/refresh-materialized-view/refresh-materialized-view.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/refresh-materialized-view",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/deploy/refresh-materialized-view/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/refresh_materialized_view",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "RefreshMaterializedViewServiceRoleDefaultPolicyCF61664F",
+        "Roles": [
+          {
+            "Ref": "RefreshMaterializedViewServiceRole8A87DE10",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "RiffRaffDatabaseCredentials2033FD7A": {
       "DeletionPolicy": "Delete",
       "Properties": {
@@ -19046,6 +19323,1146 @@ spec:
       },
       "Type": "AWS::Logs::LogGroup",
       "UpdateReplacePolicy": "Retain",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsCostExplorerTaskDefinitionD8C37FA589285154": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsCostExplorerContainer",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsCostExplorerTaskDefinition62DC1A04",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsCostExplorerTaskDefinitionD8C37FA5AllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE944871E048DF": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsCostExplorerTaskDefinitionD8C37FA589285154",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsDelegatedToSecurityAccountTaskDefinitionD9E19358AllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE944804BCC0B4": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsDelegatedToSecurityAccountTaskDefinitionD9E19358DCB18522",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsDelegatedToSecurityAccountTaskDefinitionD9E19358DCB18522": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsDelegatedToSecurityAccountContainer",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsDelegatedToSecurityAccountTaskDefinition8FFEB633",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsListOrgsTaskDefinition2D3A9A600599C2A0": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsListOrgsContainer",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsListOrgsTaskDefinition15F8AF14",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsListOrgsTaskDefinition2D3A9A60AllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE9448B643483B": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsListOrgsTaskDefinition2D3A9A600599C2A0",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideAutoScalingGroupsTaskDefinition59C11D9AA73E4306": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsOrgWideAutoScalingGroupsContainer",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsOrgWideAutoScalingGroupsTaskDefinitionA838A372",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideAutoScalingGroupsTaskDefinition59C11D9AAllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE9448E326D7BD": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideAutoScalingGroupsTaskDefinition59C11D9AA73E4306",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideBackupTaskDefinitionC269FE04AllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE9448E7D4F97D": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideBackupTaskDefinitionC269FE04F73DB427",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideBackupTaskDefinitionC269FE04F73DB427": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsOrgWideBackupContainer",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsOrgWideBackupTaskDefinition91A7A518",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideCertificatesTaskDefinition24CEF41EAllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE9448EB48E93E": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideCertificatesTaskDefinition24CEF41EBCFEBF4C",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideCertificatesTaskDefinition24CEF41EBCFEBF4C": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsOrgWideCertificatesContainer",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsOrgWideCertificatesTaskDefinitionD275457C",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideCloudFormationTaskDefinition3044E3AC429D4FA0": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsOrgWideCloudFormationContainer",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsOrgWideCloudFormationTaskDefinitionFE550760",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideCloudFormationTaskDefinition3044E3ACAllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE94488A3427AC": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideCloudFormationTaskDefinition3044E3AC429D4FA0",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideCloudwatchAlarmsTaskDefinitionEDC746AE2E169362": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsOrgWideCloudwatchAlarmsContainer",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsOrgWideCloudwatchAlarmsTaskDefinition1E4F26F4",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideCloudwatchAlarmsTaskDefinitionEDC746AEAllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE94488838469A": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideCloudwatchAlarmsTaskDefinitionEDC746AE2E169362",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideDynamoDBTaskDefinition5F181D12945D102A": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsOrgWideDynamoDBContainer",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsOrgWideDynamoDBTaskDefinition8C3ACD16",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideDynamoDBTaskDefinition5F181D12AllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE94488FBAC13A": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideDynamoDBTaskDefinition5F181D12945D102A",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideEc2TaskDefinitionBBF19A7E56A0E5BB": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsOrgWideEc2Container",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsOrgWideEc2TaskDefinition8CC129B6",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideEc2TaskDefinitionBBF19A7EAllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE944889C189EC": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideEc2TaskDefinitionBBF19A7E56A0E5BB",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideInspectorTaskDefinitionDC3485A7AllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE944831874BB8": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideInspectorTaskDefinitionDC3485A7EE598481",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideInspectorTaskDefinitionDC3485A7EE598481": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsOrgWideInspectorContainer",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsOrgWideInspectorTaskDefinitionBABA9F5D",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideLoadBalancersTaskDefinitionA0D1BDA3AllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE944890D99406": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideLoadBalancersTaskDefinitionA0D1BDA3F3FB92EC",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideLoadBalancersTaskDefinitionA0D1BDA3F3FB92EC": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsOrgWideLoadBalancersContainer",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsOrgWideLoadBalancersTaskDefinition333F61F5",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideRDSTaskDefinition222E5C6AAllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE944861B51720": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideRDSTaskDefinition222E5C6AEFE0A57D",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideRDSTaskDefinition222E5C6AEFE0A57D": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsOrgWideRDSContainer",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsOrgWideRDSTaskDefinitionB16F3CC7",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideS3TaskDefinition6734443A7D858435": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsOrgWideS3Container",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsOrgWideS3TaskDefinitionAF066748",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideS3TaskDefinition6734443AAllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE94483DC47EE3": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsOrgWideS3TaskDefinition6734443A7D858435",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsRemainingDataTaskDefinition14D0B33A8780E691": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsRemainingDataContainer",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsRemainingDataTaskDefinitionF2586400",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsRemainingDataTaskDefinition14D0B33AAllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE944883F8E339": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerServiceCatalogueCloudquerySourceAwsRemainingDataTaskDefinition14D0B33A8780E691",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "repocop20553EB8": {
       "DependsOn": [

--- a/packages/cdk/lib/refresh-materialized-view.ts
+++ b/packages/cdk/lib/refresh-materialized-view.ts
@@ -1,0 +1,77 @@
+import type { GuStack } from '@guardian/cdk/lib/constructs/core';
+import type { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
+import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
+import { Duration } from 'aws-cdk-lib';
+import type { IVpc } from 'aws-cdk-lib/aws-ec2';
+import { ScheduledFargateTask } from 'aws-cdk-lib/aws-ecs-patterns';
+import { Rule } from 'aws-cdk-lib/aws-events';
+import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
+import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
+import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
+
+interface RefreshMaterializedViewLambdaProps {
+	vpc: IVpc;
+	db: DatabaseInstance;
+	dbAccess: GuSecurityGroup;
+}
+
+export function addRefreshMaterializedViewLambda(
+	scope: GuStack,
+	props: RefreshMaterializedViewLambdaProps,
+) {
+	const app = 'refresh-materialized-view';
+
+	const { vpc, dbAccess, db } = props;
+
+	const lambda = new GuLambdaFunction(scope, 'RefreshMaterializedView', {
+		app,
+		vpc,
+		architecture: Architecture.ARM_64,
+		securityGroups: [dbAccess],
+		fileName: `${app}.zip`,
+		handler: 'index.main',
+		environment: {
+			DATABASE_HOSTNAME: db.dbInstanceEndpointAddress,
+			QUERY_LOGGING: 'false', // Set this to 'true' to enable SQL query logging
+		},
+		runtime: Runtime.NODEJS_20_X,
+		timeout: Duration.minutes(10),
+	});
+
+	// This sort of lookup is a bit fragile!
+	// TODO pass the tasks in as a prop
+	const awsTasks = scope.node.children
+		.filter((_): _ is ScheduledFargateTask => _ instanceof ScheduledFargateTask)
+		.filter((_) => _.taskDefinition.family.includes('Aws'));
+
+	if (awsTasks.length === 0) {
+		// This is only seen at synth time. It doesn't impact running infrastructure.
+		throw new Error(`Could not find any 'Aws' tasks`);
+	}
+
+	awsTasks.forEach((task) => {
+		// Invoke the lambda when the task has completed successfully
+		new Rule(scope, `${app}-lambda-trigger-${task.taskDefinition.family}`, {
+			targets: [new LambdaFunction(lambda)],
+			enabled: true,
+			eventPattern: {
+				source: ['aws.ecs'],
+				detailType: ['ECS Task State Change'],
+
+				// See https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Task.html
+				detail: {
+					clusterArn: [task.cluster.clusterArn],
+					taskDefinitionArn: [task.taskDefinition.taskDefinitionArn],
+					lastStatus: ['STOPPED'],
+					stopCode: ['EssentialContainerExited'], // The CloudQuery container is the "essential" one
+					'containers.exitCode': [{ numeric: ['=', 0] }],
+					'containers.name': [
+						task.taskDefinition.defaultContainer?.containerName,
+					],
+				},
+			},
+		});
+	});
+
+	db.grantConnect(lambda, 'refresh_materialized_view');
+}

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -45,6 +45,7 @@ import { addGithubActionsUsageLambda } from './github-actions-usage';
 import { InteractiveMonitor } from './interactive-monitor';
 import { Obligatron } from './obligatron';
 import { addPrismaMigrateTask } from './prisma-migrate-task';
+import { addRefreshMaterializedViewLambda } from './refresh-materialized-view';
 import { Repocop } from './repocop';
 
 interface ServiceCatalogueProps extends GuStackProps {
@@ -256,6 +257,12 @@ export class ServiceCatalogue extends GuStack {
 			db,
 			dbAccess: applicationToPostgresSecurityGroup,
 			cluster: cloudqueryCluster,
+		});
+
+		addRefreshMaterializedViewLambda(this, {
+			vpc,
+			db,
+			dbAccess: applicationToPostgresSecurityGroup,
 		});
 
 		new Obligatron(this, {

--- a/packages/common/prisma/migrations/20240530093317_aws_resources_owner/migration.sql
+++ b/packages/common/prisma/migrations/20240530093317_aws_resources_owner/migration.sql
@@ -1,0 +1,25 @@
+DO
+$do$
+    BEGIN
+        -- This user is used by the refresh-materialized-view lambda
+        CREATE USER refresh_materialized_view WITH LOGIN;
+
+        GRANT USAGE ON SCHEMA public to refresh_materialized_view;
+        GRANT SELECT ON ALL TABLES IN SCHEMA public TO refresh_materialized_view;
+
+        -- The rds_iam role is created by the RDS IAM extension, which is not available in DEV
+        IF EXISTS (select * from pg_roles where rolname='rds_iam') THEN
+            GRANT rds_iam TO refresh_materialized_view;
+        END IF;
+
+        /*
+         Only the owner of a materialized view can refresh it, else the following error is thrown:
+
+           > ERROR: must be owner of materialized view aws_resources
+
+         The current owner is the root user.
+         Change owner to the one used by the refresh-materialized-view lambda.
+         */
+        ALTER MATERIALIZED VIEW aws_resources OWNER TO refresh_materialized_view;
+    END
+$do$;

--- a/packages/refresh-materialized-view/README.md
+++ b/packages/refresh-materialized-view/README.md
@@ -1,0 +1,10 @@
+# Refresh Materialized View
+
+A lambda function that refreshes the materialized view `aws_resources`.
+
+## Running locally
+With your local environment running, run:
+
+```bash
+npm -w refresh-materialized-view start
+```

--- a/packages/refresh-materialized-view/README.md
+++ b/packages/refresh-materialized-view/README.md
@@ -8,3 +8,8 @@ With your local environment running, run:
 ```bash
 npm -w refresh-materialized-view start
 ```
+
+## Running on PROD
+This lambda is triggered whenever an ECS task prefixed `Aws` completes successfully.
+
+If necessary, it can also be triggered on-demand without any input.

--- a/packages/refresh-materialized-view/package.json
+++ b/packages/refresh-materialized-view/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "refresh-materialized-view",
+  "version": "0.0.0",
+  "scripts": {
+    "test": "echo \"Error: no test specified\"",
+    "start": "APP=refresh-materialized-view tsx src/run-locally.ts",
+    "prebuild": "rm -rf dist",
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@prisma/client --external:prisma",
+    "typecheck": "tsc --noEmit"
+  },
+  "type": "module"
+}

--- a/packages/refresh-materialized-view/src/config.ts
+++ b/packages/refresh-materialized-view/src/config.ts
@@ -1,0 +1,37 @@
+import type { DatabaseConfig, PrismaConfig } from 'common/database';
+import {
+	getDatabaseConfig,
+	getDatabaseConnectionString,
+	getDevDatabaseConfig,
+} from 'common/database';
+import { getEnvOrThrow } from 'common/functions';
+
+export interface Config extends PrismaConfig {
+	/**
+	 * The name of this application.
+	 */
+	app: string;
+
+	/**
+	 * The stage of the application, e.g. DEV, CODE, PROD.
+	 */
+	stage: string;
+}
+
+export async function getConfig(): Promise<Config> {
+	const stage = getEnvOrThrow('STAGE');
+
+	const databaseConfig: DatabaseConfig =
+		stage === 'DEV'
+			? await getDevDatabaseConfig()
+			: await getDatabaseConfig(stage, 'refresh_materialized_view');
+
+	const queryLogging = process.env['QUERY_LOGGING'] === 'true';
+
+	return {
+		app: getEnvOrThrow('APP'),
+		stage,
+		databaseConnectionString: getDatabaseConnectionString(databaseConfig),
+		withQueryLogging: queryLogging,
+	};
+}

--- a/packages/refresh-materialized-view/src/index.ts
+++ b/packages/refresh-materialized-view/src/index.ts
@@ -1,0 +1,14 @@
+import { getPrismaClient } from 'common/database';
+import { getConfig } from './config';
+
+export async function main(...args: unknown[]) {
+	console.debug(
+		`Called with ${args.map((arg) => JSON.stringify(arg)).join(', ')}`,
+	);
+
+	const config = await getConfig();
+	const prismaClient = getPrismaClient(config);
+
+	await prismaClient.$executeRaw`REFRESH MATERIALIZED VIEW aws_resources;`;
+	console.log(`Materialized view 'aws_resources' has been refreshed`);
+}

--- a/packages/refresh-materialized-view/src/run-locally.ts
+++ b/packages/refresh-materialized-view/src/run-locally.ts
@@ -1,0 +1,7 @@
+import { config } from 'dotenv';
+import { main } from './index';
+
+// Read the .env file from the repository root
+config({ path: `../../.env` });
+
+void main();

--- a/packages/refresh-materialized-view/tsconfig.json
+++ b/packages/refresh-materialized-view/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "references": [{ "path": "../common" }]
+}

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -76,6 +76,7 @@ createLambdaWithPrisma "repocop"
 createLambdaWithPrisma "data-audit"
 createLambdaWithPrisma "github-actions-usage"
 createLambdaWithPrisma "obligatron"
+createLambdaWithPrisma "refresh-materialized-view"
 
 # Package the dashboard...
 createZip "dashboard"


### PR DESCRIPTION
> [!TIP]
> Easiest to review [commit by commit](https://github.com/guardian/service-catalogue/pull/1048/commits).

## What does this change, and why?
The `aws_resources` materialized view is currently informing the tagging obligation, and is being used by a few dashboards. Materialized views need to be refreshed. We're currently doing this manually, and sporadically. This means our dashboards often show stale data.

This change adds a new lambda to refresh the materialized view. The lambda is triggered on the successful completion of an AWS based task. This should result in our dashboard reflecting up to date data at all times.

> [!NOTE]
> - The "obligatron" (#989) should replace this view. That is, this lambda is likely to be a short term solution.
> - This change creates a new database user.

## How has it been verified?
I've run the project locally, with success.

After [deploying to CODE](https://riffraff.gutools.co.uk/deployment/view/5002d964-1f79-40b4-8c98-37338741b050), I've manually invoked the lambda, and invoked it via manually running an Aws task. The logs for each can be seen in the screenshot below (logs at 12:05 originate from the manual invocation, logs at 12:08 originate from the event based invocation):

<img width="1772" alt="image" src="https://github.com/guardian/service-catalogue/assets/836140/e97d6e35-2d62-4314-8229-5b079840ac0d">
