### PR TITLE
Make sure that local_env_file_dir exists

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -75,6 +75,7 @@ setup_environment() {
   step "Setting up Service Catalogue environment"
 
   local_env_file_dir=$HOME/.gu/service_catalogue
+  mkdir -p "$local_env_file_dir"
 
   local_env_file=$local_env_file_dir/.env.local
 


### PR DESCRIPTION
## What does this change?

Later steps in the script assume that this directory exists and is writable. Having defined the path, let's also make sure it exists. 

## Why?

At the moment this script fails when setting up the project for the first time.

## How has it been verified?

I've run setup from scratch after this fix, to verify it works.