### PR TITLE
Round up number of days teams have to fix vulnerabilites

### DIFF
--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -285,12 +285,20 @@ describe('daysLeftToFix', () => {
 	test('should return 0 if we exceed the SLA', () => {
 		expect(daysLeftToFix(veryOldVuln)).toBe(0);
 	});
-	test('should return 30 if a high vuln was raised today', () => {
+	test('should return 30 if a high vuln was raised in the last 24 hours', () => {
 		const newHighVuln: RepocopVulnerability = {
 			...veryOldVuln,
 			alert_issue_date: new Date(),
 		};
+		const twentyThreeHoursAgo = new Date();
+		twentyThreeHoursAgo.setHours(twentyThreeHoursAgo.getHours() - 23);
+		const twentyThreeHourVuln = {
+			...newHighVuln,
+			alert_issue_date: twentyThreeHoursAgo,
+		};
+
 		expect(daysLeftToFix(newHighVuln)).toBe(30);
+		expect(daysLeftToFix(twentyThreeHourVuln)).toBe(30);
 	});
 	test('should return 2 if a critical vuln was raised today', () => {
 		const newCriticalVuln: RepocopVulnerability = {

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -286,19 +286,29 @@ describe('daysLeftToFix', () => {
 		expect(daysLeftToFix(veryOldVuln)).toBe(0);
 	});
 	test('should return 30 if a high vuln was raised in the last 24 hours', () => {
-		const newHighVuln: RepocopVulnerability = {
+		function hoursAgo(hours: number): Date {
+			const date = new Date();
+			date.setHours(date.getHours() - hours);
+			return date;
+		}
+
+		const oneHourOld: RepocopVulnerability = {
 			...veryOldVuln,
-			alert_issue_date: new Date(),
-		};
-		const twentyThreeHoursAgo = new Date();
-		twentyThreeHoursAgo.setHours(twentyThreeHoursAgo.getHours() - 23);
-		const twentyThreeHourVuln = {
-			...newHighVuln,
-			alert_issue_date: twentyThreeHoursAgo,
+			alert_issue_date: hoursAgo(1),
 		};
 
-		expect(daysLeftToFix(newHighVuln)).toBe(30);
-		expect(daysLeftToFix(twentyThreeHourVuln)).toBe(30);
+		const twentyThreeHoursOld = {
+			...oneHourOld,
+			alert_issue_date: hoursAgo(23),
+		};
+
+		const twentyFiveHoursOld = {
+			...oneHourOld,
+			alert_issue_date: hoursAgo(25),
+		};
+		expect(daysLeftToFix(oneHourOld)).toBe(30);
+		expect(daysLeftToFix(twentyThreeHoursOld)).toBe(30);
+		expect(daysLeftToFix(twentyFiveHoursOld)).toBe(29);
 	});
 	test('should return 2 if a critical vuln was raised today', () => {
 		const newCriticalVuln: RepocopVulnerability = {

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -35,15 +35,19 @@ export function getTopVulns(vulnerabilities: RepocopVulnerability[]) {
 		.sort((v1, v2) => v1.full_name.localeCompare(v2.full_name));
 }
 
-export function daysLeftToFix(vuln: RepocopVulnerability): number | undefined {
+export function daysLeftToFix(
+	vuln: RepocopVulnerability,
+	currentMoment: Date = new Date(),
+): number | undefined {
 	const daysToFix = SLAs[vuln.severity];
 	if (!daysToFix) {
 		return undefined;
 	}
 	const fixDate = new Date(vuln.alert_issue_date);
 	fixDate.setDate(fixDate.getDate() + daysToFix);
-	const daysLeftToFix = Math.floor(
-		(fixDate.getTime() - new Date().getTime()) / (1000 * 60 * 60 * 24),
+	const millisecondsInADay = 1000 * 60 * 60 * 24;
+	const daysLeftToFix = Math.ceil(
+		(fixDate.getTime() - currentMoment.getTime()) / millisecondsInADay,
 	);
 
 	return daysLeftToFix < 0 ? 0 : daysLeftToFix;

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -35,10 +35,7 @@ export function getTopVulns(vulnerabilities: RepocopVulnerability[]) {
 		.sort((v1, v2) => v1.full_name.localeCompare(v2.full_name));
 }
 
-export function daysLeftToFix(
-	vuln: RepocopVulnerability,
-	currentMoment: Date = new Date(),
-): number | undefined {
+export function daysLeftToFix(vuln: RepocopVulnerability): number | undefined {
 	const daysToFix = SLAs[vuln.severity];
 	if (!daysToFix) {
 		return undefined;
@@ -47,7 +44,7 @@ export function daysLeftToFix(
 	fixDate.setDate(fixDate.getDate() + daysToFix);
 	const millisecondsInADay = 1000 * 60 * 60 * 24;
 	const daysLeftToFix = Math.ceil(
-		(fixDate.getTime() - currentMoment.getTime()) / millisecondsInADay,
+		(fixDate.getTime() - new Date().getTime()) / millisecondsInADay,
 	);
 
 	return daysLeftToFix < 0 ? 0 : daysLeftToFix;


### PR DESCRIPTION
## What does this change?

Fixes maths so that teams have 30 days to fix a vulnerability that was raised in the last 24 hours.
Add test to verify the days left to fix is the same at the start and end of a 24 hour period

## Why?

Consistency, and to better reflect reality. Previously, it was almost impossible to get repocop to say you had two days to fix a vuln unless it had been raised at the exact instant it was executing.

## How has it been verified?

Unit tests have been updated to more precisely define the behaviour of the function