### PR TITLE
Save obligatron results to DB

### DIFF
--- a/packages/obligatron/src/config.ts
+++ b/packages/obligatron/src/config.ts
@@ -22,6 +22,7 @@ export async function getConfig(): Promise<Config> {
 	return {
 		stage,
 		databaseConnectionString: getDatabaseConnectionString(databaseConfig),
-		withQueryLogging: stage === 'DEV',
+		// Our insert queries are VERY big, so don't log them
+		withQueryLogging: false,
 	};
 }

--- a/packages/obligatron/src/obligations/index.ts
+++ b/packages/obligatron/src/obligations/index.ts
@@ -7,27 +7,17 @@ export type ObligationResult = {
 	resource: string;
 
 	/**
-	 * Did this resource meet the obligation check?
-	 */
-	result: boolean;
-
-	/**
 	 * Explanation for the assessment failing.
 	 */
-	reasons: string[];
+	reason: string;
 
 	/**
 	 * Link to where the user can see more details on the resource.
 	 */
-	deep_link?: string;
+	url?: string;
 
 	/**
-	 * Associated AWS account ID (if any)
+	 * Key-value pairs to link failing obligations to the responsible teams.
 	 */
-	aws_account_id?: string;
-
-	/**
-	 * Associated Github teams (if any)
-	 */
-	github_teams?: string[];
+	contacts?: Record<string, string>;
 };

--- a/packages/obligatron/src/obligations/tagging.test.ts
+++ b/packages/obligatron/src/obligations/tagging.test.ts
@@ -30,12 +30,7 @@ describe('The tagging obligation', () => {
 
 		const results = await evaluateTaggingObligation(client);
 
-		expect(results.filter((r) => !r.result)).toHaveLength(0);
-		expect(results[0]).toMatchObject({
-			resource: 'arn:aws:s3:::mybucket',
-			result: true,
-			reasons: [],
-		});
+		expect(results).toHaveLength(0);
 	});
 
 	it('catches missing Stack tags', async () => {
@@ -56,11 +51,11 @@ describe('The tagging obligation', () => {
 
 		const results = await evaluateTaggingObligation(client);
 
-		expect(results.filter((r) => !r.result)).toHaveLength(1);
-		expect(results[0]).toMatchObject({
+		expect(results).toHaveLength(1);
+		expect(results[0]).toEqual({
 			resource: 'arn:aws:s3:::mybucket',
-			result: false,
-			reasons: ["Resource missing 'Stack' tag."],
+			reason: "Resource missing 'Stack' tag.",
+			contacts: { aws_account: '123456789012' },
 		});
 	});
 
@@ -82,11 +77,11 @@ describe('The tagging obligation', () => {
 
 		const results = await evaluateTaggingObligation(client);
 
-		expect(results.filter((r) => !r.result)).toHaveLength(1);
-		expect(results[0]).toMatchObject({
+		expect(results).toHaveLength(1);
+		expect(results[0]).toEqual({
 			resource: 'arn:aws:s3:::mybucket',
-			result: false,
-			reasons: ["Resource missing 'Stage' tag."],
+			reason: "Resource missing 'Stage' tag.",
+			contacts: { aws_account: '123456789012' },
 		});
 	});
 
@@ -108,11 +103,11 @@ describe('The tagging obligation', () => {
 
 		const results = await evaluateTaggingObligation(client);
 
-		expect(results.filter((r) => !r.result)).toHaveLength(1);
-		expect(results[0]).toMatchObject({
+		expect(results).toHaveLength(1);
+		expect(results[0]).toEqual({
 			resource: 'arn:aws:s3:::mybucket',
-			result: false,
-			reasons: ["Resource missing 'App' tag."],
+			reason: "Resource missing 'App' tag.",
+			contacts: { aws_account: '123456789012' },
 		});
 	});
 
@@ -134,11 +129,11 @@ describe('The tagging obligation', () => {
 
 		const results = await evaluateTaggingObligation(client);
 
-		expect(results.filter((r) => !r.result)).toHaveLength(1);
-		expect(results[0]).toMatchObject({
+		expect(results).toHaveLength(1);
+		expect(results[0]).toEqual({
 			resource: 'arn:aws:s3:::mybucket',
-			result: false,
-			reasons: ["Resource missing 'gu:repo' tag."],
+			reason: "Resource missing 'gu:repo' tag.",
+			contacts: { aws_account: '123456789012' },
 		});
 	});
 
@@ -161,16 +156,11 @@ describe('The tagging obligation', () => {
 
 		const results = await evaluateTaggingObligation(client);
 
-		expect(results.filter((r) => !r.result)).toHaveLength(1);
-		expect(results[0]).toMatchObject({
+		expect(results).toHaveLength(4);
+		expect(results[0]).toEqual({
 			resource: 'arn:aws:s3:::mybucket',
-			result: false,
-			reasons: [
-				"Resource missing 'Stack' tag.",
-				"Resource missing 'Stage' tag.",
-				"Resource missing 'App' tag.",
-				"Resource missing 'gu:repo' tag.",
-			],
+			reason: "Resource missing 'Stack' tag.",
+			contacts: { aws_account: '123456789012' },
 		});
 	});
 });


### PR DESCRIPTION
## What does this change?

- Allow Obligatron to start saving results to the DB after processing obligations.
- Change the tagging obligation to return results in a way thats more friendly with our Schema.
- Add logging to Obligatron so that we can see more about what its doing in ELK.

Requires https://github.com/guardian/service-catalogue/pull/1050 to be merged.

## How has it been verified?

Ran locally:

![Untitled](https://github.com/guardian/service-catalogue/assets/21217225/6496fe28-4346-40aa-9de9-f2ef5d69d46a)
