### PR TITLE
Remove hard-coded x86 platform from docker-compose

### DIFF
--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -57,7 +57,6 @@ services:
       context: ../../containers/cloudquery
       args:
         CQ_CLI: ${CQ_CLI}
-    platform: linux/amd64
     depends_on:
       postgres:
         condition: service_healthy
@@ -81,7 +80,6 @@ services:
     command: sync /cloudquery.yaml --log-console --log-level info
   grafana:
     user: root
-    platform: linux/amd64
     build:
       context: ../dashboard/.config
       args:


### PR DESCRIPTION


## What does this change?

On our (apple silicone) macs we typcially want to use arm containers, because this comes with a significant performance boost. By not hard-coding the platform, we allow docker to decide which to use. This means on apple silicone we'll get an arm container.

## Why?

Big performance improvements!

## How has it been verified?

I've run it locally before and after, and checked that we now get a native container image.
