### PR TITLE
only send vulnerability reports when ENABLE_MESSAGING=true

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -152,13 +152,6 @@ export async function main() {
 		nonPlaygroundStacks,
 	);
 
-	await createAndSendVulnerabilityDigests(
-		config,
-		teams,
-		repoOwners,
-		evaluationResults,
-	);
-
 	await sendUnprotectedRepo(repocopRules, config, repoLanguages);
 	await writeEvaluationTable(repocopRules, prisma);
 	if (config.enableMessaging) {
@@ -174,6 +167,14 @@ export async function main() {
 				octokit,
 			);
 		}
+
+		await createAndSendVulnerabilityDigests(
+			config,
+			teams,
+			repoOwners,
+			evaluationResults,
+		);
+
 		await applyProductionTopicAndMessageTeams(
 			teams,
 			unarchivedRepos,


### PR DESCRIPTION
## What does this change?

Allows the creation of vulnerability digests to be toggled on and off

## Why?

Consistency with the rest of the code, easier regeneration of PROD repocop data
