### PR TITLE
use url parsing instead of string matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21583,8 +21583,9 @@
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -415,7 +415,6 @@ const urlSortPredicate = (maybeUrl: string) => {
 		}
 		return 0;
 	} catch {
-		//Do nothing if the url is invalid
 		console.debug(`Invalid url: ${maybeUrl}`);
 		return 0;
 	}

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -401,24 +401,22 @@ export function evaluateOneRepo(
 }
 
 //create a predicate that orders a list of urls by whether they contain snyk.io first, and then github.com second
-const urlSortPredicate = (url: string) => {
+const urlSortPredicate = (maybeUrl: string) => {
 	try {
-		const parsedUrl = new URL(url);
+		const url = new URL(maybeUrl);
 
-		if (
-			parsedUrl.hostname == 'snyk.io' ||
-			parsedUrl.hostname == 'security.snyk.io'
-		) {
+		if (url.hostname === 'snyk.io' || url.hostname === 'security.snyk.io') {
 			return -2;
 		} else if (
-			parsedUrl.hostname == 'github.com' &&
-			parsedUrl.pathname.includes('advisories')
+			url.hostname === 'github.com' &&
+			url.pathname.includes('advisories')
 		) {
 			return -1;
 		}
 		return 0;
 	} catch {
 		//Do nothing if the url is invalid
+		console.debug(`Invalid url: ${maybeUrl}`);
 		return 0;
 	}
 };

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -405,10 +405,10 @@ const urlSortPredicate = (url: string) => {
 	const parsedUrl = new URL(url);
 	console.log(parsedUrl.hostname);
 
-	if (parsedUrl.hostname.endsWith('snyk.io')) {
+	if (parsedUrl.hostname == 'snyk.io') {
 		return -2;
 	} else if (
-		parsedUrl.hostname.endsWith('github.com') &&
+		parsedUrl.hostname == 'github.com' &&
 		parsedUrl.pathname.includes('advisories')
 	) {
 		return -1;

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -402,20 +402,25 @@ export function evaluateOneRepo(
 
 //create a predicate that orders a list of urls by whether they contain snyk.io first, and then github.com second
 const urlSortPredicate = (url: string) => {
-	const parsedUrl = new URL(url);
+	try {
+		const parsedUrl = new URL(url);
 
-	if (
-		parsedUrl.hostname == 'snyk.io' ||
-		parsedUrl.hostname == 'security.snyk.io'
-	) {
-		return -2;
-	} else if (
-		parsedUrl.hostname == 'github.com' &&
-		parsedUrl.pathname.includes('advisories')
-	) {
-		return -1;
+		if (
+			parsedUrl.hostname == 'snyk.io' ||
+			parsedUrl.hostname == 'security.snyk.io'
+		) {
+			return -2;
+		} else if (
+			parsedUrl.hostname == 'github.com' &&
+			parsedUrl.pathname.includes('advisories')
+		) {
+			return -1;
+		}
+		return 0;
+	} catch {
+		//Do nothing if the url is invalid
+		return 0;
 	}
-	return 0;
 };
 
 export function dependabotAlertToRepocopVulnerability(

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -1,3 +1,4 @@
+import { URL } from 'url';
 import type {
 	github_languages,
 	github_repository_branches,
@@ -401,9 +402,15 @@ export function evaluateOneRepo(
 
 //create a predicate that orders a list of urls by whether they contain snyk.io first, and then github.com second
 const urlSortPredicate = (url: string) => {
-	if (url.includes('snyk.io')) {
+	const parsedUrl = new URL(url);
+	console.log(parsedUrl.hostname);
+
+	if (parsedUrl.hostname.includes('snyk.io')) {
 		return -2;
-	} else if (url.includes('github.com') && url.includes('advisories')) {
+	} else if (
+		parsedUrl.hostname.includes('github.com') &&
+		parsedUrl.pathname.includes('advisories')
+	) {
 		return -1;
 	}
 	return 0;

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -403,9 +403,11 @@ export function evaluateOneRepo(
 //create a predicate that orders a list of urls by whether they contain snyk.io first, and then github.com second
 const urlSortPredicate = (url: string) => {
 	const parsedUrl = new URL(url);
-	console.log(parsedUrl.hostname);
 
-	if (parsedUrl.hostname == 'snyk.io') {
+	if (
+		parsedUrl.hostname == 'snyk.io' ||
+		parsedUrl.hostname == 'security.snyk.io'
+	) {
 		return -2;
 	} else if (
 		parsedUrl.hostname == 'github.com' &&

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -405,10 +405,10 @@ const urlSortPredicate = (url: string) => {
 	const parsedUrl = new URL(url);
 	console.log(parsedUrl.hostname);
 
-	if (parsedUrl.hostname.includes('snyk.io')) {
+	if (parsedUrl.hostname.endsWith('snyk.io')) {
 		return -2;
 	} else if (
-		parsedUrl.hostname.includes('github.com') &&
+		parsedUrl.hostname.endsWith('github.com') &&
 		parsedUrl.pathname.includes('advisories')
 	) {
 		return -1;


### PR DESCRIPTION
## What does this change?

We got a CodeQL alert for unsafe URL parsing. This change checks the relevant part of the URL for the correct string, making our check a little more accurate. It shouldn't have a significant impact on code security, because URLs are always coming from Snyk or Dependabot, but this is good practice, and makes our check more precise.

## How has it been verified?

Unit tests around URL ordering continue to pass
