### PR TITLE
Increase frequency of ELB data ingestion

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -7938,7 +7938,7 @@ spec:
     },
     "CloudquerySourceAwsOrgWideLoadBalancersScheduledEventRuleE82A6C43": {
       "Properties": {
-        "ScheduleExpression": "cron(0 23 * * ? *)",
+        "ScheduleExpression": "rate(30 minutes)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -164,7 +164,7 @@ export function addCloudqueryEcsCluster(
 			name: 'AwsOrgWideLoadBalancers',
 			description:
 				'Collecting load balancer data across the organisation. Uses include building SLO dashboards.',
-			schedule: nonProdSchedule ?? Schedule.cron({ minute: '0', hour: '23' }),
+			schedule: nonProdSchedule ?? Schedule.rate(Duration.minutes(30)),
 			config: awsSourceConfigForOrganisation({
 				tables: ['aws_elbv1_*', 'aws_elbv2_*'],
 			}),


### PR DESCRIPTION
## What does this change?
Increases the frequency of ELB (v1 and v2) data ingestion from once a day to every 30 minutes.

## Why?
The query that powers the open security group dashboard joins the security group table to the ELB tables. However, we collect SG data every 30 minutes, but ELB data is only collected once a day. This means the table information might be staler than we want it to be.