### PR TITLE
Grant our weekly AWS and our AWS backups clouquery jobs more memory

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -2789,7 +2789,7 @@ spec:
             "Environment": [
               {
                 "Name": "GOMEMLIMIT",
-                "Value": "409MiB",
+                "Value": "819MiB",
               },
             ],
             "Essential": true,
@@ -3054,7 +3054,7 @@ spec:
           ],
         },
         "Family": "ServiceCatalogueCloudquerySourceAwsOrgWideBackupTaskDefinitionC269FE04",
-        "Memory": "512",
+        "Memory": "1024",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",
@@ -10297,7 +10297,7 @@ spec:
             "Environment": [
               {
                 "Name": "GOMEMLIMIT",
-                "Value": "1638MiB",
+                "Value": "2457MiB",
               },
             ],
             "Essential": true,
@@ -10562,7 +10562,7 @@ spec:
           ],
         },
         "Family": "ServiceCatalogueCloudquerySourceAwsRemainingDataTaskDefinition14D0B33A",
-        "Memory": "2048",
+        "Memory": "3072",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -258,6 +258,7 @@ export function addCloudqueryEcsCluster(
 				],
 			}),
 			policies: [listOrgsPolicy, cloudqueryAccess('*')],
+			memoryLimitMiB: 1024,
 		},
 		{
 			name: 'AwsOrgWideEc2',
@@ -320,7 +321,7 @@ export function addCloudqueryEcsCluster(
 		policies: [listOrgsPolicy, cloudqueryAccess('*')],
 
 		// This task is quite expensive, and requires more power than the default (500MB memory, 0.25 vCPU).
-		memoryLimitMiB: 2048,
+		memoryLimitMiB: 3072,
 		cpu: 1024,
 	};
 


### PR DESCRIPTION
## What does this change?

- Give our weekly AWS cloudquery job 3GB of memory.
- Give our AWS backups cloudquery job 1GB of memory.

## Why?

Seems like both of these jobs are running out of memory.

