### PR TITLE
fix(repocop): Prisma migration for repocop db user

### DIFF
--- a/packages/common/prisma/migrations/20240614105000_repocop_user/migration.sql
+++ b/packages/common/prisma/migrations/20240614105000_repocop_user/migration.sql
@@ -1,0 +1,25 @@
+DO
+$do$
+    BEGIN
+        -- Create the `repocop` user if it doesn't exist
+        IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE  rolname = 'repocop') THEN
+            CREATE USER repocop WITH LOGIN;
+        END IF;
+
+        -- Allow repocop to read all tables in the public schema
+        -- TODO should we limit permissions to exactly the tables/views that repocop uses, for POLP?
+        GRANT USAGE ON SCHEMA public to repocop;
+        GRANT SELECT ON ALL TABLES IN SCHEMA public TO repocop;
+
+        -- The rds_iam role is created by the RDS IAM extension, which is not available in DEV
+        IF EXISTS (select * from pg_roles where rolname='rds_iam') THEN
+            GRANT rds_iam TO repocop;
+        END IF;
+
+        -- These tables are created in a previous migration.
+        -- The repocop user owns these tables, so can do full CRUD operations
+        GRANT ALL ON public.repocop_github_repository_rules TO repocop;
+        GRANT ALL ON public.repocop_vulnerabilities TO repocop;
+    END
+$do$;
+

--- a/sql/dbuser.sql
+++ b/sql/dbuser.sql
@@ -1,15 +1,6 @@
 /*
  sql should not be applied directly to the db, use prisma migrations
 */
-CREATE USER repocop WITH LOGIN;
-GRANT USAGE ON SCHEMA public to repocop;
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO repocop;
-GRANT rds_iam TO repocop;
-
--- These tables are created via a Prisma migration
-GRANT ALL ON public.repocop_github_repository_rules TO repocop;
-GRANT ALL ON public.repocop_vulnerabilities TO repocop;
-
 CREATE USER dataaudit WITH LOGIN;
 GRANT USAGE ON SCHEMA public to dataaudit;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO dataaudit;


### PR DESCRIPTION
## What does this change?
Moves the manually applied SQL script to create the repocop user, and apply permissions, to a Prisma migration, so that it gets automatically applied.

Whilst it looks like a no-op, the exexution of:

```sql
GRANT SELECT ON ALL TABLES IN SCHEMA public TO repocop;
```

Will grant `repocop` access to the `view_repo_ownership` view, which was lost in #1066.

> [!NOTE]
> - The next PR will add a test that's run in CI to catch this regression in future.
> - We have [some more SQL scripts](https://github.com/guardian/service-catalogue/blob/524e0d07211ed1cbef86884878c3bb3d4eb2ab51/sql/dbuser.sql) that have been manually applied. In future PRs we will convert those to Prisma migrations too.

## Why?
The `repocop` user requires permission on `view_repo_ownership` to run. It no longer has these permissions.

## How has it been verified?
- [Deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/bd655da3-70d0-43af-aa7e-548dfac20aba)
- Successfully executed the repocop lambda (see logs below)

![image](https://github.com/guardian/service-catalogue/assets/836140/eb15bb5c-57e9-4ed2-84ee-9cbda6f5dd5b)


---
Co-authored-by: @AshCorr.