### PR TITLE
ci: Perform basic SQL tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,9 @@ jobs:
       - name: perform a DEV database migration
         run: npm -w cli start migrate -- --stage DEV
 
+      - name: basic database tests
+        run: psql -d postgresql://postgres:not_at_all_secret@localhost:5432/postgres -v ON_ERROR_STOP=1 -f sql/ci.sql
+
       - name: check schema.prisma file hasn't changed
         run: git diff --exit-code packages/common/prisma/schema.prisma
 

--- a/sql/ci.sql
+++ b/sql/ci.sql
@@ -1,0 +1,8 @@
+-- This file is run in CI.
+
+-- Switch to the `repocop` user and test access to `view_repo_ownership`
+SET ROLE repocop;
+SELECT * FROM view_repo_ownership LIMIT 1;
+
+-- Switch back to the original user
+RESET role;


### PR DESCRIPTION
## What does this change, and why?
The changes in #1066 created a regression, where the `repocop` database user lost access to a view.

In this change, we run some SQL in CI in an attempt to catch such regressions earlier.

## How has it been verified?
Observe CI. The build log (see below) shows we've switched user, and performed a `SELECT *` on the view successfully (the query returns 0 rows as the database is empty).

![image](https://github.com/guardian/service-catalogue/assets/836140/04ab8de9-9a31-4292-b7c3-865b9b110877)
