### PR TITLE
feat(obligatron): Augment tagging results with AMI info

### DIFF
--- a/packages/common/prisma/migrations/20240620104500_obligatron_ec2_images_access/migration.sql
+++ b/packages/common/prisma/migrations/20240620104500_obligatron_ec2_images_access/migration.sql
@@ -1,0 +1,1 @@
+GRANT SELECT ON public.aws_ec2_images TO obligatron;

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -84,7 +84,6 @@ model aws_ec2_images {
   virtualization_type   String?
 
   @@id([account_id, region, arn], map: "aws_ec2_images_cqpk")
-  @@ignore
 }
 
 model aws_ec2_instances {

--- a/packages/obligatron/src/obligations/tagging.test.ts
+++ b/packages/obligatron/src/obligations/tagging.test.ts
@@ -1,5 +1,5 @@
 import type { PrismaClient } from '@prisma/client';
-import { evaluateTaggingObligation } from './tagging';
+import { evaluateSecurityHubTaggingCoverage } from './tagging';
 
 const createPrismaClientWithMockedResponse = (response: unknown[]) => {
 	const aws_securityhub_findings = {
@@ -51,7 +51,7 @@ describe('The tagging obligation', () => {
 			},
 		]);
 
-		const results = await evaluateTaggingObligation(client);
+		const results = await evaluateSecurityHubTaggingCoverage(client);
 
 		expect(results).toHaveLength(2);
 		expect(results[0]).toEqual({
@@ -89,7 +89,7 @@ describe('The tagging obligation', () => {
 			},
 		]);
 
-		const results = await evaluateTaggingObligation(client);
+		const results = await evaluateSecurityHubTaggingCoverage(client);
 
 		expect(results).toHaveLength(0);
 	});
@@ -124,7 +124,7 @@ describe('The tagging obligation', () => {
 			},
 		]);
 
-		const results = await evaluateTaggingObligation(client);
+		const results = await evaluateSecurityHubTaggingCoverage(client);
 
 		expect(results).toHaveLength(2);
 	});
@@ -140,7 +140,7 @@ describe('The tagging obligation', () => {
 			},
 		]);
 
-		await expect(evaluateTaggingObligation(client)).rejects.toEqual(
+		await expect(evaluateSecurityHubTaggingCoverage(client)).rejects.toEqual(
 			new Error('Invalid resource in finding 123456789012'),
 		);
 	});


### PR DESCRIPTION
## What does this change, and why?
The adoption of [AWS Security Hub Resource Tagging Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/standards-tagging.html) means a subset of all AWS resources are having their tags evaluated.

Amazon Machine Images (AMIs) are one of the resources no covered. We produce a large number of AMIs. This change updates obligatron to query the `aws_ec2_images` table, to evaluate the tagging of our AMIs.

## How has it been verified?
[Deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/74848b28-ae9b-4f5c-bfd3-ef6fcb5c5b7a), and successfully ran the lambda with the results viewable [here](https://metrics.code.dev-gutools.co.uk/goto/cXu5XjUSg?orgId=1).