### PR TITLE
fix(obligatron): Allow usage of `obligatron_results_id_seq`

### DIFF
--- a/packages/common/prisma/migrations/20240620144000_obligatron_user/migration.sql
+++ b/packages/common/prisma/migrations/20240620144000_obligatron_user/migration.sql
@@ -1,0 +1,2 @@
+-- Allow the obligatron user to use the (implicit) obligatron_results_id_seq sequence
+GRANT USAGE ON SEQUENCE obligatron_results_id_seq TO obligatron;


### PR DESCRIPTION
## What does this change?
The `id` column of `obligatron_results` is of type `serial`. The `obligatron` database user needs permission to update the value.

See https://dba.stackexchange.com/questions/71528/explicitly-granting-permissions-to-update-the-sequence-for-a-serial-column-neces.

## Why?
The lambda runs in CODE up until it tries to write results to the database, at which point the following error is seen:

```log
permission denied for sequence obligatron_results_id_seq
```

## How has it been verified?
[Deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/0831c7eb-478f-48c6-ac3e-2c2dfa67c5af), and successfully ran the obligatron lambda with the results seen [here](https://metrics.code.dev-gutools.co.uk/goto/IHc2sC8Ig?orgId=1).