### PR TITLE
Move RepocopVulnerability logic from repocop to common

### DIFF
--- a/packages/common/src/functions.test.ts
+++ b/packages/common/src/functions.test.ts
@@ -7,6 +7,7 @@ import {
 	parseEvent,
 	parseSecretJson,
 	partition,
+	stringToSeverity,
 	topicMonitoringProductionTagCtas,
 } from './functions';
 
@@ -186,5 +187,17 @@ describe('Unwrapping an SNS message', () => {
 		const inputMsg = '{"myString":"goodbye","myArray":["how","are","you","?]}';
 		const inputEvent = eventWithMessage(inputMsg);
 		expect(() => parseEvent<MyEvent>(inputEvent)).toThrow();
+	});
+});
+
+describe('stringToSeverity', () => {
+	test('should return unknown if it is passed an unexpected string', () => {
+		expect(stringToSeverity('foo')).toBe('unknown');
+	});
+	test('should return the correct severity for valid inputs', () => {
+		expect(stringToSeverity('low')).toBe('low');
+		expect(stringToSeverity('medium')).toBe('medium');
+		expect(stringToSeverity('high')).toBe('high');
+		expect(stringToSeverity('critical')).toBe('critical');
 	});
 });

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -3,7 +3,7 @@ import type { Action } from '@guardian/anghammarad';
 import { createAppAuth } from '@octokit/auth-app';
 import type { SNSEvent } from 'aws-lambda';
 import { Octokit } from 'octokit';
-import type { GitHubAppConfig, GithubAppSecret } from 'common/types';
+import type { GitHubAppConfig, GithubAppSecret, Severity } from 'common/types';
 
 export async function getGithubClient(githubAppConfig: GitHubAppConfig) {
 	const auth = createAppAuth(githubAppConfig.strategyOptions);
@@ -153,4 +153,17 @@ export async function applyTopics(
 		.names;
 	const names = topics.concat([topic]);
 	await octokit.rest.repos.replaceAllTopics({ owner, repo, names });
+}
+
+export function stringToSeverity(severity: string): Severity {
+	if (
+		severity === 'low' ||
+		severity === 'medium' ||
+		severity === 'high' ||
+		severity === 'critical'
+	) {
+		return severity;
+	} else {
+		return 'unknown';
+	}
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,4 +1,5 @@
 import { type StrategyOptions } from '@octokit/auth-app';
+import type { repocop_vulnerabilities } from '@prisma/client';
 
 export type GithubAppSecret = {
 	appId: string;
@@ -51,3 +52,21 @@ export interface ProjectId {
 		};
 	};
 }
+
+export type Severity = 'critical' | 'high' | 'medium' | 'low' | 'unknown';
+
+export type RepocopVulnerability = Omit<
+	repocop_vulnerabilities,
+	'id' | 'repo_owner' | 'severity'
+> & {
+	severity: Severity;
+};
+
+// The number of days teams have to fix vulnerabilities of a given severity
+export const SLAs: Record<Severity, number | undefined> = {
+	critical: 2,
+	high: 30,
+	medium: undefined,
+	low: undefined,
+	unknown: undefined,
+};

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -3,11 +3,11 @@ import type {
 	github_repository_branches,
 	view_repo_ownership,
 } from '@prisma/client';
+import type { RepocopVulnerability } from 'common/src/types';
 import { example } from '../test-data/example-dependabot-alerts';
 import type {
 	AwsCloudFormationStack,
 	Coordinate,
-	RepocopVulnerability,
 	Repository,
 	SnykIssue,
 	SnykProject,

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -5,7 +5,7 @@ import type {
 	repocop_github_repository_rules,
 	view_repo_ownership,
 } from '@prisma/client';
-import { partition } from 'common/src/functions';
+import { partition, stringToSeverity } from 'common/src/functions';
 import type { RepocopVulnerability, Severity } from 'common/src/types';
 import { SLAs } from 'common/src/types';
 import {
@@ -23,7 +23,7 @@ import type {
 	SnykProject,
 	Tag,
 } from '../types';
-import { isProduction, stringToSeverity, vulnSortPredicate } from '../utils';
+import { isProduction, vulnSortPredicate } from '../utils';
 
 /**
  * Evaluate the following rule for a Github repository:

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -6,20 +6,19 @@ import type {
 	view_repo_ownership,
 } from '@prisma/client';
 import { partition } from 'common/src/functions';
+import type { RepocopVulnerability, Severity } from 'common/src/types';
+import { SLAs } from 'common/src/types';
 import {
 	supportedDependabotLanguages,
 	supportedSnykLanguages,
 } from '../languages';
-import { SLAs } from '../types';
 import type {
 	Alert,
 	AwsCloudFormationStack,
 	Dependency,
 	EvaluationResult,
 	RepoAndStack,
-	RepocopVulnerability,
 	Repository,
-	Severity,
 	SnykIssue,
 	SnykProject,
 	Tag,

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -7,6 +7,7 @@ import type {
 import { awsClientConfig } from 'common/aws';
 import { getPrismaClient } from 'common/database';
 import { partition, stageAwareOctokit } from 'common/functions';
+import type { RepocopVulnerability } from 'common/src/types';
 import type { Config } from './config';
 import { getConfig } from './config';
 import {
@@ -30,11 +31,7 @@ import { sendUnprotectedRepo } from './remediation/snyk-integrator/send-to-sns';
 import { sendPotentialInteractives } from './remediation/topics/topic-monitor-interactive';
 import { applyProductionTopicAndMessageTeams } from './remediation/topics/topic-monitor-production';
 import { createAndSendVulnerabilityDigests } from './remediation/vuln-digest/vuln-digest';
-import type {
-	AwsCloudFormationStack,
-	EvaluationResult,
-	RepocopVulnerability,
-} from './types';
+import type { AwsCloudFormationStack, EvaluationResult } from './types';
 import { isProduction } from './utils';
 
 async function writeEvaluationTable(

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -4,6 +4,7 @@ import type {
 	PrismaClient,
 	view_repo_ownership,
 } from '@prisma/client';
+import type { RepocopVulnerability } from 'common/src/types';
 import type { Octokit } from 'octokit';
 import { dependabotAlertToRepocopVulnerability } from './evaluation/repository';
 import type {
@@ -11,7 +12,6 @@ import type {
 	AwsCloudFormationStack,
 	DependabotVulnResponse,
 	NonEmptyArray,
-	RepocopVulnerability,
 	Repository,
 	SnykIssue,
 	SnykProject,

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -2,7 +2,8 @@ import type {
 	repocop_github_repository_rules,
 	view_repo_ownership,
 } from '@prisma/client';
-import type { EvaluationResult, RepocopVulnerability, Team } from '../../types';
+import type { RepocopVulnerability } from 'common/src/types';
+import type { EvaluationResult, Team } from '../../types';
 import { removeRepoOwner } from '../shared-utilities';
 import {
 	createDigestForSeverity,

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -1,13 +1,8 @@
 import { Anghammarad, RequestedChannel } from '@guardian/anghammarad';
 import type { view_repo_ownership } from '@prisma/client';
+import { type RepocopVulnerability, SLAs } from 'common/src/types';
 import type { Config } from '../../config';
-import type {
-	EvaluationResult,
-	RepocopVulnerability,
-	Team,
-	VulnerabilityDigest,
-} from '../../types';
-import { SLAs } from '../../types';
+import type { EvaluationResult, Team, VulnerabilityDigest } from '../../types';
 import { vulnSortPredicate } from '../../utils';
 
 function getOwningRepos(

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -5,8 +5,8 @@ import type {
 	github_repositories,
 	github_teams,
 	repocop_github_repository_rules,
-	repocop_vulnerabilities,
 } from '@prisma/client';
+import type { RepocopVulnerability } from 'common/src/types';
 
 export type NonEmptyArray<T> = [T, ...T[]];
 
@@ -160,24 +160,6 @@ export interface SnykProject {
 		business_criticality?: unknown[];
 	};
 }
-
-export type Severity = 'critical' | 'high' | 'medium' | 'low' | 'unknown';
-
-// The number of days teams have to fix vulnerabilities of a given severity
-export const SLAs: Record<Severity, number | undefined> = {
-	critical: 2,
-	high: 30,
-	medium: undefined,
-	low: undefined,
-	unknown: undefined,
-};
-
-export type RepocopVulnerability = Omit<
-	repocop_vulnerabilities,
-	'id' | 'repo_owner' | 'severity'
-> & {
-	severity: Severity;
-};
 
 export interface EvaluationResult {
 	fullName: string;

--- a/packages/repocop/src/utils.test.ts
+++ b/packages/repocop/src/utils.test.ts
@@ -1,10 +1,6 @@
-import type { NonEmptyArray, RepocopVulnerability, Repository } from './types';
-import {
-	isProduction,
-	stringToSeverity,
-	toNonEmptyArray,
-	vulnSortPredicate,
-} from './utils';
+import type { RepocopVulnerability } from 'common/src/types';
+import type { NonEmptyArray, Repository } from './types';
+import { isProduction, toNonEmptyArray, vulnSortPredicate } from './utils';
 
 describe('isProduction', () => {
 	test('should return correct values for prod and non-prod repos', () => {
@@ -39,18 +35,6 @@ describe('Failure on empty arrays', () => {
 		expect(() => toNonEmptyArray(nonEmptyArray)).not.toThrow();
 		expect(toNonEmptyArray(nonEmptyArray)).toEqual(nonEmptyArray);
 		expect(toNonEmptyArray(nonEmptyArray)).toEqual(typedNonEmptyArray);
-	});
-});
-
-describe('stringToSeverity', () => {
-	test('should return unknown if it is passed an unexpected string', () => {
-		expect(stringToSeverity('foo')).toBe('unknown');
-	});
-	test('should return the correct severity for valid inputs', () => {
-		expect(stringToSeverity('low')).toBe('low');
-		expect(stringToSeverity('medium')).toBe('medium');
-		expect(stringToSeverity('high')).toBe('high');
-		expect(stringToSeverity('critical')).toBe('critical');
 	});
 });
 

--- a/packages/repocop/src/utils.ts
+++ b/packages/repocop/src/utils.ts
@@ -1,4 +1,4 @@
-import type { RepocopVulnerability, Severity } from 'common/src/types';
+import type { RepocopVulnerability } from 'common/src/types';
 import type { NonEmptyArray, Repository } from './types';
 
 export function isProduction(repo: Repository) {
@@ -10,19 +10,6 @@ export function toNonEmptyArray<T>(value: T[]): NonEmptyArray<T> {
 		throw new Error(`Expected a non-empty array. Source table may be empty.`);
 	}
 	return value as NonEmptyArray<T>;
-}
-
-export function stringToSeverity(severity: string): Severity {
-	if (
-		severity === 'low' ||
-		severity === 'medium' ||
-		severity === 'high' ||
-		severity === 'critical'
-	) {
-		return severity;
-	} else {
-		return 'unknown';
-	}
 }
 
 const criticalFirstPredicate = (x: RepocopVulnerability) =>

--- a/packages/repocop/src/utils.ts
+++ b/packages/repocop/src/utils.ts
@@ -1,9 +1,5 @@
-import type {
-	NonEmptyArray,
-	RepocopVulnerability,
-	Repository,
-	Severity,
-} from './types';
+import type { RepocopVulnerability, Severity } from 'common/src/types';
+import type { NonEmptyArray, Repository } from './types';
 
 export function isProduction(repo: Repository) {
 	return repo.topics.includes('production') && !repo.archived;


### PR DESCRIPTION
## What does this change?

Obligatron will need data from the `repocop_vulnerabilities` table, to evaluate whether or not a repo is meeting its vulnerability SLA obligation. To make that work possible, we need to move some of the logic concerning the `RepocopVulnerability` type from `repocop` to `common`

## How has it been verified?

CI passes
