### PR TITLE
feat: implicitly disable snyk integrator by default

### DIFF
--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -149,7 +149,10 @@ export async function main() {
 		nonPlaygroundStacks,
 	);
 
-	await sendUnprotectedRepo(repocopRules, config, repoLanguages);
+	if (config.snykIntegrationPREnabled) {
+		await sendUnprotectedRepo(repocopRules, config, repoLanguages);
+	}
+
 	await writeEvaluationTable(repocopRules, prisma);
 	if (config.enableMessaging) {
 		await sendPotentialInteractives(repocopRules, config);


### PR DESCRIPTION
## What does this change?

Turns off the Snyk Integrator lambda.

## Why?

Because we are going to replace it with the Dependency Graph Integrator going forward.

## How has it been verified?

We logged out the value of the feature flag locally and confirmed it was `false`.