### PR TITLE
Implement the dependency graph integrator lambda

### DIFF
--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -14,8 +14,10 @@ jobs:
   dependency-graph:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1
+      - name: Checkout branch
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Submit dependencies
+        uses: scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1
     permissions:
       contents: write
 `;

--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -12,6 +12,7 @@ on:
   workflow_dispatch: 
 jobs:
   dependency-graph:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1

--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -13,8 +13,8 @@ on:
 jobs:
   dependency-graph:
     steps:
-      - uses: actions/checkout@v4
-      - uses: scalacenter/sbt-dependency-submission@v2
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1
     permissions:
       contents: write
 `;

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -16,9 +16,11 @@ export function createYaml(prBranch: string): string {
 				'runs-on': 'ubuntu-latest',
 				steps: [
 					{
+						name: 'Checkout branch',
 						uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7',
 					},
 					{
+						name: 'Submit dependencies',
 						uses: 'scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1',
 					},
 				],
@@ -35,20 +37,22 @@ export function createYaml(prBranch: string): string {
 function createPRChecklist(branchName: string): string[] {
 	const step1 =
 		'A run of this action should have been triggered when the branch was ' +
-		'created. Go to Insights -> Dependency graph and sense check a few of ' +
-		'your dependencies to make sure they show up. There may be a short delay ' +
-		'between submission and them appearing in the UI.';
+		"created. Go to action logs for the 'Submit dependencies' step and follow " +
+		'the link to the snapshot. Sense check that the snapshot looks ' +
+		'reasonable.';
 	const step2 =
 		`When you are happy the action works, remove the branch name \`${branchName}\`` +
-		'trigger from the the yaml file (aka delete line 6), approve, and merge.';
+		'trigger from the the yaml file (aka delete line 6), approve, and merge. ';
 	return [step1, step2];
 }
 
-export function generatePrBody(branchName: string): string {
+export function generatePrBody(branchName: string, repoName: string): string {
 	const body = [
 		h2('What does this change?'),
 		p(
-			'This PR sends your sbt dependencies to GitHub for vulnerability monitoring via Dependabot. ',
+			'This PR sends your sbt dependencies to GitHub for vulnerability monitoring via Dependabot. ' +
+				`The submitted dependencies will appear in the [Dependency Graph](https://github.com/guardian/${repoName}/network/dependencies) ` +
+				'on merge to main (it might take a few minutes to update).',
 		),
 		h2('Why?'),
 		p(

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -27,10 +27,9 @@ export function createYaml(prBranch: string): string {
 		},
 	};
 
-	return stringify(dependencyGraphWorkflowJson, { lineWidth: 120 }).replace(
-		'{}',
-		'',
-	);
+	return stringify(dependencyGraphWorkflowJson, { lineWidth: 120 })
+		.replace('{}', '')
+		.replaceAll('"', '');
 }
 
 function createPRChecklist(branchName: string): string[] {

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -54,7 +54,7 @@ export function generatePrBody(branchName: string): string {
 		p(
 			'If a repository is in production, we need to track its third party dependencies for vulnerabilities. ' +
 				'Historically, we have done this using Snyk, but we are now moving to GitHub’s native Dependabot. ' +
-				'Scala is not a language that Dependabot supports out of the box, this workflow is required to make it happen' +
+				'Scala is not a language that Dependabot supports out of the box, this workflow is required to make it happen. ' +
 				'As a result, we have raised this PR on your behalf to add it to the Dependency Graph.',
 		),
 		h2('How has it been verified?'),

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -56,7 +56,7 @@ export function generatePrBody(branchName: string): string {
 			'If a repository is in production, we need to track its third party dependencies for vulnerabilities. ' +
 				'Historically, we have done this using Snyk, but we are now moving to GitHub’s native Dependabot. ' +
 				'Scala is not a language that Dependabot supports out of the box, this workflow is required to make it happen' +
-				'As a result, we have raised this PR on your behalf to add it to Snyk.',
+				'As a result, we have raised this PR on your behalf to add it to the Dependency Graph.',
 		),
 		h2('How has it been verified?'),
 		p(

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -15,8 +15,12 @@ export function createYaml(prBranch: string): string {
 			'dependency-graph': {
 				// 'runs-on': 'ubuntu-latest', //let's see how we do without this
 				steps: [
-					{ uses: 'actions/checkout@v4' },
-					{ uses: 'scalacenter/sbt-dependency-submission@v2' },
+					{
+						uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7',
+					},
+					{
+						uses: 'scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1',
+					},
 				],
 				permissions: { contents: 'write' },
 			},

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -13,7 +13,7 @@ export function createYaml(prBranch: string): string {
 		},
 		jobs: {
 			'dependency-graph': {
-				// 'runs-on': 'ubuntu-latest', //let's see how we do without this
+				'runs-on': 'ubuntu-latest',
 				steps: [
 					{
 						uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7',

--- a/packages/dependency-graph-integrator/src/index.ts
+++ b/packages/dependency-graph-integrator/src/index.ts
@@ -27,7 +27,7 @@ export async function main(event: DependencyGraphIntegratorEvent) {
 		author,
 		branch,
 		title,
-		generatePrBody(branch),
+		generatePrBody(branch, event.name),
 		fileName,
 		createYaml(branch),
 		commitMessage,

--- a/packages/dependency-graph-integrator/src/index.ts
+++ b/packages/dependency-graph-integrator/src/index.ts
@@ -14,17 +14,24 @@ export async function main(event: DependencyGraphIntegratorEvent) {
 	const config: Config = getConfig();
 	const branch = generateBranchName('sbt-dependency-graph');
 
+	const boardNumber = 110;
+	const author = 'gu-snyk-integrator'; // TODO: create new 'gu-dependency-graph-integrator' app
+	const title =
+		'Submit sbt dependencies to GitHub for vulnerability monitoring';
+	const fileName = '.github/workflows/sbt-dependency-graph.yaml';
+	const commitMessage = 'Add sbt-dependency-graph.yaml';
+
 	await createPrAndAddToProject(
 		config.stage,
 		event.name,
-		'?????', //TODO - add author
+		author,
 		branch,
-		'Submit sbt dependencies to GitHub for vulnerability monitoring',
+		title,
 		generatePrBody(branch),
-		'.github/workflows/sbt-dependency-graph.yml',
+		fileName,
 		createYaml(branch),
-		'Add sbt-dependency-graph.yml',
-		NaN, //TODO - add board number
+		commitMessage,
+		boardNumber,
 	);
 }
 

--- a/packages/dependency-graph-integrator/src/index.ts
+++ b/packages/dependency-graph-integrator/src/index.ts
@@ -15,7 +15,7 @@ export async function main(event: DependencyGraphIntegratorEvent) {
 	const branch = generateBranchName('sbt-dependency-graph');
 
 	const boardNumber = 110;
-	const author = 'gu-snyk-integrator'; // TODO: create new 'gu-dependency-graph-integrator' app
+	const author = 'gu-dependency-graph-integrator'; // TODO: create new 'gu-dependency-graph-integrator' app
 	const title =
 		'Submit sbt dependencies to GitHub for vulnerability monitoring';
 	const fileName = '.github/workflows/sbt-dependency-graph.yaml';


### PR DESCRIPTION
## What does this change?

- Implements the existing lambda using the `gu-snyk-integrator` app for now (this will eventually be replaced with its own app).
- Tidies up the paramaters to the PR generator.
- Replaces the action versions in the generated `yaml` with SHA versions.  

## Why?

Because we want to replace the Snyk integrator lambda.

## How has it been verified?

Tested locally and PR contents looked sensible.