### PR TITLE
fix(obligatron): Ensure logs and markers appear correctly in Central ELK

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -20495,7 +20495,7 @@ spec:
         },
         "Handler": "index.main",
         "LoggingConfig": {
-          "LogFormat": "JSON",
+          "LogFormat": "Text",
         },
         "MemorySize": 4096,
         "Role": {

--- a/packages/cdk/lib/obligatron.ts
+++ b/packages/cdk/lib/obligatron.ts
@@ -5,7 +5,7 @@ import { Duration } from 'aws-cdk-lib';
 import type { IVpc } from 'aws-cdk-lib/aws-ec2';
 import { Rule, RuleTargetInput, Schedule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
-import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Architecture, LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
 import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
 import { Obligations } from '../../obligatron/src/obligations';
 
@@ -40,6 +40,17 @@ export class Obligatron {
 				toleratedErrorPercentage: 0,
 				snsTopicName: 'devx-alerts',
 			},
+
+			/*
+			Override the default provided by GuCDK for improved compatability with https://github.com/guardian/cloudwatch-logs-management when producing log lines with markers.
+
+			Note: `logFormat` is a deprecated property, replaced with `loggingFormat`.
+			However, we can only specify one of `logFormat` or `loggingFormat`, and as GuCDK is setting `logFormat`, we have to do the same.
+			TODO - patch GuCDK.
+
+			See also: https://github.com/guardian/cloudwatch-logs-management/issues/326.
+			 */
+			logFormat: LoggingFormat.TEXT,
 		});
 
 		for (const obligation of Obligations) {

--- a/packages/common/src/logs.ts
+++ b/packages/common/src/logs.ts
@@ -37,3 +37,36 @@ export function getCentralElkLink(props: CentralElkProps): string {
 
 	return `${base}?${queryString}`;
 }
+
+interface LogLine {
+	/**
+	 * The message to log.
+	 */
+	message: string;
+
+	/**
+	 * Any additional markers to log.
+	 */
+	[key: string]: unknown;
+}
+
+/**
+ * Produces a log message with markers compatible with https://github.com/guardian/cloudwatch-logs-management.
+ * Note: if using within AWS Lambda, the Lambda must also log in text format not JSON.
+ *
+ * @see https://github.com/guardian/cloudwatch-logs-management/issues/326
+ */
+export const logger = {
+	log: (line: LogLine) => {
+		console.log(JSON.stringify(line));
+	},
+	debug: (line: LogLine) => {
+		console.debug(JSON.stringify(line));
+	},
+	warn: (line: LogLine) => {
+		console.warn(JSON.stringify(line));
+	},
+	error: (line: LogLine) => {
+		console.error(JSON.stringify(line));
+	},
+};

--- a/packages/obligatron/src/index.ts
+++ b/packages/obligatron/src/index.ts
@@ -45,7 +45,6 @@ export async function main(obligation: string) {
 	logger.log({
 		message: 'Starting Obligatron',
 		obligation,
-		stage: config.stage,
 		withQueryLogging: config.withQueryLogging,
 		startTime,
 	});

--- a/packages/obligatron/src/index.ts
+++ b/packages/obligatron/src/index.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from '@prisma/client';
 import { getPrismaClient } from 'common/database';
+import { logger } from 'common/logs';
 import { config } from 'dotenv';
 import { getConfig } from './config';
 import {
@@ -41,7 +42,7 @@ export async function main(obligation: string) {
 	const config = await getConfig();
 	const startTime = new Date();
 
-	console.log({
+	logger.log({
 		message: 'Starting Obligatron',
 		obligation,
 		stage: config.stage,
@@ -51,13 +52,13 @@ export async function main(obligation: string) {
 
 	const db = getPrismaClient(config);
 
-	console.log({
+	logger.log({
 		message: 'Starting to process obligation resources',
 	});
 
 	const results: ObligationResult[] = await getResults(obligation, db);
 
-	console.log({
+	logger.log({
 		message: 'Finished processing obligation resources, saving results to DB.',
 		total: results.length,
 	});
@@ -73,7 +74,7 @@ export async function main(obligation: string) {
 		})),
 	});
 
-	console.log({
+	logger.log({
 		message: 'Saved results to DB. Goodbye!',
 	});
 }

--- a/packages/obligatron/src/obligations/tagging.ts
+++ b/packages/obligatron/src/obligations/tagging.ts
@@ -1,4 +1,5 @@
 import type { Prisma, PrismaClient } from '@prisma/client';
+import { logger } from 'common/src/logs';
 import type { ObligationResult } from '.';
 
 type FindingResource = {
@@ -73,7 +74,9 @@ export async function evaluateAmiTaggingCoverage(
 		const tagKeys = Object.keys(record.tags as Prisma.JsonObject);
 
 		const missingTags = amiTags.filter((tag) => !tagKeys.includes(tag));
-		console.log(`AMI ${record.arn} is missing tags: ${missingTags.join(', ')}`);
+		logger.log({
+			message: `AMI ${record.arn} is missing tags: ${missingTags.join(', ')}`,
+		});
 
 		return missingTags.map<ObligationResult>((tag) => {
 			return {
@@ -104,7 +107,7 @@ export async function evaluateSecurityHubTaggingCoverage(
 		},
 	});
 
-	console.log({
+	logger.log({
 		message: 'Received findings from security hub',
 		total: findings.length,
 	});
@@ -115,7 +118,7 @@ export async function evaluateSecurityHubTaggingCoverage(
 		const resources = finding.resources?.valueOf();
 
 		if (!Array.isArray(resources)) {
-			console.error({
+			logger.error({
 				message: `Skipping invalid SecurityHub finding, invalid 'resources' field`,
 				finding_id: finding.id,
 			});
@@ -126,7 +129,7 @@ export async function evaluateSecurityHubTaggingCoverage(
 		// I don't think this will happen for the Tagging rules, but lets be safe by
 		// handling this situation and raising a warning.
 		if (resources.length !== 1) {
-			console.warn({
+			logger.warn({
 				message: `Finding had more (or less) that 1 resource: ${resources.length}`,
 				finding_id: finding.id,
 			});


### PR DESCRIPTION
## What does this change, and why?
The logs produced by Lambdas are sent to CloudWatch Logs, and then processed by [guardian/cloudwatch-logs-management](https://github.com/guardian/cloudwatch-logs-management ) to get them into Central ELK. We're currently producing JSON formatted logs, which cloudwatch-logs-management [doesn't process correctly](https://github.com/guardian/cloudwatch-logs-management/issues/326).

Revert to the text log format so the message, and markers, are searchable in Central ELK.

## How has it been verified?
Obligatron produces log lines with markers for `total`, `withQueryLogging` and `startTime`. They can be seen using [devx-logs](https://github.com/guardian/devx-logs/tree/main/cli):

```sh
devx-logs --space devx \
  --app obligatron \
  --stage CODE \
  --column message \
  --column total \
  --column withQueryLogging \
  --column startTime
```

To test these changes:
1. Run Obligatron from `main` on CODE, and observe the logs; the "Starting Obligatron" log (and others) does not appear:
   ![image](https://github.com/guardian/service-catalogue/assets/836140/10582d5c-a62f-4050-a1fa-b9d98b48b6d9)
2. Run Obligatron from this branch [on CODE](https://riffraff.gutools.co.uk/deployment/view/75b44215-aa6e-45ba-b022-66bd0444506b), and observe the logs; they all appear:
   ![image](https://github.com/guardian/service-catalogue/assets/836140/c7ee0d44-037f-4186-b7e7-c444a927a083)
