### PR TITLE
Dependency submisison action now echoes SBOM snapshot

### DIFF
--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -3,7 +3,8 @@ import { createYaml } from './file-generator';
 describe('createYaml', () => {
 	it('should generate the following yaml file', () => {
 		const yaml = createYaml('branch');
-		const result = String.raw`name: Update Dependency Graph for SBT
+		const result =
+			String.raw`name: Update Dependency Graph for SBT
 on:
   push:
     branches:
@@ -15,9 +16,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
+        id: checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Submit dependencies
+        id: submit
         uses: scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1
+      - name: Log snapshot for user validation
+        id: validate
+        run: cat` +
+			' ${{ steps.submit.outputs.snapshot-json-path }}' + // Need to split this line to avoid syntax errors due to the template string
+			String.raw`
     permissions:
       contents: write
 `;

--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -24,7 +24,7 @@ jobs:
       - name: Log snapshot for user validation
         id: validate
         run: cat` +
-			' ${{ steps.submit.outputs.snapshot-json-path }}' + // Need to split this line to avoid syntax errors due to the template string
+			' ${{ steps.submit.outputs.snapshot-json-path }} | jq' + // Need to split this line to avoid syntax errors due to the template string
 			String.raw`
     permissions:
       contents: write

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -28,7 +28,7 @@ export function createYaml(prBranch: string): string {
 					{
 						name: 'Log snapshot for user validation',
 						id: 'validate',
-						run: 'cat ${{ steps.submit.outputs.snapshot-json-path }}',
+						run: 'cat ${{ steps.submit.outputs.snapshot-json-path }} | jq',
 					},
 				],
 				permissions: { contents: 'write' },

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -44,9 +44,9 @@ export function createYaml(prBranch: string): string {
 function createPRChecklist(branchName: string): string[] {
 	const step1 =
 		'A run of this action should have been triggered when the branch was ' +
-		"created. Go to action logs for the 'Submit dependencies' step and follow " +
-		'the link to the snapshot. Sense check that the snapshot looks ' +
-		'reasonable.';
+		'created. Sense check the output of "Log snapshot for user validation", ' +
+		'and make sure that your dependencies look okay.';
+
 	const step2 =
 		`When you are happy the action works, remove the branch name \`${branchName}\`` +
 		'trigger from the the yaml file (aka delete line 6), approve, and merge. ';

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -17,11 +17,18 @@ export function createYaml(prBranch: string): string {
 				steps: [
 					{
 						name: 'Checkout branch',
+						id: 'checkout',
 						uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7',
 					},
 					{
 						name: 'Submit dependencies',
+						id: 'submit',
 						uses: 'scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1',
+					},
+					{
+						name: 'Log snapshot for user validation',
+						id: 'validate',
+						run: 'cat ${{ steps.submit.outputs.snapshot-json-path }}',
 					},
 				],
 				permissions: { contents: 'write' },


### PR DESCRIPTION
## What does this change?

Rather than asking the use to click a link to check their dependencies look correct, we just echo them during the GHA run.

## Why?

 This improves developer experience, as there's less clicking around. It also fixes an issue where trying to view the contents of a dependency snapshot did not work in the browser for private repositories.

## How has it been verified?

Tested by raising [this PR](https://github.com/guardian/janus/pull/4211) against a private repo, and verified that we are able to see the contents of the snapshot in situ.
