### PR TITLE
move nonEmptyArray, etc to common

### DIFF
--- a/packages/common/src/functions.test.ts
+++ b/packages/common/src/functions.test.ts
@@ -8,8 +8,10 @@ import {
 	parseSecretJson,
 	partition,
 	stringToSeverity,
+	toNonEmptyArray,
 	topicMonitoringProductionTagCtas,
 } from './functions';
+import type { NonEmptyArray } from './types';
 
 function isValidUrl(str: string) {
 	try {
@@ -199,5 +201,18 @@ describe('stringToSeverity', () => {
 		expect(stringToSeverity('medium')).toBe('medium');
 		expect(stringToSeverity('high')).toBe('high');
 		expect(stringToSeverity('critical')).toBe('critical');
+	});
+});
+
+describe('Failure on empty arrays', () => {
+	test('throw an error if input is an empty array', () => {
+		const emptyArray: string[] = [];
+		const nonEmptyArray: string[] = ['a', 'b'];
+		const typedNonEmptyArray: NonEmptyArray<string> = ['a', 'b'];
+
+		expect(() => toNonEmptyArray(emptyArray)).toThrow();
+		expect(() => toNonEmptyArray(nonEmptyArray)).not.toThrow();
+		expect(toNonEmptyArray(nonEmptyArray)).toEqual(nonEmptyArray);
+		expect(toNonEmptyArray(nonEmptyArray)).toEqual(typedNonEmptyArray);
 	});
 });

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -3,7 +3,12 @@ import type { Action } from '@guardian/anghammarad';
 import { createAppAuth } from '@octokit/auth-app';
 import type { SNSEvent } from 'aws-lambda';
 import { Octokit } from 'octokit';
-import type { GitHubAppConfig, GithubAppSecret, Severity } from 'common/types';
+import type {
+	GitHubAppConfig,
+	GithubAppSecret,
+	NonEmptyArray,
+	Severity,
+} from 'common/types';
 
 export async function getGithubClient(githubAppConfig: GitHubAppConfig) {
 	const auth = createAppAuth(githubAppConfig.strategyOptions);
@@ -166,4 +171,11 @@ export function stringToSeverity(severity: string): Severity {
 	} else {
 		return 'unknown';
 	}
+}
+
+export function toNonEmptyArray<T>(value: T[]): NonEmptyArray<T> {
+	if (value.length === 0) {
+		throw new Error(`Expected a non-empty array. Source table may be empty.`);
+	}
+	return value as NonEmptyArray<T>;
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -70,3 +70,5 @@ export const SLAs: Record<Severity, number | undefined> = {
 	low: undefined,
 	unknown: undefined,
 };
+
+export type NonEmptyArray<T> = [T, ...T[]];

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -4,20 +4,19 @@ import type {
 	PrismaClient,
 	view_repo_ownership,
 } from '@prisma/client';
-import type { RepocopVulnerability } from 'common/src/types';
+import type { NonEmptyArray, RepocopVulnerability } from 'common/src/types';
 import type { Octokit } from 'octokit';
+import { toNonEmptyArray } from '../../common/src/functions';
 import { dependabotAlertToRepocopVulnerability } from './evaluation/repository';
 import type {
 	Alert,
 	AwsCloudFormationStack,
 	DependabotVulnResponse,
-	NonEmptyArray,
 	Repository,
 	SnykIssue,
 	SnykProject,
 	Team,
 } from './types';
-import { toNonEmptyArray } from './utils';
 
 export async function getRepositories(
 	client: PrismaClient,

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -8,8 +8,6 @@ import type {
 } from '@prisma/client';
 import type { RepocopVulnerability } from 'common/src/types';
 
-export type NonEmptyArray<T> = [T, ...T[]];
-
 export interface RepoAndStack {
 	fullName: string;
 	stacks: string[];

--- a/packages/repocop/src/utils.test.ts
+++ b/packages/repocop/src/utils.test.ts
@@ -1,6 +1,6 @@
 import type { RepocopVulnerability } from 'common/src/types';
-import type { NonEmptyArray, Repository } from './types';
-import { isProduction, toNonEmptyArray, vulnSortPredicate } from './utils';
+import type { Repository } from './types';
+import { isProduction, vulnSortPredicate } from './utils';
 
 describe('isProduction', () => {
 	test('should return correct values for prod and non-prod repos', () => {
@@ -22,19 +22,6 @@ describe('isProduction', () => {
 
 		expect(isProduction(prodRepo)).toBe(true);
 		expect(isProduction(nonProdRepo)).toBe(false);
-	});
-});
-
-describe('Failure on empty arrays', () => {
-	test('throw an error if input is an empty array', () => {
-		const emptyArray: string[] = [];
-		const nonEmptyArray: string[] = ['a', 'b'];
-		const typedNonEmptyArray: NonEmptyArray<string> = ['a', 'b'];
-
-		expect(() => toNonEmptyArray(emptyArray)).toThrow();
-		expect(() => toNonEmptyArray(nonEmptyArray)).not.toThrow();
-		expect(toNonEmptyArray(nonEmptyArray)).toEqual(nonEmptyArray);
-		expect(toNonEmptyArray(nonEmptyArray)).toEqual(typedNonEmptyArray);
 	});
 });
 

--- a/packages/repocop/src/utils.ts
+++ b/packages/repocop/src/utils.ts
@@ -1,15 +1,8 @@
 import type { RepocopVulnerability } from 'common/src/types';
-import type { NonEmptyArray, Repository } from './types';
+import type { Repository } from './types';
 
 export function isProduction(repo: Repository) {
 	return repo.topics.includes('production') && !repo.archived;
-}
-
-export function toNonEmptyArray<T>(value: T[]): NonEmptyArray<T> {
-	if (value.length === 0) {
-		throw new Error(`Expected a non-empty array. Source table may be empty.`);
-	}
-	return value as NonEmptyArray<T>;
 }
 
 const criticalFirstPredicate = (x: RepocopVulnerability) =>


### PR DESCRIPTION
## What does this change?

Obligatron will be making use of NonEmptyArray, so move it to the `common` package

## How has it been verified?

CI passes
