### PR TITLE
ci: Test update to `guardian/actions-riff-raff`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: ./scripts/ci.sh
 
       - name: Upload to riff-raff
-        uses: guardian/actions-riff-raff@80f11d69a223f464c96ff7a44469a4903d13989d # v4.0.3
+        uses: guardian/actions-riff-raff@0d27d08692b6941471d51fb0ecaeba98bf2fe229
         with:
           app: service-catalogue
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}


### PR DESCRIPTION
## What does this change?
Testing https://github.com/guardian/actions-riff-raff/pull/153 as a fix for https://github.com/guardian/actions-riff-raff/releases/tag/v4.0.4, which contains a regression, as demonstrated by the build of https://github.com/guardian/service-catalogue/pull/1142:

![image](https://github.com/guardian/service-catalogue/assets/836140/ed434a26-a36d-4d62-91d6-85f3e237229b)

## How has it been verified?
CI passing, including files being uploaded to RIff-Raff, and a comment added to this PR, means the regression is fixed.

Indeed, it has:

![image](https://github.com/guardian/service-catalogue/assets/836140/987437a3-538d-43d0-8beb-9fa799e4fc9b)