### PR TITLE
Create an obligation lambda for production repositories with out-of-SLA dependency vulnerabilities

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -20670,6 +20670,45 @@ spec:
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
+    "obligatronPRODUCTIONDEPENDENCIESAllowEventRuleServiceCatalogueobligatron5BD5033E5649B088": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "obligatronA58CFCF1",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "obligatronPRODUCTIONDEPENDENCIESC26096F0",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "obligatronPRODUCTIONDEPENDENCIESC26096F0": {
+      "Properties": {
+        "Description": "Daily execution of Obligatron lambda for 'PRODUCTION_DEPENDENCIES' obligation",
+        "ScheduleExpression": "cron(0 10 * * ? *)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "obligatronA58CFCF1",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+            "Input": ""PRODUCTION_DEPENDENCIES"",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "obligatronServiceRole1E85277A": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -20869,7 +20908,7 @@ spec:
     "obligatronTAGGING3F8E9BB2": {
       "Properties": {
         "Description": "Daily execution of Obligatron lambda for 'TAGGING' obligation",
-        "ScheduleExpression": "cron(0 7 * * ? *)",
+        "ScheduleExpression": "cron(0 9 * * ? *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -23157,9 +23196,9 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
-    "repocoprepocopcron3010MONFRI09611B07D": {
+    "repocoprepocopcron309MONFRI042F648A2": {
       "Properties": {
-        "ScheduleExpression": "cron(30 10 ? * MON-FRI *)",
+        "ScheduleExpression": "cron(30 9 ? * MON-FRI *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -23175,7 +23214,7 @@ spec:
       },
       "Type": "AWS::Events::Rule",
     },
-    "repocoprepocopcron3010MONFRI0AllowEventRuleServiceCataloguerepocop7BEB589205008C24": {
+    "repocoprepocopcron309MONFRI0AllowEventRuleServiceCataloguerepocop7BEB58922EC16074": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -23187,7 +23226,7 @@ spec:
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "repocoprepocopcron3010MONFRI09611B07D",
+            "repocoprepocopcron309MONFRI042F648A2",
             "Arn",
           ],
         },

--- a/packages/cdk/lib/obligatron.ts
+++ b/packages/cdk/lib/obligatron.ts
@@ -53,13 +53,19 @@ export class Obligatron {
 			logFormat: LoggingFormat.TEXT,
 		});
 
-		for (const obligation of Obligations) {
-			new Rule(stack, `obligatron-${obligation}`, {
-				description: `Daily execution of Obligatron lambda for '${obligation}' obligation`,
-				schedule: Schedule.cron({ minute: '0', hour: '7' }),
+		const ObligationsWithIndex = Obligations.map((obligation) => ({
+			obligation,
+			index: Obligations.indexOf(obligation),
+		}));
+
+		for (const obligation of ObligationsWithIndex) {
+			const startTime = (9 + obligation.index).toString();
+			new Rule(stack, `obligatron-${obligation.obligation}`, {
+				description: `Daily execution of Obligatron lambda for '${obligation.obligation}' obligation`,
+				schedule: Schedule.cron({ minute: '0', hour: startTime }),
 				targets: [
 					new LambdaFunction(lambda, {
-						event: RuleTargetInput.fromText(obligation),
+						event: RuleTargetInput.fromText(obligation.obligation),
 					}),
 				],
 			});

--- a/packages/cdk/lib/obligatron.ts
+++ b/packages/cdk/lib/obligatron.ts
@@ -53,23 +53,18 @@ export class Obligatron {
 			logFormat: LoggingFormat.TEXT,
 		});
 
-		const ObligationsWithIndex = Obligations.map((obligation) => ({
-			obligation,
-			index: Obligations.indexOf(obligation),
-		}));
-
-		for (const obligation of ObligationsWithIndex) {
-			const startTime = (9 + obligation.index).toString();
-			new Rule(stack, `obligatron-${obligation.obligation}`, {
-				description: `Daily execution of Obligatron lambda for '${obligation.obligation}' obligation`,
+		Obligations.forEach((obligation, index) => {
+			const startTime = (9 + index).toString();
+			new Rule(stack, `obligatron-${obligation}`, {
+				description: `Daily execution of Obligatron lambda for '${obligation}' obligation`,
 				schedule: Schedule.cron({ minute: '0', hour: startTime }),
 				targets: [
 					new LambdaFunction(lambda, {
-						event: RuleTargetInput.fromText(obligation.obligation),
+						event: RuleTargetInput.fromText(obligation),
 					}),
 				],
 			});
-		}
+		});
 
 		db.grantConnect(lambda, 'obligatron');
 	}

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -223,7 +223,7 @@ export class ServiceCatalogue extends GuStack {
 
 		const prodSchedule = Schedule.cron({
 			weekDay: 'MON-FRI',
-			hour: '10',
+			hour: '9',
 			minute: '30',
 		});
 

--- a/packages/common/src/functions.test.ts
+++ b/packages/common/src/functions.test.ts
@@ -2,6 +2,7 @@ import type { SNSEvent } from 'aws-lambda';
 import {
 	anghammaradThreadKey,
 	branchProtectionCtas,
+	daysLeftToFix,
 	getEnvOrThrow,
 	getGithubAppSecret,
 	parseEvent,
@@ -11,7 +12,7 @@ import {
 	toNonEmptyArray,
 	topicMonitoringProductionTagCtas,
 } from './functions';
-import type { NonEmptyArray } from './types';
+import type { NonEmptyArray, RepocopVulnerability } from './types';
 
 function isValidUrl(str: string) {
 	try {
@@ -201,6 +202,57 @@ describe('stringToSeverity', () => {
 		expect(stringToSeverity('medium')).toBe('medium');
 		expect(stringToSeverity('high')).toBe('high');
 		expect(stringToSeverity('critical')).toBe('critical');
+	});
+});
+
+describe('daysLeftToFix', () => {
+	const veryOldVuln: RepocopVulnerability = {
+		source: 'Dependabot',
+		full_name: 'guardian/repo',
+		open: true,
+		severity: 'high',
+		package: 'leftpad',
+		urls: ['example.com'],
+		ecosystem: 'pip',
+		alert_issue_date: new Date('2021-01-01'),
+		is_patchable: true,
+		cves: ['CVE-123'],
+	};
+	test('should return 0 if we exceed the SLA', () => {
+		expect(daysLeftToFix(veryOldVuln)).toBe(0);
+	});
+	test('should return 30 if a high vuln was raised in the last 24 hours', () => {
+		function hoursAgo(hours: number): Date {
+			const date = new Date();
+			date.setHours(date.getHours() - hours);
+			return date;
+		}
+
+		const oneHourOld: RepocopVulnerability = {
+			...veryOldVuln,
+			alert_issue_date: hoursAgo(1),
+		};
+
+		const twentyThreeHoursOld = {
+			...oneHourOld,
+			alert_issue_date: hoursAgo(23),
+		};
+
+		const twentyFiveHoursOld = {
+			...oneHourOld,
+			alert_issue_date: hoursAgo(25),
+		};
+		expect(daysLeftToFix(oneHourOld)).toBe(30);
+		expect(daysLeftToFix(twentyThreeHoursOld)).toBe(30);
+		expect(daysLeftToFix(twentyFiveHoursOld)).toBe(29);
+	});
+	test('should return 2 if a critical vuln was raised today', () => {
+		const newCriticalVuln: RepocopVulnerability = {
+			...veryOldVuln,
+			severity: 'critical',
+			alert_issue_date: new Date(),
+		};
+		expect(daysLeftToFix(newCriticalVuln)).toBe(2);
 	});
 });
 

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,5 +1,8 @@
 import { type StrategyOptions } from '@octokit/auth-app';
-import type { repocop_vulnerabilities } from '@prisma/client';
+import type {
+	github_repositories,
+	repocop_vulnerabilities,
+} from '@prisma/client';
 
 export type GithubAppSecret = {
 	appId: string;
@@ -61,6 +64,26 @@ export type RepocopVulnerability = Omit<
 > & {
 	severity: Severity;
 };
+
+type RepositoryFields = Pick<
+	github_repositories,
+	| 'archived'
+	| 'name'
+	| 'full_name'
+	| 'topics'
+	| 'updated_at'
+	| 'pushed_at'
+	| 'created_at'
+	| 'id'
+	| 'default_branch'
+>;
+
+export interface Repository extends RepositoryFields {
+	archived: NonNullable<RepositoryFields['archived']>;
+	name: NonNullable<RepositoryFields['name']>;
+	full_name: NonNullable<RepositoryFields['full_name']>;
+	id: NonNullable<RepositoryFields['id']>;
+}
 
 // The number of days teams have to fix vulnerabilities of a given severity
 export const SLAs: Record<Severity, number | undefined> = {

--- a/packages/obligatron/src/index.ts
+++ b/packages/obligatron/src/index.ts
@@ -9,6 +9,7 @@ import {
 	Obligations,
 	stringIsObligation,
 } from './obligations';
+import { evaluateDependencyVulnerabilityObligation } from './obligations/aws-security';
 import {
 	evaluateAmiTaggingCoverage,
 	evaluateSecurityHubTaggingCoverage,
@@ -26,6 +27,9 @@ async function getResults(
 				...(await evaluateSecurityHubTaggingCoverage(db)),
 				...(await evaluateAmiTaggingCoverage(db)),
 			];
+		}
+		case 'PRODUCTION_DEPENDENCIES': {
+			return await evaluateDependencyVulnerabilityObligation(db);
 		}
 	}
 }

--- a/packages/obligatron/src/index.ts
+++ b/packages/obligatron/src/index.ts
@@ -9,7 +9,7 @@ import {
 	Obligations,
 	stringIsObligation,
 } from './obligations';
-import { evaluateDependencyVulnerabilityObligation } from './obligations/aws-security';
+import { evaluateDependencyVulnerabilityObligation } from './obligations/dependency-vulnerabilities';
 import {
 	evaluateAmiTaggingCoverage,
 	evaluateSecurityHubTaggingCoverage,

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.test.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.test.ts
@@ -38,7 +38,7 @@ describe('The dependency vulnerabilities obligation', () => {
 		const expected = {
 			resource: 'some/repo',
 			reason: 'Repository has 1 vulnerable packages, some-package',
-			url: 'https://metrics.gutools.co.uk/d/fdib3p8l85jwgd',
+			url: 'https://metrics.gutools.co.uk/d/fdib3p8l85jwgd/?var-repo_owner=owner1',
 			contacts: { slugs: ['owner1'] },
 		};
 

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.test.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.test.ts
@@ -1,0 +1,58 @@
+import type { Repository } from 'common/types';
+import type { ObligatronRepocopVulnerability } from './dependency-vulnerabilities';
+import { evaluateObligationForOneRepo } from './dependency-vulnerabilities';
+
+describe('The dependency vulnerabilities obligation', () => {
+	const someDate = new Date('2020-01-01');
+
+	const myRepo: Repository = {
+		archived: false,
+		id: BigInt(1),
+		default_branch: 'main',
+		full_name: 'some/repo',
+		name: 'repo',
+		topics: ['production'],
+		created_at: someDate,
+		pushed_at: someDate,
+		updated_at: someDate,
+	};
+
+	const myVuln: ObligatronRepocopVulnerability = {
+		package: 'some-package',
+		full_name: 'some/repo',
+		severity: 'high',
+		open: true,
+		urls: [''],
+		ecosystem: 'npm',
+		alert_issue_date: someDate,
+		is_patchable: true,
+		cves: [''],
+		repo_owner: 'owner1',
+		source: 'Dependabot',
+	};
+
+	it('should return something if it finds a vulnerability on a repo', () => {
+		const actual = evaluateObligationForOneRepo([myVuln], myRepo);
+		console.log(actual);
+
+		const expected = {
+			resource: 'some/repo',
+			reason: 'Repository has 1 vulnerable packages, some-package',
+			url: 'https://metrics.gutools.co.uk/d/fdib3p8l85jwgd',
+			contacts: { slugs: ['owner1'] },
+		};
+
+		expect(actual).toEqual(expected);
+	});
+	it('should return undefined if it finds no vulnerabilities on a repo', () => {
+		const actual = evaluateObligationForOneRepo([], myRepo);
+		expect(actual).toBeUndefined();
+	});
+	it('should return undefined if it finds only vulnerabilities related to other repos', () => {
+		const actual = evaluateObligationForOneRepo([myVuln], {
+			...myRepo,
+			full_name: 'other/repo',
+		});
+		expect(actual).toBeUndefined();
+	});
+});

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -48,7 +48,7 @@ async function getProductionRepos(
 
 export async function evaluateDependencyVulnerabilityObligation(
 	client: PrismaClient,
-): Promise<ObligatronRepocopVulnerability[]> {
+): Promise<ObligationResult[]> {
 	const repos = await getProductionRepos(client);
 	const vulns = await getRepocopVulnerabilities(client);
 
@@ -81,15 +81,3 @@ export async function evaluateDependencyVulnerabilityObligation(
 		(r): r is ObligationResult => r !== undefined,
 	);
 }
-
-// export type ObligationResult = {
-// 	resource: string;
-// 	reason: string;
-// 	url?: string;
-// 	contacts?: {
-// 		aws_account_id?: string;
-// 		Stack?: string;
-// 		Stage?: string;
-// 		App?: string;
-// 	};
-// };

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -53,7 +53,11 @@ export function evaluateObligationForOneRepo(
 	repo: Repository,
 ): ObligationResult | undefined {
 	const repoVulns = vulns.filter((v) => v.full_name === repo.full_name);
-	const vulnOwners = [...new Set(repoVulns.flatMap((v) => v.repo_owner))];
+	const repoOwners = [...new Set(repoVulns.flatMap((v) => v.repo_owner))];
+
+	const urlParams = repoOwners
+		.map((owner) => `var-repo_owner=${owner}`)
+		.join('&');
 
 	if (repoVulns.length > 0) {
 		const vulnNames = [...new Set(repoVulns.map((v) => v.package))];
@@ -65,8 +69,8 @@ export function evaluateObligationForOneRepo(
 		return {
 			resource: repo.full_name,
 			reason: `Repository has ${vulnNames.length} vulnerable packages, ${vulnNames.join(', ')}`,
-			url: 'https://metrics.gutools.co.uk/d/fdib3p8l85jwgd',
-			contacts: { slugs: vulnOwners },
+			url: `https://metrics.gutools.co.uk/d/fdib3p8l85jwgd/?${urlParams}`,
+			contacts: { slugs: repoOwners },
 		};
 	} else {
 		return undefined;

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -4,11 +4,16 @@ import type {
 	repocop_vulnerabilities,
 } from '@prisma/client';
 import { logger } from 'common/logs';
-import { stringToSeverity, toNonEmptyArray } from 'common/src/functions';
-import type { NonEmptyArray, RepocopVulnerability } from 'common/src/types';
+import {
+	daysLeftToFix,
+	stringToSeverity,
+	toNonEmptyArray,
+} from 'common/src/functions';
+import {
+	type NonEmptyArray,
+	type RepocopVulnerability,
+} from 'common/src/types';
 import type { ObligationResult } from '.';
-
-// type UserEvent = Event & {UserId: string}
 
 type ObligatronRepocopVulnerability = RepocopVulnerability & {
 	repo_owner: string;
@@ -50,7 +55,9 @@ export async function evaluateDependencyVulnerabilityObligation(
 	client: PrismaClient,
 ): Promise<ObligationResult[]> {
 	const repos = await getProductionRepos(client);
-	const vulns = await getRepocopVulnerabilities(client);
+	const vulns = (await getRepocopVulnerabilities(client)).filter(
+		(v) => daysLeftToFix(v) === 0,
+	);
 
 	// For every repo in repos, log if it shows up in vulns
 	const resultsOrUndefined: Array<ObligationResult | undefined> = repos

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -1,10 +1,10 @@
 import type { PrismaClient, repocop_vulnerabilities } from '@prisma/client';
-import { logger } from 'common/logs';
 import {
 	daysLeftToFix,
 	stringToSeverity,
 	toNonEmptyArray,
 } from 'common/src/functions';
+import { logger } from 'common/src/logs';
 import type {
 	NonEmptyArray,
 	RepocopVulnerability,
@@ -12,7 +12,7 @@ import type {
 } from 'common/src/types';
 import type { ObligationResult } from '.';
 
-type ObligatronRepocopVulnerability = RepocopVulnerability & {
+export type ObligatronRepocopVulnerability = RepocopVulnerability & {
 	repo_owner: string;
 };
 

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -1,0 +1,88 @@
+import type {
+	github_repositories,
+	PrismaClient,
+	repocop_vulnerabilities,
+} from '@prisma/client';
+import { stringToSeverity, toNonEmptyArray } from 'common/src/functions';
+import type { NonEmptyArray, RepocopVulnerability } from 'common/src/types';
+import type { ObligationResult } from '.';
+
+// type UserEvent = Event & {UserId: string}
+
+function prismaToCustomType(
+	vuln: repocop_vulnerabilities,
+): RepocopVulnerability {
+	return {
+		...vuln,
+		severity: stringToSeverity(vuln.severity),
+	};
+}
+
+async function getRepocopVulnerabilities(
+	client: PrismaClient,
+): Promise<NonEmptyArray<RepocopVulnerability>> {
+	const rawResponse = await client.repocop_vulnerabilities.findMany({});
+
+	return toNonEmptyArray(rawResponse.map(prismaToCustomType));
+}
+
+async function getProductionRepos(
+	client: PrismaClient,
+): Promise<github_repositories[]> {
+	console.debug('Discovering repositories');
+	const repositories = await client.github_repositories.findMany({
+		where: {
+			archived: false,
+			topics: {
+				has: 'production',
+			},
+		},
+	});
+	return toNonEmptyArray(repositories);
+}
+
+export async function evaluateDependencyVulnerabilityObligation(
+	client: PrismaClient,
+): Promise<ObligationResult[]> {
+	const repos = await getProductionRepos(client);
+	const vulns = await getRepocopVulnerabilities(client);
+
+	// For every repo in repos, log if it shows up in vulns
+	const resultsOrUndefined: Array<ObligationResult | undefined> = repos
+		.slice(0, 40)
+		.map((repo) => {
+			const repoVulns = vulns.filter((v) => v.full_name === repo.full_name);
+
+			if (repoVulns.length > 0) {
+				const vulnNames = repoVulns.map((v) => v.package);
+				console.log({
+					message: `Repository ${repo.full_name} has ${repoVulns.length} vulnerabilities`,
+					vulnNames,
+				});
+
+				return {
+					resource: repo.full_name ?? 'unknown', //This will never happen in reality
+					reason: `Repository has ${repoVulns.length} vulnerabilities, ${vulnNames.join(', ')}`,
+					url: 'https://metrics.gutools.co.uk/d/fdib3p8l85jwgd',
+				};
+			} else {
+				return undefined;
+			}
+		});
+
+	return resultsOrUndefined.filter(
+		(r): r is ObligationResult => r !== undefined,
+	);
+}
+
+// export type ObligationResult = {
+// 	resource: string;
+// 	reason: string;
+// 	url?: string;
+// 	contacts?: {
+// 		aws_account_id?: string;
+// 		Stack?: string;
+// 		Stage?: string;
+// 		App?: string;
+// 	};
+// };

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -59,10 +59,8 @@ export async function evaluateDependencyVulnerabilityObligation(
 		(v) => daysLeftToFix(v) === 0,
 	);
 
-	// For every repo in repos, log if it shows up in vulns
-	const resultsOrUndefined: Array<ObligationResult | undefined> = repos
-		.slice(0, 40)
-		.map((repo) => {
+	const resultsOrUndefined: Array<ObligationResult | undefined> = repos.map(
+		(repo) => {
 			const repoVulns = vulns.filter((v) => v.full_name === repo.full_name);
 			const vulnOwners = [...new Set(repoVulns.flatMap((v) => v.repo_owner))];
 
@@ -82,7 +80,8 @@ export async function evaluateDependencyVulnerabilityObligation(
 			} else {
 				return undefined;
 			}
-		});
+		},
+	);
 
 	return resultsOrUndefined.filter(
 		(r): r is ObligationResult => r !== undefined,

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -3,6 +3,7 @@ import type {
 	PrismaClient,
 	repocop_vulnerabilities,
 } from '@prisma/client';
+import { logger } from 'common/logs';
 import { stringToSeverity, toNonEmptyArray } from 'common/src/functions';
 import type { NonEmptyArray, RepocopVulnerability } from 'common/src/types';
 import type { ObligationResult } from '.';
@@ -54,15 +55,15 @@ export async function evaluateDependencyVulnerabilityObligation(
 			const repoVulns = vulns.filter((v) => v.full_name === repo.full_name);
 
 			if (repoVulns.length > 0) {
-				const vulnNames = repoVulns.map((v) => v.package);
-				console.log({
+				const vulnNames = [...new Set(repoVulns.map((v) => v.package))];
+				logger.log({
 					message: `Repository ${repo.full_name} has ${repoVulns.length} vulnerabilities`,
 					vulnNames,
 				});
 
 				return {
 					resource: repo.full_name ?? 'unknown', //This will never happen in reality
-					reason: `Repository has ${repoVulns.length} vulnerabilities, ${vulnNames.join(', ')}`,
+					reason: `Repository has ${vulnNames.length} vulnerable packages, ${vulnNames.join(', ')}`,
 					url: 'https://metrics.gutools.co.uk/d/fdib3p8l85jwgd',
 				};
 			} else {

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -69,7 +69,7 @@ export async function evaluateDependencyVulnerabilityObligation(
 			if (repoVulns.length > 0) {
 				const vulnNames = [...new Set(repoVulns.map((v) => v.package))];
 				logger.log({
-					message: `Repository ${repo.full_name} has ${repoVulns.length} vulnerabilities`,
+					message: `Repository ${repo.full_name} has ${repoVulns.length} vulnerable packages: ${vulnNames.join(', ')}`,
 					vulnNames,
 				});
 

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -47,7 +47,6 @@ async function getProductionRepos(client: PrismaClient): Promise<Repository[]> {
 	return toNonEmptyArray(repositories.map((r) => r as Repository));
 }
 
-//TODO test me
 export function evaluateObligationForOneRepo(
 	vulns: ObligatronRepocopVulnerability[],
 	repo: Repository,

--- a/packages/obligatron/src/obligations/index.ts
+++ b/packages/obligatron/src/obligations/index.ts
@@ -7,6 +7,15 @@ export const stringIsObligation = (input: string): input is Obligation => {
 	return Obligations.filter((v) => v === input).length > 0;
 };
 
+type AwsContact = {
+	aws_account_id?: string;
+	Stack?: string;
+	Stage?: string;
+	App?: string;
+};
+
+type GitHubContact = { slugs: string[] };
+
 export type ObligationResult = {
 	/**
 	 * Resource identifier. Varies depending on resource platform.
@@ -29,10 +38,5 @@ export type ObligationResult = {
 	 * Key-value pairs to link failing obligations to the responsible teams.
 	 */
 
-	contacts?: {
-		aws_account_id?: string;
-		Stack?: string;
-		Stage?: string;
-		App?: string;
-	};
+	contacts?: AwsContact | GitHubContact;
 };

--- a/packages/obligatron/src/obligations/index.ts
+++ b/packages/obligatron/src/obligations/index.ts
@@ -1,6 +1,6 @@
 // Slightly hacky file to allow CDK project to import the list of obligations without having to compile the whole Obligatron project
 
-export const Obligations = ['TAGGING'] as const;
+export const Obligations = ['TAGGING', 'PRODUCTION_DEPENDENCIES'] as const;
 export type Obligation = (typeof Obligations)[number];
 
 export const stringIsObligation = (input: string): input is Obligation => {

--- a/packages/obligatron/src/run-locally.ts
+++ b/packages/obligatron/src/run-locally.ts
@@ -1,6 +1,12 @@
+import { Obligations } from './obligations';
 import { main } from './index';
 
 const [, , obligation] = process.argv;
 
-void main(obligation ?? 'TAGGING');
-void main(obligation ?? 'PRODUCTION_DEPENDENCIES');
+if (obligation) {
+	void main(obligation);
+} else {
+	Obligations.forEach((obligation) => {
+		void main(obligation);
+	});
+}

--- a/packages/obligatron/src/run-locally.ts
+++ b/packages/obligatron/src/run-locally.ts
@@ -3,3 +3,4 @@ import { main } from './index';
 const [, , obligation] = process.argv;
 
 void main(obligation ?? 'TAGGING');
+void main(obligation ?? 'PRODUCTION_DEPENDENCIES');

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -3,12 +3,11 @@ import type {
 	github_repository_branches,
 	view_repo_ownership,
 } from '@prisma/client';
-import type { RepocopVulnerability } from 'common/src/types';
+import type { RepocopVulnerability, Repository } from 'common/src/types';
 import { example } from '../test-data/example-dependabot-alerts';
 import type {
 	AwsCloudFormationStack,
 	Coordinate,
-	Repository,
 	SnykIssue,
 	SnykProject,
 } from '../types';

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -6,8 +6,12 @@ import type {
 	view_repo_ownership,
 } from '@prisma/client';
 import { partition, stringToSeverity } from 'common/src/functions';
-import type { RepocopVulnerability, Severity } from 'common/src/types';
 import { SLAs } from 'common/src/types';
+import type {
+	RepocopVulnerability,
+	Repository,
+	Severity,
+} from 'common/src/types';
 import {
 	supportedDependabotLanguages,
 	supportedSnykLanguages,
@@ -18,7 +22,6 @@ import type {
 	Dependency,
 	EvaluationResult,
 	RepoAndStack,
-	Repository,
 	SnykIssue,
 	SnykProject,
 	Tag,

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -4,7 +4,11 @@ import type {
 	PrismaClient,
 	view_repo_ownership,
 } from '@prisma/client';
-import type { NonEmptyArray, RepocopVulnerability } from 'common/src/types';
+import type {
+	NonEmptyArray,
+	RepocopVulnerability,
+	Repository,
+} from 'common/src/types';
 import type { Octokit } from 'octokit';
 import { toNonEmptyArray } from '../../common/src/functions';
 import { dependabotAlertToRepocopVulnerability } from './evaluation/repository';
@@ -12,7 +16,6 @@ import type {
 	Alert,
 	AwsCloudFormationStack,
 	DependabotVulnResponse,
-	Repository,
 	SnykIssue,
 	SnykProject,
 	Team,

--- a/packages/repocop/src/remediation/branch-protector/branch-protection.ts
+++ b/packages/repocop/src/remediation/branch-protector/branch-protection.ts
@@ -3,10 +3,10 @@ import type {
 	view_repo_ownership,
 } from '@prisma/client';
 import { shuffle } from 'common/src/functions';
-import type { UpdateMessageEvent } from 'common/types';
+import type { Repository, UpdateMessageEvent } from 'common/src/types';
 import type { Octokit } from 'octokit';
 import type { Config } from '../../config';
-import type { Repository, Team } from '../../types';
+import type { Team } from '../../types';
 import { findContactableOwners } from '../shared-utilities';
 import { notify } from './aws-requests';
 import {

--- a/packages/repocop/src/remediation/topics/topic-monitor-production.test.ts
+++ b/packages/repocop/src/remediation/topics/topic-monitor-production.test.ts
@@ -1,5 +1,6 @@
+import type { Repository } from 'common/src/types';
 import { nullRepo } from '../../evaluation/repository.test';
-import type { AwsCloudFormationStack, Repository } from '../../types';
+import type { AwsCloudFormationStack } from '../../types';
 import {
 	createMessage,
 	findReposInProdWithoutProductionTopic,

--- a/packages/repocop/src/remediation/topics/topic-monitor-production.ts
+++ b/packages/repocop/src/remediation/topics/topic-monitor-production.ts
@@ -6,9 +6,10 @@ import {
 	topicMonitoringProductionTagCtas,
 } from 'common/src/functions';
 import { stripMargin } from 'common/src/string';
+import type { Repository } from 'common/src/types';
 import type { Octokit } from 'octokit';
 import type { Config } from '../../config';
-import type { AwsCloudFormationStack, Repository, Team } from '../../types';
+import type { AwsCloudFormationStack, Team } from '../../types';
 import { findContactableOwners, removeRepoOwner } from '../shared-utilities';
 
 const MONTHS = 3;

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -5,11 +5,7 @@ import type {
 import type { RepocopVulnerability } from 'common/src/types';
 import type { EvaluationResult, Team } from '../../types';
 import { removeRepoOwner } from '../shared-utilities';
-import {
-	createDigestForSeverity,
-	daysLeftToFix,
-	getTopVulns,
-} from './vuln-digest';
+import { createDigestForSeverity, getTopVulns } from './vuln-digest';
 
 const fullName = 'guardian/repo';
 const anotherFullName = 'guardian/another-repo';
@@ -267,56 +263,5 @@ describe('getTopVulns', () => {
 
 		expect(criticalCount).toBe(8);
 		expect(highCount).toBe(2);
-	});
-});
-
-describe('daysLeftToFix', () => {
-	const veryOldVuln: RepocopVulnerability = {
-		source: 'Dependabot',
-		full_name: fullName,
-		open: true,
-		severity: 'high',
-		package: 'leftpad',
-		urls: ['example.com'],
-		ecosystem: 'pip',
-		alert_issue_date: new Date('2021-01-01'),
-		is_patchable: true,
-		cves: ['CVE-123'],
-	};
-	test('should return 0 if we exceed the SLA', () => {
-		expect(daysLeftToFix(veryOldVuln)).toBe(0);
-	});
-	test('should return 30 if a high vuln was raised in the last 24 hours', () => {
-		function hoursAgo(hours: number): Date {
-			const date = new Date();
-			date.setHours(date.getHours() - hours);
-			return date;
-		}
-
-		const oneHourOld: RepocopVulnerability = {
-			...veryOldVuln,
-			alert_issue_date: hoursAgo(1),
-		};
-
-		const twentyThreeHoursOld = {
-			...oneHourOld,
-			alert_issue_date: hoursAgo(23),
-		};
-
-		const twentyFiveHoursOld = {
-			...oneHourOld,
-			alert_issue_date: hoursAgo(25),
-		};
-		expect(daysLeftToFix(oneHourOld)).toBe(30);
-		expect(daysLeftToFix(twentyThreeHoursOld)).toBe(30);
-		expect(daysLeftToFix(twentyFiveHoursOld)).toBe(29);
-	});
-	test('should return 2 if a critical vuln was raised today', () => {
-		const newCriticalVuln: RepocopVulnerability = {
-			...veryOldVuln,
-			severity: 'critical',
-			alert_issue_date: new Date(),
-		};
-		expect(daysLeftToFix(newCriticalVuln)).toBe(2);
 	});
 });

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -1,5 +1,6 @@
 import { Anghammarad, RequestedChannel } from '@guardian/anghammarad';
 import type { view_repo_ownership } from '@prisma/client';
+import { daysLeftToFix } from 'common/src/functions';
 import { type RepocopVulnerability, SLAs } from 'common/src/types';
 import type { Config } from '../../config';
 import type { EvaluationResult, Team, VulnerabilityDigest } from '../../types';
@@ -24,25 +25,11 @@ function getOwningRepos(
 }
 
 export function getTopVulns(vulnerabilities: RepocopVulnerability[]) {
+	//TODO delete this. It's no longer being used
 	return vulnerabilities
 		.sort(vulnSortPredicate)
 		.slice(0, 10)
 		.sort((v1, v2) => v1.full_name.localeCompare(v2.full_name));
-}
-
-export function daysLeftToFix(vuln: RepocopVulnerability): number | undefined {
-	const daysToFix = SLAs[vuln.severity];
-	if (!daysToFix) {
-		return undefined;
-	}
-	const fixDate = new Date(vuln.alert_issue_date);
-	fixDate.setDate(fixDate.getDate() + daysToFix);
-	const millisecondsInADay = 1000 * 60 * 60 * 24;
-	const daysLeftToFix = Math.ceil(
-		(fixDate.getTime() - new Date().getTime()) / millisecondsInADay,
-	);
-
-	return daysLeftToFix < 0 ? 0 : daysLeftToFix;
 }
 
 function createHumanReadableVulnMessage(vuln: RepocopVulnerability): string {

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -2,7 +2,6 @@ import type { Action } from '@guardian/anghammarad';
 import type { Endpoints } from '@octokit/types';
 import type {
 	aws_cloudformation_stacks,
-	github_repositories,
 	github_teams,
 	repocop_github_repository_rules,
 } from '@prisma/client';
@@ -19,26 +18,6 @@ export interface Team extends TeamFields {
 	slug: NonNullable<TeamFields['slug']>;
 	id: NonNullable<TeamFields['id']>;
 	name: NonNullable<TeamFields['name']>;
-}
-
-type RepositoryFields = Pick<
-	github_repositories,
-	| 'archived'
-	| 'name'
-	| 'full_name'
-	| 'topics'
-	| 'updated_at'
-	| 'pushed_at'
-	| 'created_at'
-	| 'id'
-	| 'default_branch'
->;
-
-export interface Repository extends RepositoryFields {
-	archived: NonNullable<RepositoryFields['archived']>;
-	name: NonNullable<RepositoryFields['name']>;
-	full_name: NonNullable<RepositoryFields['full_name']>;
-	id: NonNullable<RepositoryFields['id']>;
 }
 
 export interface Dependency {

--- a/packages/repocop/src/utils.test.ts
+++ b/packages/repocop/src/utils.test.ts
@@ -1,5 +1,4 @@
-import type { RepocopVulnerability } from 'common/src/types';
-import type { Repository } from './types';
+import type { RepocopVulnerability, Repository } from 'common/src/types';
 import { isProduction, vulnSortPredicate } from './utils';
 
 describe('isProduction', () => {

--- a/packages/repocop/src/utils.ts
+++ b/packages/repocop/src/utils.ts
@@ -1,5 +1,4 @@
-import type { RepocopVulnerability } from 'common/src/types';
-import type { Repository } from './types';
+import type { RepocopVulnerability, Repository } from 'common/src/types';
 
 export function isProduction(repo: Repository) {
 	return repo.topics.includes('production') && !repo.archived;


### PR DESCRIPTION
## What does this change?

Creates a new running mode for the obligation lambda, called `PRODUCTION_DEPENDENCIES`. This summarises whether or not a repository contains vulnerable dependencies that exceed our SLAs.

Eventually, it should just link directly to the security or insights tab on the given repo, but while we still have vulnerabilities being sourced from Snyk, let's link to grafana instead to provide visibility of the vulnerabilities regardless of source.

Runs obligation lambdas on a staggered schedule to avoid overloading the DB (to avoid problems when we have like 10 of these things executing at once)

## Why?

So we are able to track our SLA progress over time

## How has it been verified?

Added unit tests, local execution works.

## Next steps

Change the way the CDK works to guarantee that repocop (which generates the `repocop_vulnerabilities` table) executes just before the lambda.

Reuse some of this logic to create a lambda that evaluates AWS FSBP vulnerabilities
