### PR TITLE
try to open docker rather than failing the setup script

### DIFF
--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -9,6 +9,7 @@ MAIN_ENV_FILE=$ROOT_DIR/.env
 LOCAL_ENV_FILE=$HOME/.gu/service_catalogue/.env.local
 clear='\033[0m'
 cyan='\033[0;36m'
+yellow="\033[1;33m"
 
 step() {
   ((STEP_COUNT++))
@@ -46,12 +47,17 @@ check_aws_credentials() {
 
 start_containers() {
   step "Launching Docker containers"
+  
+  set +e
   open -a Docker
+  set -e
 
 while (! docker stats --no-stream ); do
   # Docker takes a few seconds to initialize
-  echo "Waiting for Docker to launch..."
-  sleep 1
+  sleep 5
+  echo -e "${yellow}Do you have an alternative Docker install, such as podman or minikube, aliased to 'docker'? If so, please launch it now${clear}"
+  echo "Standing by for Docker to start..."
+  echo ""
 done
 
 docker-compose -f "${DIR}/../docker-compose.yaml" --env-file "$MAIN_ENV_FILE" --env-file "$LOCAL_ENV_FILE" up -d --build

--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -23,9 +23,9 @@ create_sql_migrations() {
   rm -rf "$SQL_DIR"
   mkdir -p "$SQL_DIR"
 
-  MIGRATIONS=$(ls -d $ROOT_DIR/packages/common/prisma/migrations/*/)
+  MIGRATIONS=$(ls -d "$ROOT_DIR"/packages/common/prisma/migrations/*/)
   for MIGRATION in $MIGRATIONS; do
-    cp $MIGRATION/migration.sql $SQL_DIR/$(basename $MIGRATION).sql;
+    cp "$MIGRATION"/migration.sql "$SQL_DIR"/$(basename "$MIGRATION").sql;
   done
 }
 
@@ -46,13 +46,16 @@ check_aws_credentials() {
 
 start_containers() {
   step "Launching Docker containers"
+  open -a Docker
 
-  if (docker info) 2>&1 >/dev/null; then
-    docker-compose -f "${DIR}/../docker-compose.yaml" --env-file "$MAIN_ENV_FILE" --env-file "$LOCAL_ENV_FILE" up -d --build
-  else
-    echo "Docker is not running. Please start Docker."
-    exit 1
-  fi
+while (! docker stats --no-stream ); do
+  # Docker takes a few seconds to initialize
+  echo "Waiting for Docker to launch..."
+  sleep 1
+done
+
+docker-compose -f "${DIR}/../docker-compose.yaml" --env-file "$MAIN_ENV_FILE" --env-file "$LOCAL_ENV_FILE" up -d --build
+    
 }
 
 check_vpn_connection() {


### PR DESCRIPTION
## What does this change?

When starting up the dev environment, we exit immediately if docker is not running. Instead, let's launch docker and wait for it to start, then continue launching the containers

## Why?

There are several seconds between the start of the script and the launch of the containers, and users may end up running through the script a few times trying to get all their ducks in a row. Off the top of my head, this includes

- Verifying AWS credentials
- Checking to see if the user is on the VPN
- Checking to see if docker is running

This PR eliminates one of those sources of friction, for a smoother development experience

## How has it been verified?

I have tested 3 scenarios

1. Docker is already running. The script continues, and docker does not restart, it just continues to run
2. Docker is not running. Docker starts up, and the script waits for the launch to complete before launching the containers
3. Docker is not installed. Often, this is because something like podman has been installed instead. In this case, the script will hang until whatever is aliased to `docker` is launched by the user.

## Next steps

If this approach is useful, maybe we could do something similar for the AWS Credential check, launching Janus in the browser on failure.


