### PR TITLE
only create refresh-materialized-view user if it doesn't already exist

### DIFF
--- a/packages/common/prisma/migrations/20240530093317_aws_resources_owner/migration.sql
+++ b/packages/common/prisma/migrations/20240530093317_aws_resources_owner/migration.sql
@@ -2,7 +2,11 @@ DO
 $do$
     BEGIN
         -- This user is used by the refresh-materialized-view lambda
-        CREATE USER refresh_materialized_view WITH LOGIN;
+        -- Create the `refresh_materialized_view` user if it doesn't exist
+        IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE  rolname = 'refresh_materialized_view') THEN
+            CREATE USER refresh_materialized_view WITH LOGIN;
+        END IF;
+
 
         GRANT USAGE ON SCHEMA public to refresh_materialized_view;
         GRANT SELECT ON ALL TABLES IN SCHEMA public TO refresh_materialized_view;


### PR DESCRIPTION
## What does this change?

Adds the equivalent of an IF NOT EXISTS to the `refresh-materialized-view` user.

## Why?

To stop DEV migrations from failing.

## How has it been verified?

Deployed to CODE, which detected no new migrations. If we want to be good citizens, after merging, we can go in and manually adjust the checksum for this migration, but this is not required.
