### PR TITLE
chore(deps): Update CloudQuery AWS source plugin to v27.5.0

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ CQ_POSTGRES_DESTINATION=7.2.0
 CQ_POSTGRES_SOURCE=3.0.7
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/aws/versions
-CQ_AWS=26.0.0
+CQ_AWS=27.5.0
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/github/versions
 CQ_GITHUB=10.0.1

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -124,7 +124,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_costexplorer_*
   destinations:
@@ -776,7 +776,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_accessanalyzer_*
     - aws_securityhub_*
@@ -1472,7 +1472,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_lambda_*
   destinations:
@@ -2094,7 +2094,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_organization*
   destinations:
@@ -2745,7 +2745,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_autoscaling_groups
   destinations:
@@ -3397,7 +3397,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_backup_protected_resources
     - aws_backup_vaults
@@ -4081,7 +4081,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_acm*
   destinations:
@@ -4937,7 +4937,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_cloudformation_*
   destinations:
@@ -5355,7 +5355,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_cloudwatch_alarms
   destinations:
@@ -6007,7 +6007,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_dynamodb*
   destinations:
@@ -6659,7 +6659,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_ec2_instances
     - aws_ec2_security_groups
@@ -7344,7 +7344,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_iam_credential_reports
   destinations:
@@ -7996,7 +7996,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_inspector_findings
     - aws_inspector2_findings
@@ -8649,7 +8649,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_elbv1_*
     - aws_elbv2_*
@@ -9302,7 +9302,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_rds_instances
     - aws_rds_clusters
@@ -9957,7 +9957,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_s3*
   destinations:
@@ -10843,7 +10843,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_*
   skip_tables:
@@ -11357,7 +11357,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_ssm_parameters
   destinations:

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -35,7 +35,7 @@ describe('Config generation, and converting to YAML', () => {
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_s3_buckets
   destinations:
@@ -61,7 +61,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - '*'
   skip_tables:
@@ -92,7 +92,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_accessanalyzer_analyzers
     - aws_accessanalyzer_analyzer_archive_rules
@@ -128,7 +128,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v26.0.0
+  version: v27.5.0
   tables:
     - aws_securityhub_findings
   destinations:

--- a/packages/common/prisma/migrations/20240703090946_cloudquery_aws_27_5_0/migration.sql
+++ b/packages/common/prisma/migrations/20240703090946_cloudquery_aws_27_5_0/migration.sql
@@ -1,0 +1,47 @@
+-- This migration is to update the CloudQuery AWS source plugin from from v26.0.0 to v27.5.0.
+-- The `_cq_id` changes actually originate from v24.0.0.
+-- It's not a field that we use in Prisma, so the schema wasn't updated at the time.
+-- See https://hub.cloudquery.io/plugins/source/cloudquery/aws/v24.0.0/versions.
+
+-- These indices are replaced with primary keys on the `_cq_id` column.
+DROP INDEX IF EXISTS "aws_cloudformation_stacks__cq_id_key";
+DROP INDEX IF EXISTS "aws_ec2_images__cq_id_key";
+DROP INDEX IF EXISTS "aws_ec2_instances__cq_id_key";
+DROP INDEX IF EXISTS "aws_lambda_functions__cq_id_key";
+DROP INDEX IF EXISTS "aws_organizations_account_parents__cq_id_key";
+DROP INDEX IF EXISTS "aws_organizations_accounts__cq_id_key";
+DROP INDEX IF EXISTS "aws_organizations_organizational_units__cq_id_key";
+DROP INDEX IF EXISTS "aws_s3_buckets__cq_id_key";
+DROP INDEX IF EXISTS "aws_securityhub_findings__cq_id_key";
+DROP INDEX IF EXISTS "idx_aws_account_name";
+
+ALTER TABLE "aws_cloudformation_stacks" DROP CONSTRAINT "aws_cloudformation_stacks_cqpk",
+ADD COLUMN     "deletion_mode" TEXT,
+ADD COLUMN     "detailed_status" TEXT,
+ADD CONSTRAINT "aws_cloudformation_stacks_cqpk" PRIMARY KEY ("_cq_id");
+
+ALTER TABLE "aws_ec2_images" DROP CONSTRAINT "aws_ec2_images_cqpk",
+ADD COLUMN     "deregistration_protection" TEXT,
+ADD COLUMN     "last_launched_time" TEXT,
+ADD CONSTRAINT "aws_ec2_images_cqpk" PRIMARY KEY ("_cq_id");
+
+ALTER TABLE "aws_ec2_instances" DROP CONSTRAINT "aws_ec2_instances_cqpk",
+ADD CONSTRAINT "aws_ec2_instances_cqpk" PRIMARY KEY ("_cq_id");
+
+ALTER TABLE "aws_lambda_functions" DROP CONSTRAINT "aws_lambda_functions_cqpk",
+ADD CONSTRAINT "aws_lambda_functions_cqpk" PRIMARY KEY ("_cq_id");
+
+ALTER TABLE "aws_organizations_account_parents" DROP CONSTRAINT "aws_organizations_account_parents_cqpk",
+ADD CONSTRAINT "aws_organizations_account_parents_cqpk" PRIMARY KEY ("_cq_id");
+
+ALTER TABLE "aws_organizations_accounts" DROP CONSTRAINT "aws_organizations_accounts_cqpk",
+ADD CONSTRAINT "aws_organizations_accounts_cqpk" PRIMARY KEY ("_cq_id");
+
+ALTER TABLE "aws_organizations_organizational_units" DROP CONSTRAINT "aws_organizations_organizational_units_cqpk",
+ADD CONSTRAINT "aws_organizations_organizational_units_cqpk" PRIMARY KEY ("_cq_id");
+
+ALTER TABLE "aws_s3_buckets" DROP CONSTRAINT "aws_s3_buckets_cqpk",
+ADD CONSTRAINT "aws_s3_buckets_cqpk" PRIMARY KEY ("_cq_id");
+
+ALTER TABLE "aws_securityhub_findings" DROP CONSTRAINT "aws_securityhub_findings_cqpk",
+ADD CONSTRAINT "aws_securityhub_findings_cqpk" PRIMARY KEY ("_cq_id");

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -24,10 +24,8 @@ model aws_cloudformation_stacks {
   stack_status                  String?
   capabilities                  String[]
   change_set_id                 String?
-  deletion_mode                 String?
   deletion_time                 DateTime? @db.Timestamp(6)
   description                   String?
-  detailed_status               String?
   disable_rollback              Boolean?
   drift_information             Json?
   enable_termination_protection Boolean?
@@ -43,6 +41,8 @@ model aws_cloudformation_stacks {
   stack_id                      String?
   stack_status_reason           String?
   timeout_in_minutes            BigInt?
+  deletion_mode                 String?
+  detailed_status               String?
 }
 
 model aws_ec2_images {
@@ -59,7 +59,6 @@ model aws_ec2_images {
   boot_mode                 String?
   creation_date             DateTime? @db.Timestamp(6)
   deprecation_time          DateTime? @db.Timestamp(6)
-  deregistration_protection String?
   description               String?
   ena_support               Boolean?
   hypervisor                String?
@@ -69,7 +68,6 @@ model aws_ec2_images {
   image_type                String?
   imds_support              String?
   kernel_id                 String?
-  last_launched_time        String?
   name                      String?
   owner_id                  String?
   platform                  String?
@@ -86,6 +84,8 @@ model aws_ec2_images {
   tpm_support               String?
   usage_operation           String?
   virtualization_type       String?
+  deregistration_protection String?
+  last_launched_time        String?
 }
 
 model aws_ec2_instances {

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -12,20 +12,22 @@ datasource db {
 model aws_cloudformation_stacks {
   cq_sync_time                  DateTime? @map("_cq_sync_time") @db.Timestamp(6)
   cq_source_name                String?   @map("_cq_source_name")
-  cq_id                         String    @unique @map("_cq_id") @db.Uuid
+  cq_id                         String    @id(map: "aws_cloudformation_stacks_cqpk") @map("_cq_id") @db.Uuid
   cq_parent_id                  String?   @map("_cq_parent_id") @db.Uuid
   account_id                    String?
   region                        String?
   id                            String?
-  arn                           String    @id(map: "aws_cloudformation_stacks_cqpk")
+  arn                           String
   tags                          Json?
   creation_time                 DateTime? @db.Timestamp(6)
   stack_name                    String?
   stack_status                  String?
   capabilities                  String[]
   change_set_id                 String?
+  deletion_mode                 String?
   deletion_time                 DateTime? @db.Timestamp(6)
   description                   String?
+  detailed_status               String?
   disable_rollback              Boolean?
   drift_information             Json?
   enable_termination_protection Boolean?
@@ -44,56 +46,56 @@ model aws_cloudformation_stacks {
 }
 
 model aws_ec2_images {
-  cq_sync_time          DateTime? @map("_cq_sync_time") @db.Timestamp(6)
-  cq_source_name        String?   @map("_cq_source_name")
-  cq_id                 String    @unique @map("_cq_id") @db.Uuid
-  cq_parent_id          String?   @map("_cq_parent_id") @db.Uuid
-  account_id            String
-  region                String
-  arn                   String
-  tags                  Json?
-  architecture          String?
-  block_device_mappings Json?
-  boot_mode             String?
-  creation_date         DateTime? @db.Timestamp(6)
-  deprecation_time      DateTime? @db.Timestamp(6)
-  description           String?
-  ena_support           Boolean?
-  hypervisor            String?
-  image_id              String?
-  image_location        String?
-  image_owner_alias     String?
-  image_type            String?
-  imds_support          String?
-  kernel_id             String?
-  name                  String?
-  owner_id              String?
-  platform              String?
-  platform_details      String?
-  product_codes         Json?
-  public                Boolean?
-  ramdisk_id            String?
-  root_device_name      String?
-  root_device_type      String?
-  source_instance_id    String?
-  sriov_net_support     String?
-  state                 String?
-  state_reason          Json?
-  tpm_support           String?
-  usage_operation       String?
-  virtualization_type   String?
-
-  @@id([account_id, region, arn], map: "aws_ec2_images_cqpk")
+  cq_sync_time              DateTime? @map("_cq_sync_time") @db.Timestamp(6)
+  cq_source_name            String?   @map("_cq_source_name")
+  cq_id                     String    @id(map: "aws_ec2_images_cqpk") @map("_cq_id") @db.Uuid
+  cq_parent_id              String?   @map("_cq_parent_id") @db.Uuid
+  account_id                String
+  region                    String
+  arn                       String
+  tags                      Json?
+  architecture              String?
+  block_device_mappings     Json?
+  boot_mode                 String?
+  creation_date             DateTime? @db.Timestamp(6)
+  deprecation_time          DateTime? @db.Timestamp(6)
+  deregistration_protection String?
+  description               String?
+  ena_support               Boolean?
+  hypervisor                String?
+  image_id                  String?
+  image_location            String?
+  image_owner_alias         String?
+  image_type                String?
+  imds_support              String?
+  kernel_id                 String?
+  last_launched_time        String?
+  name                      String?
+  owner_id                  String?
+  platform                  String?
+  platform_details          String?
+  product_codes             Json?
+  public                    Boolean?
+  ramdisk_id                String?
+  root_device_name          String?
+  root_device_type          String?
+  source_instance_id        String?
+  sriov_net_support         String?
+  state                     String?
+  state_reason              Json?
+  tpm_support               String?
+  usage_operation           String?
+  virtualization_type       String?
 }
 
 model aws_ec2_instances {
   cq_sync_time                               DateTime? @map("_cq_sync_time") @db.Timestamp(6)
   cq_source_name                             String?   @map("_cq_source_name")
-  cq_id                                      String    @unique @map("_cq_id") @db.Uuid
+  cq_id                                      String    @id(map: "aws_ec2_instances_cqpk") @map("_cq_id") @db.Uuid
   cq_parent_id                               String?   @map("_cq_parent_id") @db.Uuid
   account_id                                 String?
   region                                     String?
-  arn                                        String    @id(map: "aws_ec2_instances_cqpk")
+  arn                                        String
   state_transition_reason_time               DateTime? @db.Timestamp(6)
   tags                                       Json?
   ami_launch_index                           BigInt?
@@ -159,21 +161,20 @@ model aws_ec2_instances {
 model aws_organizations_account_parents {
   cq_sync_time       DateTime? @map("_cq_sync_time") @db.Timestamp(6)
   cq_source_name     String?   @map("_cq_source_name")
-  cq_id              String    @unique @map("_cq_id") @db.Uuid
+  cq_id              String    @id(map: "aws_organizations_account_parents_cqpk") @map("_cq_id") @db.Uuid
   cq_parent_id       String?   @map("_cq_parent_id") @db.Uuid
   request_account_id String
   id                 String
   parent_id          String
   type               String
 
-  @@id([request_account_id, id, parent_id, type], map: "aws_organizations_account_parents_cqpk")
   @@ignore
 }
 
 model aws_organizations_accounts {
   cq_sync_time       DateTime? @map("_cq_sync_time") @db.Timestamp(6)
   cq_source_name     String?   @map("_cq_source_name")
-  cq_id              String    @unique @map("_cq_id") @db.Uuid
+  cq_id              String    @id(map: "aws_organizations_accounts_cqpk") @map("_cq_id") @db.Uuid
   cq_parent_id       String?   @map("_cq_parent_id") @db.Uuid
   request_account_id String
   tags               Json?
@@ -185,21 +186,19 @@ model aws_organizations_accounts {
   name               String?
   status             String?
 
-  @@id([request_account_id, arn], map: "aws_organizations_accounts_cqpk")
   @@ignore
 }
 
 model aws_organizations_organizational_units {
   cq_sync_time       DateTime? @map("_cq_sync_time") @db.Timestamp(6)
   cq_source_name     String?   @map("_cq_source_name")
-  cq_id              String    @unique @map("_cq_id") @db.Uuid
+  cq_id              String    @id(map: "aws_organizations_organizational_units_cqpk") @map("_cq_id") @db.Uuid
   cq_parent_id       String?   @map("_cq_parent_id") @db.Uuid
   request_account_id String
   arn                String
   id                 String?
   name               String?
 
-  @@id([request_account_id, arn], map: "aws_organizations_organizational_units_cqpk")
   @@ignore
 }
 
@@ -539,11 +538,11 @@ model github_languages {
 model aws_lambda_functions {
   cq_sync_time         DateTime? @map("_cq_sync_time") @db.Timestamp(6)
   cq_source_name       String?   @map("_cq_source_name")
-  cq_id                String    @unique @map("_cq_id") @db.Uuid
+  cq_id                String    @id(map: "aws_lambda_functions_cqpk") @map("_cq_id") @db.Uuid
   cq_parent_id         String?   @map("_cq_parent_id") @db.Uuid
   account_id           String?
   region               String?
-  arn                  String    @id(map: "aws_lambda_functions_cqpk")
+  arn                  String
   policy_revision_id   String?
   policy_document      Json?
   code_signing_config  Json?
@@ -559,10 +558,10 @@ model aws_lambda_functions {
 model aws_s3_buckets {
   cq_sync_time   DateTime? @map("_cq_sync_time") @db.Timestamp(6)
   cq_source_name String?   @map("_cq_source_name")
-  cq_id          String    @unique @map("_cq_id") @db.Uuid
+  cq_id          String    @id(map: "aws_s3_buckets_cqpk") @map("_cq_id") @db.Uuid
   cq_parent_id   String?   @map("_cq_parent_id") @db.Uuid
   account_id     String?
-  arn            String    @id(map: "aws_s3_buckets_cqpk")
+  arn            String
   creation_date  DateTime? @db.Timestamp(6)
   name           String?
   region         String?
@@ -645,7 +644,7 @@ model repocop_vulnerabilities {
 model aws_securityhub_findings {
   cq_sync_time            DateTime? @map("_cq_sync_time") @db.Timestamp(6)
   cq_source_name          String?   @map("_cq_source_name")
-  cq_id                   String    @unique @map("_cq_id") @db.Uuid
+  cq_id                   String    @id(map: "aws_securityhub_findings_cqpk") @map("_cq_id") @db.Uuid
   cq_parent_id            String?   @map("_cq_parent_id") @db.Uuid
   request_account_id      String
   request_region          String
@@ -693,9 +692,6 @@ model aws_securityhub_findings {
   vulnerabilities         Json?
   workflow                Json?
   workflow_state          String?
-
-  @@id([request_account_id, request_region, aws_account_id, created_at, description, generator_id, id, product_arn, schema_version, title, updated_at, region], map: "aws_securityhub_findings_cqpk")
-  @@index([aws_account_name], map: "idx_aws_account_name")
 }
 
 model obligatron_results {


### PR DESCRIPTION
> [!NOTE]
> Easiest to review [w/out whitespace](https://github.com/guardian/service-catalogue/pull/1153/files?diff=split&w=1).

## What does this change, and why?
Update the [CloudQuery AWS source plugin](https://hub.cloudquery.io/plugins/source/cloudquery/aws/latest/docs) to latest (v27.5.0), and update the Prisma files to match.

The Prisma migration looks bigger than the release notes might suggest. This is because we hadn't reflected the changes in v24.0.0 when we previously updated. v24.0.0 made a change to the `_cq_id` column; this is now the primary key for tables. Consequently, we can remove some now redundant indices.

## How has it been verified?
- Deployed to [CODE](https://riffraff.gutools.co.uk/deployment/view/0d71285e-67d8-4c61-916c-13fd079ce9a0)
- Ran the tasks to collect data for the tables `aws_cloudformation_stacks` and `aws_ec2_images`
- Queried the data, and saw the `_cq_sync_time` being now, that is, the data was successfully collected

![image](https://github.com/guardian/service-catalogue/assets/836140/dfb1b86e-d61b-497e-a37a-4c56382946e7)


---
Co-authored-by: @NovemberTang 