### PR TITLE
parallelise ci

### DIFF
--- a/.github/actions/npm-run/action.yml
+++ b/.github/actions/npm-run/action.yml
@@ -1,0 +1,32 @@
+name: Run an npm script
+description: 'Run an npm script'
+inputs:
+  script:
+    description: 'The npm script to run'
+    required: true
+  deployment_key:
+    description: 'The private key to use for deployment'
+    required: true
+
+
+runs:
+  using: 'composite'
+  steps:
+
+    - name: Setup Node
+      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'npm'
+
+    - uses: guardian/actions-read-private-repos@8792b5279dc2e6dfb6b9aa6ba2f26b6226be444c # v0.1.1
+      with:
+        private-ssh-keys: ${{ inputs.deployment_key }}
+
+    - name: install dependencies
+      shell: bash
+      run: npm ci
+
+    - name: Run script
+      shell: bash
+      run: npm run ${{ github.event.inputs.script }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,22 +56,10 @@ jobs:
           script: typecheck
           deployment_key: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
 
-  synth:
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: ./.github/actions/npm-run
-        with:
-          script: synth
-          deployment_key: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
-
   CI:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    needs: [lint, test, typecheck, synth]
+    needs: [lint, test, typecheck]
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,8 @@ jobs:
         with:
           private-ssh-keys: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
 
-      - name: Run script/ci
-        run: ./scripts/ci.sh
+      - name: Build zip files
+        run: ./scripts/build.sh
 
       - name: Upload to riff-raff
         uses: guardian/actions-riff-raff@68a3a1914dda09a4a965f310c6be368715e97018 # v4.0.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
   lint:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-
-    # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
       contents: read
     steps:
@@ -37,8 +35,6 @@ jobs:
   test:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-
-    # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
       contents: read
     steps:
@@ -51,8 +47,6 @@ jobs:
   typecheck:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-
-    # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
       contents: read
     steps:
@@ -62,10 +56,22 @@ jobs:
           script: typecheck
           deployment_key: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
 
+  synth:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: ./.github/actions/npm-run
+        with:
+          script: synth
+          deployment_key: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
+
   CI:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    needs: [lint, test, typecheck]
+    needs: [lint, test, typecheck, synth]
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: ./.github/actions/npm-run
+        with:
+          script: lint
+          deployment_key: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
+
+  test:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: ./.github/actions/npm-run
+        with:
+          script: test
+          deployment_key: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
+
+  typecheck:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+
+    # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: ./.github/actions/npm-run
+        with:
+          script: typecheck
+          deployment_key: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
+
   CI:
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    needs: [lint, test, typecheck]
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "test": "jest --detectOpenHandles --config ../../jest.config.js --selectProjects cdk",
     "synth": "cdk synth --path-metadata false --version-reporting false",
+    "build": "npm run synth",
     "diff:code": "cdk diff --path-metadata false --version-reporting false --profile deployTools ServiceCatalogue-CODE",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -54,7 +54,6 @@ verify() {
   fi
 }
 
-
 npm ci
 
 # Run the following in parallel.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -55,10 +55,6 @@ verify() {
 }
 
 npm ci
-
-# Run the following in parallel.
-# Logs will be interleaved, but the `--print-label` flag will prefix each line with the name of the script being run.
-# See https://github.com/mysticatea/npm-run-all.
 npm run build
 
 verify best-practices "packages/best-practices/best-practices.md"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -56,12 +56,11 @@ verify() {
 
 
 npm ci
-npm test
 
 # Run the following in parallel.
 # Logs will be interleaved, but the `--print-label` flag will prefix each line with the name of the script being run.
 # See https://github.com/mysticatea/npm-run-all.
-npx npm-run-all --print-label --parallel typecheck lint synth build
+npm run build
 
 verify best-practices "packages/best-practices/best-practices.md"
 

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+npm i
+
+npx npm-run-all --print-label --parallel typecheck lint test build 


### PR DESCRIPTION
## What does this change?

Creates a composite action for running an arbitrary npm script. Then, uses that action to run `lint`, `typecheck`, etc in parallel, before moving on to the final build step.

So that we can still run these steps locally, I've created a `local-ci.sh` to run those steps.

## Why?

The CI script runs pretty fast on our machines with a bajillion cores. GH runners only have two, meaning CI times on GHA have crept up over the last 2 years from about 1:30 to over 5 minutes. This change brings that time back down to 2:49-ish.

## How has it been verified?

CI passes. `local-ci.sh` works.
