### PR TITLE
Enable Dependency Graph Integrator to raise PRs to add workflow

### DIFF
--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
 
       # These tables will be copied from the CODE database, and loaded into the DEV database.
       TABLES: |
+        - guardian_github_actions_usage
         - snyk_issues
         - snyk_projects
         - galaxies_teams_table

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -102,8 +102,6 @@ export async function getConfig(): Promise<Config> {
 		snykIntegrationPREnabled:
 			process.env.SNYK_INTEGRATION_PR_ENABLED === 'true',
 		snykIntegratorTopic: getEnvOrThrow('SNYK_INTEGRATOR_INPUT_TOPIC_ARN'),
-		dependencyGraphIntegrationPrEnabled:
-			process.env.DEPENDENCY_GRAPH_INTEGRATION_ENABLED === 'true',
 		dependencyGraphIntegratorTopic: getEnvOrThrow(
 			'DEPENDENCY_GRAPH_INPUT_TOPIC_ARN',
 		),

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -62,6 +62,16 @@ export interface Config extends PrismaConfig {
 	 * The ARN of the Snyk Integrator input topic.
 	 */
 	snykIntegratorTopic: string;
+
+	/**
+	 * Flag to enable creation of dependency graph integration PRs
+	 */
+	dependencyGraphIntegrationPrEnabled: boolean;
+
+	/**
+	 * The ARN of the Dependency Graph Integrator input topic.
+	 */
+	dependencyGraphIntegratorTopic: string;
 }
 
 export async function getConfig(): Promise<Config> {
@@ -92,5 +102,10 @@ export async function getConfig(): Promise<Config> {
 		snykIntegrationPREnabled:
 			process.env.SNYK_INTEGRATION_PR_ENABLED === 'true',
 		snykIntegratorTopic: getEnvOrThrow('SNYK_INTEGRATOR_INPUT_TOPIC_ARN'),
+		dependencyGraphIntegrationPrEnabled:
+			process.env.DEPENDENCY_GRAPH_INTEGRATION_ENABLED === 'true',
+		dependencyGraphIntegratorTopic: getEnvOrThrow(
+			'DEPENDENCY_GRAPH_INPUT_TOPIC_ARN',
+		),
 	};
 }

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -64,11 +64,6 @@ export interface Config extends PrismaConfig {
 	snykIntegratorTopic: string;
 
 	/**
-	 * Flag to enable creation of dependency graph integration PRs
-	 */
-	dependencyGraphIntegrationPrEnabled: boolean;
-
-	/**
 	 * The ARN of the Dependency Graph Integrator input topic.
 	 */
 	dependencyGraphIntegratorTopic: string;

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -1,5 +1,6 @@
 import { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
 import type {
+	guardian_github_actions_usage,
 	PrismaClient,
 	repocop_github_repository_rules,
 	view_repo_ownership,
@@ -17,6 +18,7 @@ import {
 import { sendToCloudwatch } from './metrics';
 import {
 	getDependabotVulnerabilities,
+	getProductionWorkflowUsages,
 	getRepoOwnership,
 	getRepositories,
 	getRepositoryBranches,
@@ -27,6 +29,7 @@ import {
 	getTeams,
 } from './query';
 import { protectBranches } from './remediation/branch-protector/branch-protection';
+import { sendOneRepo } from './remediation/dependency_graph-integrator/send-to-sns';
 import { sendUnprotectedRepo } from './remediation/snyk-integrator/send-to-sns';
 import { sendPotentialInteractives } from './remediation/topics/topic-monitor-interactive';
 import { applyProductionTopicAndMessageTeams } from './remediation/topics/topic-monitor-production';
@@ -151,6 +154,18 @@ export async function main() {
 
 	if (config.snykIntegrationPREnabled) {
 		await sendUnprotectedRepo(repocopRules, config, repoLanguages);
+	}
+
+	if (config.dependencyGraphIntegrationPrEnabled) {
+		const productionWorkflowUsages: guardian_github_actions_usage[] =
+			await getProductionWorkflowUsages(prisma, productionRepos);
+
+		await sendOneRepo(
+			config,
+			repoLanguages,
+			productionRepos,
+			productionWorkflowUsages,
+		);
 	}
 
 	await writeEvaluationTable(repocopRules, prisma);

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -93,6 +93,11 @@ export async function main() {
 
 	console.log(productionDependabotVulnerabilities);
 
+	// Dependency Graph Integrator
+	const productionWorkflowUsages: guardian_github_actions_usage[] =
+		await getProductionWorkflowUsages(prisma, productionRepos);
+
+
 	const evaluationResults: EvaluationResult[] = await evaluateRepositories(
 		unarchivedRepos,
 		branches,
@@ -192,9 +197,6 @@ export async function main() {
 		);
 	}
 
-	// Dependency Graph Integrator
-	const productionWorkflowUsages: guardian_github_actions_usage[] =
-		await getProductionWorkflowUsages(prisma, productionRepos);
 	await sendOneRepoToDepGraphIntegrator(
 		config,
 		repoLanguages,

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -1,6 +1,7 @@
 import type {
 	github_languages,
 	github_repository_branches,
+	guardian_github_actions_usage,
 	PrismaClient,
 	view_repo_ownership,
 } from '@prisma/client';
@@ -181,4 +182,16 @@ export async function getDependabotVulnerabilities(
 	);
 
 	return dependabotVulnerabilities;
+}
+
+export async function getProductionWorkflowUsages(
+	client: PrismaClient,
+	productionRepos: Repository[],
+): Promise<NonEmptyArray<guardian_github_actions_usage>> {
+	const actions_usage = await client.guardian_github_actions_usage.findMany({
+		where: {
+			full_name: { in: productionRepos.map((repo) => repo.full_name) },
+		},
+	});
+	return toNonEmptyArray(actions_usage);
 }

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
@@ -6,8 +6,8 @@ import type { Repository } from 'common/src/types';
 import { removeRepoOwner } from '../shared-utilities';
 import {
 	checkRepoForLanguage,
+	createSnsEventsForDependencyGraphIntegration,
 	doesRepoHaveWorkflow,
-	getSuitableRepoEvents,
 } from './send-to-sns';
 
 const fullName = 'guardian/repo-name';
@@ -117,7 +117,7 @@ describe('When checking a repo for an existing dependency submission workflow', 
 
 describe('When getting suitable events to send to SNS', () => {
 	test('return an event when a Scala repo is found without an existing workflow', () => {
-		const result = getSuitableRepoEvents(
+		const result = createSnsEventsForDependencyGraphIntegration(
 			[repoWithTargetLanguage(fullName)],
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
@@ -125,7 +125,7 @@ describe('When getting suitable events to send to SNS', () => {
 		expect(result).toEqual([{ name: removeRepoOwner(fullName) }]);
 	});
 	test('return empty event array when a Scala repo is found with an existing workflow', () => {
-		const result = getSuitableRepoEvents(
+		const result = createSnsEventsForDependencyGraphIntegration(
 			[repoWithTargetLanguage(fullName)],
 			[repository(fullName)],
 			[repoWithDepSubmissionWorkflow(fullName)],
@@ -133,7 +133,7 @@ describe('When getting suitable events to send to SNS', () => {
 		expect(result).toEqual([]);
 	});
 	test('return empty array when non-Scala repo is found with without an existing workflow', () => {
-		const result = getSuitableRepoEvents(
+		const result = createSnsEventsForDependencyGraphIntegration(
 			[repoWithoutTargetLanguage(fullName)],
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
@@ -141,7 +141,7 @@ describe('When getting suitable events to send to SNS', () => {
 		expect(result).toEqual([]);
 	});
 	test('return 2 events when 2 Scala repos are found without an existing workflow', () => {
-		const result = getSuitableRepoEvents(
+		const result = createSnsEventsForDependencyGraphIntegration(
 			[repoWithTargetLanguage(fullName), repoWithTargetLanguage(fullName2)],
 			[repository(fullName), repository(fullName2)],
 			[repoWithoutWorkflow(fullName), repoWithoutWorkflow(fullName2)],

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
@@ -1,0 +1,154 @@
+import type {
+	github_languages,
+	guardian_github_actions_usage,
+} from '@prisma/client';
+import type { Repository } from 'common/src/types';
+import { removeRepoOwner } from '../shared-utilities';
+import {
+	checkRepoForLanguage,
+	doesRepoHaveWorkflow,
+	getSuitableRepoEvents,
+} from './send-to-sns';
+
+const fullName = 'guardian/repo-name';
+const fullName2 = 'guardian/repo2';
+const scalaLang = 'Scala';
+
+function createActionsUsage(
+	fullName: string,
+	workflowUses: string[],
+): guardian_github_actions_usage {
+	return {
+		evaluated_on: new Date('2024-01-01'),
+		full_name: fullName,
+		workflow_path: '.github/workflows/some-workflow.yaml',
+		workflow_uses: workflowUses,
+	};
+}
+
+function repoWithLanguages(
+	fullName: string,
+	languages: string[],
+): github_languages {
+	return {
+		cq_sync_time: null,
+		cq_parent_id: null,
+		cq_id: '',
+		cq_source_name: null,
+		full_name: fullName,
+		name: fullName,
+		languages,
+	};
+}
+
+function repository(fullName: string): Repository {
+	return {
+		archived: false,
+		name: removeRepoOwner(fullName),
+		full_name: fullName,
+		id: BigInt(1),
+		default_branch: null,
+		created_at: null,
+		pushed_at: null,
+		updated_at: null,
+		topics: [],
+	};
+}
+
+function repoWithTargetLanguage(fullName: string): github_languages {
+	return repoWithLanguages(fullName, ['Scala', 'TypeScript']);
+}
+
+function repoWithoutTargetLanguage(fullName: string): github_languages {
+	return repoWithLanguages(fullName, ['Rust', 'Typescript']);
+}
+
+function repoWithDepSubmissionWorkflow(
+	fullName: string,
+): guardian_github_actions_usage {
+	return createActionsUsage(fullName, [
+		'actions/checkout@v2',
+		'scalacenter/sbt-dependency-submission@v2',
+		'aws-actions/configure-aws-credentials@v1',
+	]);
+}
+
+function repoWithoutWorkflow(fullName: string): guardian_github_actions_usage {
+	return createActionsUsage(fullName, [
+		'actions/checkout@v2',
+		'aws-actions/configure-aws-credentials@v1',
+	]);
+}
+
+describe('When trying to find repos using Scala', () => {
+	test('return true if Scala is found in the repo', () => {
+		const result = checkRepoForLanguage(
+			repository(fullName),
+			[repoWithTargetLanguage(fullName)],
+			scalaLang,
+		);
+
+		expect(result).toBe(true);
+	});
+	test('return false if Scala is not found in the repo', () => {
+		const result = checkRepoForLanguage(
+			repository(fullName),
+			[repoWithoutTargetLanguage(fullName)],
+			scalaLang,
+		);
+		expect(result).toBe(false);
+	});
+});
+
+describe('When checking a repo for an existing dependency submission workflow', () => {
+	test('return true if repo workflow is present', () => {
+		const result = doesRepoHaveWorkflow(repository(fullName), [
+			repoWithDepSubmissionWorkflow(fullName),
+		]);
+		expect(result).toBe(true);
+	});
+	test('return false if workflow is not present', () => {
+		const result = doesRepoHaveWorkflow(repository(fullName), [
+			repoWithoutWorkflow(fullName),
+		]);
+		expect(result).toBe(false);
+	});
+});
+
+describe('When getting suitable events to send to SNS', () => {
+	test('return an event when a Scala repo is found without an existing workflow', () => {
+		const result = getSuitableRepoEvents(
+			[repoWithTargetLanguage(fullName)],
+			[repository(fullName)],
+			[repoWithoutWorkflow(fullName)],
+		);
+		expect(result).toEqual([{ name: removeRepoOwner(fullName) }]);
+	});
+	test('return empty event array when a Scala repo is found with an existing workflow', () => {
+		const result = getSuitableRepoEvents(
+			[repoWithTargetLanguage(fullName)],
+			[repository(fullName)],
+			[repoWithDepSubmissionWorkflow(fullName)],
+		);
+		expect(result).toEqual([]);
+	});
+	test('return empty array when non-Scala repo is found with without an existing workflow', () => {
+		const result = getSuitableRepoEvents(
+			[repoWithoutTargetLanguage(fullName)],
+			[repository(fullName)],
+			[repoWithoutWorkflow(fullName)],
+		);
+		expect(result).toEqual([]);
+	});
+	test('return 2 events when 2 Scala repos are found without an existing workflow', () => {
+		const result = getSuitableRepoEvents(
+			[repoWithTargetLanguage(fullName), repoWithTargetLanguage(fullName2)],
+			[repository(fullName), repository(fullName2)],
+			[repoWithoutWorkflow(fullName), repoWithoutWorkflow(fullName2)],
+		);
+		expect(result).toEqual([
+			{ name: removeRepoOwner(fullName) },
+			{ name: removeRepoOwner(fullName2) },
+		]);
+	});
+});

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -24,7 +24,7 @@ export function checkRepoForLanguage(
 	return languagesInRepo.includes(targetLanguage);
 }
 
-function doesRepoHaveWorkflow(
+export function doesRepoHaveWorkflow(
 	repo: Repository,
 	workflow_usages: guardian_github_actions_usage[],
 ): boolean {

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -77,14 +77,20 @@ export async function sendOneRepoToDepGraphIntegrator(
 	)[0];
 
 	if (eventToSend) {
-		const publishRequestEntry = new PublishCommand({
-			Message: JSON.stringify(eventToSend),
-			TopicArn: config.dependencyGraphIntegratorTopic,
-		});
-		console.log(`Sending ${eventToSend.name} to Dependency Graph Integrator`);
-		await new SNSClient(awsClientConfig(config.stage)).send(
-			publishRequestEntry,
-		);
+		if (config.stage === 'PROD') {
+			const publishRequestEntry = new PublishCommand({
+				Message: JSON.stringify(eventToSend),
+				TopicArn: config.dependencyGraphIntegratorTopic,
+			});
+			console.log(`Sending ${eventToSend.name} to Dependency Graph Integrator`);
+			await new SNSClient(awsClientConfig(config.stage)).send(
+				publishRequestEntry,
+			);
+		} else {
+			console.log(
+				`Would have sent ${eventToSend.name} to Dependency Graph Integrator`,
+			);
+		}
 	} else {
 		console.log(
 			'No Scala repos found without SBT dependency submission workflow',

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -1,0 +1,94 @@
+import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
+import type {
+	github_languages,
+	guardian_github_actions_usage,
+} from '@prisma/client';
+import { awsClientConfig } from 'common/src/aws';
+import { shuffle } from 'common/src/functions';
+import type {
+	DependencyGraphIntegratorEvent,
+	Repository,
+} from 'common/src/types';
+import type { Config } from '../../config';
+import { removeRepoOwner } from '../shared-utilities';
+
+export function checkRepoForLanguage(
+	repo: Repository,
+	languages: github_languages[],
+	targetLanguage: string,
+): boolean {
+	const languagesInRepo: string[] =
+		languages.find((language) => language.full_name === repo.full_name)
+			?.languages ?? [];
+
+	return languagesInRepo.includes(targetLanguage);
+}
+
+function doesRepoHaveWorkflow(
+	repo: Repository,
+	workflow_usages: guardian_github_actions_usage[],
+): boolean {
+	const usagesForRepo = workflow_usages.find(
+		(usages) => repo.full_name === usages.full_name,
+	) as guardian_github_actions_usage;
+
+	const actionsForRepo: string[] = usagesForRepo.workflow_uses;
+
+	const dependencySubmissionWorkflow = actionsForRepo.find((action) =>
+		action.includes('scalacenter/sbt-dependency-submission'),
+	);
+
+	if (dependencySubmissionWorkflow) {
+		return true;
+	}
+	return false;
+}
+
+export function getSuitableRepoEvents(
+	languages: github_languages[],
+	productionRepos: Repository[],
+	workflow_usages: guardian_github_actions_usage[],
+): DependencyGraphIntegratorEvent[] {
+	const scalaRepos = productionRepos.filter((repo) =>
+		checkRepoForLanguage(repo, languages, 'Scala'),
+	);
+
+	const scalaReposWithoutWorkflows = scalaRepos.filter(
+		(repo) => !doesRepoHaveWorkflow(repo, workflow_usages),
+	);
+
+	const events = scalaReposWithoutWorkflows.map((repo) => ({
+		name: removeRepoOwner(repo.full_name),
+	}));
+
+	console.log(events);
+
+	return events;
+}
+
+export async function sendOneRepo(
+	config: Config,
+	repoLanguages: github_languages[],
+	productionRepos: Repository[],
+	workflowUsages: guardian_github_actions_usage[],
+) {
+	const eventToSend = shuffle(
+		getSuitableRepoEvents(repoLanguages, productionRepos, workflowUsages),
+	)[0];
+
+	if (eventToSend) {
+		const publishRequestEntry = new PublishCommand({
+			Message: JSON.stringify(eventToSend),
+			TopicArn: config.dependencyGraphIntegratorTopic,
+		});
+
+		console.log(`Sending ${eventToSend.name} to Dependency Graph Integrator`);
+		await new SNSClient(awsClientConfig(config.stage)).send(
+			publishRequestEntry,
+		);
+	} else {
+		console.log(
+			'No Scala repos found without SBT dependency submission workflow',
+		);
+	}
+}

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -40,7 +40,7 @@ export function doesRepoHaveWorkflow(
 	return false;
 }
 
-export function getSuitableRepoEvents(
+export function createSnsEventsForDependencyGraphIntegration(
 	languages: github_languages[],
 	productionRepos: Repository[],
 	workflow_usages: guardian_github_actions_usage[],
@@ -73,7 +73,11 @@ export async function sendOneRepoToDepGraphIntegrator(
 	workflowUsages: guardian_github_actions_usage[],
 ) {
 	const eventToSend = shuffle(
-		getSuitableRepoEvents(repoLanguages, productionRepos, workflowUsages),
+		createSnsEventsForDependencyGraphIntegration(
+			repoLanguages,
+			productionRepos,
+			workflowUsages,
+		),
 	)[0];
 
 	if (eventToSend) {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -87,6 +87,8 @@ setup_environment() {
 
   SNYK_INTEGRATOR_INPUT_TOPIC_ARN=$(aws sns list-topics --profile "$PROFILE" --region "$REGION" --output text --query 'Topics[*]' | grep snykintegratorinputtopicCODE)
 
+  DEPENDENCY_GRAPH_INPUT_TOPIC_ARN=$(aws sns list-topics --profile "$PROFILE" --region "$REGION" --output text --query 'Topics[*]' | grep dependencygraphintegratorinputtopicCODE)
+
   CLOUDQUERY_API_KEY=$(
     aws secretsmanager get-secret-value \
     --secret-id /CODE/deploy/service-catalogue/cloudquery-api-key \
@@ -113,6 +115,7 @@ INTERACTIVE_MONITOR_TOPIC_ARN=${INTERACTIVE_MONITOR_TOPIC_ARN}
 GITHUB_PRIVATE_KEY_PATH=${GITHUB_PRIVATE_KEY_PATH}
 CLOUDQUERY_API_KEY=${CLOUDQUERY_API_KEY}
 SNYK_INTEGRATOR_INPUT_TOPIC_ARN=${SNYK_INTEGRATOR_INPUT_TOPIC_ARN}
+DEPENDENCY_GRAPH_INPUT_TOPIC_ARN=${DEPENDENCY_GRAPH_INPUT_TOPIC_ARN}
 "
 
   # Check if .env.local file exists in ~/.gu/service_catalogue/


### PR DESCRIPTION
## What does this change?

Enables repocop to identify production Scala repos that don't have the SBT dependency submission workflow already, and pick one repo at random to call Dependency Graph Integrator which will raise a PR on the repo to include the workflow, and enable Dependabot alerts/Dependency Graph if not enabled.

## Why?

This is part of our migration away from Snyk over the next year. 

## How has it been verified?

Tested locally with CODE data. 

## Next steps
- Prioritise this for repos that don't have the Snyk workflow - this could be handled manually as it's only a handful.
- Enable the integrator for Gradle/Kotlin repos, and any other of our languages for which there is a dependency submission workflow available.
- Increase the number of PRs raised per run...?
- Update our recommendations
