### PR TITLE
Open janus before exiting setup script

### DIFF
--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -29,15 +29,22 @@ create_sql_migrations() {
   done
 }
 
+open_janus() {
+  echo "$1"
+  echo "Opening Janus"
+  sleep 3
+  open "https://janus.gutools.co.uk"
+}
+
 check_aws_credentials() {
   step "Checking AWS credentials"
 
   STATUS=$(aws sts get-caller-identity --profile deployTools 2>&1 || true)
   if [[ ${STATUS} =~ (ExpiredToken) ]]; then
-    echo "Credentials for the deployTools profile have expired. Please fetch new credentials, and run this script again."
+    open_janus "Credentials for the deployTools profile have expired. Please fetch new credentials, and run this script again."
     exit 1
   elif [[ ${STATUS} =~ ("could not be found") ]]; then
-    echo "Credentials for the deployTools profile are missing. Please fetch some, and run this script again."
+    open_janus "Credentials for the deployTools profile are missing. Please fetch some, and run this script again."
     exit 1
   else
     echo "AWS credentials are valid"


### PR DESCRIPTION
## What does this change?

Almost every time this script fails due to invalid AWS credentials, the user needs to manually navigate to Janus. Let's automate this step

## Why?

Shaving a few seconds off the startup time for users who don't already have credentials.

## How has it been verified?

Tested locally
