### PR TITLE
Vulnerability digest should show CVEs, to make two vulns from the same library look distinct

### DIFF
--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -5,6 +5,7 @@ import { type RepocopVulnerability, SLAs } from 'common/src/types';
 import type { Config } from '../../config';
 import type { EvaluationResult, Team, VulnerabilityDigest } from '../../types';
 import { vulnSortPredicate } from '../../utils';
+import { removeRepoOwner } from '../shared-utilities';
 
 function getOwningRepos(
 	team: Team,
@@ -44,7 +45,7 @@ function createHumanReadableVulnMessage(vuln: RepocopVulnerability): string {
 
 	const cveHyperlink = vuln.cves[0] ? vuln.cves[0] : 'no CVE provided';
 
-	return String.raw`[${vuln.full_name}](https://github.com/${vuln.full_name}) contains a high severity vulnerability, ${cveHyperlink}, from ${vulnHyperlink}, introduced via ${ecosystem}.
+	return String.raw`[${removeRepoOwner(vuln.full_name)}](https://github.com/${vuln.full_name}) contains a high severity vulnerability, ${cveHyperlink}, from ${vulnHyperlink}, introduced via ${ecosystem}.
 There are ${daysToFix} days left to fix this vulnerability. It ${vuln.is_patchable ? 'is ' : 'might not be '}patchable.`;
 }
 

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -38,7 +38,13 @@ function createHumanReadableVulnMessage(vuln: RepocopVulnerability): string {
 
 	const daysToFix = daysLeftToFix(vuln);
 
-	return String.raw`[${vuln.full_name}](https://github.com/${vuln.full_name}) uses [${vuln.package}](${vuln.urls[0]}), introduced via ${ecosystem}.
+	const vulnHyperlink: string = vuln.urls[0]
+		? `[${vuln.package}](${vuln.urls[0]})`
+		: vuln.package;
+
+	const cveHyperlink = vuln.cves[0] ? vuln.cves[0] : 'no CVE provided';
+
+	return String.raw`[${vuln.full_name}](https://github.com/${vuln.full_name}) contains a high severity vulnerability, ${cveHyperlink}, from ${vulnHyperlink}, introduced via ${ecosystem}.
 There are ${daysToFix} days left to fix this vulnerability. It ${vuln.is_patchable ? 'is ' : 'might not be '}patchable.`;
 }
 


### PR DESCRIPTION
## What does this change?

When a single library was causing multiple CVEs to show up against a repo, the vulnerability digests can end up looking identical, especially if dependabot is being enabled for the first time. Let's include the CVE in the vulnerability digest to make it clearer that these are unique issues, as they may have slightly different remediations (ie one requires bumping to `x.y.z+1`, and another requires patching to `x.y.z+4`).

Also, removed boilerplate from the tests by setting up a vuln object at the beginning that is reused in subsequent tests.

## How has it been verified?

Added unit tests to verify expected behaviour