### PR TITLE
fix: Copy data from CODE with column names

### DIFF
--- a/containers/db-copy/entrypoint.sh
+++ b/containers/db-copy/entrypoint.sh
@@ -38,5 +38,5 @@ for tbl in $tables_to_copy; do
   echo "Dumping table $tbl to /sql/$tbl.sql"
   # We use --data-only here as unfortunately pg_dump does not have a --create-if-not-exists to stop it from
   # erroring when it tries to dump a table that prisma has already created.
-  pg_dump "$REMOTE_URL" -t "$tbl" -f "/sql/$tbl.sql" --no-owner --no-privileges --inserts --data-only
+  pg_dump "$REMOTE_URL" -t "$tbl" -f "/sql/$tbl.sql" --no-owner --no-privileges --column-inserts --data-only
 done


### PR DESCRIPTION
## What does this change?
In #1153 we synced the schemas between DEV and CODE (and PROD). However the _order_ of the columns still differ. This means we can be inserting differing types, e.g. if column 2 in CODE is boolean, and column 2 in DEV is text. Indeed the DEV environment currently errors with:

```
psql:/docker-entrypoint-initdb.d/aws_cloudformation_stacks.sql:23: ERROR:  invalid input syntax for type boolean: ""
LINE 1: ...1009b1a-2e93-4644-9f76-00a43cbcdcc0', NULL, NULL, '', false,...`
```

Update the `pg_dump` command to create `INSERT` statements with named columns (`--column-inserts`), going from:

```sql
-- positional inserts
INSERT INTO table VALUES ('')
```

To:

```sql
-- named column inserts
INSERT INTO table (col1, col2) VALUES ('', '')
```

From https://www.postgresql.org/docs/current/app-pgdump.html

> --column-inserts
> Dump data as INSERT commands with explicit column names (INSERT INTO table (column, ...) VALUES ...). This will make restoration very slow; it is mainly useful for making dumps that can be loaded into non-PostgreSQL databases. Any error during restoring will cause only rows that are part of the problematic INSERT to be lost, rather than the entire table contents.

> [!NOTE]
> An alternative to this could be to sync the column orders between DEV and CODE, however history suggests this'll be difficult to enforce/maintain.

## How has it been verified?
Ran `npm -w dev-environment start` locally, and observed the DEV environment starting successfully.