### PR TITLE
feat(prisma): Create `aws_organizations_tree` view 

### DIFF
--- a/packages/common/prisma/migrations/20240709072758_additional_aws_organizations_tables/migration.sql
+++ b/packages/common/prisma/migrations/20240709072758_additional_aws_organizations_tables/migration.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS "aws_organizations_organizational_unit_parents" (
+    "_cq_sync_time" TIMESTAMP(6),
+    "_cq_source_name" TEXT,
+    "_cq_id" UUID NOT NULL,
+    "_cq_parent_id" UUID,
+    "request_account_id" TEXT NOT NULL,
+    "id" TEXT NOT NULL,
+    "parent_id" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+
+    CONSTRAINT "aws_organizations_organizational_unit_parents_cqpk" PRIMARY KEY ("_cq_id")
+);
+
+CREATE TABLE IF NOT EXISTS "aws_organizations_roots" (
+    "_cq_sync_time" TIMESTAMP(6),
+    "_cq_source_name" TEXT,
+    "_cq_id" UUID NOT NULL,
+    "_cq_parent_id" UUID,
+    "request_account_id" TEXT NOT NULL,
+    "tags" JSONB,
+    "arn" TEXT NOT NULL,
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "policy_types" JSONB,
+
+    CONSTRAINT "aws_organizations_roots_cqpk" PRIMARY KEY ("_cq_id")
+);

--- a/packages/common/prisma/migrations/20240709073818_aws_organizations_tree/migration.sql
+++ b/packages/common/prisma/migrations/20240709073818_aws_organizations_tree/migration.sql
@@ -1,0 +1,72 @@
+-- Uses recursive common table expressions to build an ancestry of accounts and organisational units.
+CREATE OR REPLACE FUNCTION fn_aws_organizations_tree() RETURNS TABLE (
+    id                              TEXT
+    , type                          TEXT
+    , name                          TEXT
+    , ancestors                     TEXT[]
+    , is_product_and_engineering    BOOLEAN
+) AS $$
+    WITH RECURSIVE
+        nodes AS (
+            -- Root node
+            SELECT  r.id
+                    , r.name
+                    , 'ROOT' AS type
+                    , NULL   AS parent_id
+            FROM    aws_organizations_roots r
+
+            UNION ALL
+
+            -- Branch nodes
+            SELECT  ou.id
+                    , ou.name
+                    , 'ORGANIZATIONAL_UNIT' AS type
+                    , ou_p.parent_id
+            FROM    aws_organizations_organizational_units ou
+                        JOIN aws_organizations_organizational_unit_parents ou_p ON ou.id = ou_p.id
+
+            UNION ALL
+
+            -- Leaf nodes
+            SELECT  acc.id
+                    , acc.name
+                    , 'ACCOUNT' AS type
+                    , p.parent_id
+            FROM    aws_organizations_accounts acc
+                        JOIN aws_organizations_account_parents p ON acc.id = p.id
+        )
+        , tree(id, type, name, ancestors) AS (
+            SELECT  nodes.id
+                    , nodes.type
+                    , nodes.name
+                    , ARRAY [nodes.name]
+            FROM    nodes
+            WHERE   nodes.parent_id IS NULL
+
+            UNION ALL
+
+            SELECT  nodes.id
+                    , nodes.type
+                    , nodes.name
+                    , ARRAY_APPEND(tree.ancestors, nodes.id)
+            FROM    tree
+                    , nodes
+            WHERE   nodes.parent_id = tree.id
+        )
+        , productAndEngineering AS (
+            SELECT  id
+                    , name
+            FROM    aws_organizations_organizational_units
+            WHERE   name = 'Product & Engineering' -- assumes this string will never change
+    )
+
+    SELECT  tree.*
+            , productAndEngineering.id = ANY (tree.ancestors) AS is_product_and_engineering
+    FROM    tree
+            , productAndEngineering;
+$$ LANGUAGE SQL;
+
+CREATE OR REPLACE VIEW aws_organizations_tree AS (
+    SELECT  *
+    FROM    fn_aws_organizations_tree()
+);

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -802,3 +802,14 @@ view view_github_actions {
 
   @@ignore
 }
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view aws_organizations_tree {
+  id                         String?
+  type                       String?
+  name                       String?
+  ancestors                  String[]
+  is_product_and_engineering Boolean?
+
+  @@ignore
+}

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -202,6 +202,34 @@ model aws_organizations_organizational_units {
   @@ignore
 }
 
+model aws_organizations_organizational_unit_parents {
+  cq_sync_time       DateTime? @map("_cq_sync_time") @db.Timestamp(6)
+  cq_source_name     String?   @map("_cq_source_name")
+  cq_id              String    @id(map: "aws_organizations_organizational_unit_parents_cqpk") @map("_cq_id") @db.Uuid
+  cq_parent_id       String?   @map("_cq_parent_id") @db.Uuid
+  request_account_id String
+  id                 String
+  parent_id          String
+  type               String
+
+  @@ignore
+}
+
+model aws_organizations_roots {
+  cq_sync_time       DateTime? @map("_cq_sync_time") @db.Timestamp(6)
+  cq_source_name     String?   @map("_cq_source_name")
+  cq_id              String    @id(map: "aws_organizations_roots_cqpk") @map("_cq_id") @db.Uuid
+  cq_parent_id       String?   @map("_cq_parent_id") @db.Uuid
+  request_account_id String
+  tags               Json?
+  arn                String
+  id                 String
+  name               String
+  policy_types       Json?
+
+  @@ignore
+}
+
 model github_repositories {
   cq_sync_time                   DateTime? @map("_cq_sync_time") @db.Timestamp(6)
   cq_source_name                 String?   @map("_cq_source_name")

--- a/packages/common/prisma/views/public/aws_organizations_tree.sql
+++ b/packages/common/prisma/views/public/aws_organizations_tree.sql
@@ -1,0 +1,14 @@
+SELECT
+  fn_aws_organizations_tree.id,
+  fn_aws_organizations_tree.type,
+  fn_aws_organizations_tree.name,
+  fn_aws_organizations_tree.ancestors,
+  fn_aws_organizations_tree.is_product_and_engineering
+FROM
+  fn_aws_organizations_tree() fn_aws_organizations_tree(
+    id,
+    TYPE,
+    name,
+    ancestors,
+    is_product_and_engineering
+  );

--- a/packages/dev-environment/config/cloudquery.yaml
+++ b/packages/dev-environment/config/cloudquery.yaml
@@ -9,6 +9,11 @@ spec:
     - aws_securityhub_findings
     - aws_s3_buckets
     - aws_ec2_images
+    - aws_organizations_accounts
+    - aws_organizations_account_parents
+    - aws_organizations_organizational_units
+    - aws_organizations_organizational_unit_parents
+    - aws_organizations_roots
   skip_dependent_tables: true
   spec:
     regions:

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -28,8 +28,6 @@ services:
         - github_repository_branches
         - github_workflows
         - github_languages
-        - aws_organizations_account_parents
-        - aws_organizations_organizational_units
         - aws_ec2_instances
         - aws_cloudformation_stacks
   postgres:


### PR DESCRIPTION
## What does this change?
AWS Organisations allows one to structure accounts into business units, with seemingly limitless levels.

We currently have something like this:

```
root
├── Editorial
│   └── multimedia
├── Product & Engineering
│   ├── Editorial Tools
│   │   ├── cmsFronts
│   │   └── composer
│   └── deployTools
└── glabs
```

The `aws_organizations_tree` view allows one to query accounts via a tree structure, allowing for ancestry queries. This differs from the `aws_organizations_account_parents` table, which only shows the immediate parent. The `aws_organizations_tree` view also includes each node in the tree: the root, the organisational units, and the accounts.

With `aws_organizations_tree` we can identify the `cmsFronts` account sits within `Product & Engineering`.

The format was inspired by https://leonardqmarcq.com/posts/modeling-hierarchical-tree-data. I opted against using the [`ltree` data type](https://www.postgresql.org/docs/current/ltree.html) as we're not dealing with large numbers of records (fewer than 100).

This change is split across two Prisma migrations (and [two commits](https://github.com/guardian/service-catalogue/pull/1174/commits)):
1. Add the necessary base tables to Prisma. This should be a no-op on CODE and PROD.
2. Create the view.

## Why?
A number of apps within Service Catalogue currently run against Product & Engineering (P&E) owned accounts, for example Obligatron. We're currently [evaluating AMI tag coverage for all accounts](https://github.com/guardian/service-catalogue/blob/9b05209f7f78cf27b8943121898d7b5d878648b2/packages/obligatron/src/obligations/tagging.ts#L49-L55), which is producing some noise. The next PR (https://github.com/guardian/service-catalogue/pull/1175) will utilise `aws_organizations_tree` to filter for P&E accounts.

## How has it been verified?
- Either run the project locally, run `SELECT * FROM aws_organizations_tree;`, and observe the results.
- OR [execute the query body on PROD](https://metrics.gutools.co.uk/goto/NXja3t_IR?orgId=1), and observe the results.