### PR TITLE
Add ancestry path to `aws_accounts` view

### DIFF
--- a/packages/common/prisma/migrations/20240709110616_update_aws_accounts_view/migration.sql
+++ b/packages/common/prisma/migrations/20240709110616_update_aws_accounts_view/migration.sql
@@ -1,0 +1,43 @@
+/*
+ Redefine the view `aws_accounts`.
+
+ Removed:
+   - organizational_unit
+
+ Added:
+   - ancestors
+   - is_product_and_engineering
+ */
+
+BEGIN TRANSACTION;
+
+DROP VIEW IF EXISTS aws_accounts;
+DROP FUNCTION IF EXISTS fn_aws_accounts;
+
+CREATE FUNCTION fn_aws_accounts() RETURNS TABLE (
+    id                              TEXT
+    , name                          TEXT
+    , email                         TEXT
+    , status                        TEXT
+    , joined_timestamp              TIMESTAMP
+    , ancestors                     TEXT[]
+    , is_product_and_engineering    BOOLEAN
+) AS $$
+    SELECT acc.id
+           , acc.name
+           , acc.email
+           , acc.status
+           , acc.joined_timestamp
+           , tree.ancestors
+           , tree.is_product_and_engineering
+    FROM    aws_organizations_tree tree
+                JOIN aws_organizations_accounts acc ON tree.id = acc.id
+    WHERE   tree.type = 'ACCOUNT';
+$$ LANGUAGE SQL;
+
+CREATE VIEW aws_accounts AS (
+    SELECT  *
+    FROM    fn_aws_accounts()
+);
+
+COMMIT TRANSACTION;

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -751,12 +751,13 @@ view view_repo_ownership {
 }
 
 view aws_accounts {
-  id                  String
-  name                String
-  email               String
-  status              String
-  joined_timestamp    DateTime @db.Timestamp(6)
-  organizational_unit String
+  id                         String
+  name                       String
+  email                      String
+  status                     String
+  joined_timestamp           DateTime @db.Timestamp(6)
+  ancestors                  String[]
+  is_product_and_engineering Boolean
 
   @@unique([id, name])
 }

--- a/packages/common/prisma/views/public/aws_accounts.sql
+++ b/packages/common/prisma/views/public/aws_accounts.sql
@@ -4,7 +4,8 @@ SELECT
   fn_aws_accounts.email,
   fn_aws_accounts.status,
   fn_aws_accounts.joined_timestamp,
-  fn_aws_accounts.organizational_unit
+  fn_aws_accounts.ancestors,
+  fn_aws_accounts.is_product_and_engineering
 FROM
   fn_aws_accounts() fn_aws_accounts(
     id,
@@ -12,5 +13,6 @@ FROM
     email,
     STATUS,
     joined_timestamp,
-    organizational_unit
+    ancestors,
+    is_product_and_engineering
   );


### PR DESCRIPTION
> [!NOTE]
> Builds on (and requires) #1174 and #1176.

## What does this change?
The `organizational_unit` column in the `aws_accounts` view shows the immediate parent. This change replaces this column with an `ancestors` column, detailing the full ancestry path.

A boolean `is_product_and_engineering` column is also added to make it easy to filter for P&E accounts:

```sql
SELECT * FROM aws_accounts WHERE is_product_and_engineering = TRUE;
```

> [!WARNING]
> This is a breaking change to the `aws_accounts` view.
> 
>  Columns removed:
>   - `organizational_unit` (`TEXT`)
>
> Columns added:
>   - `ancestors` (`TEXT[]`)
>   - `is_product_and_engineering` (`BOOLEAN`)

## Why?
A number of apps within Service Catalogue currently run against Product & Engineering (P&E) owned accounts, for example Obligatron. We're currently [evaluating AMI tag coverage for all accounts](https://github.com/guardian/service-catalogue/blob/9b05209f7f78cf27b8943121898d7b5d878648b2/packages/obligatron/src/obligations/tagging.ts#L49-L55), which is producing some noise.

## How has it been verified?
Run the project locally, run `SELECT * FROM aws_accounts;`, and observe the results.

I've [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/d6a40ce1-3065-4c3a-9274-2a7194ed7084), and [querying the view on CODE](https://metrics.code.dev-gutools.co.uk/goto/4q2Yc2lIg?orgId=1) shows the migration applied successfully.