### PR TITLE
fix: Grant all database users blanket read access

### DIFF
--- a/packages/common/prisma/migrations/20240709104714_user_permissions/migration.sql
+++ b/packages/common/prisma/migrations/20240709104714_user_permissions/migration.sql
@@ -1,0 +1,13 @@
+-- Grant read access to all current tables, and views
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO refresh_materialized_view;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO repocop;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO dataaudit;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO github_actions_usage;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO obligatron;
+
+-- Grant read access to all future tables, and views
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO refresh_materialized_view;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO repocop;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO dataaudit;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO github_actions_usage;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO obligatron;


### PR DESCRIPTION
## What does this change?
Extends #1154 to all database users.

## Why?
This'll make the changes in #1175 easier.

#1175 drops and recreates a view. To keep the current access status quo, we would need to re-grant permissions on each table the view queries, which is a bit longer than this option.

## How has it been verified?
Observe CI, the [checks](https://github.com/guardian/service-catalogue/blob/main/sql/ci.sql) should continue to pass.

I've [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/8950dbc0-e1ba-4dd0-8b40-3c2f7f2e1699), and the migration logs show the migration was successfully applied.