### PR TITLE
fix(obligatron): Only evaluate AMI tagging within P&E accounts

### DIFF
--- a/packages/common/prisma/migrations/20240709114326_remove_non_pande_ami_tagging_results/migration.sql
+++ b/packages/common/prisma/migrations/20240709114326_remove_non_pande_ami_tagging_results/migration.sql
@@ -1,0 +1,6 @@
+-- Remove Obligatron results for AMI tagging against non P&E accounts
+DELETE FROM obligatron_results
+WHERE       resource LIKE 'arn:aws:ec2:%:%:image/ami-%'
+            AND contacts ->> 'aws_account' IN (
+                SELECT id FROM aws_accounts WHERE is_product_and_engineering = FALSE
+            )


### PR DESCRIPTION
## What does this change?
The tagging obligation currently only applies to AWS accounts owned by P&E. Remove past findings for non-P&E accounts (about 190,000 rows in CODE), and produce future findings from P&E accounts only.

## Why?
This removes an amount of noise on the [Obligatron dashboard](https://metrics.gutools.co.uk/d/cdokcsudhxrswa/obligatron?orgId=1), particularly within the "Departmental Results" section.

## How has it been verified?
I've [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/1dd3da63-abc5-4fd0-ac0b-b597d048fab2), observed the `obligatron_results` table having no results for non-P&E accounts, and [around 60,000 for P&E accounts](https://metrics.code.dev-gutools.co.uk/goto/Bdst2h_Sg?orgId=1).

I've also successfully run Obligatron on CODE, and observed the `obligatron_results` table having results for P&E accounts only. The logs reflect this (there are [25 P&E AWS accounts](https://metrics.code.dev-gutools.co.uk/goto/crXvoh_SR?orgId=1)):

![image](https://github.com/guardian/service-catalogue/assets/836140/a2815599-692b-4618-96f0-08ba0a0e3673)
