### PR TITLE
Update the dependency graph integrator PR body 

### DIFF
--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -51,7 +51,7 @@ function createPRChecklist(branchName: string): string[] {
 		'and make sure that your dependencies look okay.';
 
 	const step3 =
-		`When you are happy the action works, remove the branch name \`${branchName}\`` +
+		`When you are happy the action works, remove the branch name \`${branchName}\` ` +
 		'trigger from the the yaml file (aka delete line 6), approve, and merge. ';
 
 	return [step1, step2, step3];

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -43,14 +43,18 @@ export function createYaml(prBranch: string): string {
 
 function createPRChecklist(branchName: string): string[] {
 	const step1 =
+		'Ensure that the [version of sbt in the project is v1.5 or above](https://github.com/scalacenter/sbt-dependency-submission?tab=readme-ov-file#support) in order for the dependency submission action to run.';
+
+	const step2 =
 		'A run of this action should have been triggered when the branch was ' +
 		'created. Sense check the output of "Log snapshot for user validation", ' +
 		'and make sure that your dependencies look okay.';
 
-	const step2 =
+	const step3 =
 		`When you are happy the action works, remove the branch name \`${branchName}\`` +
 		'trigger from the the yaml file (aka delete line 6), approve, and merge. ';
-	return [step1, step2];
+
+	return [step1, step2, step3];
 }
 
 export function generatePrBody(branchName: string, repoName: string): string {

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -97,7 +97,6 @@ export async function main() {
 	const productionWorkflowUsages: guardian_github_actions_usage[] =
 		await getProductionWorkflowUsages(prisma, productionRepos);
 
-
 	const evaluationResults: EvaluationResult[] = await evaluateRepositories(
 		unarchivedRepos,
 		branches,


### PR DESCRIPTION
## What does this change?

Adds a new step to the PR checklist for the dependency graph integrator to let users know that sbt needs to be v1.5+.

## Why?

We noticed that some repos have lower versions of sbt and the dependency submission action failed.

## How has it been verified?

Ran `dependency-graph-integrator` locally and the extra checklist item rendered correctly in the PR output.