### PR TITLE
ci: are tests being run?

### DIFF
--- a/packages/common/src/dummy.test.ts
+++ b/packages/common/src/dummy.test.ts
@@ -1,0 +1,5 @@
+describe('something', () => {
+	it('should fail', () => {
+		expect(1).toEqual(2);
+	});
+});


### PR DESCRIPTION
## What does this change?
I think the changes in https://github.com/guardian/service-catalogue/pull/1156 have broken CI such that the unit tests are not actually being run.

This PR should fail the build as 1 does not equal 2.