### PR TITLE
fix FSBP filtering in cloudbuster

### DIFF
--- a/packages/cloudbuster/src/config.ts
+++ b/packages/cloudbuster/src/config.ts
@@ -27,7 +27,7 @@ export async function getConfig(): Promise<Config> {
 		: await getDatabaseConfig(stage, 'repocop'); //TODO create a new db user for cloudbuster before deploying.
 
 	const severities: SecurityHubSeverity[] = isDev
-		? ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFORMATION']
+		? ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFORMATION'] // Using all severities in DEV for more data.
 		: ['CRITICAL', 'HIGH'];
 
 	return {

--- a/packages/cloudbuster/src/findings.ts
+++ b/packages/cloudbuster/src/findings.ts
@@ -13,6 +13,11 @@ export async function getFsbpFindings(
 			OR: severities.map((s) => ({
 				severity: { path: ['Label'], equals: s },
 			})),
+			AND: {
+				generator_id: {
+					startsWith: 'aws-foundational-security-best-practices/v/1.0.0',
+				},
+			},
 		},
 	});
 


### PR DESCRIPTION
## What does this change?

Previously, we were evaluating the results of all Security Hub standards. Now, we are filtering specifically for FSBP control failures


## Why?

So teams aren't getting infrastructure digests about tags, etc

## How has it been verified?

Run locally, verified digests were smaller, and only contained relevant information
