### PR TITLE
Create obligatron mode for AWS infrastructure vulnerabilities

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -20544,6 +20544,45 @@ spec:
       },
       "Type": "AWS::Lambda::Function",
     },
+    "obligatronAWSVULNERABILITIES8E81FCF9": {
+      "Properties": {
+        "Description": "Daily execution of Obligatron lambda for 'AWS_VULNERABILITIES' obligation",
+        "ScheduleExpression": "cron(0 11 * * ? *)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "obligatronA58CFCF1",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+            "Input": ""AWS_VULNERABILITIES"",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "obligatronAWSVULNERABILITIESAllowEventRuleServiceCatalogueobligatron5BD5033E8F5FADB8": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "obligatronA58CFCF1",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "obligatronAWSVULNERABILITIES8E81FCF9",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
     "obligatronErrorPercentageAlarmForLambda8AFDF23F": {
       "Properties": {
         "ActionsEnabled": true,

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -192,7 +192,7 @@ export function daysLeftToFix(vuln: RepocopVulnerability): number | undefined {
 
 export function toNonEmptyArray<T>(value: T[]): NonEmptyArray<T> {
 	if (value.length === 0) {
-		throw new Error(`Expected a non-empty array. Source table may be empty.`);
+		throw new Error(`Expected a non-empty array.`);
 	}
 	return value as NonEmptyArray<T>;
 }

--- a/packages/obligatron/src/index.ts
+++ b/packages/obligatron/src/index.ts
@@ -9,6 +9,7 @@ import {
 	Obligations,
 	stringIsObligation,
 } from './obligations';
+import { evaluateFsbpVulnerabilities } from './obligations/aws-vulnerabilities';
 import { evaluateDependencyVulnerabilityObligation } from './obligations/dependency-vulnerabilities';
 import {
 	evaluateAmiTaggingCoverage,
@@ -30,6 +31,9 @@ async function getResults(
 		}
 		case 'PRODUCTION_DEPENDENCIES': {
 			return await evaluateDependencyVulnerabilityObligation(db);
+		}
+		case 'AWS_VULNERABILITIES': {
+			return await evaluateFsbpVulnerabilities(db);
 		}
 	}
 }

--- a/packages/obligatron/src/obligations/aws-vulnerabilities.test.ts
+++ b/packages/obligatron/src/obligations/aws-vulnerabilities.test.ts
@@ -31,7 +31,6 @@ describe('The dependency vulnerabilities obligation', () => {
 
 	it('should return a result in the expected format', () => {
 		const actual = fsbpFindingsToObligatronResults([oneResourceFinding]);
-		console.log(actual);
 
 		const expected = {
 			contacts: {
@@ -50,8 +49,6 @@ describe('The dependency vulnerabilities obligation', () => {
 
 	it('should return multiple results if two resources are referenced in the same finding', () => {
 		const actual = fsbpFindingsToObligatronResults([twoResourceFinding]);
-		console.log(actual);
-
 		expect(actual.length).toEqual(2);
 	});
 
@@ -65,7 +62,6 @@ describe('The dependency vulnerabilities obligation', () => {
 			oneResourceFinding,
 			extraFinding,
 		])[0]?.reason;
-		console.log(actual);
 
 		expect(actual).toContain('S.1');
 		expect(actual).toContain('S.2');

--- a/packages/obligatron/src/obligations/aws-vulnerabilities.test.ts
+++ b/packages/obligatron/src/obligations/aws-vulnerabilities.test.ts
@@ -1,3 +1,4 @@
+import type { AwsContact } from '../obligations/index';
 import {
 	fsbpFindingsToObligatronResults,
 	type SecurityHubFinding,
@@ -65,5 +66,16 @@ describe('The dependency vulnerabilities obligation', () => {
 
 		expect(actual).toContain('S.1');
 		expect(actual).toContain('S.2');
+	});
+	it('should handle a resource with no tags', () => {
+		const finding = {
+			...oneResourceFinding,
+			resources: [{ ...resource1, Tags: {} }],
+		};
+
+		const actual = fsbpFindingsToObligatronResults([finding]);
+		const contacts = actual[0]?.contacts as AwsContact;
+
+		expect(contacts.Stack).toBeUndefined();
 	});
 });

--- a/packages/obligatron/src/obligations/aws-vulnerabilities.test.ts
+++ b/packages/obligatron/src/obligations/aws-vulnerabilities.test.ts
@@ -1,0 +1,73 @@
+import {
+	fsbpFindingsToObligatronResults,
+	type SecurityHubFinding,
+} from './aws-vulnerabilities';
+
+describe('The dependency vulnerabilities obligation', () => {
+	const resource1 = {
+		Id: 'arn:service:1',
+		Tags: { Stack: 'myStack' },
+		Region: 'some-region',
+		Type: 'some-type',
+	};
+
+	const resource2 = {
+		...resource1,
+		Id: 'arn:service:2',
+	};
+
+	const oneResourceFinding: SecurityHubFinding = {
+		resources: [resource1],
+		severity: { Label: 'HIGH', Normalized: 75 },
+		aws_account_id: '0123456',
+		first_observed_at: new Date('2020-01-01'),
+		product_fields: { ControlId: 'S.1', StandardsArn: 'arn:1' },
+	};
+
+	const twoResourceFinding: SecurityHubFinding = {
+		...oneResourceFinding,
+		resources: [resource1, resource2],
+	};
+
+	it('should return a result in the expected format', () => {
+		const actual = fsbpFindingsToObligatronResults([oneResourceFinding]);
+		console.log(actual);
+
+		const expected = {
+			contacts: {
+				App: undefined,
+				Stack: 'myStack',
+				Stage: undefined,
+				aws_account_id: '0123456',
+			},
+			reason: 'The following AWS FSBP controls are failing: S.1',
+			resource: 'arn:service:1',
+			url: 'https://docs.aws.amazon.com/securityhub/latest/userguide/fsbp-standard.html',
+		};
+
+		expect(actual).toEqual([expected]);
+	});
+
+	it('should return multiple results if two resources are referenced in the same finding', () => {
+		const actual = fsbpFindingsToObligatronResults([twoResourceFinding]);
+		console.log(actual);
+
+		expect(actual.length).toEqual(2);
+	});
+
+	it('should list multiple control IDs in one finding if the same resource has failed two controls', () => {
+		const extraFinding = {
+			...oneResourceFinding,
+			product_fields: { ControlId: 'S.2', StandardsArn: 'arn:1' },
+		};
+
+		const actual = fsbpFindingsToObligatronResults([
+			oneResourceFinding,
+			extraFinding,
+		])[0]?.reason;
+		console.log(actual);
+
+		expect(actual).toContain('S.1');
+		expect(actual).toContain('S.2');
+	});
+});

--- a/packages/obligatron/src/obligations/aws-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/aws-vulnerabilities.ts
@@ -102,6 +102,8 @@ export async function evaluateFsbpVulnerabilities(
 		(v) => v as unknown as SecurityHubFinding,
 	);
 
+	console.log(`Found ${findings.length} FSBP findings`);
+
 	const results = fsbpFindingsToObligatronResults(findings);
 	console.log(results.slice(0, 5));
 

--- a/packages/obligatron/src/obligations/aws-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/aws-vulnerabilities.ts
@@ -101,8 +101,8 @@ export async function evaluateFsbpVulnerabilities(
 		(v) => v as unknown as SecurityHubFinding,
 	);
 
-	const results = fsbpFindingsToObligatronResults(findings).slice(0, 5);
-	console.log(results);
+	const results = fsbpFindingsToObligatronResults(findings);
+	console.log(results.slice(0, 5));
 
-	return []; //failuresToObligationResults(failuresByResource).slice(0, 5);
+	return [];
 }

--- a/packages/obligatron/src/obligations/aws-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/aws-vulnerabilities.ts
@@ -85,6 +85,7 @@ function failuresToObligationResults(
 	);
 }
 
+//TODO filter out findings that are within the SLA window
 export function fsbpFindingsToObligatronResults(
 	findings: SecurityHubFinding[],
 ): ObligationResult[] {

--- a/packages/obligatron/src/obligations/aws-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/aws-vulnerabilities.ts
@@ -28,7 +28,7 @@ type Failure = {
 	resource: string;
 	controlId: string;
 	accountId: string;
-	tags: Record<string, string>;
+	tags: Record<string, string> | null;
 };
 
 function findingToFailures(finding: SecurityHubFinding): Failure[] {
@@ -71,9 +71,9 @@ function failuresToObligationResult(
 		url: 'https://docs.aws.amazon.com/securityhub/latest/userguide/fsbp-standard.html',
 		contacts: {
 			aws_account_id: accountId,
-			Stack: tags.Stack,
-			Stage: tags.Stage,
-			App: tags.App,
+			Stack: tags === null ? undefined : tags.Stack,
+			Stage: tags === null ? undefined : tags.Stage,
+			App: tags === null ? undefined : tags.App,
 		},
 	};
 }

--- a/packages/obligatron/src/obligations/aws-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/aws-vulnerabilities.ts
@@ -48,8 +48,8 @@ function groupFailuresByResource(
 		if (!grouped[failure.resource]) {
 			grouped[failure.resource] = [];
 		}
-		// @ts-expect-error - TS doesn't understand that we've just checked for the key
-		grouped[failure.resource].push(failure);
+
+		grouped[failure.resource]?.push(failure);
 	}
 
 	return grouped;

--- a/packages/obligatron/src/obligations/aws-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/aws-vulnerabilities.ts
@@ -1,0 +1,85 @@
+import type { aws_securityhub_findings, PrismaClient } from '@prisma/client';
+import { logger } from 'common/logs';
+import { getFsbpFindings } from 'common/src/database-queries';
+import type { ObligationResult } from '.';
+
+type Resource = {
+	Id: string;
+	Tags: Record<string, string>;
+	Region: string;
+	Type: string;
+};
+
+type ProductFields = {
+	ControlId: string;
+	StandardsArn: string;
+};
+
+type SecurityHubFinding = Pick<
+	aws_securityhub_findings,
+	'first_observed_at'
+> & {
+	severity: { Label: string; Normalized: number };
+	resources: Resource[];
+	product_fields: ProductFields;
+};
+
+type Failure = {
+	resource: string;
+	controlId: string;
+};
+
+function findingToFailures(finding: SecurityHubFinding): Failure[] {
+	return finding.resources.map((resource) => ({
+		resource: resource.Id,
+		controlId: finding.product_fields.ControlId,
+	}));
+}
+
+function groupFailuresByResource(
+	failures: Failure[],
+): Record<string, string[]> {
+	const grouped: Record<string, string[]> = {};
+
+	for (const failure of failures) {
+		if (!grouped[failure.resource]) {
+			grouped[failure.resource] = [];
+		}
+		// @ts-expect-error - TS doesn't understand that we've just checked for the key
+		grouped[failure.resource].push(failure.controlId);
+	}
+
+	return grouped;
+}
+
+function failuresToObligationResults(
+	failuresByResource: Record<string, string[]>,
+): ObligationResult[] {
+	return Object.entries(failuresByResource).map(([resource, controlIds]) => ({
+		resource,
+		reason: `The following AWS FSBP controls are failing: ${controlIds.join(', ')}`,
+		url: 'https://docs.aws.amazon.com/securityhub/latest/userguide/fsbp-standard.html',
+		//TODO get AWS account ID
+	}));
+}
+
+export function fsbpFindingsToObligatronResults(
+	findings: SecurityHubFinding[],
+): ObligationResult[] {
+	const allFailures = findings.flatMap(findingToFailures);
+	const failuresByResource = groupFailuresByResource(allFailures);
+	return failuresToObligationResults(failuresByResource);
+}
+
+export async function evaluateFsbpVulnerabilities(
+	client: PrismaClient,
+): Promise<ObligationResult[]> {
+	const findings = (await getFsbpFindings(client, ['CRITICAL', 'HIGH'])).map(
+		(v) => v as unknown as SecurityHubFinding,
+	);
+
+	const results = fsbpFindingsToObligatronResults(findings).slice(0, 5);
+	console.log(results);
+
+	return []; //failuresToObligationResults(failuresByResource).slice(0, 5);
+}

--- a/packages/obligatron/src/obligations/aws-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/aws-vulnerabilities.ts
@@ -1,5 +1,6 @@
 import type { aws_securityhub_findings, PrismaClient } from '@prisma/client';
 import { getFsbpFindings } from 'common/src/database-queries';
+import { toNonEmptyArray } from 'common/src/functions';
 import type { ObligationResult } from '.';
 
 type Resource = {
@@ -59,20 +60,20 @@ function failuresToObligationResult(
 	arn: string,
 	failures: Failure[],
 ): ObligationResult {
-	const oneFailure = failures[0]; //this should always exist because groupFailuresByResource should always return at least one failure
+	const oneFailure = toNonEmptyArray(failures)[0];
 
 	const controlIds: string[] = failures.map((f) => f.controlId);
-	const accountId: string | undefined = oneFailure?.accountId;
-	const tags = oneFailure?.tags;
+	const accountId: string | undefined = oneFailure.accountId;
+	const tags = oneFailure.tags;
 	return {
 		resource: arn,
 		reason: `The following AWS FSBP controls are failing: ${controlIds.join(', ')}`,
 		url: 'https://docs.aws.amazon.com/securityhub/latest/userguide/fsbp-standard.html',
 		contacts: {
 			aws_account_id: accountId,
-			Stack: tags?.Stack,
-			Stage: tags?.Stage,
-			App: tags?.App,
+			Stack: tags.Stack,
+			Stage: tags.Stage,
+			App: tags.App,
 		},
 	};
 }

--- a/packages/obligatron/src/obligations/index.ts
+++ b/packages/obligatron/src/obligations/index.ts
@@ -1,6 +1,10 @@
 // Slightly hacky file to allow CDK project to import the list of obligations without having to compile the whole Obligatron project
 
-export const Obligations = ['TAGGING', 'PRODUCTION_DEPENDENCIES'] as const;
+export const Obligations = [
+	'TAGGING',
+	'PRODUCTION_DEPENDENCIES',
+	'AWS_VULNERABILITIES',
+] as const;
 export type Obligation = (typeof Obligations)[number];
 
 export const stringIsObligation = (input: string): input is Obligation => {

--- a/packages/obligatron/src/obligations/index.ts
+++ b/packages/obligatron/src/obligations/index.ts
@@ -11,7 +11,7 @@ export const stringIsObligation = (input: string): input is Obligation => {
 	return Obligations.filter((v) => v === input).length > 0;
 };
 
-type AwsContact = {
+export type AwsContact = {
 	aws_account_id?: string;
 	Stack?: string;
 	Stage?: string;


### PR DESCRIPTION
## What does this change

Creates a new obligatron mode that collects information about AWS infrastructure vulnerabilities. Currently, it only logs the output and does not write to the table. This is because we are currently not filtering out results that are within SLA. This will need to be done as a separate PR as further work is needed to unify:

1. the various `Severity` types
2. the calculations we perform on those types to calculate whether a resource is inside or outside SLA

So, that work will be done as a follow up PR. At that point, we will start writing to the DB

## Why?

So we can track departmental progress against our obligation to keep our AWS infrastructure compliant with AWS FSBP

## How has it been verified?

Verified locally. Added unit tests to confirm expected behaviour
