### PR TITLE
ci: Silence console messages to make build log easier to read

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,8 @@ const transform = {
 	'^.+\\.tsx?$': ['@swc/jest', { jsc: { target: 'esnext' } }],
 };
 
+const setupFilesAfterEnv = [`<rootDir>/jest.setup.js`];
+
 /*
 When running in CI (GitHub Actions), use the GitHub Actions reporter to annotate the PR with any test failures.
 Locally, use the default reporter.
@@ -37,16 +39,19 @@ module.exports = {
 		{
 			displayName: 'cloudbuster',
 			transform,
+			setupFilesAfterEnv,
 			testMatch: ['<rootDir>/packages/cloudbuster/**/*.test.ts'],
 		},
 		{
 			displayName: 'common',
 			transform,
+			setupFilesAfterEnv,
 			testMatch: ['<rootDir>/packages/common/**/*.test.ts'],
 		},
 		{
 			displayName: 'dependency-graph-integrator',
 			transform,
+			setupFilesAfterEnv,
 			testMatch: [
 				'<rootDir>/packages/dependency-graph-integrator/**/*.test.ts',
 			],
@@ -54,6 +59,7 @@ module.exports = {
 		{
 			displayName: 'repocop',
 			transform,
+			setupFilesAfterEnv,
 			transformIgnorePatterns: [
 				'node_modules/(?!@guardian/private-infrastructure-config)',
 			],
@@ -62,16 +68,19 @@ module.exports = {
 		{
 			displayName: 'interactive-monitor',
 			transform,
+			setupFilesAfterEnv,
 			testMatch: ['<rootDir>/packages/interactive-monitor/**/*.test.ts'],
 		},
 		{
 			displayName: 'snyk-integrator',
 			transform,
+			setupFilesAfterEnv,
 			testMatch: ['<rootDir>/packages/snyk-integrator/**/*.test.ts'],
 		},
 		{
 			displayName: 'obligatron',
 			transform,
+			setupFilesAfterEnv,
 			testMatch: ['<rootDir>/packages/obligatron/**/*.test.ts'],
 		},
 	],

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,11 @@
+// Silence the console during the CI build to make the build log easier to read
+if (process.env.CI === 'true') {
+	global.console = {
+		...console,
+		log: jest.fn(),
+		debug: jest.fn(),
+		info: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+	};
+}


### PR DESCRIPTION
## What does this change?
Silence the console during the CI build to make the build log easier to read, and see build errors.

## How has it been verified?
Observe CI log on this branch, and compare it to the build log of main. Has it improved?