### PR TITLE
Filter out FSBP results within SLA time and write to obligatron DB

### DIFF
--- a/packages/cloudbuster/src/findings.test.ts
+++ b/packages/cloudbuster/src/findings.test.ts
@@ -1,10 +1,5 @@
-import { groupFindingsByAccount, isWithinSlaTime } from './findings';
+import { groupFindingsByAccount } from './findings';
 import type { Finding, GroupedFindings } from './types';
-
-const MOCK_TODAY = new Date('2024-01-10');
-const MOCK_ONE_DAY_AGO = new Date('2024-01-09');
-const MOCK_NEARLY_TWO_DAYS_AGO = new Date('2024-01-08').setMinutes(1);
-const MOCK_ONE_WEEK_AGO = new Date('2024-01-03');
 
 function mockFinding(awsAccountId: string, title: string): Finding {
 	return {
@@ -18,73 +13,6 @@ function mockFinding(awsAccountId: string, title: string): Finding {
 		isWithinSla: true,
 	};
 }
-
-describe('FBSP SLA window', () => {
-	beforeEach(() => {
-		jest.useFakeTimers().setSystemTime(MOCK_TODAY);
-	});
-
-	afterEach(() => {
-		jest.useRealTimers();
-	});
-
-	it('Returns true if a critical finding was first observed within a day', () => {
-		const firstObservedAt = new Date(MOCK_ONE_DAY_AGO);
-		const severity = 'critical';
-
-		const isWithinSla = isWithinSlaTime(firstObservedAt, severity);
-		expect(isWithinSla).toBe(true);
-	});
-
-	it('Returns true if a high finding was first observed within a day', () => {
-		const firstObservedAt = new Date(MOCK_ONE_DAY_AGO);
-		const severity = 'high';
-
-		const isWithinSla = isWithinSlaTime(firstObservedAt, severity);
-		expect(isWithinSla).toBe(true);
-	});
-
-	it('Returns true if a critical finding was first observed within two days', () => {
-		const firstObservedAt = new Date(MOCK_NEARLY_TWO_DAYS_AGO);
-		const severity = 'critical';
-
-		const isWithinSla = isWithinSlaTime(firstObservedAt, severity);
-		expect(isWithinSla).toBe(true);
-	});
-
-	it('Returns false if a critical finding is outside the window', () => {
-		const firstObservedAt = new Date(MOCK_ONE_WEEK_AGO);
-		const severity = 'critical';
-
-		const isWithinSla = isWithinSlaTime(firstObservedAt, severity);
-		expect(isWithinSla).toBe(false);
-	});
-
-	it('Returns false if a low finding was first observed one day ago', () => {
-		const firstObservedAt = new Date(MOCK_ONE_DAY_AGO);
-		const severity = 'low';
-
-		const isWithinSla = isWithinSlaTime(firstObservedAt, severity);
-		expect(isWithinSla).toBe(false);
-	});
-
-	it('Returns false if a low finding was observed within one day', () => {
-		const firstObservedAt = new Date(MOCK_ONE_DAY_AGO);
-		const severity = 'low';
-
-		const isWithinSla = isWithinSlaTime(firstObservedAt, severity);
-		expect(isWithinSla).toBe(false);
-	});
-
-	it('Returns false if a critical finding has no information about when it was first observed', () => {
-		// This can happen as it's a nullable column in the DB
-		const firstObservedAt = null;
-		const severity = 'critical';
-
-		const isWithinSla = isWithinSlaTime(firstObservedAt, severity);
-		expect(isWithinSla).toBe(false);
-	});
-});
 
 describe('Grouping logic', () => {
 	const TEAM_A_ACCOUNT_ID = '000000000';

--- a/packages/cloudbuster/src/findings.ts
+++ b/packages/cloudbuster/src/findings.ts
@@ -1,5 +1,5 @@
 import type { aws_securityhub_findings } from '@prisma/client';
-import { daysLeftToFix, stringToSeverity } from 'common/src/functions';
+import { isWithinSlaTime, stringToSeverity } from 'common/src/functions';
 import type { Severity } from 'common/src/types';
 import type { Finding, GroupedFindings } from './types';
 
@@ -59,26 +59,6 @@ export function transformFinding(finding: aws_securityhub_findings): Finding {
 		remediationUrl,
 		isWithinSla: isWithinSlaTime(finding.first_observed_at, severity),
 	};
-}
-
-/**
- * Determines whether a Security Hub finding is within the SLA window
- */
-export function isWithinSlaTime(
-	firstObservedAt: Date | null,
-	severity: Severity,
-): boolean {
-	if (!firstObservedAt) {
-		console.warn('No first observed date provided');
-		return false;
-	}
-
-	const daysToFix = daysLeftToFix(firstObservedAt, severity);
-	if (daysToFix === undefined) {
-		return false;
-	}
-
-	return daysToFix > 0;
 }
 
 /**

--- a/packages/common/src/functions.test.ts
+++ b/packages/common/src/functions.test.ts
@@ -5,6 +5,7 @@ import {
 	daysLeftToFix,
 	getEnvOrThrow,
 	getGithubAppSecret,
+	isWithinSlaTime,
 	parseEvent,
 	parseSecretJson,
 	partition,
@@ -227,6 +228,78 @@ describe('daysLeftToFix', () => {
 	});
 	test('should return 2 if a critical vuln was raised today', () => {
 		expect(daysLeftToFix(new Date(), 'critical')).toBe(2);
+	});
+});
+
+const MOCK_TODAY = new Date('2024-01-10');
+const MOCK_ONE_DAY_AGO = new Date('2024-01-09');
+const MOCK_NEARLY_TWO_DAYS_AGO = new Date('2024-01-08').setMinutes(1);
+const MOCK_ONE_WEEK_AGO = new Date('2024-01-03');
+
+describe('FBSP SLA window', () => {
+	beforeEach(() => {
+		jest.useFakeTimers().setSystemTime(MOCK_TODAY);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	it('Returns true if a critical finding was first observed within a day', () => {
+		const firstObservedAt = new Date(MOCK_ONE_DAY_AGO);
+		const severity = 'critical';
+
+		const isWithinSla = isWithinSlaTime(firstObservedAt, severity);
+		expect(isWithinSla).toBe(true);
+	});
+
+	it('Returns true if a high finding was first observed within a day', () => {
+		const firstObservedAt = new Date(MOCK_ONE_DAY_AGO);
+		const severity = 'high';
+
+		const isWithinSla = isWithinSlaTime(firstObservedAt, severity);
+		expect(isWithinSla).toBe(true);
+	});
+
+	it('Returns true if a critical finding was first observed within two days', () => {
+		const firstObservedAt = new Date(MOCK_NEARLY_TWO_DAYS_AGO);
+		const severity = 'critical';
+
+		const isWithinSla = isWithinSlaTime(firstObservedAt, severity);
+		expect(isWithinSla).toBe(true);
+	});
+
+	it('Returns false if a critical finding is outside the window', () => {
+		const firstObservedAt = new Date(MOCK_ONE_WEEK_AGO);
+		const severity = 'critical';
+
+		const isWithinSla = isWithinSlaTime(firstObservedAt, severity);
+		expect(isWithinSla).toBe(false);
+	});
+
+	it('Returns false if a low finding was first observed one day ago', () => {
+		const firstObservedAt = new Date(MOCK_ONE_DAY_AGO);
+		const severity = 'low';
+
+		const isWithinSla = isWithinSlaTime(firstObservedAt, severity);
+		expect(isWithinSla).toBe(false);
+	});
+
+	it('Returns false if a low finding was observed within one day', () => {
+		const firstObservedAt = new Date(MOCK_ONE_DAY_AGO);
+		const severity = 'low';
+
+		const isWithinSla = isWithinSlaTime(firstObservedAt, severity);
+		expect(isWithinSla).toBe(false);
+	});
+
+	it('Returns false if a critical finding has no information about when it was first observed', () => {
+		// This can happen as it's a nullable column in the DB
+		const firstObservedAt = null;
+		const severity = 'critical';
+
+		const isWithinSla = isWithinSlaTime(firstObservedAt, severity);
+		expect(isWithinSla).toBe(false);
 	});
 });
 

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -195,6 +195,26 @@ export function daysLeftToFix(
 	return daysLeftToFix < 0 ? 0 : daysLeftToFix;
 }
 
+/**
+ * Determines whether a vulnerability is within the SLA window
+ */
+export function isWithinSlaTime(
+	firstObservedAt: Date | null,
+	severity: Severity,
+): boolean {
+	if (!firstObservedAt) {
+		console.warn('No first observed date provided');
+		return false;
+	}
+
+	const daysToFix = daysLeftToFix(firstObservedAt, severity);
+	if (daysToFix === undefined) {
+		return false;
+	}
+
+	return daysToFix > 0;
+}
+
 export function toNonEmptyArray<T>(value: T[]): NonEmptyArray<T> {
 	if (value.length === 0) {
 		throw new Error(`Expected a non-empty array.`);

--- a/packages/obligatron/src/obligations/aws-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/aws-vulnerabilities.ts
@@ -118,7 +118,6 @@ export async function evaluateFsbpVulnerabilities(
 	console.log(`Found ${outOfSlaFindings.length} findings out of SLA`);
 
 	const results = fsbpFindingsToObligatronResults(outOfSlaFindings);
-	console.log(results.slice(0, 5));
 
-	return [];
+	return results;
 }


### PR DESCRIPTION
## What does this change?

- Moves `isWithinSlaTime` and associated tests to common
- Filter FSBP obligatron results so that anything within SLA is excluded

## Why?

So we can start collecting accurate data about which resources have out of SLA FSBP vulnerabilities.

## How has it been verified?

Tests have been moved, CI passes, local execution produces the expected results
