### PR TITLE
Reduce dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     ignore:
       # The version of AWS CDK libraries must match those from @guardian/cdk.
       # We'd never be able to update them here independently, so just ignore them.
@@ -41,4 +41,4 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'


### PR DESCRIPTION
## What does this change?

Knocks down dependency updates from weekly to monthly

## Why?

In the DevX channel, the proportion of PRs that are dependency updates is almost always 75%. In the Security channel, it's more like 90%. This makes actual feature work difficult to spot, creating alert fatigue, and results in most developers ignoring the PR bot until someone highlights the PR that is actually a priority, defeating the point of the PRnouncer.

Additionally monthly vs weekly updates don't meaningfully make a difference to the security of the repo, as dependabot is configured to raise PRs for high and critical level vulnerabilities as soon as a patch is available, completely separate from the dependency bump cycle.

Eventually it would be nice to build a system that was able to verify and merge these in automatically, but until that point, I think this will make our lives easier without impacting security/maintainability significantly