### PR TITLE
feat: Add Kotlin to Dependency Graph Integrator

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -29,15 +29,6 @@ export type GitHubAppConfig = {
 };
 
 export type DepGraphLanguage = 'Scala' | 'Kotlin';
-export type DepGraphStepForLanguage = string;
-export type DepGraphWorkflow = string;
-
-export type DepGraphPrSteps = Record<
-	DepGraphLanguage,
-	DepGraphStepForLanguage[]
->;
-
-export type DepGraphWorkflows = Record<DepGraphLanguage, DepGraphWorkflow>;
 
 export interface DependencyGraphIntegratorEvent {
 	name: string;

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -28,8 +28,20 @@ export type GitHubAppConfig = {
 	installationId: string;
 };
 
+export type DepGraphLanguage = 'Scala' | 'Kotlin';
+export type DepGraphStepForLanguage = string;
+export type DepGraphWorkflow = string;
+
+export type DepGraphPrSteps = Record<
+	DepGraphLanguage,
+	DepGraphStepForLanguage[]
+>;
+
+export type DepGraphWorkflows = Record<DepGraphLanguage, DepGraphWorkflow>;
+
 export interface DependencyGraphIntegratorEvent {
 	name: string;
+	language: DepGraphLanguage;
 }
 
 export interface SnykIntegratorEvent {

--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -2,7 +2,7 @@ import { createYaml } from './file-generator';
 
 describe('createYaml for Scala', () => {
 	it('should generate the following yaml file', () => {
-		const yaml = createYaml('branch', 'Scala');
+		const yaml = createYaml('branch', 'Scala', 'repo1');
 		const result =
 			String.raw`name: Update Dependency Graph for Scala
 on:
@@ -33,9 +33,9 @@ jobs:
 	});
 });
 
-describe('createYaml for Scala', () => {
+describe('createYaml for Kotlin', () => {
 	it('should generate the following yaml file', () => {
-		const yaml = createYaml('branch', 'Kotlin');
+		const yaml = createYaml('branch', 'Kotlin', 'repo2');
 		const result =
 			String.raw`name: Update Dependency Graph for Kotlin
 on:
@@ -51,13 +51,19 @@ jobs:
       - name: Checkout branch
         id: checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Set up Java
+        id: setup
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        with:
+          distribution: temurin
+          java-version: 17
       - name: Submit dependencies
         id: submit
         uses: gradle/actions/dependency-submission@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
       - name: Log snapshot for user validation
         id: validate
-        run: cat` +
-			' ${{ steps.submit.outputs.snapshot-json-path }} | jq' + // Need to split this line to avoid syntax errors due to the template string
+        run: cat ` + // Need to split this line to avoid errors due to new line produced in yaml
+			'/home/runner/work/repo2/repo2/dependency-graph-reports/update_dependency_graph_for_kotlin-dependency-graph.json\n          | jq' +
 			String.raw`
     permissions:
       contents: write

--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -1,10 +1,10 @@
 import { createYaml } from './file-generator';
 
-describe('createYaml', () => {
+describe('createYaml for Scala', () => {
 	it('should generate the following yaml file', () => {
-		const yaml = createYaml('branch');
+		const yaml = createYaml('branch', 'Scala');
 		const result =
-			String.raw`name: Update Dependency Graph for SBT
+			String.raw`name: Update Dependency Graph for Scala
 on:
   push:
     branches:
@@ -21,6 +21,39 @@ jobs:
       - name: Submit dependencies
         id: submit
         uses: scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1
+      - name: Log snapshot for user validation
+        id: validate
+        run: cat` +
+			' ${{ steps.submit.outputs.snapshot-json-path }} | jq' + // Need to split this line to avoid syntax errors due to the template string
+			String.raw`
+    permissions:
+      contents: write
+`;
+		expect(yaml).toEqual(result);
+	});
+});
+
+describe('createYaml for Scala', () => {
+	it('should generate the following yaml file', () => {
+		const yaml = createYaml('branch', 'Kotlin');
+		const result =
+			String.raw`name: Update Dependency Graph for Kotlin
+on:
+  push:
+    branches:
+      - main
+      - branch
+  workflow_dispatch: 
+jobs:
+  dependency-graph:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        id: checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Submit dependencies
+        id: submit
+        uses: gradle/actions/dependency-submission@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
       - name: Log snapshot for user validation
         id: validate
         run: cat` +

--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -1,10 +1,10 @@
 import { createYaml } from './file-generator';
 
-describe('createYaml for Scala', () => {
+describe('createYaml for sbt', () => {
 	it('should generate the following yaml file', () => {
 		const yaml = createYaml('branch', 'Scala', 'repo1');
 		const result =
-			String.raw`name: Update Dependency Graph for Scala
+			String.raw`name: Update Dependency Graph for sbt
 on:
   push:
     branches:
@@ -37,7 +37,7 @@ describe('createYaml for Kotlin', () => {
 	it('should generate the following yaml file', () => {
 		const yaml = createYaml('branch', 'Kotlin', 'repo2');
 		const result =
-			String.raw`name: Update Dependency Graph for Kotlin
+			String.raw`name: Update Dependency Graph for Gradle
 on:
   push:
     branches:

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -3,7 +3,12 @@ import type { DepGraphLanguage } from 'common/types';
 import { h2, p, tsMarkdown } from 'ts-markdown';
 import { stringify } from 'yaml';
 
-function createYamlLanguageSteps(
+export const depGraphPackageManager: Record<DepGraphLanguage, string> = {
+	Scala: 'sbt',
+	Kotlin: 'Gradle',
+};
+
+function createLanguageSpecificWorkflowSteps(
 	repo: string,
 ): Record<DepGraphLanguage, ConcatArray<object>> {
 	return {
@@ -59,7 +64,7 @@ export function createYaml(
 	repo: string,
 ): string {
 	const dependencyGraphWorkflowJson = {
-		name: `Update Dependency Graph for ${language}`,
+		name: `Update Dependency Graph for ${depGraphPackageManager[language]}`,
 		on: {
 			push: {
 				branches: ['main', prBranch],
@@ -69,7 +74,7 @@ export function createYaml(
 		jobs: {
 			'dependency-graph': {
 				'runs-on': 'ubuntu-latest',
-				steps: createYamlLanguageSteps(repo)[language],
+				steps: createLanguageSpecificWorkflowSteps(repo)[language],
 				permissions: { contents: 'write' },
 			},
 		},
@@ -80,28 +85,25 @@ export function createYaml(
 		.replaceAll('"', '');
 }
 
-const stepsForLanguages: Record<DepGraphLanguage, string[]> = {
-	Scala: [
+const stepsForLanguages: Record<DepGraphLanguage, string> = {
+	Scala:
 		'Ensure that the [version of sbt in the project is v1.5 or above](https://github.com/scalacenter/sbt-dependency-submission?tab=readme-ov-file#support) in order for the dependency submission action to run.',
-	],
-	Kotlin: [
+
+	Kotlin:
 		'Ensure that the [version of Gradle is v5.2 or above](https://github.com/gradle/actions/blob/main/docs/dependency-submission.md#gradle-version-compatibility)',
-	],
 };
 
 const languageSpecificInfo: Record<DepGraphLanguage, string> = {
 	Scala:
-		'See [the SBT workflow documentation](https://github.com/scalacenter/sbt-dependency-submission?tab=readme-ov-file) for further information and configuration options.',
+		'See [the sbt workflow documentation](https://github.com/scalacenter/sbt-dependency-submission?tab=readme-ov-file) for further information and configuration options.',
 	Kotlin:
 		'See [the Gradle workflow documentation](https://github.com/gradle/actions/blob/main/docs/dependency-submission.md) for further information and configuration options, and the [FAQ for troubleshooting](https://github.com/gradle/actions/blob/main/docs/dependency-submission-faq.md).',
 };
 
 function createPRChecklist(
 	branchName: string,
-	stepsForLanguage: string[],
+	stepsForLanguage: string,
 ): string[] {
-	const allSteps: string[] = [];
-
 	const finalSteps = [
 		'A run of this action should have been triggered when the branch was ' +
 			'created. Sense check the output of "Log snapshot for user validation", ' +
@@ -109,9 +111,7 @@ function createPRChecklist(
 		`When you are happy the action works, remove the branch name \`${branchName}\` ` +
 			'trigger from the the yaml file (aka delete line 6), approve, and merge. ',
 	];
-	stepsForLanguage.forEach((step) => allSteps.push(step));
-	finalSteps.forEach((step) => allSteps.push(step));
-	return allSteps;
+	return [stepsForLanguage, ...finalSteps];
 }
 
 export function generatePrBody(
@@ -122,7 +122,7 @@ export function generatePrBody(
 	const body = [
 		h2('What does this change?'),
 		p(
-			`This PR sends your ${language} dependencies to GitHub for vulnerability monitoring via Dependabot. ` +
+			`This PR sends your ${depGraphPackageManager[language]} dependencies to GitHub for vulnerability monitoring via Dependabot. ` +
 				`The submitted dependencies will appear in the [Dependency Graph](https://github.com/guardian/${repoName}/network/dependencies) ` +
 				'on merge to main (it might take a few minutes to update).',
 		),
@@ -139,7 +139,7 @@ export function generatePrBody(
 				'However, we have included some instructions below to help you verify that it works for you. ' +
 				'Please do not hesitate to contact DevX Security if you have any questions or concerns.',
 		),
-		h2(`Further information for ${language}`),
+		h2(`Further information for ${depGraphPackageManager[language]}`),
 		p(languageSpecificInfo[`${language}`]),
 		h2('What do I need to do?'),
 		markdownChecklist(

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -3,16 +3,60 @@ import type { DepGraphLanguage } from 'common/types';
 import { h2, p, tsMarkdown } from 'ts-markdown';
 import { stringify } from 'yaml';
 
-const workflowsForLanguages = {
-	Scala:
-		'scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1',
-	Kotlin:
-		'gradle/actions/dependency-submission@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0',
-};
+function createYamlLanguageSteps(
+	repo: string,
+): Record<DepGraphLanguage, ConcatArray<object>> {
+	return {
+		Scala: [
+			{
+				name: 'Checkout branch',
+				id: 'checkout',
+				uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7',
+			},
+			{
+				name: 'Submit dependencies',
+				id: 'submit',
+				uses: 'scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1',
+			},
+			{
+				name: 'Log snapshot for user validation',
+				id: 'validate',
+				run: 'cat ${{ steps.submit.outputs.snapshot-json-path }} | jq',
+			},
+		],
+		Kotlin: [
+			{
+				name: 'Checkout branch',
+				id: 'checkout',
+				uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7',
+			},
+			{
+				name: 'Set up Java',
+				id: 'setup',
+				uses: 'actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1',
+				with: {
+					distribution: 'temurin',
+					'java-version': '17',
+				},
+			},
+			{
+				name: 'Submit dependencies',
+				id: 'submit',
+				uses: 'gradle/actions/dependency-submission@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0',
+			},
+			{
+				name: 'Log snapshot for user validation',
+				id: 'validate',
+				run: `cat /home/runner/work/${repo}/${repo}/dependency-graph-reports/update_dependency_graph_for_kotlin-dependency-graph.json | jq`,
+			},
+		],
+	};
+}
 
 export function createYaml(
 	prBranch: string,
 	language: DepGraphLanguage,
+	repo: string,
 ): string {
 	const dependencyGraphWorkflowJson = {
 		name: `Update Dependency Graph for ${language}`,
@@ -25,30 +69,14 @@ export function createYaml(
 		jobs: {
 			'dependency-graph': {
 				'runs-on': 'ubuntu-latest',
-				steps: [
-					{
-						name: 'Checkout branch',
-						id: 'checkout',
-						uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7',
-					},
-					{
-						name: 'Submit dependencies',
-						id: 'submit',
-						uses: workflowsForLanguages[`${language}`],
-					},
-					{
-						name: 'Log snapshot for user validation',
-						id: 'validate',
-						run: 'cat ${{ steps.submit.outputs.snapshot-json-path }} | jq',
-					},
-				],
+				steps: createYamlLanguageSteps(repo)[language],
 				permissions: { contents: 'write' },
 			},
 		},
 	};
 
 	return stringify(dependencyGraphWorkflowJson, { lineWidth: 120 })
-		.replace('{}', '')
+		.replaceAll('{}', '')
 		.replaceAll('"', '');
 }
 
@@ -56,14 +84,16 @@ const stepsForLanguages: Record<DepGraphLanguage, string[]> = {
 	Scala: [
 		'Ensure that the [version of sbt in the project is v1.5 or above](https://github.com/scalacenter/sbt-dependency-submission?tab=readme-ov-file#support) in order for the dependency submission action to run.',
 	],
-	Kotlin: [],
+	Kotlin: [
+		'Ensure that the [version of Gradle is v5.2 or above](https://github.com/gradle/actions/blob/main/docs/dependency-submission.md#gradle-version-compatibility)',
+	],
 };
 
 const languageSpecificInfo: Record<DepGraphLanguage, string> = {
 	Scala:
 		'See [the SBT workflow documentation](https://github.com/scalacenter/sbt-dependency-submission?tab=readme-ov-file) for further information and configuration options.',
 	Kotlin:
-		'See [the Gradle workflow documentation](https://github.com/gradle/actions/blob/main/docs/dependency-submission.md) for further information and configuration options.',
+		'See [the Gradle workflow documentation](https://github.com/gradle/actions/blob/main/docs/dependency-submission.md) for further information and configuration options, and the [FAQ for troubleshooting](https://github.com/gradle/actions/blob/main/docs/dependency-submission-faq.md).',
 };
 
 function createPRChecklist(

--- a/packages/dependency-graph-integrator/src/index.ts
+++ b/packages/dependency-graph-integrator/src/index.ts
@@ -23,7 +23,7 @@ export async function main(event: DependencyGraphIntegratorEvent) {
 	const title = `Submit ${event.language} dependencies to GitHub for vulnerability monitoring`;
 	const fileName = `.github/workflows/${languageLowerCase}-dependency-graph.yaml`;
 	const commitMessage = `Add ${languageLowerCase}-dependency-graph.yaml`;
-	const yamlContents = createYaml(branch);
+	const yamlContents = createYaml(branch, event.language);
 	const repo = event.name;
 	const prContents = generatePrBody(branch, repo, event.language);
 	const stage = config.stage;

--- a/packages/dependency-graph-integrator/src/index.ts
+++ b/packages/dependency-graph-integrator/src/index.ts
@@ -12,19 +12,20 @@ import {
 import type { StatusCode } from './types';
 
 export async function main(event: DependencyGraphIntegratorEvent) {
-	console.log(`Generating Dependabot PR for ${event.name}`);
+	console.log(
+		`Generating Dependabot PR for ${event.name} repo with ${event.language} language`,
+	);
 	const config: Config = getConfig();
-	const branch = generateBranchName('sbt-dependency-graph');
-
+	const languageLowerCase = event.language.toLowerCase();
+	const branch = generateBranchName(`${languageLowerCase}-dependency-graph`);
 	const boardNumber = 110;
-	const author = 'gu-dependency-graph-integrator'; // TODO: create new 'gu-dependency-graph-integrator' app
-	const title =
-		'Submit sbt dependencies to GitHub for vulnerability monitoring';
-	const fileName = '.github/workflows/sbt-dependency-graph.yaml';
-	const commitMessage = 'Add sbt-dependency-graph.yaml';
+	const author = 'gu-dependency-graph-integrator';
+	const title = `Submit ${event.language} dependencies to GitHub for vulnerability monitoring`;
+	const fileName = `.github/workflows/${languageLowerCase}-dependency-graph.yaml`;
+	const commitMessage = `Add ${languageLowerCase}-dependency-graph.yaml`;
 	const yamlContents = createYaml(branch);
 	const repo = event.name;
-	const prContents = generatePrBody(branch, repo);
+	const prContents = generatePrBody(branch, repo, event.language);
 	const stage = config.stage;
 
 	if (stage === 'PROD') {

--- a/packages/dependency-graph-integrator/src/index.ts
+++ b/packages/dependency-graph-integrator/src/index.ts
@@ -23,7 +23,7 @@ export async function main(event: DependencyGraphIntegratorEvent) {
 	const title = `Submit ${event.language} dependencies to GitHub for vulnerability monitoring`;
 	const fileName = `.github/workflows/${languageLowerCase}-dependency-graph.yaml`;
 	const commitMessage = `Add ${languageLowerCase}-dependency-graph.yaml`;
-	const yamlContents = createYaml(branch, event.language);
+	const yamlContents = createYaml(branch, event.language, event.name);
 	const repo = event.name;
 	const prContents = generatePrBody(branch, repo, event.language);
 	const stage = config.stage;

--- a/packages/dependency-graph-integrator/src/run-locally.ts
+++ b/packages/dependency-graph-integrator/src/run-locally.ts
@@ -8,5 +8,6 @@ config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 if (require.main === module) {
 	void main({
 		name: 'service-catalogue',
+		language: 'Scala',
 	});
 }

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -64,6 +64,11 @@ export interface Config extends PrismaConfig {
 	snykIntegratorTopic: string;
 
 	/**
+	 * Flag to enable creation of Depedency Graph integration PRs
+	 */
+	depGraphIntegrationPREnabled: boolean;
+
+	/**
 	 * The ARN of the Dependency Graph Integrator input topic.
 	 */
 	dependencyGraphIntegratorTopic: string;
@@ -97,6 +102,7 @@ export async function getConfig(): Promise<Config> {
 		snykIntegrationPREnabled:
 			process.env.SNYK_INTEGRATION_PR_ENABLED === 'true',
 		snykIntegratorTopic: getEnvOrThrow('SNYK_INTEGRATOR_INPUT_TOPIC_ARN'),
+		depGraphIntegrationPREnabled: false,
 		dependencyGraphIntegratorTopic: getEnvOrThrow(
 			'DEPENDENCY_GRAPH_INPUT_TOPIC_ARN',
 		),

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -196,12 +196,18 @@ export async function main() {
 		);
 	}
 
-	await sendOneRepoToDepGraphIntegrator(
-		config,
-		repoLanguages,
-		productionRepos,
-		productionWorkflowUsages,
-	);
+	if (config.depGraphIntegrationPREnabled) {
+		await sendOneRepoToDepGraphIntegrator(
+			config,
+			repoLanguages,
+			productionRepos,
+			productionWorkflowUsages,
+		);
+	} else {
+		console.log(
+			'Messaging to Dependency Graph Integrator is not enabled, use console to send SNS message and raise a PR if required.',
+		);
+	}
 
 	console.log('Done');
 }

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
@@ -102,15 +102,19 @@ describe('When trying to find repos using Scala', () => {
 
 describe('When checking a repo for an existing dependency submission workflow', () => {
 	test('return true if repo workflow is present', () => {
-		const result = doesRepoHaveWorkflow(repository(fullName), [
-			repoWithDepSubmissionWorkflow(fullName),
-		]);
+		const result = doesRepoHaveWorkflow(
+			repository(fullName),
+			[repoWithDepSubmissionWorkflow(fullName)],
+			'Scala',
+		);
 		expect(result).toBe(true);
 	});
 	test('return false if workflow is not present', () => {
-		const result = doesRepoHaveWorkflow(repository(fullName), [
-			repoWithoutWorkflow(fullName),
-		]);
+		const result = doesRepoHaveWorkflow(
+			repository(fullName),
+			[repoWithoutWorkflow(fullName)],
+			'Scala',
+		);
 		expect(result).toBe(false);
 	});
 });
@@ -122,7 +126,9 @@ describe('When getting suitable events to send to SNS', () => {
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
 		);
-		expect(result).toEqual([{ name: removeRepoOwner(fullName) }]);
+		expect(result).toEqual([
+			{ name: removeRepoOwner(fullName), language: 'Scala' },
+		]);
 	});
 	test('return empty event array when a Scala repo is found with an existing workflow', () => {
 		const result = createSnsEventsForDependencyGraphIntegration(
@@ -147,8 +153,8 @@ describe('When getting suitable events to send to SNS', () => {
 			[repoWithoutWorkflow(fullName), repoWithoutWorkflow(fullName2)],
 		);
 		expect(result).toEqual([
-			{ name: removeRepoOwner(fullName) },
-			{ name: removeRepoOwner(fullName2) },
+			{ name: removeRepoOwner(fullName), language: 'Scala' },
+			{ name: removeRepoOwner(fullName2), language: 'Scala' },
 		]);
 	});
 });

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -8,7 +8,6 @@ import { shuffle } from 'common/src/functions';
 import type {
 	DependencyGraphIntegratorEvent,
 	DepGraphLanguage,
-	DepGraphWorkflows,
 	Repository,
 } from 'common/src/types';
 import type { Config } from '../../config';
@@ -34,7 +33,7 @@ export function doesRepoHaveWorkflow(
 		.filter((usages) => repo.full_name === usages.full_name)
 		.flatMap((workflow) => workflow.workflow_uses);
 
-	const workflows: DepGraphWorkflows = {
+	const workflows: Record<DepGraphLanguage, string> = {
 		Scala: 'scalacenter/sbt-dependency-submission',
 		Kotlin: 'gradle/actions/dependency-submission',
 	};

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -115,7 +115,7 @@ export async function sendOneRepoToDepGraphIntegrator(
 		}
 	} else {
 		console.log(
-			'No Scala repos found without SBT dependency submission workflow',
+			'No suitable production repos found without dependency submission workflow',
 		);
 	}
 }


### PR DESCRIPTION
## What does this change?

- The Dependency Graph Integrator takes a language parameter, and generates the workflow yaml and PR for both Scala and Kotlin.
- We now refer to the language rather than the package manager in the PR, as this makes things simpler. 

## Why?

We want to support Kotlin repos, and this now gives the flexibility to add further languages/workflows to the integrator.

## How has it been verified?
- [x] Tested locally
- [x] Tested on CODE 