### PR TITLE
chore(deps): Update CloudQuery source plugin for Galaxies

### DIFF
--- a/.env
+++ b/.env
@@ -21,7 +21,7 @@ CQ_GITHUB=10.0.1
 CQ_FASTLY=3.0.7
 
 # See https://github.com/guardian/cq-source-galaxies
-CQ_GUARDIAN_GALAXIES=1.1.6
+CQ_GUARDIAN_GALAXIES=1.1.8
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/snyk/versions
 CQ_SNYK=5.4.0

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -12663,7 +12663,7 @@ spec:
   name: galaxies
   path: guardian/galaxies
   registry: github
-  version: v1.1.6
+  version: v1.1.8
   destinations:
     - postgresql
   tables:


### PR DESCRIPTION
## What does this change?
The 1.1.7, and 1.1.8 patch releases include dependency updates.

Full Changelog: [v1.1.6...v1.1.8](https://github.com/guardian/cq-source-galaxies/compare/v1.1.6...v1.1.8)