### PR TITLE
Switch off automatic PR creation by Dependency Graph Integrator

### DIFF
--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -64,6 +64,11 @@ export interface Config extends PrismaConfig {
 	snykIntegratorTopic: string;
 
 	/**
+	 * Flag to enable creation of Depedency Graph integration PRs
+	 */
+	depGraphIntegrationPREnabled: boolean;
+
+	/**
 	 * The ARN of the Dependency Graph Integrator input topic.
 	 */
 	dependencyGraphIntegratorTopic: string;
@@ -97,6 +102,7 @@ export async function getConfig(): Promise<Config> {
 		snykIntegrationPREnabled:
 			process.env.SNYK_INTEGRATION_PR_ENABLED === 'true',
 		snykIntegratorTopic: getEnvOrThrow('SNYK_INTEGRATOR_INPUT_TOPIC_ARN'),
+		depGraphIntegrationPREnabled: false,
 		dependencyGraphIntegratorTopic: getEnvOrThrow(
 			'DEPENDENCY_GRAPH_INPUT_TOPIC_ARN',
 		),

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -196,12 +196,18 @@ export async function main() {
 		);
 	}
 
-	await sendOneRepoToDepGraphIntegrator(
-		config,
-		repoLanguages,
-		productionRepos,
-		productionWorkflowUsages,
-	);
+	if (config.depGraphIntegrationPREnabled) {
+		await sendOneRepoToDepGraphIntegrator(
+			config,
+			repoLanguages,
+			productionRepos,
+			productionWorkflowUsages,
+		);
+	} else {
+		console.log(
+			'Messaging to Dependency Graph Integrator is not enabled, use console to send SNS message and raise a PR if required.',
+		);
+	}
 
 	console.log('Done');
 }


### PR DESCRIPTION
## What does this change?

This PR adds a flag to config to stop the sending of SNS messages to the Dependency Graph Integrator by Repocop. Currently Repocop sends one message per run and thus raises one PR a day while there are suitable repos.

## Why?

The security team has identified a potential bug with the sbt dependency submission workflow and needs time to investigate and remediate if necessary. The Gradle workflow can be implemented manually for now, to allow the security team to test it with teams who have Kotlin/Gradle expertise and ensure it's fit for purpose.

## How has it been verified?
- [x] Tests run locally
- [x] Tested in CODE - run repocop, see message about messaging not being enabled.
