### PR TITLE
Repocop should skip resolved snyk issues

### DIFF
--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -785,18 +785,6 @@ describe('NO RULE - Snyk vulnerabilities', () => {
 		);
 		expect(result.length).toEqual(0);
 	});
-	test('Should not be detected if the issue has been resolved', () => {
-		const resolvedIssue: SnykIssue = {
-			...snykIssue,
-			attributes: { ...snykIssue.attributes, status: 'resolved' },
-		};
-		const result = collectAndFormatUrgentSnykAlerts(
-			thePerfectRepo,
-			[resolvedIssue],
-			[exampleSnykProject],
-		);
-		expect(result.length).toEqual(0);
-	});
 	test('Should not be considered patchable if there is no possible upgrade path', () => {
 		const result = collectAndFormatUrgentSnykAlerts(
 			thePerfectRepo,

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -785,6 +785,18 @@ describe('NO RULE - Snyk vulnerabilities', () => {
 		);
 		expect(result.length).toEqual(0);
 	});
+	test('Should not be detected if the issue has been resolved', () => {
+		const resolvedIssue: SnykIssue = {
+			...snykIssue,
+			attributes: { ...snykIssue.attributes, status: 'resolved' },
+		};
+		const result = collectAndFormatUrgentSnykAlerts(
+			thePerfectRepo,
+			[resolvedIssue],
+			[exampleSnykProject],
+		);
+		expect(result.length).toEqual(0);
+	});
 	test('Should not be considered patchable if there is no possible upgrade path', () => {
 		const result = collectAndFormatUrgentSnykAlerts(
 			thePerfectRepo,

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -620,7 +620,7 @@ describe('NO RULE - Dependabot alerts', () => {
 });
 
 const snykIssue: SnykIssue = {
-	id: 'issue1', //is this correct??
+	id: 'issue1',
 	attributes: {
 		status: 'open',
 

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -773,18 +773,6 @@ describe('NO RULE - Snyk vulnerabilities', () => {
 		);
 		expect(result.length).toEqual(0);
 	});
-	test('Should not be detected if the issue has been ignored', () => {
-		const ignoredIssue: SnykIssue = {
-			...snykIssue,
-			attributes: { ...snykIssue.attributes, ignored: true },
-		};
-		const result = collectAndFormatUrgentSnykAlerts(
-			thePerfectRepo,
-			[ignoredIssue],
-			[exampleSnykProject],
-		);
-		expect(result.length).toEqual(0);
-	});
 	test('Should not be considered patchable if there is no possible upgrade path', () => {
 		const result = collectAndFormatUrgentSnykAlerts(
 			thePerfectRepo,

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -279,9 +279,9 @@ export function collectAndFormatUrgentSnykAlerts(
 		})
 		.map((project) => project.id);
 
-	const snykIssuesForRepo: SnykIssue[] = snykProjectIdsForRepo
-		.flatMap((projectId) => getIssuesForProject(projectId, snykIssues))
-		.filter((i) => !i.attributes.ignored && i.attributes.status == 'open');
+	const snykIssuesForRepo: SnykIssue[] = snykProjectIdsForRepo.flatMap(
+		(projectId) => getIssuesForProject(projectId, snykIssues),
+	);
 
 	const processedVulns = snykIssuesForRepo.map((v) =>
 		snykAlertToRepocopVulnerability(repo.full_name, v, snykProjects),

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -281,7 +281,7 @@ export function collectAndFormatUrgentSnykAlerts(
 
 	const snykIssuesForRepo: SnykIssue[] = snykProjectIdsForRepo
 		.flatMap((projectId) => getIssuesForProject(projectId, snykIssues))
-		.filter((i) => !i.attributes.ignored);
+		.filter((i) => !i.attributes.ignored && i.attributes.status == 'open');
 
 	const processedVulns = snykIssuesForRepo.map((v) =>
 		snykAlertToRepocopVulnerability(repo.full_name, v, snykProjects),

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -82,7 +82,10 @@ export async function main() {
 	const nonPlaygroundStacks: AwsCloudFormationStack[] = (
 		await getStacks(prisma)
 	).filter((s) => s.tags.Stack !== 'playground');
-	const snykIssues = await getSnykIssues(prisma);
+	const openSnykIssues = (await getSnykIssues(prisma)).filter(
+		(issue) => issue.attributes.status === 'open' && !issue.attributes.ignored,
+	);
+
 	const snykProjects = await getSnykProjects(prisma);
 	const teams = await getTeams(prisma);
 	const repoOwners = await getRepoOwnership(prisma);
@@ -102,7 +105,7 @@ export async function main() {
 		branches,
 		repoOwners,
 		repoLanguages,
-		snykIssues,
+		openSnykIssues,
 		snykProjects,
 		productionDependabotVulnerabilities,
 	);

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -35,7 +35,7 @@ import { sendPotentialInteractives } from './remediation/topics/topic-monitor-in
 import { applyProductionTopicAndMessageTeams } from './remediation/topics/topic-monitor-production';
 import { createAndSendVulnerabilityDigests } from './remediation/vuln-digest/vuln-digest';
 import type { AwsCloudFormationStack, EvaluationResult } from './types';
-import { isProduction } from './utils';
+import { isOpenSnykIssue, isProduction } from './utils';
 
 async function writeEvaluationTable(
 	evaluatedRepos: repocop_github_repository_rules[],
@@ -82,9 +82,7 @@ export async function main() {
 	const nonPlaygroundStacks: AwsCloudFormationStack[] = (
 		await getStacks(prisma)
 	).filter((s) => s.tags.Stack !== 'playground');
-	const openSnykIssues = (await getSnykIssues(prisma)).filter(
-		(issue) => issue.attributes.status === 'open' && !issue.attributes.ignored,
-	);
+	const openSnykIssues = (await getSnykIssues(prisma)).filter(isOpenSnykIssue);
 
 	const snykProjects = await getSnykProjects(prisma);
 	const teams = await getTeams(prisma);

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -99,13 +99,15 @@ export async function getStacks(
 export async function getSnykIssues(
 	client: PrismaClient,
 ): Promise<SnykIssue[]> {
-	return (await client.snyk_issues.findMany({})).map((i) => {
+	const resp = (await client.snyk_issues.findMany({})).map((i) => {
 		return {
 			id: i.id,
 			attributes: i.attributes as unknown as SnykIssue['attributes'],
 			relationships: i.relationships as unknown as SnykIssue['relationships'],
 		};
 	});
+
+	return toNonEmptyArray(resp);
 }
 
 export async function getSnykProjects(

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -98,7 +98,7 @@ export async function getStacks(
 
 export async function getSnykIssues(
 	client: PrismaClient,
-): Promise<SnykIssue[]> {
+): Promise<NonEmptyArray<SnykIssue>> {
 	const resp = (await client.snyk_issues.findMany({})).map((i) => {
 		return {
 			id: i.id,

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -53,7 +53,7 @@ interface Attributes {
 	};
 	type?: string;
 	title?: string;
-	status: string;
+	status: 'resolved' | 'open';
 	classes?: [{ id: string; type: string; source: string }] | null;
 	ignored: boolean;
 	problems: [

--- a/packages/repocop/src/utils.test.ts
+++ b/packages/repocop/src/utils.test.ts
@@ -89,6 +89,18 @@ describe('isOpenSnykIssue', () => {
 		const result = isOpenSnykIssue(resolvedIssue);
 		expect(result).toEqual(false);
 	});
+	test('Should return false if the issue is both ignored and resolved', () => {
+		const resolvedIgnoredIssue: SnykIssue = {
+			...snykIssue,
+			attributes: {
+				...snykIssue.attributes,
+				status: 'resolved',
+				ignored: true,
+			},
+		};
+		const result = isOpenSnykIssue(resolvedIgnoredIssue);
+		expect(result).toBe(false);
+	});
 	test('Should return true if the issue is open and not ignored', () => {
 		const result = isOpenSnykIssue(snykIssue);
 		expect(result).toBe(true);

--- a/packages/repocop/src/utils.test.ts
+++ b/packages/repocop/src/utils.test.ts
@@ -26,7 +26,7 @@ describe('isProduction', () => {
 });
 
 const snykIssue: SnykIssue = {
-	id: 'issue1', //is this correct??
+	id: 'issue1',
 	attributes: {
 		status: 'open',
 

--- a/packages/repocop/src/utils.ts
+++ b/packages/repocop/src/utils.ts
@@ -1,4 +1,5 @@
 import type { RepocopVulnerability, Repository } from 'common/src/types';
+import type { SnykIssue } from './types';
 
 export function isProduction(repo: Repository) {
 	return repo.topics.includes('production') && !repo.archived;
@@ -20,3 +21,9 @@ export const vulnSortPredicate = (
 		return criticalFirstPredicate(v1);
 	}
 };
+
+export function isOpenSnykIssue(snykIssue: SnykIssue): boolean {
+	const isOpen = snykIssue.attributes.status === 'open';
+	const isIgnored = snykIssue.attributes.ignored;
+	return isOpen && !isIgnored;
+}


### PR DESCRIPTION
## What does this change?

- make `snyk_issues.attributes.status` a union type, that can either be `open` or `resolved`
- filter out `resolved` issues
- test the new filter

## Why?

Resolved issues have been remediated, so repocop doesn't care about them.

## How has it been verified?

A new unit test has been added to verify this behaviour.
After running on CODE, we see 80% fewer snyk issues loaded into the lambda's memory, and a reduction in runtime from 30s to 22s.
