### PR TITLE
Change vulnerability digest cutoff from a fixed date to a 60 day window

### DIFF
--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -163,21 +163,26 @@ describe('createDigest', () => {
 		expect(anotherDigest?.message).toContain('rightpad');
 	});
 
-	it('only returns vulnerabilities created after 30th April 2024', () => {
-		const vuln: RepocopVulnerability = {
+	it('only returns vulnerabilities created in  the last 60 days', () => {
+		const fiftyNineDaysAgo = new Date();
+		fiftyNineDaysAgo.setDate(fiftyNineDaysAgo.getDate() - 59);
+		const sixtyOneDaysAgo = new Date();
+		sixtyOneDaysAgo.setDate(sixtyOneDaysAgo.getDate() - 61);
+
+		const excluded: RepocopVulnerability = {
 			...highRecentVuln,
-			alert_issue_date: new Date('2024-04-30'),
+			alert_issue_date: sixtyOneDaysAgo,
 		};
 
-		const todayVuln = {
-			...vuln,
+		const included = {
+			...excluded,
 			package: 'rightpad',
-			alert_issue_date: new Date('2024-05-01'),
+			alert_issue_date: fiftyNineDaysAgo,
 		};
 
 		const resultWithVuln: EvaluationResult = {
 			...result,
-			vulnerabilities: [vuln, todayVuln],
+			vulnerabilities: [excluded, included],
 		};
 
 		const msg = createDigestForSeverity(
@@ -187,8 +192,8 @@ describe('createDigest', () => {
 			[resultWithVuln],
 		)?.message;
 		console.log(msg);
-		expect(msg).toContain('rightpad');
-		expect(msg).not.toContain('leftpad');
+		expect(msg).toContain(included.package);
+		expect(msg).not.toContain(excluded.package);
 	});
 });
 

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -91,6 +91,7 @@ describe('createDigest', () => {
 				'high',
 				[ownershipRecord],
 				[result, anotherResult],
+				60,
 			),
 		).toBeUndefined();
 	});
@@ -101,8 +102,13 @@ describe('createDigest', () => {
 			vulnerabilities: [highRecentVuln],
 		};
 		expect(
-			createDigestForSeverity(team, 'high', [ownershipRecord], [resultWithVuln])
-				?.message,
+			createDigestForSeverity(
+				team,
+				'high',
+				[ownershipRecord],
+				[resultWithVuln],
+				60,
+			)?.message,
 		).toContain('leftpad');
 	});
 
@@ -118,8 +124,13 @@ describe('createDigest', () => {
 			vulnerabilities: [vuln],
 		};
 		expect(
-			createDigestForSeverity(team, 'high', [ownershipRecord], [resultWithVuln])
-				?.message,
+			createDigestForSeverity(
+				team,
+				'high',
+				[ownershipRecord],
+				[resultWithVuln],
+				60,
+			)?.message,
 		).toContain('sbt or maven');
 	});
 
@@ -149,6 +160,7 @@ describe('createDigest', () => {
 			'high',
 			[ownershipRecord, anotherOwnershipRecord],
 			[resultWithVuln, anotherResultWithVuln],
+			60,
 		);
 		expect(digest?.teamSlug).toBe(team.slug);
 		expect(digest?.message).toContain('leftpad');
@@ -158,6 +170,7 @@ describe('createDigest', () => {
 			'high',
 			[ownershipRecord, anotherOwnershipRecord],
 			[resultWithVuln, anotherResultWithVuln],
+			60,
 		);
 		expect(anotherDigest?.teamSlug).toBe(anotherTeam.slug);
 		expect(anotherDigest?.message).toContain('rightpad');
@@ -190,6 +203,7 @@ describe('createDigest', () => {
 			'high',
 			[ownershipRecord],
 			[resultWithVuln],
+			60,
 		)?.message;
 		console.log(msg);
 		expect(msg).toContain(included.package);
@@ -208,8 +222,13 @@ describe('createDigestForSeverity', () => {
 			vulnerabilities: [noCveVuln],
 		};
 		expect(
-			createDigestForSeverity(team, 'high', [ownershipRecord], [resultWithVuln])
-				?.message,
+			createDigestForSeverity(
+				team,
+				'high',
+				[ownershipRecord],
+				[resultWithVuln],
+				60,
+			)?.message,
 		).toContain('no CVE provided');
 	});
 });
@@ -225,8 +244,13 @@ describe('createDigestForSeverity', () => {
 			vulnerabilities: [noUrlVuln],
 		};
 		expect(
-			createDigestForSeverity(team, 'high', [ownershipRecord], [resultWithVuln])
-				?.message,
+			createDigestForSeverity(
+				team,
+				'high',
+				[ownershipRecord],
+				[resultWithVuln],
+				60,
+			)?.message,
 		).not.toContain(`[${noUrlVuln.package}](`);
 	});
 });

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -70,7 +70,8 @@ export function createDigestForSeverity(
 	);
 	const vulns = resultsForTeam.flatMap((r) => r.vulnerabilities);
 
-	const startDate = new Date('2024-04-30');
+	const sixtyDaysAgo = new Date();
+	sixtyDaysAgo.setDate(sixtyDaysAgo.getDate() - 60);
 
 	const patchableFirst = (a: RepocopVulnerability, b: RepocopVulnerability) => {
 		if (a.is_patchable && !b.is_patchable) {
@@ -84,7 +85,8 @@ export function createDigestForSeverity(
 
 	const vulnsSinceImplementationDate = vulns
 		.filter(
-			(v) => v.severity == severity && new Date(v.alert_issue_date) > startDate,
+			(v) =>
+				v.severity == severity && new Date(v.alert_issue_date) > sixtyDaysAgo,
 		)
 		.sort(patchableFirst);
 
@@ -94,7 +96,7 @@ export function createDigestForSeverity(
 		return undefined;
 	}
 
-	const preamble = String.raw`Found ${totalNewVulnsCount} ${severity} vulnerabilities introduced since ${startDate.toDateString()}. Teams have ${SLAs[severity]} days to fix these.
+	const preamble = String.raw`Found ${totalNewVulnsCount} ${severity} vulnerabilities introduced in the last 60 days. Teams have ${SLAs[severity]} days to fix these.
 Note: DevX only aggregates vulnerability information for runtime dependencies in repositories with a production topic.`;
 
 	const digestString = vulnsSinceImplementationDate

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -97,7 +97,7 @@ export function createDigestForSeverity(
 		return undefined;
 	}
 
-	const preamble = String.raw`Found ${totalNewVulnsCount} ${severity} vulnerabilities introduced in the last 60 days. Teams have ${SLAs[severity]} days to fix these.
+	const preamble = String.raw`Found ${totalNewVulnsCount} ${severity} vulnerabilities introduced in the last ${cutOffInDays} days. Teams have ${SLAs[severity]} days to fix these.
 Note: DevX only aggregates vulnerability information for runtime dependencies in repositories with a production topic.`;
 
 	const digestString = vulnsSinceImplementationDate


### PR DESCRIPTION
## What does this change?

Only show vulnerabilities from the last 60 days in vulnerability digests

## Why?

Previously, we were sending teams notifications, potentially daily, about vulnerabilities that were nearly six months old. I think vulnerabilities that old can reasonably be considered part of a 'historical backlog', and continuing to pester teams about it is unlikely to result in meaningful change. It may be actively detrimental, as it causes alert fatigue, resulting in teams ignoring messages.

#### Why 60 days?

The choice of 60 days is slightly arbitrary, and if it doesn't work, we can always change it later. I've made this value configurable, so we could, for example, experiment with different windows for different severities; but doubling the window given to resolve highs seemed like a reasonable starting point.

## How has it been verified?

Unit tests have been modified to test the desired behaviour
