### PR TITLE
Update RepoCop README

### DIFF
--- a/packages/repocop/README.md
+++ b/packages/repocop/README.md
@@ -1,33 +1,31 @@
 # RepoCop
 
-RepoCop is a tool to help us discover and apply best practices across our estate.
-It is deployed as an AWS Lambda.
+RepoCop is a tool to help us discover and apply best practices and obligations across our estate.
+It is deployed as an AWS Lambda, and powers the [Dependency Vulnerability dashboard](https://metrics.gutools.co.uk/d/fdib3p8l85jwgd), as well as the [Best Practices Compliance dashboard](https://metrics.gutools.co.uk/d/EOPnljWIz)
 
 See the [Grafana dashboard](https://metrics.gutools.co.uk/d/2uaV8PiIz/repocop?orgId=1) for a definition of the rules and how they are met.
 
 ## Running RepoCop locally
 
-Prerequisites:
+From the root of the repo:
 
-1. [CloudQuery](../dev-environment/README.md) has populated the local database
-2. The prisma migrations have been applied to the local database
+1. Connect to the VPN
+2. Retrieve Deploy Tools credentials
+3. Run the setup script (only if running for the first time, or for the first time in a while)
+4. Create a local [CloudQuery](../dev-environment/README.md) database by running `npm run start -w dev-environment`, and wait for the tables to be populated (this will take a few minutes)
+5. Run repocop using `npm -w repocop start`
 
-```bash
-npm -w cli start migrate -- --stage DEV
-```
+## How to write DB queries in RepoCop
 
-To run RepoCop locally, run:
+There are lots of ways of writing/making queries to the database, depending on what you want to optimise for. To support a more functional code style, we have chosen to minimise the number of side-effecting DB calls, and pushed them as close to the edge of the lamda as possible (i.e. only making calls to the database at the very beginning, and at the very end of the lambda). This is slightly more memory intensive than making DB calls as and when we need them, but has a few advantages. These are:
 
-```bash
-npm -w repocop start
-```
+- Fewer side effects make the code easier to reason about.
+- Writing in a functional style is easier, so unit testing of business logic can be more comprehensive, requiring less mocking.
+- If there are any issues connecting to the database, or even just a particular table, the lambda will fail quickly, wasting less time.
 
-## How to interact with the database
-
-There are lots of ways of writing/making queries to the database, depending on what you want to optimise for. If you are optimising for memory usage, you might want to make lots of highly targeted queries in each function so objects are small and short lived. We have chosen an approach that minimises side effecting calls, and tries to make them all at the beginning or the end of the lambda. This makes it easier to reason about, and test the code, and if there are any issues connecting to the database, or a particular table, it will fail quickly, wasting the fewest amount of resources.
-
-Our guidelines for interacting with the database are:
+Our guidelines for DB calls in RepoCop are:
 
 1. Only make one call to the database per table
 2. Make all calls to the database at the beginning or end of the lambda
 3. To reduce memory usage, when creating the query function, only select the columns you need. You can always come back later and select more if you need them.
+4. When retrieving rows from the database, try not to do anything more complicated than a simple WHERE clause (for example, don't try to join two tables in one prisma query). Any complex logic should be handled by a unit-tested function.

--- a/packages/repocop/README.md
+++ b/packages/repocop/README.md
@@ -20,6 +20,10 @@ From the root of the repo:
 4. Create a local [CloudQuery](../dev-environment/README.md) database by running `npm run start -w dev-environment`, and wait for the tables to be populated (this will take a few minutes)
 5. Run repocop using `npm -w repocop start`
 
+## Running RepoCop on AWS
+
+The CODE Repocop lambda can safely be executed from the AWS console. This is because it doesn't have any `write` level GitHub permissions, and the functionality that sends messages to dev teams sits behind a stage-based feature flag, making it quite difficult to disrupt teams with false alarms. RepoCop's downstream lambdas also do not have the ability to make any changes to GitHub, and generally don't have any GitHub permissions at all on CODE. It will instead log the messages that it would have sent.
+
 ## How to write DB queries in RepoCop
 
 There are lots of ways of writing/making queries to the database, depending on what you want to optimise for. To support a more functional code style, we have chosen to minimise the number of side-effecting DB calls, and pushed them as close to the edge of the lamda as possible (i.e. only making calls to the database at the very beginning, and at the very end of the lambda). This is slightly more memory intensive than making DB calls as and when we need them, but has a few advantages. These are:

--- a/packages/repocop/README.md
+++ b/packages/repocop/README.md
@@ -1,9 +1,14 @@
 # RepoCop
 
-RepoCop is a tool to help us discover and apply best practices and obligations across our estate.
-It is deployed as an AWS Lambda, and powers the [Dependency Vulnerability dashboard](https://metrics.gutools.co.uk/d/fdib3p8l85jwgd), as well as the [Best Practices Compliance dashboard](https://metrics.gutools.co.uk/d/EOPnljWIz)
+RepoCop is a tool to help us discover and apply best practices and security obligations across our estate. In particular, it's concerned with the security of our GitHub repositories.
+It is deployed as an AWS Lambda, and powers:
 
-See the [Grafana dashboard](https://metrics.gutools.co.uk/d/2uaV8PiIz/repocop?orgId=1) for a definition of the rules and how they are met.
+- The [Dependency Vulnerability dashboard](https://metrics.gutools.co.uk/d/fdib3p8l85jwgd)
+- The [Best Practices Compliance dashboard](https://metrics.gutools.co.uk/d/EOPnljWIz)
+- Team vulnerability digests
+- The [interactive-monitor](../interactive-monitor/README.md) lambda
+- The [dependency-graph-integrator](../dependency-graph-integrator/README.md) lambda
+- The [snyk-integrator](../snyk-integrator/README.md) lambda
 
 ## Running RepoCop locally
 

--- a/packages/repocop/README.md
+++ b/packages/repocop/README.md
@@ -14,7 +14,7 @@ It is deployed as an AWS Lambda, and powers:
 
 From the root of the repo:
 
-1. Connect to the VPN
+1. Connect to the VPN (even in the office)
 2. Retrieve Deploy Tools credentials
 3. Run the setup script (only if running for the first time, or for the first time in a while)
 4. Create a local [CloudQuery](../dev-environment/README.md) database by running `npm run start -w dev-environment`, and wait for the tables to be populated (this will take a few minutes)


### PR DESCRIPTION
## What does this change?

- More information about RepoCop's downstream dependencies, such as dashboards and other Lambdas
- Updated instructions on how to run RepoCop locally
- A new section about testing the lambda on AWS
- Expanding the section on how RepoCop should be interacting with the CloudQuery DB

## Why?

RepoCop's README hasn't been meaningfully updated for over 9 months. In that time a lot has changed, so the README is being updated to reflect that. We're also overhauling our approach to communicating DevX's work, and departmental security standards. Clear, up-to-date documentation is an important part of that.

## How has it been verified?

Running instructions work.
