### PR TITLE
parameterise github org

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -23342,6 +23342,7 @@ spec:
             "GITHUB_APP_SECRET": {
               "Ref": "branchprotectorgithubappauth4E91892E",
             },
+            "GITHUB_ORG": "guardian",
             "INTERACTIVES_COUNT": "3",
             "INTERACTIVE_MONITOR_TOPIC_ARN": {
               "Ref": "TopicBFC7AF6E",

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -147,7 +147,10 @@ spec:
 	});
 
 	it('Should create a GitHub source configuration', () => {
-		const config = githubSourceConfig({ tables: ['github_repositories'] });
+		const config = githubSourceConfig({
+			tables: ['github_repositories'],
+			org: 'guardian',
+		});
 		expect(dump(config)).toMatchInlineSnapshot(`
 		"kind: source
 		spec:

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -15,6 +15,10 @@ interface CloudqueryTableConfig {
 	concurrency?: number;
 }
 
+interface GitHubCloudqueryTableConfig extends CloudqueryTableConfig {
+	org: string;
+}
+
 /**
  * Create a ServiceCatalogue destination configuration for Postgres.
  */
@@ -115,10 +119,9 @@ export function awsSourceConfigForAccount(
 }
 
 export function githubSourceConfig(
-	tableConfig: CloudqueryTableConfig,
+	tableConfig: GitHubCloudqueryTableConfig,
 ): CloudqueryConfig {
-	const org = 'guardian';
-	const { tables, skipTables } = tableConfig;
+	const { tables, skipTables, org } = tableConfig;
 
 	if (!tables && !skipTables) {
 		throw new Error('Must specify either tables or skipTables');

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -117,6 +117,7 @@ export function awsSourceConfigForAccount(
 export function githubSourceConfig(
 	tableConfig: CloudqueryTableConfig,
 ): CloudqueryConfig {
+	const org = 'guardian';
 	const { tables, skipTables } = tableConfig;
 
 	if (!tables && !skipTables) {
@@ -134,10 +135,10 @@ export function githubSourceConfig(
 			destinations: ['postgresql'],
 			spec: {
 				concurrency: 1000, // TODO what's the ideal value here?!
-				orgs: ['guardian'],
+				orgs: [org],
 				app_auth: [
 					{
-						org: 'guardian',
+						org,
 
 						// For simplicity, read all configuration from disk.
 						private_key_path: `${serviceCatalogueConfigDirectory}/github-private-key`,

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -37,6 +37,7 @@ interface CloudqueryEcsClusterProps {
 	snykCredentials: SecretsManager;
 	loggingStreamName: string;
 	logShippingPolicy: PolicyStatement;
+	gitHubOrg: string;
 }
 
 export function addCloudqueryEcsCluster(
@@ -51,6 +52,7 @@ export function addCloudqueryEcsCluster(
 		nonProdSchedule,
 		loggingStreamName,
 		logShippingPolicy,
+		gitHubOrg: gitHubOrgName,
 	} = props;
 
 	const riffRaffDatabaseAccessSecurityGroupParam =
@@ -379,6 +381,7 @@ export function addCloudqueryEcsCluster(
 				'Collect GitHub repository data. Uses include RepoCop, which flags repositories that do not meet certain obligations.',
 			schedule: nonProdSchedule ?? Schedule.cron({ minute: '0', hour: '0' }),
 			config: githubSourceConfig({
+				org: gitHubOrgName,
 				tables: [
 					'github_repositories',
 					'github_repository_branches',
@@ -407,6 +410,7 @@ export function addCloudqueryEcsCluster(
 				nonProdSchedule ??
 				Schedule.cron({ weekDay: '1', hour: '10', minute: '0' }),
 			config: githubSourceConfig({
+				org: gitHubOrgName,
 				tables: [
 					'github_organizations',
 					'github_organization_members',
@@ -435,6 +439,7 @@ export function addCloudqueryEcsCluster(
 			description: 'Collect GitHub issue data (PRs and Issues)',
 			schedule: nonProdSchedule ?? Schedule.cron({ minute: '0', hour: '2' }),
 			config: githubSourceConfig({
+				org: gitHubOrgName,
 				tables: ['github_issues'],
 			}),
 			secrets: githubSecrets,

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -29,6 +29,7 @@ export class Repocop {
 		interactiveMonitorTopic: Topic,
 		dbSecurityGroup: SecurityGroup,
 		repocopGithubSecret: Secret,
+		gitHubOrg: string,
 	) {
 		const snykIntegratorInputTopic = new Topic(
 			guStack,
@@ -65,6 +66,7 @@ export class Repocop {
 				SNYK_INTEGRATOR_INPUT_TOPIC_ARN: snykIntegratorInputTopic.topicArn,
 				DEPENDENCY_GRAPH_INPUT_TOPIC_ARN:
 					dependencyGraphIntegratorInputTopic.topicArn,
+				GITHUB_ORG: gitHubOrg,
 			},
 			vpc,
 			securityGroups: [dbSecurityGroup],

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -62,6 +62,11 @@ interface ServiceCatalogueProps extends GuStackProps {
 	 */
 	rdsDeletionProtection?: boolean;
 	multiAz?: boolean;
+
+	/**
+	 * The GitHub org to search for repositories in.
+	 */
+	gitHubOrg?: string;
 }
 
 export class ServiceCatalogue extends GuStack {
@@ -71,7 +76,11 @@ export class ServiceCatalogue extends GuStack {
 		const { stage, stack } = this;
 		const app = props.app ?? 'service-catalogue';
 
-		const { rdsDeletionProtection = true, multiAz = false } = props;
+		const {
+			rdsDeletionProtection = true,
+			multiAz = false,
+			gitHubOrg = 'guardian',
+		} = props;
 
 		const nonProdSchedule = props.schedule;
 
@@ -172,8 +181,6 @@ export class ServiceCatalogue extends GuStack {
 			effect: Effect.ALLOW,
 			resources: [loggingStreamArn],
 		});
-
-		const gitHubOrg = 'guardian';
 
 		const cloudqueryCluster = addCloudqueryEcsCluster(this, {
 			nonProdSchedule,

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -173,6 +173,8 @@ export class ServiceCatalogue extends GuStack {
 			resources: [loggingStreamArn],
 		});
 
+		const gitHubOrg = 'guardian';
+
 		const cloudqueryCluster = addCloudqueryEcsCluster(this, {
 			nonProdSchedule,
 			db,
@@ -181,6 +183,7 @@ export class ServiceCatalogue extends GuStack {
 			snykCredentials: snykReadOnlyKey,
 			loggingStreamName,
 			logShippingPolicy,
+			gitHubOrg,
 		});
 
 		const anghammaradTopicParameter =
@@ -238,6 +241,7 @@ export class ServiceCatalogue extends GuStack {
 			interactiveMonitor.topic,
 			applicationToPostgresSecurityGroup,
 			githubCredentials,
+			gitHubOrg,
 		);
 
 		addDataAuditLambda(this, {

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -72,6 +72,11 @@ export interface Config extends PrismaConfig {
 	 * The ARN of the Dependency Graph Integrator input topic.
 	 */
 	dependencyGraphIntegratorTopic: string;
+
+	/**
+	 * The name of the GitHub organisation that owns the repositories.
+	 */
+	gitHubOrg: string;
 }
 
 export async function getConfig(): Promise<Config> {
@@ -106,5 +111,6 @@ export async function getConfig(): Promise<Config> {
 		dependencyGraphIntegratorTopic: getEnvOrThrow(
 			'DEPENDENCY_GRAPH_INPUT_TOPIC_ARN',
 		),
+		gitHubOrg: process.env['GITHUB_ORG'] ?? 'guardian',
 	};
 }

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -90,7 +90,11 @@ export async function main() {
 
 	const productionRepos = unarchivedRepos.filter((repo) => isProduction(repo));
 	const productionDependabotVulnerabilities: RepocopVulnerability[] =
-		await getDependabotVulnerabilities(productionRepos, octokit);
+		await getDependabotVulnerabilities(
+			productionRepos,
+			config.gitHubOrg,
+			octokit,
+		);
 
 	console.log(productionDependabotVulnerabilities);
 

--- a/packages/repocop/src/remediation/topics/topic-monitor-production.ts
+++ b/packages/repocop/src/remediation/topics/topic-monitor-production.ts
@@ -135,12 +135,11 @@ async function applyProductionTopicToOneRepoAndMessageTeams(
 	octokit: Octokit,
 	config: Config,
 ): Promise<void> {
-	const owner = 'guardian';
 	const topic = 'production';
 	const shortRepoName = removeRepoOwner(fullRepoName);
 	const { stage } = config;
 	if (stage === 'PROD') {
-		await applyTopics(shortRepoName, owner, octokit, topic);
+		await applyTopics(shortRepoName, config.gitHubOrg, octokit, topic);
 	} else {
 		console.log(
 			`Would have applied the ${topic} topic to ${shortRepoName} with stack ${stackName} if stage was PROD.`,


### PR DESCRIPTION
## What does this change?

the `guardian` github org shows up all the time in our codebase, let's make it a constant that we set via config, and pass it in via CDK. This PR does this for repocop and cloudquery. Follow-up PRs will be raised for other packages. 

## Why?

Magic values are bad! And this will make it easier for people outside the guardian to use and modify the service catalogue if they wish

## How has it been verified?

- [x] CI passes.
- [x] Local execution
- [x] CODE execution
