### PR TITLE
feat: update hasDependencyTracking to include repos with dep graph wo…

### DIFF
--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -539,7 +539,6 @@ describe('REPOSITORY_09 - Dependency tracking', () => {
 		);
 		expect(actual).toEqual(true);
 	});
-	//TODO: update this test to include dep graph integrator
 	test('is not valid if a project is not on snyk, and uses a language dependabot/dependency graph integrator does not support', () => {
 		const repo: Repository = {
 			...nullRepo,

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -1,6 +1,7 @@
 import type {
 	github_languages,
 	github_repository_branches,
+	guardian_github_actions_usage,
 	view_repo_ownership,
 } from '@prisma/client';
 import type { RepocopVulnerability, Repository } from 'common/src/types';
@@ -32,6 +33,7 @@ function evaluateRepoTestHelper(
 	latestSnykIssues: SnykIssue[] = [],
 	snykProjects: SnykProject[] = [],
 	reposOnSnyk: string[] = [],
+	workflowsForRepo: guardian_github_actions_usage[] = [],
 ) {
 	return evaluateOneRepo(
 		dependabotAlerts,
@@ -42,6 +44,7 @@ function evaluateRepoTestHelper(
 		latestSnykIssues,
 		snykProjects,
 		reposOnSnyk,
+		workflowsForRepo,
 	).repocopRules;
 }
 
@@ -494,6 +497,7 @@ describe('REPOSITORY_09 - Dependency tracking', () => {
 			repo,
 			[snykSupportedLanguages],
 			['guardian/some-repo'],
+			[],
 		);
 		expect(actual).toEqual(true);
 	});
@@ -503,16 +507,27 @@ describe('REPOSITORY_09 - Dependency tracking', () => {
 			topics: ['production'],
 			full_name: 'guardian/some-repo',
 		};
-		const actual = hasDependencyTracking(repo, [fullySupportedLanguages], []);
+		const actual = hasDependencyTracking(
+			repo,
+			[fullySupportedLanguages],
+			[],
+			[],
+		);
 		expect(actual).toEqual(true);
 	});
+	//TODO: update this test to include dep graph integrator
 	test('is not valid if a project is not on snyk, and uses a language dependabot does not support', () => {
 		const repo: Repository = {
 			...nullRepo,
 			topics: ['production'],
 			full_name: 'guardian/some-repo',
 		};
-		const actual = hasDependencyTracking(repo, [snykSupportedLanguages], []);
+		const actual = hasDependencyTracking(
+			repo,
+			[snykSupportedLanguages],
+			[],
+			[],
+		);
 		expect(actual).toEqual(false);
 	});
 	test('is not valids not valid if a project is on snyk, and uses a language not supported by snyk', () => {
@@ -521,7 +536,7 @@ describe('REPOSITORY_09 - Dependency tracking', () => {
 			topics: ['production'],
 			full_name: 'guardian/some-repo',
 		};
-		const actual = hasDependencyTracking(repo, [unsupportedLanguages], []);
+		const actual = hasDependencyTracking(repo, [unsupportedLanguages], [], []);
 		expect(actual).toEqual(false);
 	});
 	test('is valid if a repository has been archived', () => {
@@ -530,7 +545,7 @@ describe('REPOSITORY_09 - Dependency tracking', () => {
 			archived: true,
 			full_name: 'guardian/some-repo',
 		};
-		const actual = hasDependencyTracking(repo, [unsupportedLanguages], []);
+		const actual = hasDependencyTracking(repo, [unsupportedLanguages], [], []);
 		expect(actual).toEqual(true);
 	});
 	test('is valid if a repository has a non-production tag', () => {
@@ -539,7 +554,7 @@ describe('REPOSITORY_09 - Dependency tracking', () => {
 			topics: [],
 			full_name: 'guardian/some-repo',
 		};
-		const actual = hasDependencyTracking(repo, [unsupportedLanguages], []);
+		const actual = hasDependencyTracking(repo, [unsupportedLanguages], [], []);
 		expect(actual).toEqual(true);
 	});
 	test('is valid if a repository has no languages', () => {
@@ -556,7 +571,7 @@ describe('REPOSITORY_09 - Dependency tracking', () => {
 			languages: [],
 		};
 
-		const actual = hasDependencyTracking(repo, [noLanguages], []);
+		const actual = hasDependencyTracking(repo, [noLanguages], [], []);
 		expect(actual).toEqual(true);
 	});
 });

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -61,6 +61,23 @@ const nullBranch: github_repository_branches = {
 	protected: null,
 };
 
+const nullWorkflows: guardian_github_actions_usage = {
+	evaluated_on: new Date('2024-01-01'),
+	full_name: '',
+	workflow_path: '',
+	workflow_uses: [],
+};
+
+const sbtWorkflows: guardian_github_actions_usage = {
+	...nullWorkflows,
+	full_name: 'guardian/some-repo',
+	workflow_path: '.github/workflows/sbt-dependency-graph.yaml',
+	workflow_uses: [
+		'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332',
+		'scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e',
+	],
+};
+
 export const nullRepo: Repository = {
 	full_name: '',
 	name: '',
@@ -468,6 +485,13 @@ describe('REPOSITORY_09 - Dependency tracking', () => {
 		...emptyLanguages,
 		full_name: 'guardian/some-repo',
 		name: 'some-repo',
+		languages: ['JavaScript', 'Objective-C'],
+	};
+
+	const dependabotAndDepGraphSupportedLanguages: github_languages = {
+		...emptyLanguages,
+		full_name: 'guardian/some-repo',
+		name: 'some-repo',
 		languages: ['JavaScript', 'Scala'],
 	};
 
@@ -516,7 +540,7 @@ describe('REPOSITORY_09 - Dependency tracking', () => {
 		expect(actual).toEqual(true);
 	});
 	//TODO: update this test to include dep graph integrator
-	test('is not valid if a project is not on snyk, and uses a language dependabot does not support', () => {
+	test('is not valid if a project is not on snyk, and uses a language dependabot/dependency graph integrator does not support', () => {
 		const repo: Repository = {
 			...nullRepo,
 			topics: ['production'],
@@ -530,7 +554,35 @@ describe('REPOSITORY_09 - Dependency tracking', () => {
 		);
 		expect(actual).toEqual(false);
 	});
-	test('is not valids not valid if a project is on snyk, and uses a language not supported by snyk', () => {
+	test('is not valid if a project is not on snyk, uses a language supported by dependency graph integrator but there is no submission workflow for that language', () => {
+		const repo: Repository = {
+			...nullRepo,
+			topics: ['production'],
+			full_name: 'guardian/some-repo',
+		};
+		const actual = hasDependencyTracking(
+			repo,
+			[snykSupportedLanguages],
+			[],
+			[nullWorkflows],
+		);
+		expect(actual).toEqual(false);
+	});
+	test('is valid if a project is not on snyk, uses a language supported by dependency graph integrator and has associated submission workflow for that language', () => {
+		const repo: Repository = {
+			...nullRepo,
+			topics: ['production'],
+			full_name: 'guardian/some-repo',
+		};
+		const actual = hasDependencyTracking(
+			repo,
+			[dependabotAndDepGraphSupportedLanguages],
+			[],
+			[sbtWorkflows],
+		);
+		expect(actual).toEqual(true);
+	});
+	test('is not valid if a project is on snyk, and uses a language not supported by snyk', () => {
 		const repo: Repository = {
 			...nullRepo,
 			topics: ['production'],

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -179,7 +179,7 @@ export function hasDependencyTracking(
 			);
 
 		if (allUnsupportedLanguagesSupportedByDepGraphIntegrator) {
-			// Do all these languages have dep graph workflows?
+			// Do all these languages have dependency submission workflows?
 			const allDepGraphSupportedLanguagesHaveWorkflows =
 				languagesNotSupportedByDependabot.every((language) =>
 					doesRepoHaveWorkflow(

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -194,7 +194,7 @@ function isSupportedByDependabot(
 				`${repo.name} contains the following languages not supported by Dependabot or Dependency Graph Integrator`,
 				languages.filter(
 					(language) =>
-						!depGraphIntegratorSupportedLanguages.includes(language) ||
+						!depGraphIntegratorSupportedLanguages.includes(language) &&
 						!supportedDependabotLanguages.includes(language),
 				),
 			);

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -133,22 +133,18 @@ function isSupportedBySnyk(
 	reposOnSnyk: string[],
 ): boolean {
 	const repoIsOnSnyk = reposOnSnyk.includes(repo.full_name);
-	if (repoIsOnSnyk) {
-		const containsOnlySnykSupportedLanguages = languages.every((language) =>
-			supportedSnykLanguages.includes(language),
+	const containsOnlySnykSupportedLanguages = languages.every((language) =>
+		supportedSnykLanguages.includes(language),
+	);
+	if (repoIsOnSnyk && !containsOnlySnykSupportedLanguages) {
+		console.log(
+			`${repo.name} is on Snyk, but contains the following languages not supported by Snyk: `,
+			languages.filter(
+				(language) => !supportedSnykLanguages.includes(language),
+			),
 		);
-		if (!containsOnlySnykSupportedLanguages) {
-			console.log(
-				`${repo.name} is on Snyk, but contains the following languages not supported by Snyk: `,
-				languages.filter(
-					(language) => !supportedSnykLanguages.includes(language),
-				),
-			);
-			return false;
-		}
-		return true;
 	}
-	return false;
+	return repoIsOnSnyk && containsOnlySnykSupportedLanguages;
 }
 
 function isSupportedByDependabot(

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -110,6 +110,7 @@ export async function main() {
 		openSnykIssues,
 		snykProjects,
 		productionDependabotVulnerabilities,
+		productionWorkflowUsages,
 	);
 
 	const repocopRules = evaluationResults.map((r) => r.repocopRules);

--- a/packages/repocop/src/languages.ts
+++ b/packages/repocop/src/languages.ts
@@ -43,12 +43,14 @@ const snykOnlySupportedLanguages = [
 	'Apex',
 	'Bazel',
 	'Elixir',
-	'Kotlin',
 	'PHP',
-	'Scala',
 	'Objective-C',
 	'Visual Basic .NET',
+	'Scala', // Also supported by dependency graph integrator for Dependabot
+	'Kotlin', // Also supported by dependency graph integrator for Dependabot
 ];
+
+export const depGraphIntegratorSupportedLanguages = ['Scala', 'Kotlin'];
 
 export const actionSupportedLanguages = ignoredLanguages.concat(
 	'Scala',

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
@@ -7,7 +7,7 @@ import { removeRepoOwner } from '../shared-utilities';
 import {
 	checkRepoForLanguage,
 	createSnsEventsForDependencyGraphIntegration,
-	doesRepoHaveWorkflow,
+	doesRepoHaveDepSubmissionWorkflowForLanguage,
 } from './send-to-sns';
 
 const fullName = 'guardian/repo-name';
@@ -102,7 +102,7 @@ describe('When trying to find repos using Scala', () => {
 
 describe('When checking a repo for an existing dependency submission workflow', () => {
 	test('return true if repo workflow is present', () => {
-		const result = doesRepoHaveWorkflow(
+		const result = doesRepoHaveDepSubmissionWorkflowForLanguage(
 			repository(fullName),
 			[repoWithDepSubmissionWorkflow(fullName)],
 			'Scala',
@@ -110,7 +110,7 @@ describe('When checking a repo for an existing dependency submission workflow', 
 		expect(result).toBe(true);
 	});
 	test('return false if workflow is not present', () => {
-		const result = doesRepoHaveWorkflow(
+		const result = doesRepoHaveDepSubmissionWorkflowForLanguage(
 			repository(fullName),
 			[repoWithoutWorkflow(fullName)],
 			'Scala',

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -24,7 +24,7 @@ export function checkRepoForLanguage(
 	return languagesInRepo.includes(targetLanguage);
 }
 
-export function doesRepoHaveWorkflow(
+export function doesRepoHaveDepSubmissionWorkflowForLanguage(
 	repo: Repository,
 	workflow_usages: guardian_github_actions_usage[],
 	language: DepGraphLanguage,
@@ -53,16 +53,20 @@ export function getDepGraphLanguageReposWithoutWorkflows(
 	workflow_usages: guardian_github_actions_usage[],
 	language: DepGraphLanguage,
 ): Repository[] {
-	let reposWithDepGraphLanguages: Repository[] = [];
-	const repos = productionRepos.filter((repo) =>
-		checkRepoForLanguage(repo, languages, language),
+	const reposWithDepGraphLanguages: Repository[] = productionRepos.filter(
+		(repo) => checkRepoForLanguage(repo, languages, language),
 	);
-	console.log(`Found ${repos.length} ${language} repos in production`);
-
-	reposWithDepGraphLanguages = reposWithDepGraphLanguages.concat(repos);
+	console.log(
+		`Found ${reposWithDepGraphLanguages.length} ${language} repos in production`,
+	);
 
 	const reposWithoutWorkflows = reposWithDepGraphLanguages.filter(
-		(repo) => !doesRepoHaveWorkflow(repo, workflow_usages, language),
+		(repo) =>
+			!doesRepoHaveDepSubmissionWorkflowForLanguage(
+				repo,
+				workflow_usages,
+				language,
+			),
 	);
 	console.log(
 		`Found ${reposWithoutWorkflows.length} production repos without ${language} dependency submission workflows`,

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -47,33 +47,6 @@ export function doesRepoHaveDepSubmissionWorkflowForLanguage(
 	return false;
 }
 
-export function getDepGraphLanguageReposWithoutWorkflows(
-	languages: github_languages[],
-	productionRepos: Repository[],
-	workflow_usages: guardian_github_actions_usage[],
-	language: DepGraphLanguage,
-): Repository[] {
-	const reposWithDepGraphLanguages: Repository[] = productionRepos.filter(
-		(repo) => checkRepoForLanguage(repo, languages, language),
-	);
-	console.log(
-		`Found ${reposWithDepGraphLanguages.length} ${language} repos in production`,
-	);
-
-	const reposWithoutWorkflows = reposWithDepGraphLanguages.filter(
-		(repo) =>
-			!doesRepoHaveDepSubmissionWorkflowForLanguage(
-				repo,
-				workflow_usages,
-				language,
-			),
-	);
-	console.log(
-		`Found ${reposWithoutWorkflows.length} production repos without ${language} dependency submission workflows`,
-	);
-	return reposWithoutWorkflows;
-}
-
 export function createSnsEventsForDependencyGraphIntegration(
 	languages: github_languages[],
 	productionRepos: Repository[],
@@ -83,11 +56,24 @@ export function createSnsEventsForDependencyGraphIntegration(
 	const eventsForAllLanguages: DependencyGraphIntegratorEvent[] = [];
 
 	depGraphLanguages.forEach((language) => {
-		const reposWithoutWorkflows = getDepGraphLanguageReposWithoutWorkflows(
-			languages,
-			productionRepos,
-			workflow_usages,
-			language,
+		let reposWithDepGraphLanguages: Repository[] = [];
+		const repos = productionRepos.filter((repo) =>
+			checkRepoForLanguage(repo, languages, language),
+		);
+		console.log(`Found ${repos.length} ${language} repos in production`);
+
+		reposWithDepGraphLanguages = reposWithDepGraphLanguages.concat(repos);
+
+		const reposWithoutWorkflows = reposWithDepGraphLanguages.filter(
+			(repo) =>
+				!doesRepoHaveDepSubmissionWorkflowForLanguage(
+					repo,
+					workflow_usages,
+					language,
+				),
+		);
+		console.log(
+			`Found ${reposWithoutWorkflows.length} production repos without ${language} dependency submission workflows`,
 		);
 
 		reposWithoutWorkflows.map((repo) =>


### PR DESCRIPTION
## What does this change?

Changes the logic of the `hasDependencyTracking` function to include repos that have dependency submission workflows. The logic is a bit convoluted. The check now returns true for repos (not on Snyk) that have all their languages covered by dependabot and dependency graph integrator (Scala and Kotlin), as long as they also have the associated dependency submission workflow for each dependency graph integrator-supported language.

Tests have been added to cover these cases.

## Why?

This will give us a more accurate representation of repos with dependency vulnerability tracking.

## How has it been verified?

- [x] Tests pass locally
- [x] Vulns table reports 'true' for 'vulnerability_tracking' when repo only has dep submission workflow (no Snyk) and reports 'false' on 'main' (guardian/apps-anomaly-detection)
- [ ] Vulns table correctly reports for repos without dep submission workflows.