### PR TITLE
Finish paramaterisation of org name

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19932,6 +19932,7 @@ spec:
             "GITHUB_APP_SECRET": {
               "Ref": "dependencygraphintegratorgithubappauthB8B9DE78",
             },
+            "GITHUB_ORG": "guardian",
             "STACK": "deploy",
             "STAGE": "TEST",
           },
@@ -27520,6 +27521,7 @@ spec:
             "GITHUB_APP_SECRET": {
               "Ref": "snykintegratorgithubappauth8C64864D",
             },
+            "GITHUB_ORG": "guardian",
             "STACK": "deploy",
             "STAGE": "TEST",
           },

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -20579,6 +20579,7 @@ spec:
                 ],
               ],
             },
+            "GITHUB_ORG": "guardian",
             "STACK": "deploy",
             "STAGE": "TEST",
           },

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -9,7 +9,7 @@ import { LambdaSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 const service = 'interactive-monitor';
 export class InteractiveMonitor {
 	public readonly topic: Topic;
-	constructor(guStack: GuStack) {
+	constructor(guStack: GuStack, gitHubOrg: string) {
 		const app = guStack.app ?? 'service-catalogue'; //shouldn't be undefined, but make linter happy
 		const { stage, stack } = guStack;
 		const topic = new Topic(guStack, 'Topic', {
@@ -28,6 +28,7 @@ export class InteractiveMonitor {
 			runtime: Runtime.NODEJS_20_X,
 			environment: {
 				GITHUB_APP_SECRET: githubCredentials.secretName,
+				GITHUB_ORG: gitHubOrg,
 			},
 			reservedConcurrentExecutions: 1,
 		});

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -102,6 +102,7 @@ export class Repocop {
 			guStack,
 			vpc,
 			'snyk-integrator',
+			gitHubOrg,
 		);
 
 		snykIntegratorInputTopic.addSubscription(
@@ -112,6 +113,7 @@ export class Repocop {
 			guStack,
 			vpc,
 			'dependency-graph-integrator',
+			gitHubOrg,
 		);
 
 		dependencyGraphIntegratorInputTopic.addSubscription(
@@ -124,6 +126,7 @@ function stageAwareIntegratorLambda(
 	guStack: GuStack,
 	vpc: IVpc,
 	app: `${string}-integrator`,
+	gitHubOrg: string,
 ): GuLambdaFunction {
 	const nonProdLambdaProps = {
 		app,
@@ -134,6 +137,9 @@ function stageAwareIntegratorLambda(
 		runtime: Runtime.NODEJS_20_X,
 		vpc,
 		timeout: Duration.minutes(5),
+		environment: {
+			GITHUB_ORG: gitHubOrg,
+		},
 	};
 
 	if (guStack.stage === 'PROD' || guStack.stage === 'TEST') {
@@ -144,6 +150,7 @@ function stageAwareIntegratorLambda(
 		const lambda = new GuLambdaFunction(guStack, app, {
 			...nonProdLambdaProps,
 			environment: {
+				...nonProdLambdaProps.environment,
 				GITHUB_APP_SECRET: githubAppSecret.secretArn,
 			},
 		});

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -216,7 +216,7 @@ export class ServiceCatalogue extends GuStack {
 		const repocopMonitoringConfiguration =
 			stage === 'PROD' ? repocopProdMonitoring : repocopCodeMonitoring;
 
-		const interactiveMonitor = new InteractiveMonitor(this);
+		const interactiveMonitor = new InteractiveMonitor(this, gitHubOrg);
 
 		const anghammaradTopic = Topic.fromTopicArn(
 			this,

--- a/packages/common/src/pull-requests.test.ts
+++ b/packages/common/src/pull-requests.test.ts
@@ -49,6 +49,7 @@ describe('getPullRequest', () => {
 		const foundPull = await getExistingPullRequest(
 			mockOctokit(pulls),
 			'repo',
+			'owner',
 			'gu-snyk-integrator[bot]',
 		);
 		expect(foundPull).toBeUndefined();
@@ -59,6 +60,7 @@ describe('getPullRequest', () => {
 		const foundPull = await getExistingPullRequest(
 			mockOctokit(pulls),
 			'repo',
+			'owner',
 			'gu-snyk-integrator[bot]',
 		);
 		expect(foundPull).toEqual(snykBranch);
@@ -70,6 +72,7 @@ describe('getPullRequest', () => {
 		const foundPull = await getExistingPullRequest(
 			mockOctokit(pulls),
 			'repo',
+			'owner',
 			'gu-snyk-integrator[bot]',
 		);
 		expect(foundPull).toEqual(snykBranch);

--- a/packages/common/src/pull-requests.ts
+++ b/packages/common/src/pull-requests.ts
@@ -71,10 +71,11 @@ function isGithubAuthor(pull: PullRequest, author: string) {
 export async function getExistingPullRequest(
 	octokit: Octokit,
 	repoName: string,
+	owner: string,
 	author: string,
 ) {
 	const pulls = await octokit.paginate(octokit.rest.pulls.list, {
-		owner: 'guardian',
+		owner,
 		repo: repoName,
 		state: 'open',
 	} satisfies PullRequestParameters);
@@ -106,6 +107,7 @@ export async function createPrAndAddToProject(
 		const existingPullRequest = await getExistingPullRequest(
 			octokit,
 			repoName,
+			owner,
 			`${author}[bot]`,
 		);
 

--- a/packages/common/src/pull-requests.ts
+++ b/packages/common/src/pull-requests.ts
@@ -12,6 +12,7 @@ interface Change {
 
 interface CreatePullRequestOptions {
 	repoName: string;
+	owner: string;
 	title: string;
 	body: string;
 	branchName: string;
@@ -33,6 +34,7 @@ export async function createPullRequest(
 ): Promise<string | undefined> {
 	const {
 		repoName,
+		owner,
 		title,
 		body,
 		branchName,
@@ -41,7 +43,7 @@ export async function createPullRequest(
 	} = props;
 
 	const response = await composeCreatePullRequest(octokit, {
-		owner: 'guardian',
+		owner,
 		repo: repoName,
 		title,
 		body,
@@ -89,6 +91,7 @@ export async function getExistingPullRequest(
 export async function createPrAndAddToProject(
 	stage: string,
 	repoName: string,
+	owner: string,
 	author: string,
 	branch: string,
 	prTitle: string,
@@ -109,6 +112,7 @@ export async function createPrAndAddToProject(
 		if (!existingPullRequest) {
 			const pullRequestUrl = await createPullRequest(octokit, {
 				repoName,
+				owner,
 				title: prTitle,
 				body: prBody,
 				branchName: branch,

--- a/packages/interactive-monitor/src/config.ts
+++ b/packages/interactive-monitor/src/config.ts
@@ -3,10 +3,16 @@ export interface Config {
 	 * The stage to run in.
 	 */
 	stage: string;
+
+	/**
+	 * The GitHub org to use
+	 */
+	owner: string;
 }
 
 export function getConfig(): Config {
 	return {
 		stage: process.env['STAGE'] ?? 'DEV',
+		owner: process.env['GITHUB_ORG'] ?? 'guardian',
 	};
 }

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -92,7 +92,7 @@ export async function assessRepo(repo: string, config: Config) {
 	const onProd = stage === 'PROD';
 
 	async function foundInJs(): Promise<boolean> {
-		const path = await tryToParseJsConfig(octokit, repo);
+		const path = await tryToParseJsConfig(octokit, repo, owner);
 		if (!path) {
 			console.debug(`${repo}: Found in JS config: `, false);
 			return false;

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -84,11 +84,11 @@ async function s3PathIsInConfig(
 	}
 }
 
-export async function assessRepo(repo: string, owner: string, config: Config) {
+export async function assessRepo(repo: string, config: Config) {
 	const octokit = await stageAwareOctokit(config.stage);
 	const awsConfig = awsClientConfig(config.stage);
 	const s3 = new S3Client({ ...awsConfig, region: 'us-east-1' });
-	const { stage } = config;
+	const { stage, owner } = config;
 	const onProd = stage === 'PROD';
 
 	async function foundInJs(): Promise<boolean> {
@@ -135,11 +135,8 @@ export async function assessRepo(repo: string, owner: string, config: Config) {
 
 export const handler: SNSHandler = async (event) => {
 	const config = getConfig();
-	const owner = 'guardian';
 	console.log(`Detected stage: ${config.stage}`);
 	const events = parseEvent<string[]>(event).flat();
 
-	await Promise.all(
-		events.map(async (repo) => await assessRepo(repo, owner, config)),
-	);
+	await Promise.all(events.map(async (repo) => await assessRepo(repo, config)));
 };

--- a/packages/interactive-monitor/src/js-parser.ts
+++ b/packages/interactive-monitor/src/js-parser.ts
@@ -41,10 +41,11 @@ export function getPathFromConfigFile(
 export async function tryToParseJsConfig(
 	octokit: Octokit,
 	repo: string,
+	owner: string,
 ): Promise<string | undefined> {
 	try {
 		const configFile: ContentResponse = await octokit.rest.repos.getContent({
-			owner: 'guardian',
+			owner,
 			repo,
 			path: 'project.config.js',
 		});

--- a/packages/interactive-monitor/src/run-locally.ts
+++ b/packages/interactive-monitor/src/run-locally.ts
@@ -8,4 +8,4 @@ config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
 const testRepo = 'ofm-awards-label-2019-atom';
 const devConfig = getConfig();
-void assessRepo(testRepo, 'guardian', devConfig);
+void assessRepo(testRepo, devConfig);

--- a/packages/snyk-integrator/src/config.ts
+++ b/packages/snyk-integrator/src/config.ts
@@ -5,10 +5,16 @@ export interface Config {
 	 * The stage of the application, e.g. DEV, CODE, PROD.
 	 */
 	stage: string;
+
+	/**
+	 * The GitHub org to use
+	 */
+	owner: string;
 }
 
 export function getConfig(): Config {
 	return {
 		stage: getEnvOrThrow('STAGE'),
+		owner: process.env['GITHUB_ORG'] ?? 'guardian',
 	};
 }

--- a/packages/snyk-integrator/src/index.ts
+++ b/packages/snyk-integrator/src/index.ts
@@ -25,6 +25,7 @@ export async function main(event: SnykIntegratorEvent) {
 	await createPrAndAddToProject(
 		config.stage,
 		event.name,
+		config.owner,
 		author,
 		branch,
 		title,


### PR DESCRIPTION
## What does this change?

A follow up to #1271 , this finishes the work to paramaterise all relevant instances of the `guardian` github org across the service catalogue.

## Why?

For the same reasons as the previous PR. Magic values are bad! And this will make it easier for people outside the guardian to use and modify the service catalogue if they wish

## How has it been verified?

- [ ]  CI passes.
- [ ]  Local execution
- [ ]  CODE execution