### PR TITLE
Create a cloudbuster user

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19802,7 +19802,7 @@ spec:
                         "DbiResourceId",
                       ],
                     },
-                    "/repocop",
+                    "/cloudbuster",
                   ],
                 ],
               },

--- a/packages/cdk/lib/cloudbuster.ts
+++ b/packages/cdk/lib/cloudbuster.ts
@@ -69,6 +69,6 @@ export class CloudBuster {
 		// 	],
 		// });
 
-		db.grantConnect(lambda, 'repocop');
+		db.grantConnect(lambda, 'cloudbuster');
 	}
 }

--- a/packages/cloudbuster/src/config.ts
+++ b/packages/cloudbuster/src/config.ts
@@ -29,8 +29,7 @@ export async function getConfig(): Promise<Config> {
 
 	const databaseConfig = isDev
 		? await getDevDatabaseConfig()
-		: await getDatabaseConfig(stage, 'repocop'); //TODO create a new db user for cloudbuster before deploying.
-
+		: await getDatabaseConfig(stage, 'cloudbuster');
 	return {
 		stage,
 		databaseConnectionString: getDatabaseConnectionString(databaseConfig),

--- a/packages/common/prisma/migrations/20240930091139_cloudbuster_user/migration.sql
+++ b/packages/common/prisma/migrations/20240930091139_cloudbuster_user/migration.sql
@@ -8,7 +8,7 @@ $do$
         END IF;
 
         -- Allow cloudbuster to read from all tables and views in the public schema
-        GRANT USAGE ON SCHEMA public to cloudbuster;
+        GRANT SELECT ON ALL TABLES IN SCHEMA public TO cloudbuster;
         -- Grant read access to all future tables, and views
         ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO cloudbuster;
 

--- a/packages/common/prisma/migrations/20240930091139_cloudbuster_user/migration.sql
+++ b/packages/common/prisma/migrations/20240930091139_cloudbuster_user/migration.sql
@@ -1,0 +1,22 @@
+-- This is an empty migration.
+
+DO
+$do$
+    BEGIN
+        -- Create the `cloudbuster` user if it doesn't exist
+        IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE  rolname = 'cloudbuster') THEN
+            CREATE USER cloudbuster WITH LOGIN;
+        END IF;
+
+        -- Allow cloudbuster to read AWS SecurityHub Findings
+        GRANT USAGE ON SCHEMA public to cloudbuster;
+        GRANT SELECT ON public.aws_securityhub_findings TO cloudbuster;
+
+        -- The rds_iam role is created by the RDS IAM extension, which is not available in DEV
+        IF EXISTS (select * from pg_roles where rolname='rds_iam') THEN
+            GRANT rds_iam TO cloudbuster;
+        END IF;
+
+    END
+$do$;
+

--- a/packages/common/prisma/migrations/20240930091139_cloudbuster_user/migration.sql
+++ b/packages/common/prisma/migrations/20240930091139_cloudbuster_user/migration.sql
@@ -1,4 +1,3 @@
--- This is an empty migration.
 
 DO
 $do$

--- a/packages/common/prisma/migrations/20240930091139_cloudbuster_user/migration.sql
+++ b/packages/common/prisma/migrations/20240930091139_cloudbuster_user/migration.sql
@@ -7,10 +7,9 @@ $do$
             CREATE USER cloudbuster WITH LOGIN;
         END IF;
 
-        -- Allow cloudbuster to read from all tables and views in the public schema
-        GRANT SELECT ON ALL TABLES IN SCHEMA public TO cloudbuster;
-        -- Grant read access to all future tables, and views
-        ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO cloudbuster;
+        -- Allow cloudbuster to read AWS SecurityHub Findings
+        GRANT USAGE ON SCHEMA public to cloudbuster;
+        GRANT SELECT ON public.aws_securityhub_findings TO cloudbuster;
 
         -- The rds_iam role is created by the RDS IAM extension, which is not available in DEV
         IF EXISTS (select * from pg_roles where rolname='rds_iam') THEN

--- a/packages/common/prisma/migrations/20240930091139_cloudbuster_user/migration.sql
+++ b/packages/common/prisma/migrations/20240930091139_cloudbuster_user/migration.sql
@@ -7,9 +7,10 @@ $do$
             CREATE USER cloudbuster WITH LOGIN;
         END IF;
 
-        -- Allow cloudbuster to read AWS SecurityHub Findings
+        -- Allow cloudbuster to read from all tables and views in the public schema
         GRANT USAGE ON SCHEMA public to cloudbuster;
-        GRANT SELECT ON public.aws_securityhub_findings TO cloudbuster;
+        -- Grant read access to all future tables, and views
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO cloudbuster;
 
         -- The rds_iam role is created by the RDS IAM extension, which is not available in DEV
         IF EXISTS (select * from pg_roles where rolname='rds_iam') THEN

--- a/sql/ci.sql
+++ b/sql/ci.sql
@@ -27,7 +27,7 @@ VALUES (
 
 -- Switch to the `cloudbuster` user and test access to the tables used in the cloudbuster app
 SET ROLE cloudbuster;
--- It should only be able to read from this table
+-- It should be able to read from this table
 SELECT * FROM aws_securityhub_findings LIMIT 1;
 
 

--- a/sql/ci.sql
+++ b/sql/ci.sql
@@ -25,6 +25,12 @@ VALUES (
     , '{}'
 );
 
+-- Switch to the `cloudbuster` user and test access to the tables used in the cloudbuster app
+SET ROLE cloudbuster;
+-- It should only be able to read from this table
+SELECT * FROM aws_securityhub_findings LIMIT 1;
+
+
 -- Switch to the `dataaudit` user and test access to the tables/views used in the data-audit app
 SET ROLE dataaudit;
 -- It should be able to read from these tables


### PR DESCRIPTION
## What does this change?

As cloudbuster will now be writing to a table, it requires different permissions to repocop. In this PR, we create a user that can only read the table containing security hub findings. It will also need to read from `cloudbuster_fsbp_findings`, but that permission will be granted in #1274 , the same PR the creates the table

## How has it been verified?

- [ ] Deployed and run cloudbuster on CODE (will do after approval)
- [x] updated SQL CI test
