### PR TITLE
update dependency submission workflow versions

### DIFF
--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Submit dependencies
         id: submit
-        uses: scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1
+        uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0
       - name: Log snapshot for user validation
         id: validate
         run: cat` +

--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -59,7 +59,7 @@ jobs:
           java-version: 17
       - name: Submit dependencies
         id: submit
-        uses: gradle/actions/dependency-submission@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/dependency-submission@d156388eb19639ec20ade50009f3d199ce1e2808 # v4.1.0
       - name: Log snapshot for user validation
         id: validate
         run: cat ` + // Need to split this line to avoid errors due to new line produced in yaml

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -47,7 +47,7 @@ function createLanguageSpecificWorkflowSteps(
 			{
 				name: 'Submit dependencies',
 				id: 'submit',
-				uses: 'gradle/actions/dependency-submission@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0',
+				uses: 'gradle/actions/dependency-submission@d156388eb19639ec20ade50009f3d199ce1e2808 # v4.1.0',
 			},
 			{
 				name: 'Log snapshot for user validation',

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -21,7 +21,7 @@ function createLanguageSpecificWorkflowSteps(
 			{
 				name: 'Submit dependencies',
 				id: 'submit',
-				uses: 'scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1',
+				uses: 'scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0',
 			},
 			{
 				name: 'Log snapshot for user validation',


### PR DESCRIPTION
## What does this change?

Bumps the versions of the sbt and gradle dependency submission workflows that are used in the PRs created by Dependency Graph Integrator.

## Why?

To keep things up-to-date.

## How has it been verified?

NOTE: depends on #1291 .

- [x] Tested the gradle workflow on `snyk-test-toolargetool` - [success](https://github.com/guardian/snyk-test-toolargetool/actions/runs/11163350541/job/31030080606)
- [x] The sbt workflow has already been udpated to latest in repos and is functioning as normal (example: [`janus-app`](https://github.com/guardian/janus-app/actions/workflows/dependency-graph.yml))
