### PR TITLE
Eliminate race condition

### DIFF
--- a/packages/cloudbuster/src/digests.test.ts
+++ b/packages/cloudbuster/src/digests.test.ts
@@ -1,0 +1,64 @@
+import type { cloudbuster_fsbp_vulnerabilities } from '@prisma/client';
+import type { SecurityHubSeverity } from 'common/types';
+import { createDigestsFromFindings } from './digests';
+
+function mockFinding(
+	aws_account_id: string,
+	severity: SecurityHubSeverity,
+): cloudbuster_fsbp_vulnerabilities {
+	return {
+		aws_account_id,
+		title: 'mock title',
+		aws_account_name: 'mock-account',
+		arn: 'arn::mock::123',
+		remediation: 'https://mock.url/mock',
+		severity,
+		within_sla: true,
+		first_observed_at: new Date('2020-01-01'),
+		control_id: 'MOCK.1',
+		aws_region: 'eu-mock-1',
+		repo: null,
+		stack: null,
+		stage: null,
+		app: null,
+	};
+}
+
+describe('createDigestsFromFindings', () => {
+	it('should filter findings by severity', () => {
+		const findings = [
+			mockFinding('1', 'CRITICAL'),
+			mockFinding('2', 'HIGH'),
+			mockFinding('3', 'CRITICAL'),
+		];
+		const criticalDigests = createDigestsFromFindings(findings, 'CRITICAL');
+		expect(criticalDigests.length).toBe(2);
+
+		const highDigests = createDigestsFromFindings(findings, 'HIGH');
+		expect(highDigests.length).toBe(1);
+	});
+	it('should create one digest per account', () => {
+		const findingsFromTwoAccounts = [
+			mockFinding('1', 'CRITICAL'),
+			mockFinding('2', 'CRITICAL'),
+			mockFinding('3', 'CRITICAL'),
+		];
+		const result = createDigestsFromFindings(
+			findingsFromTwoAccounts,
+			'CRITICAL',
+		);
+		expect(result.length).toBe(3);
+	});
+	it('should combine findings of the same account and severity into one digest', () => {
+		const findingsFromOneAccount = [
+			mockFinding('1', 'CRITICAL'),
+			mockFinding('1', 'CRITICAL'),
+			mockFinding('1', 'CRITICAL'),
+		];
+		const result = createDigestsFromFindings(
+			findingsFromOneAccount,
+			'CRITICAL',
+		);
+		expect(result.length).toBe(1);
+	});
+});

--- a/packages/cloudbuster/src/digests.ts
+++ b/packages/cloudbuster/src/digests.ts
@@ -1,6 +1,7 @@
 import { RequestedChannel } from '@guardian/anghammarad';
 import type { Anghammarad, NotifyParams } from '@guardian/anghammarad';
 import type { cloudbuster_fsbp_vulnerabilities } from '@prisma/client';
+import type { SecurityHubSeverity } from 'common/src/types';
 import { type Config } from './config';
 import { groupFindingsByAccount } from './findings';
 import type { Digest } from './types';
@@ -8,10 +9,13 @@ import type { Digest } from './types';
 /**
  * Given a list of findings, creates a list of digests ready to be emailed out
  */
-export function createDigestsFromFindings(
+export function createDigestsFromFindings( //TODO test me
 	findings: cloudbuster_fsbp_vulnerabilities[],
+	severity: SecurityHubSeverity,
 ): Digest[] {
-	const groupedFindings = groupFindingsByAccount(findings);
+	const filteredFindings = findings.filter((f) => f.severity === severity);
+
+	const groupedFindings = groupFindingsByAccount(filteredFindings);
 
 	return Object.keys(groupedFindings)
 		.map((awsAccountId) =>

--- a/packages/cloudbuster/src/digests.ts
+++ b/packages/cloudbuster/src/digests.ts
@@ -9,7 +9,7 @@ import type { Digest } from './types';
 /**
  * Given a list of findings, creates a list of digests ready to be emailed out
  */
-export function createDigestsFromFindings( //TODO test me
+export function createDigestsFromFindings(
 	findings: cloudbuster_fsbp_vulnerabilities[],
 	severity: SecurityHubSeverity,
 ): Digest[] {

--- a/packages/cloudbuster/src/run-locally.ts
+++ b/packages/cloudbuster/src/run-locally.ts
@@ -1,8 +1,5 @@
 import { main } from './index';
 
 if (require.main === module) {
-	void main({
-		// Using all severities in DEV for more data.
-		severities: ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFORMATION'],
-	});
+	void main();
 }


### PR DESCRIPTION
## What does this change?

Now that cloudbuster writes to a DB, to avoid race conditions, we should not be running two instances simultaneously, as this could create race conditions. Instead, we can follow repocop's model of running every day, with high severities being evaluated once a week

## How has it been verified?

- Added unit tests to verify behaviour
- CI passes
