### PR TITLE
fix: Kotlin dependency submission log snapshot output

### DIFF
--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -63,7 +63,7 @@ jobs:
       - name: Log snapshot for user validation
         id: validate
         run: cat ` + // Need to split this line to avoid errors due to new line produced in yaml
-			'/home/runner/work/repo2/repo2/dependency-graph-reports/update_dependency_graph_for_kotlin-dependency-graph.json\n          | jq' +
+			'/home/runner/work/repo2/repo2/dependency-graph-reports/update_dependency_graph_for_gradle-dependency-graph.json\n          | jq' +
 			String.raw`
     permissions:
       contents: write

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -52,7 +52,7 @@ function createLanguageSpecificWorkflowSteps(
 			{
 				name: 'Log snapshot for user validation',
 				id: 'validate',
-				run: `cat /home/runner/work/${repo}/${repo}/dependency-graph-reports/update_dependency_graph_for_kotlin-dependency-graph.json | jq`,
+				run: `cat /home/runner/work/${repo}/${repo}/dependency-graph-reports/update_dependency_graph_for_gradle-dependency-graph.json | jq`,
 			},
 		],
 	};


### PR DESCRIPTION
## What does this change?

Fixes a typo in the path to the JSON file which logs the snapshot of dependencies when the PR raised by dependency graph integrator first runs the 'submit dependencies' action. 

## Why?

So that users can correctly see the output before merging the workflow to main, where it will submit the dependencies to the dependency graph.

## How has it been verified?

Tested on `snyk-test-toolargetool` - see 'Log snapshot for user validation' step: [before](https://github.com/guardian/snyk-test-toolargetool/actions/runs/11160575335/job/31021305450) and [after](https://github.com/guardian/snyk-test-toolargetool/actions/runs/11160800827/job/31022017175)