### PR TITLE
upgrade octokit as far as we can

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3061,8 +3061,9 @@
       }
     },
     "node_modules/@octokit/auth-app": {
-      "version": "6.1.1",
-      "license": "MIT",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.1.2.tgz",
+      "integrity": "sha512-fWjIOpxnL8/YFY3kqquciFQ4o99aCqHw5kMFoGPYbz/h5HNZ11dJlV9zag5wS2nt0X1wJ5cs9BUo+CsAPfW4jQ==",
       "dependencies": {
         "@octokit/auth-oauth-app": "^7.1.0",
         "@octokit/auth-oauth-user": "^4.1.0",
@@ -3291,8 +3292,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "22.1.0",
-      "license": "MIT"
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg=="
     },
     "node_modules/@octokit/plugin-paginate-graphql": {
       "version": "4.0.1",
@@ -3329,27 +3331,17 @@
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "10.4.1",
-      "license": "MIT",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.2.tgz",
+      "integrity": "sha512-EI7kXWidkt3Xlok5uN43suK99VWqc8OaIMktY9d9+RNKl69juoTyxmLoWPIZgJYzi41qj/9zU7G/ljnNOJ5AFA==",
       "dependencies": {
-        "@octokit/types": "^12.6.0"
+        "@octokit/types": "^13.5.0"
       },
       "engines": {
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": "5"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
-      "version": "20.0.0",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "12.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^20.0.0"
+        "@octokit/core": "^5"
       }
     },
     "node_modules/@octokit/plugin-retry": {
@@ -3429,10 +3421,11 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "13.4.1",
-      "license": "MIT",
+      "version": "13.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.1.tgz",
+      "integrity": "sha512-PHZE9Z+kWXb23Ndik8MKPirBPziOc0D2/3KH1P+6jK5nGWe96kadZuE4jev2/Jq7FvIfTlT2Ltg8Fv2x1v0a5g==",
       "dependencies": {
-        "@octokit/openapi-types": "^22.1.0"
+        "@octokit/openapi-types": "^22.2.0"
       }
     },
     "node_modules/@octokit/webhooks": {
@@ -10511,19 +10504,20 @@
       "link": true
     },
     "node_modules/octokit": {
-      "version": "3.2.0",
-      "license": "MIT",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/octokit/-/octokit-3.2.1.tgz",
+      "integrity": "sha512-u+XuSejhe3NdIvty3Jod00JvTdAE/0/+XbhIDhefHbu+2OcTRHd80aCiH6TX19ZybJmwPQBKFQmHGxp0i9mJrg==",
       "dependencies": {
         "@octokit/app": "^14.0.2",
         "@octokit/core": "^5.0.0",
         "@octokit/oauth-app": "^6.0.0",
         "@octokit/plugin-paginate-graphql": "^4.0.0",
-        "@octokit/plugin-paginate-rest": "^9.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+        "@octokit/plugin-paginate-rest": "11.3.1",
+        "@octokit/plugin-rest-endpoint-methods": "13.2.2",
         "@octokit/plugin-retry": "^6.0.0",
         "@octokit/plugin-throttling": "^8.0.0",
         "@octokit/request-error": "^5.0.0",
-        "@octokit/types": "^12.0.0"
+        "@octokit/types": "^13.0.0"
       },
       "engines": {
         "node": ">= 18"
@@ -10547,15 +10541,18 @@
         "@octokit/openapi-types": "^14.0.0"
       }
     },
-    "node_modules/octokit/node_modules/@octokit/openapi-types": {
-      "version": "20.0.0",
-      "license": "MIT"
-    },
-    "node_modules/octokit/node_modules/@octokit/types": {
-      "version": "12.6.0",
-      "license": "MIT",
+    "node_modules/octokit/node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.1.tgz",
+      "integrity": "sha512-ryqobs26cLtM1kQxqeZui4v8FeznirUsksiA+RYemMPJ7Micju0WSkv50dBksTuZks9O5cg4wp+t8fZ/cLY56g==",
       "dependencies": {
-        "@octokit/openapi-types": "^20.0.0"
+        "@octokit/types": "^13.5.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
       }
     },
     "node_modules/once": {
@@ -13012,14 +13009,14 @@
         "@aws-sdk/credential-providers": "^3.662.0",
         "@aws-sdk/rds-signer": "^3.662.0",
         "@guardian/anghammarad": "^1.8.3",
-        "@octokit/auth-app": "^6.1.1",
+        "@octokit/auth-app": "^6.1.2",
         "@prisma/client": "^5.20.0",
-        "octokit": "^3.2.0",
+        "octokit": "^3.2.1",
         "octokit-plugin-create-pull-request": "^5.1.1"
       },
       "devDependencies": {
         "@octokit/graphql": "^8.1.1",
-        "@octokit/types": "^13.4.1",
+        "@octokit/types": "^13.6.1",
         "@types/aws-lambda": "^8.10.141",
         "prisma": "^5.20.0"
       }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -12,15 +12,15 @@
 		"@guardian/anghammarad": "^1.8.3",
 		"@aws-sdk/credential-providers": "^3.662.0",
 		"@aws-sdk/rds-signer": "^3.662.0",
-		"@octokit/auth-app": "^6.1.1",
-		"octokit": "^3.2.0",
+		"@octokit/auth-app": "^6.1.2",
+		"octokit": "^3.2.1",
 		"octokit-plugin-create-pull-request": "^5.1.1",
 		"@prisma/client": "^5.20.0"
 	},
 	"devDependencies": {
 		"prisma": "^5.20.0",
 		"@octokit/graphql": "^8.1.1",
-		"@octokit/types": "^13.4.1",
+		"@octokit/types": "^13.6.1",
 		"@types/aws-lambda": "^8.10.141"
 	},
 	"prisma": {

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -11,7 +11,9 @@ import {
 	SLAs,
 } from 'common/src/types';
 
-export async function getGithubClient(githubAppConfig: GitHubAppConfig) {
+export async function getGithubClient(
+	githubAppConfig: GitHubAppConfig,
+): Promise<Octokit> {
 	const auth = createAppAuth(githubAppConfig.strategyOptions);
 
 	const installationAuthentication = await auth({
@@ -63,7 +65,7 @@ export async function getGitHubAppConfig(): Promise<GitHubAppConfig> {
 	return githubAppConfig;
 }
 
-export async function stageAwareOctokit(stage: string) {
+export async function stageAwareOctokit(stage: string): Promise<Octokit> {
 	if (stage === 'CODE' || stage === 'PROD') {
 		const githubAppConfig: GitHubAppConfig = await getGitHubAppConfig();
 		const octokit: Octokit = await getGithubClient(githubAppConfig);


### PR DESCRIPTION
## What does this change?

Upgrade octokit packages, stopping just short of the next major version. This is because octokit libraries then become ESM only, which is a much more involved job.

## How has it been verified?

CI passes
