### PR TITLE
add a weekend offset for vulnerabilities raised on Fri/Sat/Sun

### DIFF
--- a/packages/common/src/functions.test.ts
+++ b/packages/common/src/functions.test.ts
@@ -229,6 +229,35 @@ describe('daysLeftToFix', () => {
 	test('should return 2 if a critical vuln was raised today', () => {
 		expect(daysLeftToFix(new Date(), 'critical')).toBe(2);
 	});
+
+	const monday = new Date('2024-10-07'); // Oct 7th 2024 is a Monday
+	beforeEach(() => {
+		jest.useFakeTimers().setSystemTime(monday);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	test('should add an extra two days to fix vulnerabilities raised on a Friday or Saturday', () => {
+		const friday = new Date('2024-10-04'); // Oct 4th 2024 is a Friday
+		const saturday = new Date('2024-10-05'); // Oct 5th 2024 is a Saturday
+		const isSaturday = saturday.getDay() === 6;
+		const isFriday = friday.getDay() === 5;
+
+		expect(isFriday).toBe(true);
+		expect(daysLeftToFix(friday, 'critical')).toBe(1);
+
+		expect(isSaturday).toBe(true);
+		expect(daysLeftToFix(saturday, 'critical')).toBe(2);
+	});
+	test('should add an extra day to fix vulnerabilities raised on a Sunday', () => {
+		const sunday = new Date('2024-10-06'); // Oct 6th 2024 is a Sunday
+		const isSunday = sunday.getDay() === 0;
+
+		expect(isSunday).toBe(true);
+		expect(daysLeftToFix(sunday, 'critical')).toBe(2);
+	});
 });
 
 const MOCK_TODAY = new Date('2024-01-10');

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -179,6 +179,21 @@ export function stringToSeverity(severity: string): Severity {
 	}
 }
 
+function weekendOffset(date: Date): number {
+	const isFriday = date.getDay() === 5;
+	const isSaturday = date.getDay() === 6;
+	const isSunday = date.getDay() === 0;
+
+	if (isSunday) {
+		return 1;
+	}
+	if (isSaturday || isFriday) {
+		return 2;
+	} else {
+		return 0;
+	}
+}
+
 export function daysLeftToFix(
 	alert_date: Date,
 	severity: Severity,
@@ -194,7 +209,12 @@ export function daysLeftToFix(
 		(fixDate.getTime() - new Date().getTime()) / millisecondsInADay,
 	);
 
-	return daysLeftToFix < 0 ? 0 : daysLeftToFix;
+	if (severity === 'critical') {
+		const weekendOffsetValue = weekendOffset(alert_date);
+		return Math.max(0, daysLeftToFix + weekendOffsetValue);
+	} else {
+		return Math.max(0, daysLeftToFix);
+	}
 }
 
 /**


### PR DESCRIPTION
## What does this change?

Give developers extra time to resolve critical vulnerbilities raised on or close to the weekend

## Why?

Provide a more realistic timeline for remediation. Currently, vulnerabilities raised on a friday afternoon (ie after repocop has run that day) are already out of date by the time monday rolls around

## How has it been verified?

Unit tests have been added to verify the status of a vuln raised over the weekend on the following Monday

## Next steps

~~As a follow up PR, we should include an `is_within_sla` field in the repocop table, so that the dashboard has the same information as repocop's vulnerability digest~~ resolved in #1296 