### PR TITLE
feat: add within_sla column to repocop vulnerabilities table

### DIFF
--- a/packages/common/prisma/migrations/20241009103331_repocop_sla/migration.sql
+++ b/packages/common/prisma/migrations/20241009103331_repocop_sla/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `within_sla` to the `repocop_vulnerabilities` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "repocop_vulnerabilities" ADD COLUMN     "within_sla" BOOLEAN NOT NULL;

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -685,6 +685,7 @@ model repocop_vulnerabilities {
   cves             String[]
   repo_owner       String
   id               String   @id @default(uuid())
+  within_sla       Boolean
 }
 
 /// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.test.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.test.ts
@@ -29,6 +29,7 @@ describe('The dependency vulnerabilities obligation', () => {
 		cves: [''],
 		repo_owner: 'owner1',
 		source: 'Dependabot',
+		within_sla: false,
 	};
 
 	it('should return something if it finds a vulnerability on a repo', () => {

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -638,6 +638,7 @@ const oldCriticalDependabotVuln: RepocopVulnerability = {
 	alert_issue_date: new Date('2021-01-01T00:00:00.000Z'),
 	is_patchable: true,
 	cves: ['CVE-2021-1234'],
+	within_sla: false,
 };
 
 const newCriticalDependabotVuln: RepocopVulnerability = {
@@ -922,6 +923,7 @@ describe('NO RULE - Vulnerabilities from Dependabot', () => {
 			alert_issue_date: new Date('2022-06-15T07:43:03Z'),
 			is_patchable: true,
 			cves: ['CVE-2018-6188'],
+			within_sla: false,
 		};
 
 		const expected2: RepocopVulnerability = {
@@ -939,6 +941,7 @@ describe('NO RULE - Vulnerabilities from Dependabot', () => {
 			alert_issue_date: new Date('2022-06-14T15:21:52Z'),
 			is_patchable: true,
 			cves: ['CVE-2021-20191'],
+			within_sla: false,
 		};
 
 		expect(result).toStrictEqual([expected1, expected2]);
@@ -973,6 +976,7 @@ describe('NO RULE - Vulnerabilities from Snyk', () => {
 			alert_issue_date: new Date('2020-01-01'),
 			is_patchable: true,
 			cves: ['CVE-1234'],
+			within_sla: false,
 		});
 	});
 
@@ -998,6 +1002,7 @@ describe('Deduplication of repocop vulnerabilities', () => {
 		alert_issue_date: new Date('2022-06-15T07:43:03Z'),
 		is_patchable: true,
 		cves: ['CVE-2018-6188'],
+		within_sla: false,
 	};
 	const vuln2: RepocopVulnerability = {
 		full_name: fullName,
@@ -1010,6 +1015,7 @@ describe('Deduplication of repocop vulnerabilities', () => {
 		alert_issue_date: new Date('2022-06-15T07:43:03Z'),
 		is_patchable: true,
 		cves: ['CVE-2018-6188'],
+		within_sla: false,
 	};
 	const actual = deduplicateVulnerabilitiesByCve([vuln1, vuln2]);
 	test('Should happen if two vulnerabilities share the same CVEs', () => {

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -81,6 +81,7 @@ const highRecentVuln: RepocopVulnerability = {
 	alert_issue_date: new Date(),
 	is_patchable: true,
 	cves: ['CVE-123'],
+	within_sla: true,
 };
 
 describe('createDigest', () => {
@@ -150,6 +151,7 @@ describe('createDigest', () => {
 			alert_issue_date: new Date(),
 			is_patchable: true,
 			cves: ['CVE-123'],
+			within_sla: true,
 		};
 		const anotherResultWithVuln: EvaluationResult = {
 			...anotherResult,

--- a/packages/repocop/src/utils.test.ts
+++ b/packages/repocop/src/utils.test.ts
@@ -120,6 +120,7 @@ describe('vulnSortingPredicate', () => {
 			source: 'Dependabot',
 			alert_issue_date: new Date(),
 			cves: [],
+			within_sla: true,
 		};
 		const criticalNotPatchable: RepocopVulnerability = {
 			...criticalPatchable,


### PR DESCRIPTION
Co-authored-by: Natasha <67543397+NovemberTang@users.noreply.github.com>

## What does this change?

Adds a column to the `repocop_vulnerabilities` table to track whether vulnerabilities meet their SLAs (2 days for criticals, 30 days for highs).

## Why?

To simplify the SQL in the Grafana dashboard.

## How has it been verified?

Tested locally and observed the table with the new column and populated with data.

NOTE: We will have to clear the live tables in advance of running the migration.
