### PR TITLE
Allow cloudbuster to run, without sending messages

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -21,8 +21,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaErrorPercentageAlarm",
-      "GuLambdaFunction",
-      "GuLambdaErrorPercentageAlarm",
+      "GuScheduledLambda",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -19555,132 +19554,6 @@ spec:
       },
       "Type": "AWS::Lambda::Function",
     },
-    "cloudbusterErrorPercentageAlarmForLambda3A9AF5A0": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":devx-alerts",
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": {
-          "Fn::Join": [
-            "",
-            [
-              {
-                "Ref": "cloudbuster8C461939",
-              },
-              " exceeded 0% error rate",
-            ],
-          ],
-        },
-        "AlarmName": {
-          "Fn::Join": [
-            "",
-            [
-              "High error percentage from ",
-              {
-                "Ref": "cloudbuster8C461939",
-              },
-              " lambda in TEST",
-            ],
-          ],
-        },
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 1,
-        "Metrics": [
-          {
-            "Expression": "100*m1/m2",
-            "Id": "expr_1",
-            "Label": {
-              "Fn::Join": [
-                "",
-                [
-                  "Error % of ",
-                  {
-                    "Ref": "cloudbuster8C461939",
-                  },
-                ],
-              ],
-            },
-          },
-          {
-            "Id": "m1",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "cloudbuster8C461939",
-                    },
-                  },
-                ],
-                "MetricName": "Errors",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-          {
-            "Id": "m2",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "cloudbuster8C461939",
-                    },
-                  },
-                ],
-                "MetricName": "Invocations",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Threshold": 0,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "cloudbusterServiceRoleDefaultPolicy173FB27F": {
       "Properties": {
         "PolicyDocument": {
@@ -19883,6 +19756,43 @@ spec:
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "cloudbustercloudbustercron309MONFRI0A90AE33E": {
+      "Properties": {
+        "ScheduleExpression": "cron(30 9 ? * MON-FRI *)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "cloudbuster8C461939",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "cloudbustercloudbustercron309MONFRI0AllowEventRuleServiceCataloguecloudbuster82FA89E4F5116C2E": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "cloudbuster8C461939",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "cloudbustercloudbustercron309MONFRI0A90AE33E",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "cloudqueryapikeyCCF82F53": {
       "DeletionPolicy": "Delete",

--- a/packages/cloudbuster/src/config.ts
+++ b/packages/cloudbuster/src/config.ts
@@ -34,7 +34,7 @@ export async function getConfig(): Promise<Config> {
 		stage,
 		databaseConnectionString: getDatabaseConnectionString(databaseConfig),
 		withQueryLogging: isDev,
-		enableMessaging: !isDev,
+		enableMessaging: false, //!isDev,
 		anghammaradSnsTopic,
 	};
 }

--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -19,7 +19,7 @@ export async function main() {
 		`Starting Cloudbuster. Level of severities that will be scanned: ${severities.join(', ')}`,
 	);
 
-	const dbResults = (await getFsbpFindings(prisma, severities)).slice(0, 5); //TODO: remove slice when ready to go live
+	const dbResults = await getFsbpFindings(prisma, severities);
 
 	const tableContents: cloudbuster_fsbp_vulnerabilities[] = dbResults.flatMap(
 		findingsToGuardianFormat,


### PR DESCRIPTION
## What does this change?

- Start collecting all cloudbuster data, not just the first five rows
- Convert cloudbuster to a scheduled lambda cloudbuster, allow it to start running on AWS
- Switch off all messaging temporarily
- Cloudbuster's schedule and monitoring configuration echoes repocop's

## Why?

Cloudbuster is ready to be rolled out after the comms announcement. In advance of this, we need to start migrating the grafana tables. To migrate the grafana tables, we need a complete set of data in the Cloudquery DB. So let's allow cloudbuster to collect this

I've switched off messaging as we don't want to start alerting teams before the comms are sent out. We can reconfigure this next week

## How has it been verified?

CI passes, snapshots look normal.
Works on CODE
