### PR TITLE
stop logging the full cloudbuster findings table

### DIFF
--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -24,7 +24,10 @@ export async function main() {
 	const tableContents: cloudbuster_fsbp_vulnerabilities[] = dbResults.flatMap(
 		findingsToGuardianFormat,
 	);
-	console.table(tableContents);
+
+	console.log(
+		`${tableContents.length} high and critical FSBP findings detected`,
+	);
 
 	await prisma.cloudbuster_fsbp_vulnerabilities.deleteMany();
 	await prisma.cloudbuster_fsbp_vulnerabilities.createMany({


### PR DESCRIPTION
## What does this change?

Previously, we were logging the entire table out, in a tabular format. In ELK this is very ugly, and the message also cuts off early because it's so large. Now, we just capture the total number of vulnerabilities so we can sense check the count while debugging

