### PR TITLE
filter out suppressed findings

### DIFF
--- a/packages/cloudbuster/src/findings.test.ts
+++ b/packages/cloudbuster/src/findings.test.ts
@@ -24,6 +24,7 @@ describe('findingsToGuardianFormat', () => {
 		first_observed_at: new Date('2020-01-01'),
 		product_fields: { ControlId: 'S.1' },
 		resources: [resource1, resource2],
+		workflow: { Status: 'NEW' },
 	};
 	it('should return n elements if n resources are associated with a finding', () => {
 		const actual = findingsToGuardianFormat(x);

--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -19,7 +19,9 @@ export async function main() {
 		`Starting Cloudbuster. Level of severities that will be scanned: ${severities.join(', ')}`,
 	);
 
-	const dbResults = await getFsbpFindings(prisma, severities);
+	const dbResults = (await getFsbpFindings(prisma, severities)).filter(
+		(f) => f.workflow.Status !== 'SUPPRESSED',
+	);
 
 	const tableContents: cloudbuster_fsbp_vulnerabilities[] = dbResults.flatMap(
 		findingsToGuardianFormat,

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -123,4 +123,5 @@ export type SecurityHubFinding = Pick<
 	severity: { Label: SecurityHubSeverity; Normalized: number };
 	resources: Resource[];
 	product_fields: { ControlId: string };
+	workflow: { Status: 'NEW' | 'NOTIFIED' | 'SUPPRESSED' | 'RESOLVED' }; //https://docs.aws.amazon.com/securityhub/latest/userguide/findings-workflow-status.html
 };

--- a/packages/obligatron/src/obligations/aws-vulnerabilities.test.ts
+++ b/packages/obligatron/src/obligations/aws-vulnerabilities.test.ts
@@ -23,6 +23,7 @@ describe('The dependency vulnerabilities obligation', () => {
 		aws_account_id: '0123456',
 		first_observed_at: new Date('2020-01-01'),
 		product_fields: { ControlId: 'S.1' },
+		workflow: { Status: 'NEW' },
 	};
 
 	const twoResourceFinding: SecurityHubFinding = {


### PR DESCRIPTION
## What does this change?

Cloudbuster should not act on suppressed findings

## Why?

Suppressed vulnerabilities are handled by a different process

## How has it been verified?

Deployed and ran, saw the expected drop in vulnerability counts. Fixed relevant unit tests.
