### PR TITLE
fix: update sbt dependency submission workflow to install sbt

### DIFF
--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -18,6 +18,9 @@ jobs:
       - name: Checkout branch
         id: checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Install sbt
+        id: install
+        uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
       - name: Submit dependencies
         id: submit
         uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -19,6 +19,11 @@ function createLanguageSpecificWorkflowSteps(
 				uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7',
 			},
 			{
+				name: 'Install sbt',
+				id: 'install',
+				uses: 'sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0',
+			},
+			{
 				name: 'Submit dependencies',
 				id: 'submit',
 				uses: 'scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0',


### PR DESCRIPTION
## What does this change?

Adds a step to the dependency graph integrator PR generator to install sbt.

## Why?

The workflow currently fails because sbt is no longer bundled with latest Ubuntu.

## How has it been verified?

Tested by copying the output of running locally in `janus-app` and observed that the workflow [succeeded](https://github.com/guardian/janus-app/actions/runs/11349830699).