### PR TITLE
Obligatron filters on within_sla

### DIFF
--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -1,9 +1,5 @@
 import type { PrismaClient, repocop_vulnerabilities } from '@prisma/client';
-import {
-	daysLeftToFix,
-	stringToSeverity,
-	toNonEmptyArray,
-} from 'common/src/functions';
+import { stringToSeverity, toNonEmptyArray } from 'common/src/functions';
 import { logger } from 'common/src/logs';
 import type {
 	NonEmptyArray,
@@ -81,7 +77,7 @@ export async function evaluateDependencyVulnerabilityObligation(
 ): Promise<ObligationResult[]> {
 	const repos = await getProductionRepos(client);
 	const vulns = (await getRepocopVulnerabilities(client)).filter(
-		(v) => daysLeftToFix(v.alert_issue_date, v.severity) === 0,
+		(v) => !v.within_sla,
 	);
 
 	const resultsOrUndefined: Array<ObligationResult | undefined> = repos.map(


### PR DESCRIPTION
## What does this change?

Repocop now contains a `within_sla` column, which used `daysLeftToFix()` under the hood. Now, instead of performing the calculation twice, we just work out whether or not something is within SLA by using the column repocop provides

## Why?

Efficiency
