### PR TITLE
feat: explicitly install java in sbt dep submission workflow

### DIFF
--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -17,9 +17,15 @@ jobs:
     steps:
       - name: Checkout branch
         id: checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Install Java
+        id: java
+        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0
+        with:
+          distribution: corretto
+          java-version: 17
       - name: Install sbt
-        id: install
+        id: sbt
         uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
       - name: Submit dependencies
         id: submit
@@ -53,7 +59,7 @@ jobs:
     steps:
       - name: Checkout branch
         id: checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Set up Java
         id: setup
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -16,11 +16,20 @@ function createLanguageSpecificWorkflowSteps(
 			{
 				name: 'Checkout branch',
 				id: 'checkout',
-				uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7',
+				uses: 'actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1',
+			},
+			{
+				name: 'Install Java',
+				id: 'java',
+				uses: 'actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0',
+				with: {
+					distribution: 'corretto',
+					'java-version': '17',
+				},
 			},
 			{
 				name: 'Install sbt',
-				id: 'install',
+				id: 'sbt',
 				uses: 'sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0',
 			},
 			{
@@ -38,7 +47,7 @@ function createLanguageSpecificWorkflowSteps(
 			{
 				name: 'Checkout branch',
 				id: 'checkout',
-				uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7',
+				uses: 'actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1',
 			},
 			{
 				name: 'Set up Java',


### PR DESCRIPTION
## What does this change?

- Explicitly installs java in the sbt dependency submission workflow created by the dependency graph integrator
- Updates `actions/checkout` to latest
- Updates tests

## Why?

We can't guarantee that future versions of Ubuntu will ship with Java, and it's required by sbt in this workflow.

## How has it been verified?

- [x] Run tests locally
- [x] Test PR created on another repo to ensure it runs -[ tested on `security-hq`](https://github.com/guardian/security-hq/actions/runs/11388986269)
