### PR TITLE
enable cloudbuster messaging on CODE/PROD

### DIFF
--- a/packages/cloudbuster/src/config.ts
+++ b/packages/cloudbuster/src/config.ts
@@ -34,7 +34,7 @@ export async function getConfig(): Promise<Config> {
 		stage,
 		databaseConnectionString: getDatabaseConnectionString(databaseConfig),
 		withQueryLogging: isDev,
-		enableMessaging: false, //!isDev,
+		enableMessaging: !isDev,
 		anghammaradSnsTopic,
 	};
 }


### PR DESCRIPTION
## What does this change?

Allow cloudbuster to contact teams about new FSBP vulnerabilities

## Why?

So they can act on them in a timely manner

