### PR TITLE
Request admin reviews on PRs raised by the service catalogue

### DIFF
--- a/packages/common/src/pull-requests.ts
+++ b/packages/common/src/pull-requests.ts
@@ -135,18 +135,19 @@ export async function createPrAndAddToProject(
 	commitMessage: string,
 	boardNumber: number,
 	admins: string[],
+	octokit?: Octokit,
 ) {
 	if (stage === 'PROD') {
-		const octokit = await stageAwareOctokit(stage);
+		const ghClient = octokit ?? (await stageAwareOctokit(stage));
 		const existingPullRequest = await getExistingPullRequest(
-			octokit,
+			ghClient,
 			repoName,
 			owner,
 			`${author}[bot]`,
 		);
 
 		if (!existingPullRequest) {
-			const pullRequestResponse = await createPullRequest(octokit, {
+			const pullRequestResponse = await createPullRequest(ghClient, {
 				repoName,
 				owner,
 				title: prTitle,
@@ -170,7 +171,7 @@ export async function createPrAndAddToProject(
 				);
 
 				await requestTeamReview(
-					octokit,
+					ghClient,
 					repoName,
 					owner,
 					pullRequestResponse.number,

--- a/packages/common/src/pull-requests.ts
+++ b/packages/common/src/pull-requests.ts
@@ -18,10 +18,16 @@ interface CreatePullRequestOptions {
 	branchName: string;
 	baseBranch?: string;
 	changes: Change[];
+	admins: string[];
 }
 
 export function generateBranchName(prefix: string) {
 	return `${prefix}-${randomBytes(8).toString('hex')}`;
+}
+
+interface UrlAndNumber {
+	html_url: string | undefined;
+	number: number | undefined;
 }
 
 /**
@@ -31,7 +37,7 @@ export function generateBranchName(prefix: string) {
 export async function createPullRequest(
 	octokit: Octokit,
 	props: CreatePullRequestOptions,
-): Promise<string | undefined> {
+): Promise<UrlAndNumber | undefined> {
 	const {
 		repoName,
 		owner,
@@ -55,7 +61,34 @@ export async function createPullRequest(
 		})),
 	});
 
-	return response?.data.html_url;
+	console.log('PR url:', response?.data.html_url);
+	console.log('PR number:', response?.data.number);
+
+	return response?.data as UrlAndNumber;
+}
+
+export async function requestTeamReview(
+	octokit: Octokit,
+	repoName: string,
+	owner: string,
+	pullNumber: number,
+	admins: string[],
+) {
+	console.log('Requesting team review:', admins);
+	if (admins.length > 0) {
+		const response = await octokit.rest.pulls.requestReviewers({
+			owner,
+			repo: repoName,
+			pull_number: pullNumber,
+			team_reviewers: admins,
+		});
+		console.log('Requested team review:', response.data.requested_teams);
+		console.log(response.status);
+		return response;
+	} else {
+		console.log('No team reviewers to request');
+		return undefined;
+	}
 }
 
 type PullRequestParameters =
@@ -101,6 +134,7 @@ export async function createPrAndAddToProject(
 	fileContents: string,
 	commitMessage: string,
 	boardNumber: number,
+	admins: string[],
 ) {
 	if (stage === 'PROD') {
 		const octokit = await stageAwareOctokit(stage);
@@ -112,7 +146,7 @@ export async function createPrAndAddToProject(
 		);
 
 		if (!existingPullRequest) {
-			const pullRequestUrl = await createPullRequest(octokit, {
+			const pullRequestResponse = await createPullRequest(octokit, {
 				repoName,
 				owner,
 				title: prTitle,
@@ -126,10 +160,23 @@ export async function createPrAndAddToProject(
 						},
 					},
 				],
+				admins,
 			});
 
-			if (pullRequestUrl) {
-				console.log('Pull request successfully created:', pullRequestUrl);
+			if (pullRequestResponse?.html_url && pullRequestResponse.number) {
+				console.log(
+					'Pull request successfully created:',
+					pullRequestResponse.html_url,
+				);
+
+				await requestTeamReview(
+					octokit,
+					repoName,
+					owner,
+					pullRequestResponse.number,
+					admins,
+				);
+
 				await addPrToProject(stage, repoName, boardNumber, author);
 				console.log('Updated project board');
 			}

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -34,6 +34,7 @@ export type DepGraphLanguage = 'Scala' | 'Kotlin';
 export interface DependencyGraphIntegratorEvent {
 	name: string;
 	language: DepGraphLanguage;
+	admins: string[];
 }
 
 export interface SnykIntegratorEvent {

--- a/packages/dependency-graph-integrator/src/index.ts
+++ b/packages/dependency-graph-integrator/src/index.ts
@@ -1,6 +1,9 @@
 import type { SNSHandler } from 'aws-lambda';
 import { parseEvent, stageAwareOctokit } from 'common/functions';
-import { generateBranchName } from 'common/src/pull-requests';
+import {
+	createPrAndAddToProject,
+	generateBranchName,
+} from 'common/src/pull-requests';
 import type { DependencyGraphIntegratorEvent } from 'common/src/types';
 import type { Config } from './config';
 import { getConfig } from './config';
@@ -9,10 +12,7 @@ import {
 	depGraphPackageManager,
 	generatePrBody,
 } from './file-generator';
-import {
-	createPrAndAddToProject,
-	enableDependabotAlerts,
-} from './repo-functions';
+import { enableDependabotAlerts } from './repo-functions';
 import type { StatusCode } from './types';
 
 export async function main(event: DependencyGraphIntegratorEvent) {
@@ -48,6 +48,7 @@ export async function main(event: DependencyGraphIntegratorEvent) {
 			await createPrAndAddToProject(
 				stage,
 				repo,
+				'guardian', //TODO pass in through CDK as config
 				author,
 				branch,
 				title,
@@ -56,8 +57,8 @@ export async function main(event: DependencyGraphIntegratorEvent) {
 				yamlContents,
 				commitMessage,
 				boardNumber,
+				admins,
 				octokit,
-				event.admins,
 			);
 		} else {
 			throw Error(

--- a/packages/dependency-graph-integrator/src/index.ts
+++ b/packages/dependency-graph-integrator/src/index.ts
@@ -18,8 +18,9 @@ import type { StatusCode } from './types';
 export async function main(event: DependencyGraphIntegratorEvent) {
 	const language = event.language;
 	const name = event.name;
+	const admins = event.admins;
 	console.log(
-		`Generating Dependabot PR for ${name} repo with ${language} language`,
+		`Generating Dependabot PR for ${name} repo with ${language} language, admins: ${admins.join(', ')}.`,
 	);
 	const config: Config = getConfig();
 	const stage = config.stage;
@@ -56,6 +57,7 @@ export async function main(event: DependencyGraphIntegratorEvent) {
 				commitMessage,
 				boardNumber,
 				octokit,
+				event.admins,
 			);
 		} else {
 			throw Error(

--- a/packages/dependency-graph-integrator/src/repo-functions.ts
+++ b/packages/dependency-graph-integrator/src/repo-functions.ts
@@ -46,6 +46,7 @@ export async function createPrAndAddToProject(
 	commitMessage: string,
 	boardNumber: number,
 	octokit: Octokit,
+	admins: string[],
 ) {
 	const existingPullRequest = await getExistingPullRequest(
 		octokit,
@@ -68,6 +69,7 @@ export async function createPrAndAddToProject(
 					},
 				},
 			],
+			admins,
 		});
 
 		if (pullRequestUrl) {

--- a/packages/dependency-graph-integrator/src/repo-functions.ts
+++ b/packages/dependency-graph-integrator/src/repo-functions.ts
@@ -1,7 +1,5 @@
 import { randomBytes } from 'crypto';
-import { createPullRequest } from 'common/src/pull-requests';
 import type { Octokit } from 'octokit';
-import { addPrToProject } from '../../common/src/projects-graphql';
 import type { PullRequest, PullRequestParameters, StatusCode } from './types';
 
 export function generateBranchName(prefix: string) {
@@ -32,59 +30,6 @@ export async function getExistingPullRequest(
 	}
 
 	return found[0] ?? undefined;
-}
-
-export async function createPrAndAddToProject(
-	stage: string,
-	repoName: string,
-	author: string,
-	branch: string,
-	prTitle: string,
-	prBody: string,
-	fileName: string,
-	fileContents: string,
-	commitMessage: string,
-	boardNumber: number,
-	octokit: Octokit,
-	admins: string[],
-) {
-	const existingPullRequest = await getExistingPullRequest(
-		octokit,
-		repoName,
-		`${author}[bot]`,
-	);
-
-	if (!existingPullRequest) {
-		const pullRequestUrl = await createPullRequest(octokit, {
-			repoName,
-			owner: OWNER,
-			title: prTitle,
-			body: prBody,
-			branchName: branch,
-			changes: [
-				{
-					commitMessage,
-					files: {
-						[fileName]: fileContents,
-					},
-				},
-			],
-			admins,
-		});
-
-		if (pullRequestUrl) {
-			console.log('Pull request successfully created:', pullRequestUrl);
-			await addPrToProject(stage, repoName, boardNumber, author);
-			console.log('Updated project board');
-		}
-	} else {
-		console.log(
-			`Existing pull request found. Skipping creating a new one.`,
-			existingPullRequest.html_url,
-		);
-	}
-
-	console.log('Done');
 }
 
 const ghHeaders = { 'X-GitHub-Api-Version': '2022-11-28' };

--- a/packages/dependency-graph-integrator/src/run-locally.ts
+++ b/packages/dependency-graph-integrator/src/run-locally.ts
@@ -9,5 +9,6 @@ if (require.main === module) {
 	void main({
 		name: 'service-catalogue',
 		language: 'Scala',
+		admins: ['devx-security'],
 	});
 }

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -174,7 +174,6 @@ export async function main() {
 			await protectBranches(
 				repocopRules,
 				repoOwners,
-				teams,
 				config,
 				unarchivedRepos,
 				octokit,
@@ -189,7 +188,6 @@ export async function main() {
 		);
 
 		await applyProductionTopicAndMessageTeams(
-			teams,
 			unarchivedRepos,
 			nonPlaygroundStacks,
 			repoOwners,
@@ -208,7 +206,6 @@ export async function main() {
 		productionRepos,
 		productionWorkflowUsages,
 		repoOwners,
-		teams,
 	);
 
 	console.log('Done');

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -207,6 +207,8 @@ export async function main() {
 		repoLanguages,
 		productionRepos,
 		productionWorkflowUsages,
+		repoOwners,
+		teams,
 	);
 
 	console.log('Done');

--- a/packages/repocop/src/remediation/branch-protector/branch-protection.test.ts
+++ b/packages/repocop/src/remediation/branch-protector/branch-protection.test.ts
@@ -2,7 +2,6 @@ import type {
 	repocop_github_repository_rules,
 	view_repo_ownership,
 } from '@prisma/client';
-import type { Team } from '../../types';
 import { createBranchProtectionEvents } from './branch-protection';
 
 const nullOwner: view_repo_ownership = {
@@ -15,12 +14,6 @@ const nullOwner: view_repo_ownership = {
 	archived: false,
 	galaxies_team: null,
 	team_contact_email: null,
-};
-
-const teamOne: Team = {
-	name: 'Team One',
-	id: BigInt(1),
-	slug: 'team-one',
 };
 
 describe('Team slugs should be findable for every team associated with a repo', () => {
@@ -44,13 +37,12 @@ describe('Team slugs should be findable for every team associated with a repo', 
 			full_repo_name: repo,
 			github_team_id: BigInt(1),
 			github_team_name: 'Team One',
-			github_team_slug: teamOne.slug,
+			github_team_slug: 'team-one',
 		};
 
 		const actual = createBranchProtectionEvents(
 			[evaluatedRepo],
 			[teamOneOwner],
-			[teamOne],
 			5,
 		);
 
@@ -72,12 +64,7 @@ describe('Team slugs should be findable for every team associated with a repo', 
 			evaluated_on: new Date(),
 		};
 
-		const actual = createBranchProtectionEvents(
-			[evaluatedRepo],
-			[],
-			[teamOne],
-			5,
-		);
+		const actual = createBranchProtectionEvents([evaluatedRepo], [], 5);
 
 		expect(actual.length).toEqual(0);
 	});

--- a/packages/repocop/src/remediation/branch-protector/branch-protection.ts
+++ b/packages/repocop/src/remediation/branch-protector/branch-protection.ts
@@ -6,7 +6,6 @@ import { shuffle } from 'common/src/functions';
 import type { Repository, UpdateMessageEvent } from 'common/src/types';
 import type { Octokit } from 'octokit';
 import type { Config } from '../../config';
-import type { Team } from '../../types';
 import { findContactableOwners } from '../shared-utilities';
 import { notify } from './aws-requests';
 import {
@@ -18,7 +17,6 @@ import {
 export function createBranchProtectionEvents(
 	evaluatedRepos: repocop_github_repository_rules[],
 	repoOwners: view_repo_ownership[],
-	teams: Team[],
 	msgCount: number,
 ): UpdateMessageEvent[] {
 	const reposWithoutBranchProtection = evaluatedRepos.filter(
@@ -28,7 +26,7 @@ export function createBranchProtectionEvents(
 		.map((repo) => {
 			return {
 				fullName: repo.full_name,
-				teamNameSlugs: findContactableOwners(repo.full_name, repoOwners, teams),
+				teamNameSlugs: findContactableOwners(repo.full_name, repoOwners),
 			};
 		})
 		.filter((repo) => repo.teamNameSlugs.length > 0);
@@ -43,7 +41,6 @@ export function createBranchProtectionEvents(
 export async function protectBranches(
 	evaluatedRepos: repocop_github_repository_rules[],
 	repoOwners: view_repo_ownership[],
-	teams: Team[],
 	config: Config,
 	unarchivedRepositories: Repository[],
 	octokit: Octokit,
@@ -62,7 +59,7 @@ export async function protectBranches(
 	);
 
 	const branchProtectionEvents: UpdateMessageEvent[] =
-		createBranchProtectionEvents(relevantRepos, repoOwners, teams, 5);
+		createBranchProtectionEvents(relevantRepos, repoOwners, 5);
 
 	await Promise.all(
 		branchProtectionEvents.map((event) =>

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
@@ -1,8 +1,10 @@
 import type {
 	github_languages,
 	guardian_github_actions_usage,
+	view_repo_ownership,
 } from '@prisma/client';
 import type { Repository } from 'common/src/types';
+import type { Team } from '../../types';
 import { removeRepoOwner } from '../shared-utilities';
 import {
 	checkRepoForLanguage,
@@ -125,9 +127,11 @@ describe('When getting suitable events to send to SNS', () => {
 			[repoWithTargetLanguage(fullName)],
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
+			[],
+			[],
 		);
 		expect(result).toEqual([
-			{ name: removeRepoOwner(fullName), language: 'Scala' },
+			{ name: removeRepoOwner(fullName), language: 'Scala', admins: [] },
 		]);
 	});
 	test('return empty event array when a Scala repo is found with an existing workflow', () => {
@@ -135,6 +139,8 @@ describe('When getting suitable events to send to SNS', () => {
 			[repoWithTargetLanguage(fullName)],
 			[repository(fullName)],
 			[repoWithDepSubmissionWorkflow(fullName)],
+			[],
+			[],
 		);
 		expect(result).toEqual([]);
 	});
@@ -143,6 +149,8 @@ describe('When getting suitable events to send to SNS', () => {
 			[repoWithoutTargetLanguage(fullName)],
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
+			[],
+			[],
 		);
 		expect(result).toEqual([]);
 	});
@@ -151,10 +159,80 @@ describe('When getting suitable events to send to SNS', () => {
 			[repoWithTargetLanguage(fullName), repoWithTargetLanguage(fullName2)],
 			[repository(fullName), repository(fullName2)],
 			[repoWithoutWorkflow(fullName), repoWithoutWorkflow(fullName2)],
+			[],
+			[],
 		);
 		expect(result).toEqual([
-			{ name: removeRepoOwner(fullName), language: 'Scala' },
-			{ name: removeRepoOwner(fullName2), language: 'Scala' },
+			{ name: removeRepoOwner(fullName), language: 'Scala', admins: [] },
+			{ name: removeRepoOwner(fullName2), language: 'Scala', admins: [] },
+		]);
+	});
+
+	const ownershipRecord1: view_repo_ownership = {
+		full_repo_name: fullName,
+		github_team_id: BigInt(1),
+		github_team_name: 'team-name',
+		github_team_slug: 'team-slug',
+		short_repo_name: 'repo-name',
+		role_name: 'admin',
+		archived: false,
+		galaxies_team: 'Team',
+		team_contact_email: 'team@team.com',
+	};
+	const team1: Team = {
+		id: ownershipRecord1.github_team_id,
+		slug: ownershipRecord1.github_team_slug,
+		name: ownershipRecord1.github_team_name,
+	};
+
+	test('return an event with an admins where they exist', () => {
+		const ownershipRecord2: view_repo_ownership = {
+			...ownershipRecord1,
+			github_team_id: BigInt(2),
+			github_team_slug: 'team-slug2',
+			github_team_name: 'team-name2',
+		};
+		const team2: Team = {
+			id: ownershipRecord2.github_team_id,
+			slug: ownershipRecord2.github_team_slug,
+			name: ownershipRecord2.github_team_name,
+		};
+
+		const result = createSnsEventsForDependencyGraphIntegration(
+			[repoWithTargetLanguage(fullName)],
+			[repository(fullName)],
+			[repoWithoutWorkflow(fullName)],
+			[ownershipRecord1, ownershipRecord2],
+			[team1, team2],
+		);
+		expect(result).toEqual([
+			{
+				name: removeRepoOwner(fullName),
+				language: 'Scala',
+				admins: ['team-slug', 'team-slug2'],
+			},
+		]);
+	});
+	test('return not event with an admin if none are correct', () => {
+		const ownershipRecord: view_repo_ownership = {
+			...ownershipRecord1,
+			full_repo_name: 'guardian/other-repo',
+			short_repo_name: 'other-repo',
+		};
+
+		const result = createSnsEventsForDependencyGraphIntegration(
+			[repoWithTargetLanguage(fullName)],
+			[repository(fullName)],
+			[repoWithoutWorkflow(fullName)],
+			[ownershipRecord],
+			[team1],
+		);
+		expect(result).toEqual([
+			{
+				name: removeRepoOwner(fullName),
+				language: 'Scala',
+				admins: [],
+			},
 		]);
 	});
 });

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
@@ -4,7 +4,6 @@ import type {
 	view_repo_ownership,
 } from '@prisma/client';
 import type { Repository } from 'common/src/types';
-import type { Team } from '../../types';
 import { removeRepoOwner } from '../shared-utilities';
 import {
 	checkRepoForLanguage,
@@ -128,7 +127,6 @@ describe('When getting suitable events to send to SNS', () => {
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
 			[],
-			[],
 		);
 		expect(result).toEqual([
 			{ name: removeRepoOwner(fullName), language: 'Scala', admins: [] },
@@ -140,7 +138,6 @@ describe('When getting suitable events to send to SNS', () => {
 			[repository(fullName)],
 			[repoWithDepSubmissionWorkflow(fullName)],
 			[],
-			[],
 		);
 		expect(result).toEqual([]);
 	});
@@ -150,7 +147,6 @@ describe('When getting suitable events to send to SNS', () => {
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
 			[],
-			[],
 		);
 		expect(result).toEqual([]);
 	});
@@ -159,7 +155,6 @@ describe('When getting suitable events to send to SNS', () => {
 			[repoWithTargetLanguage(fullName), repoWithTargetLanguage(fullName2)],
 			[repository(fullName), repository(fullName2)],
 			[repoWithoutWorkflow(fullName), repoWithoutWorkflow(fullName2)],
-			[],
 			[],
 		);
 		expect(result).toEqual([
@@ -179,11 +174,6 @@ describe('When getting suitable events to send to SNS', () => {
 		galaxies_team: 'Team',
 		team_contact_email: 'team@team.com',
 	};
-	const team1: Team = {
-		id: ownershipRecord1.github_team_id,
-		slug: ownershipRecord1.github_team_slug,
-		name: ownershipRecord1.github_team_name,
-	};
 
 	test('return an event with an admins where they exist', () => {
 		const ownershipRecord2: view_repo_ownership = {
@@ -192,18 +182,12 @@ describe('When getting suitable events to send to SNS', () => {
 			github_team_slug: 'team-slug2',
 			github_team_name: 'team-name2',
 		};
-		const team2: Team = {
-			id: ownershipRecord2.github_team_id,
-			slug: ownershipRecord2.github_team_slug,
-			name: ownershipRecord2.github_team_name,
-		};
 
 		const result = createSnsEventsForDependencyGraphIntegration(
 			[repoWithTargetLanguage(fullName)],
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
 			[ownershipRecord1, ownershipRecord2],
-			[team1, team2],
 		);
 		expect(result).toEqual([
 			{
@@ -225,7 +209,6 @@ describe('When getting suitable events to send to SNS', () => {
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
 			[ownershipRecord],
-			[team1],
 		);
 		expect(result).toEqual([
 			{

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -12,7 +12,6 @@ import type {
 	Repository,
 } from 'common/src/types';
 import type { Config } from '../../config';
-import type { Team } from '../../types';
 import { findContactableOwners, removeRepoOwner } from '../shared-utilities';
 
 export function checkRepoForLanguage(
@@ -54,7 +53,6 @@ export function createSnsEventsForDependencyGraphIntegration(
 	productionRepos: Repository[],
 	workflow_usages: guardian_github_actions_usage[],
 	view_repo_ownership: view_repo_ownership[],
-	teams: Team[],
 ): DependencyGraphIntegratorEvent[] {
 	const depGraphLanguages: DepGraphLanguage[] = ['Scala', 'Kotlin'];
 	const eventsForAllLanguages: DependencyGraphIntegratorEvent[] = [];
@@ -83,11 +81,7 @@ export function createSnsEventsForDependencyGraphIntegration(
 			eventsForAllLanguages.push({
 				name: removeRepoOwner(repo.full_name),
 				language,
-				admins: findContactableOwners(
-					repo.full_name,
-					view_repo_ownership,
-					teams,
-				),
+				admins: findContactableOwners(repo.full_name, view_repo_ownership),
 			}),
 		);
 	});
@@ -102,7 +96,6 @@ export async function sendOneRepoToDepGraphIntegrator(
 	productionRepos: Repository[],
 	workflowUsages: guardian_github_actions_usage[],
 	view_repo_ownership: view_repo_ownership[],
-	teams: Team[],
 ) {
 	const eventToSend = shuffle(
 		createSnsEventsForDependencyGraphIntegration(
@@ -110,7 +103,6 @@ export async function sendOneRepoToDepGraphIntegrator(
 			productionRepos,
 			workflowUsages,
 			view_repo_ownership,
-			teams,
 		),
 	)[0];
 

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -2,6 +2,7 @@ import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
 import type {
 	github_languages,
 	guardian_github_actions_usage,
+	view_repo_ownership,
 } from '@prisma/client';
 import { awsClientConfig } from 'common/src/aws';
 import { shuffle } from 'common/src/functions';
@@ -11,7 +12,8 @@ import type {
 	Repository,
 } from 'common/src/types';
 import type { Config } from '../../config';
-import { removeRepoOwner } from '../shared-utilities';
+import type { Team } from '../../types';
+import { findContactableOwners, removeRepoOwner } from '../shared-utilities';
 
 export function checkRepoForLanguage(
 	repo: Repository,
@@ -51,6 +53,8 @@ export function createSnsEventsForDependencyGraphIntegration(
 	languages: github_languages[],
 	productionRepos: Repository[],
 	workflow_usages: guardian_github_actions_usage[],
+	view_repo_ownership: view_repo_ownership[],
+	teams: Team[],
 ): DependencyGraphIntegratorEvent[] {
 	const depGraphLanguages: DepGraphLanguage[] = ['Scala', 'Kotlin'];
 	const eventsForAllLanguages: DependencyGraphIntegratorEvent[] = [];
@@ -75,11 +79,15 @@ export function createSnsEventsForDependencyGraphIntegration(
 		console.log(
 			`Found ${reposWithoutWorkflows.length} production repos without ${language} dependency submission workflows`,
 		);
-
 		reposWithoutWorkflows.map((repo) =>
 			eventsForAllLanguages.push({
 				name: removeRepoOwner(repo.full_name),
 				language,
+				admins: findContactableOwners(
+					repo.full_name,
+					view_repo_ownership,
+					teams,
+				),
 			}),
 		);
 	});
@@ -93,12 +101,16 @@ export async function sendOneRepoToDepGraphIntegrator(
 	repoLanguages: github_languages[],
 	productionRepos: Repository[],
 	workflowUsages: guardian_github_actions_usage[],
+	view_repo_ownership: view_repo_ownership[],
+	teams: Team[],
 ) {
 	const eventToSend = shuffle(
 		createSnsEventsForDependencyGraphIntegration(
 			repoLanguages,
 			productionRepos,
 			workflowUsages,
+			view_repo_ownership,
+			teams,
 		),
 	)[0];
 

--- a/packages/repocop/src/remediation/shared-utilities.test.ts
+++ b/packages/repocop/src/remediation/shared-utilities.test.ts
@@ -1,9 +1,48 @@
-import { removeRepoOwner } from './shared-utilities';
+import { findContactableOwners, removeRepoOwner } from './shared-utilities';
 
 describe('removeRepoOwner', () => {
 	it('should strip the owner from the full repo name', () => {
 		const fullRepoName = 'guardian/repo-1';
 		const result: string = removeRepoOwner(fullRepoName);
 		expect(result).toEqual('repo-1');
+	});
+});
+
+describe('findContactableOwners', () => {
+	it('should not return anything if nothing is passed in', () => {
+		const result = findContactableOwners('my-repo', []);
+		expect(result).toEqual([]);
+	});
+	it('should not return anything if the repo is not found in the table', () => {
+		const result = findContactableOwners('my-repo', [
+			{
+				full_repo_name: 'not-my-repo',
+				github_team_id: BigInt(1),
+				github_team_name: 'Team One',
+				github_team_slug: 'team-one',
+				short_repo_name: 'not-my-repo',
+				role_name: 'admin',
+				archived: false,
+				galaxies_team: 'Team One',
+				team_contact_email: 'team-one@email.com',
+			},
+		]);
+		expect(result).toEqual([]);
+	});
+	it('should return a team if the full repo name is correct', () => {
+		const result = findContactableOwners('my-repo', [
+			{
+				full_repo_name: 'my-repo',
+				github_team_id: BigInt(1),
+				github_team_name: 'Team One',
+				github_team_slug: 'team-one',
+				short_repo_name: '',
+				role_name: 'admin',
+				archived: false,
+				galaxies_team: 'Team One',
+				team_contact_email: 'team-one@email.com',
+			},
+		]);
+		expect(result).toEqual(['team-one']);
 	});
 });

--- a/packages/repocop/src/remediation/shared-utilities.ts
+++ b/packages/repocop/src/remediation/shared-utilities.ts
@@ -6,7 +6,7 @@ function findTeamSlugFromId(id: bigint, teams: Team[]): string | undefined {
 	return match?.slug ?? undefined;
 }
 
-export function findContactableOwners(
+export function findContactableOwners( //TODO we don't need teams any more, view_repo_ownership has the team slug
 	repo: string,
 	allRepoOwners: view_repo_ownership[],
 	teams: Team[],

--- a/packages/repocop/src/remediation/shared-utilities.ts
+++ b/packages/repocop/src/remediation/shared-utilities.ts
@@ -1,20 +1,11 @@
 import type { view_repo_ownership } from '@prisma/client';
-import type { Team } from '../types';
 
-function findTeamSlugFromId(id: bigint, teams: Team[]): string | undefined {
-	const match: Team | undefined = teams.find((team) => team.id === id);
-	return match?.slug ?? undefined;
-}
-
-export function findContactableOwners( //TODO we don't need teams any more, view_repo_ownership has the team slug
+export function findContactableOwners(
 	repo: string,
 	allRepoOwners: view_repo_ownership[],
-	teams: Team[],
 ): string[] {
 	const owners = allRepoOwners.filter((owner) => owner.full_repo_name === repo);
-	const teamSlugs = owners
-		.map((owner) => findTeamSlugFromId(owner.github_team_id, teams))
-		.filter((slug): slug is string => !!slug);
+	const teamSlugs = owners.map((owner) => owner.github_team_slug);
 	return teamSlugs;
 }
 

--- a/packages/repocop/src/remediation/topics/topic-monitor-production.ts
+++ b/packages/repocop/src/remediation/topics/topic-monitor-production.ts
@@ -9,7 +9,7 @@ import { stripMargin } from 'common/src/string';
 import type { Repository } from 'common/src/types';
 import type { Octokit } from 'octokit';
 import type { Config } from '../../config';
-import type { AwsCloudFormationStack, Team } from '../../types';
+import type { AwsCloudFormationStack } from '../../types';
 import { findContactableOwners, removeRepoOwner } from '../shared-utilities';
 
 const MONTHS = 3;
@@ -162,7 +162,6 @@ async function applyProductionTopicToOneRepoAndMessageTeams(
 }
 
 export async function applyProductionTopicAndMessageTeams(
-	teams: Team[],
 	unarchivedRepos: Repository[],
 	stacks: AwsCloudFormationStack[],
 	repoOwners: view_repo_ownership[],
@@ -182,11 +181,7 @@ export async function applyProductionTopicAndMessageTeams(
 		.map((names) => {
 			const fullRepoName = names.fullRepoName ?? '';
 			const stackName = names.stackName;
-			const teamNameSlugs = findContactableOwners(
-				fullRepoName,
-				repoOwners,
-				teams,
-			);
+			const teamNameSlugs = findContactableOwners(fullRepoName, repoOwners);
 			return {
 				fullName: fullRepoName,
 				stackName: stackName,

--- a/packages/snyk-integrator/src/index.ts
+++ b/packages/snyk-integrator/src/index.ts
@@ -34,6 +34,7 @@ export async function main(event: SnykIntegratorEvent) {
 		snykFileContents,
 		commitMessage,
 		boardNumber,
+		[], //TODO: add admins when snyk integrator is re-enabled
 	);
 }
 


### PR DESCRIPTION
## What does this change?

### NB: there are three quite distinct code changes in this PR. As such, it's probably less complicated to review this commit-by-commit

- Adds a function that requests repository admins as reviewers on any PR raised using `createPrAndAddToProject`
- Simplifies findContactableOwners, as since #831 , `view_repo_ownership` has included the team slug, meaning we don't need to cross-reference with `github_teams` to retrieve it
- Deletes one instance of the previously duplicated `createPrAndAddToProject`

> [!WARNING]  
> Requires a GitHub permission change. In addition to `pull-request:write`, we need `members:read` to validate the team name

## Why?

Engineers are sometimes slow to respond to PRs. By requesting reviews, we hope to speed up the process of having DevX-raised PRs merged. If no significant change is observed, we can try another method

## How has it been verified?

- [x] Added relevant unit tests to make sure correct admins are being passed through
- [x] Updated relevant github app permission, and tested on PROD using [devx-docs](https://github.com/guardian/devx-docs/pull/29)
