### PR TITLE
remove s3 checks from the interactive monitor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13056,7 +13056,6 @@
     "packages/interactive-monitor": {
       "version": "1.0.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.662.0",
         "@types/aws-lambda": "^8.10.141",
         "octokit": "^3.2.0"
       },

--- a/packages/interactive-monitor/package.json
+++ b/packages/interactive-monitor/package.json
@@ -11,7 +11,6 @@
 	},
 	"author": "guardian",
 	"dependencies": {
-		"@aws-sdk/client-s3": "^3.662.0",
 		"@types/aws-lambda": "^8.10.141",
 		"octokit": "^3.2.0"
 	},


### PR DESCRIPTION
## What does this change?

Previously, the interactive monitor was checking buckets in S3 to make sure that interactives had been published to S3 before labelling them. This is overly restrictive, so we're now just checking for the presence of certain config files, so we can catch interactives while they're still in development.

## Why?

To reduce the amount of time it takes to catch an interactive, and increase the number of repos with a correct topic

## How has it been verified?

- [x] CI passes
- [x] Run on CODE
