### PR TITLE
delete code duplicated in dependency-graph-integrator

### DIFF
--- a/packages/dependency-graph-integrator/src/repo-functions.ts
+++ b/packages/dependency-graph-integrator/src/repo-functions.ts
@@ -1,36 +1,7 @@
-import { randomBytes } from 'crypto';
 import type { Octokit } from 'octokit';
-import type { PullRequest, PullRequestParameters, StatusCode } from './types';
-
-export function generateBranchName(prefix: string) {
-	return `${prefix}-${randomBytes(8).toString('hex')}`;
-}
-
-function isGithubAuthor(pull: PullRequest, author: string) {
-	return pull.user?.login === author && pull.user.type === 'Bot';
-}
+import type { StatusCode } from './types';
 
 const OWNER = 'guardian';
-
-export async function getExistingPullRequest(
-	octokit: Octokit,
-	repoName: string,
-	author: string,
-): Promise<PullRequest | undefined> {
-	const pulls = await octokit.paginate(octokit.rest.pulls.list, {
-		owner: OWNER,
-		repo: repoName,
-		state: 'open',
-	} satisfies PullRequestParameters);
-
-	const found = pulls.filter((pull) => isGithubAuthor(pull, author));
-
-	if (found.length > 1) {
-		console.warn(`More than one PR found on ${repoName} - choosing the first.`);
-	}
-
-	return found[0] ?? undefined;
-}
 
 const ghHeaders = { 'X-GitHub-Api-Version': '2022-11-28' };
 

--- a/packages/dependency-graph-integrator/src/types.ts
+++ b/packages/dependency-graph-integrator/src/types.ts
@@ -1,9 +1,1 @@
-import type { Endpoints } from '@octokit/types';
-
-export type PullRequestParameters =
-	Endpoints['GET /repos/{owner}/{repo}/pulls']['parameters'];
-
-export type PullRequest =
-	Endpoints['GET /repos/{owner}/{repo}/pulls']['response']['data'][number];
-
 export type StatusCode = number;


### PR DESCRIPTION
## What does this change?

In #1305 , we deleted `createPrAndAddToProject`, as it was duplicated in `dependency-graph-integrator`. Its underlying functions, however, were left behind. This PR cleans that code up

## Why?

Maintainability

## How has it been verified?

The code wasn't actually being used, so as long as CI passes we're good
