### PR TITLE
Group Cloudbuster findings in digest messages

### DIFF
--- a/packages/cloudbuster/src/digests.test.ts
+++ b/packages/cloudbuster/src/digests.test.ts
@@ -32,11 +32,27 @@ describe('createDigestForAccount', () => {
 			{ ...testVuln, control_id: 'S.2' },
 		]);
 		expect(actual?.message).toContain(
-			`[2 findings](https://metrics.gutools.co.uk/d/ddi3x35x70jy8d?var-account_name=test-account&var-control_id=S.1) for control [S.1](https://example.com), (test-title) in app my-app`,
+			`[2 findings](https://metrics.gutools.co.uk/d/ddi3x35x70jy8d?var-account_name=test-account&var-control_id=S.1) in app: **my-app**, for control [S.1](https://example.com), (test-title)`,
 		);
 		expect(actual?.message).toContain(
-			`[1 findings](https://metrics.gutools.co.uk/d/ddi3x35x70jy8d?var-account_name=test-account&var-control_id=S.2) for control [S.2](https://example.com), (test-title) in app my-app`,
+			`[1 finding](https://metrics.gutools.co.uk/d/ddi3x35x70jy8d?var-account_name=test-account&var-control_id=S.2) in app: **my-app**, for control [S.2](https://example.com), (test-title)`,
 		);
+	});
+	it('should show the issues with the most findings first, regardless of input ordering', () => {
+		const actual = createDigestForAccount([
+			{ ...testVuln, control_id: 'S.2' },
+			testVuln,
+			testVuln,
+		]);
+
+		const msg = actual?.message;
+
+		const twoFindingStartPosition = msg?.indexOf('2 findings');
+		const oneFindingStartPosition = msg?.indexOf('1 finding');
+		expect(twoFindingStartPosition).toBeDefined();
+		expect(oneFindingStartPosition).toBeDefined();
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we have checked that these are defined
+		expect(twoFindingStartPosition!).toBeLessThan(oneFindingStartPosition!);
 	});
 	it('should aggregate findings by app', () => {
 		const actual = createDigestForAccount([
@@ -45,10 +61,10 @@ describe('createDigestForAccount', () => {
 			{ ...testVuln, app: 'my-other-app' },
 		]);
 		expect(actual?.message).toContain(
-			`[2 findings](https://metrics.gutools.co.uk/d/ddi3x35x70jy8d?var-account_name=test-account&var-control_id=S.1) for control [S.1](https://example.com), (test-title) in app my-app`,
+			`[2 findings](https://metrics.gutools.co.uk/d/ddi3x35x70jy8d?var-account_name=test-account&var-control_id=S.1) in app: **my-app**, for control [S.1](https://example.com), (test-title)`,
 		);
 		expect(actual?.message).toContain(
-			`[1 findings](https://metrics.gutools.co.uk/d/ddi3x35x70jy8d?var-account_name=test-account&var-control_id=S.1) for control [S.1](https://example.com), (test-title) in app my-other-app`,
+			`[1 finding](https://metrics.gutools.co.uk/d/ddi3x35x70jy8d?var-account_name=test-account&var-control_id=S.1) in app: **my-other-app**, for control [S.1](https://example.com), (test-title)`,
 		);
 	});
 	it('should return the correct fields', () => {

--- a/packages/cloudbuster/src/digests.ts
+++ b/packages/cloudbuster/src/digests.ts
@@ -96,14 +96,14 @@ function formatFindings(
 	account_name: string,
 	findings: cloudbuster_fsbp_vulnerabilities[],
 ) {
-	console.log(`formatting findings for ${key}`);
 	const findingsCount = findings.length;
 	const control_id = findings[0]?.control_id;
-	const app = findings[0]?.app ?? 'unknown-app';
+	const app = findings[0]?.app ?? 'unknown';
 	const remediation = findings[0]?.remediation;
 	const title = findings[0]?.title;
+	const findingsString = findingsCount === 1 ? 'finding' : 'findings';
 	const url = `https://metrics.gutools.co.uk/d/ddi3x35x70jy8d?var-account_name=${encodeURIComponent(account_name)}&var-control_id=${control_id}`;
-	return `[${findingsCount} findings](${url}) for control [${control_id}](${remediation}), (${title}) in app ${app}`;
+	return `[${findingsCount} ${findingsString}](${url}) in app: **${app}**, for control [${control_id}](${remediation}), (${title})`;
 }
 
 function createEmailBody(
@@ -112,9 +112,12 @@ function createEmailBody(
 	account_name: string,
 	severity: Severity,
 ): string {
-	const listOfLists = Object.values(groupByControlIdAndApp(findings)); //None of the sublists will ever be empty
+	//None of the sublists will ever be empty
+	const listOfGroupedFindings = Object.values(
+		groupByControlIdAndApp(findings),
+	).sort((a, b) => b.length - a.length);
 
-	const msg = listOfLists
+	const msg = listOfGroupedFindings
 		.map((list) => {
 			const key = `${list[0]?.control_id} ${list[0]?.app ?? 'unknown-app'}`;
 			return formatFindings(key, account_name, list);

--- a/packages/cloudbuster/src/digests.ts
+++ b/packages/cloudbuster/src/digests.ts
@@ -138,7 +138,7 @@ export async function sendDigest(
 		actions: digest.actions,
 		target: { AwsAccount: digest.accountId },
 		threadKey: digest.accountId,
-		channel: RequestedChannel.HangoutsChat,
+		channel: RequestedChannel.PreferHangouts,
 		sourceSystem: `cloudbuster ${config.stage}`,
 		topicArn: config.anghammaradSnsTopic,
 	};

--- a/packages/cloudbuster/src/digests.ts
+++ b/packages/cloudbuster/src/digests.ts
@@ -1,7 +1,8 @@
 import { RequestedChannel } from '@guardian/anghammarad';
 import type { Action, Anghammarad, NotifyParams } from '@guardian/anghammarad';
 import type { cloudbuster_fsbp_vulnerabilities } from '@prisma/client';
-import type { SecurityHubSeverity } from 'common/src/types';
+import { stringToSeverity } from 'common/src/functions';
+import type { SecurityHubSeverity, Severity } from 'common/src/types';
 import { type Config } from './config';
 import { groupFindingsByAccount } from './findings';
 import type { Digest } from './types';
@@ -62,26 +63,66 @@ export function createDigestForAccount(
 			accountName: aws_account_name,
 			actions: createCta(aws_account_name),
 			subject: `Security Hub findings for AWS account ${aws_account_name}`,
-			message: createEmailBody(recentFindings, vulnCutOffInDays),
+			message: createEmailBody(
+				recentFindings,
+				vulnCutOffInDays,
+				aws_account_name,
+				stringToSeverity(finding.severity),
+			),
 		};
 	} else {
 		return undefined;
 	}
 }
 
+function groupByControlIdAndApp(
+	findings: cloudbuster_fsbp_vulnerabilities[],
+): Record<string, cloudbuster_fsbp_vulnerabilities[]> {
+	return findings.reduce<Record<string, cloudbuster_fsbp_vulnerabilities[]>>(
+		(acc, f) => {
+			const key = `${f.control_id} ${f.app ?? 'unknown-app'}`;
+			if (!acc[key]) {
+				acc[key] = [];
+			}
+			acc[key].push(f);
+			return acc;
+		},
+		{},
+	);
+}
+
+function formatFindings(
+	key: string,
+	account_name: string,
+	findings: cloudbuster_fsbp_vulnerabilities[],
+) {
+	console.log(`formatting findings for ${key}`);
+	const findingsCount = findings.length;
+	const control_id = findings[0]?.control_id;
+	const app = findings[0]?.app ?? 'unknown-app';
+	const remediation = findings[0]?.remediation;
+	const title = findings[0]?.title;
+	const url = `https://metrics.gutools.co.uk/d/ddi3x35x70jy8d?var-account_name=${encodeURIComponent(account_name)}&var-control_id=${control_id}`;
+	return `[${findingsCount} findings](${url}) for control [${control_id}](${remediation}), (${title}) in app ${app}`;
+}
+
 function createEmailBody(
 	findings: cloudbuster_fsbp_vulnerabilities[],
 	cutOffInDays: number,
+	account_name: string,
+	severity: Severity,
 ): string {
-	return `The following vulnerabilities have been found in your account in the last ${cutOffInDays} days:
-        ${findings
-					.map(
-						(f) =>
-							`**[${f.severity}] ${f.title}**
-Affected resource: ${f.arn}
-Remediation: ${f.remediation ? `[Documentation](${f.remediation})` : 'Unknown'}`,
-					)
-					.join('\n\n')}`;
+	const listOfLists = Object.values(groupByControlIdAndApp(findings)); //None of the sublists will ever be empty
+
+	const msg = listOfLists
+		.map((list) => {
+			const key = `${list[0]?.control_id} ${list[0]?.app ?? 'unknown-app'}`;
+			return formatFindings(key, account_name, list);
+		})
+		.join('\n\n');
+
+	return `The following ${severity} vulnerabilities have been found in your account in the last ${cutOffInDays} days:
+	        ${msg}`;
 }
 
 export async function sendDigest(


### PR DESCRIPTION
## What does this change?

Group FSBP findings by Control ID, and app. Users can click through on the findings link to see a prefiltered FSBP dashboard.

## Why?

Any given account could have an arbitrary number of FSBP failures. This means that digests could be (and have been) hundreds of lines long, making them unreadable. Let's start tackling this by grouping control failures by control ID and app, to make them a bit more readable at a glance, which is the point of a digest.

### Why group only by app?

I'm still figuring out the balance between granularity and conciseness. If you group by too may variables, you _can_ end up with almost as many entries as if you'd just listed them all individually. Too few, and you hide information that's useful. I've chosen to group by control ID and app for now.

**Why not Stack?** Most of the time there's only one riff-raff stack in any given account, and its vanishingly rare to have more than three. I think grouping by stack would only really be useful if there were two services running in the same account with the same app tag, 
deployed via different stacks, which (a) is an unlikely edge case, and (b) can be resolved by clicking through to the dashboard and looking at the other tags

**Why not Stage?** Generally, infrastructure configuration doesn't vary massively across stage. This means that in nearly every case, over 90% of the time, disambiguating resources by stage is not useful, so I've not implemented this grouping as part of this PR.

## How has it been verified?

Added and modified unit tests to verify new behaviour

Running on CODE produces messages like these. In this example, we have aggregated nineteen separate issues into three groups:

<img width="733" alt="Screenshot 2024-10-29 at 13 28 13" src="https://github.com/user-attachments/assets/a74ddb7d-22e4-474f-a7c3-c257fbf624ef">


## Future work

This work is intended as a starting point to be iterated on, rather than a finished product, due to time constraints, and a desire to keep the complexity of this PR manageable. As a piece of future work, we should add an `app` variable to the list of filters on the dashboard (maybe stack/stage/repo too), to further help teams zoom in on their outstanding issues, and then wire that back into the URL we generate in the digest. It might be worth reviewing in a few weeks to see if more granular grouping would be useful to teams, or make the digest long enough that people stop reading it again.

It would also be useful to introduce another layer of grouping, to reduce repetition. The current data structure for grouping FSBP results looks like this:

```mermaid
flowchart LR

ControlId-App1
ControlId-App2
Vulnerabilities1
Vulnerabilities2

ControlId-App1 --> Vulnerabilities1
ControlId-App2 --> Vulnerabilities2

```

But it might make more sense for our data, and therefore digests, could be structured more like this, to avoid repeating fields like the full control title in every line

```mermaid
flowchart LR

ControlId
App1
App2
Vulnerabilities1
Vulnerabilities2

ControlId --> App1 --> Vulnerabilities1
ControlId --> App2 --> Vulnerabilities2

```
