### PR TITLE
Fix workflow check in repocop dep graph integration

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -97,6 +97,10 @@ export interface Repository extends RepositoryFields {
 	id: NonNullable<RepositoryFields['id']>;
 }
 
+export interface RepositoryWithDepGraphLanguage extends Repository {
+	language: DepGraphLanguage;
+}
+
 // The number of days teams have to fix vulnerabilities of a given severity
 export const SLAs: Record<Severity, number | undefined> = {
 	critical: 2,

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -98,7 +98,7 @@ export interface Repository extends RepositoryFields {
 }
 
 export interface RepositoryWithDepGraphLanguage extends Repository {
-	language: DepGraphLanguage;
+	dependency_graph_language: DepGraphLanguage;
 }
 
 // The number of days teams have to fix vulnerabilities of a given severity

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -611,7 +611,7 @@ export function evaluateRepositories(
 		const teamsForRepo = owners.filter((o) => o.full_repo_name === r.full_name);
 		const branchesForRepo = branches.filter((b) => b.repository_id === r.id);
 		const workflowsForRepo = productionWorkflowUsages.filter(
-			(repo) => (repo.full_name === r.full_name),
+			(repo) => repo.full_name === r.full_name,
 		);
 
 		return evaluateOneRepo(

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -611,7 +611,7 @@ export function evaluateRepositories(
 		const teamsForRepo = owners.filter((o) => o.full_repo_name === r.full_name);
 		const branchesForRepo = branches.filter((b) => b.repository_id === r.id);
 		const workflowsForRepo = productionWorkflowUsages.filter(
-			(repo) => (repo.full_name = r.full_name),
+			(repo) => (repo.full_name === r.full_name),
 		);
 
 		return evaluateOneRepo(

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
@@ -68,7 +68,7 @@ function repositoryWithDepGraphLanguage(
 	const repo = repository(fullName);
 	return {
 		...repo,
-		language,
+		dependency_graph_language: language,
 	};
 }
 

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -145,9 +145,14 @@ export async function sendReposToDependencyGraphIntegrator(
 		);
 
 	if (suitableRepos.length !== 0) {
-		const eventsToSend: DependencyGraphIntegratorEvent[] = shuffle(
-			createSnsEventsForDependencyGraphIntegration(suitableRepos, repoOwners),
-		).slice(0, repoCount);
+		console.log(
+			`Found ${suitableRepos.length} suitable repos without dependency submission workflows`,
+		);
+
+		const selectedRepos = shuffle(suitableRepos).slice(0, repoCount);
+
+		const eventsToSend: DependencyGraphIntegratorEvent[] =
+			createSnsEventsForDependencyGraphIntegration(selectedRepos, repoOwners);
 
 		for (const event of eventsToSend) {
 			await sendOneRepoToDepGraphIntegrator(config, event);

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -10,6 +10,7 @@ import type {
 	DependencyGraphIntegratorEvent,
 	DepGraphLanguage,
 	Repository,
+	RepositoryWithDepGraphLanguage,
 } from 'common/src/types';
 import type { Config } from '../../config';
 import { findContactableOwners, removeRepoOwner } from '../shared-utilities';
@@ -27,12 +28,12 @@ export function checkRepoForLanguage(
 
 export function doesRepoHaveDepSubmissionWorkflowForLanguage(
 	repo: Repository,
-	workflow_usages: guardian_github_actions_usage[],
+	workflowUsagesForRepo: guardian_github_actions_usage[],
 	language: DepGraphLanguage,
 ): boolean {
-	const actionsForRepo = workflow_usages
-		.filter((usages) => repo.full_name === usages.full_name)
-		.flatMap((workflow) => workflow.workflow_uses);
+	const actionsForRepo = workflowUsagesForRepo.flatMap(
+		(workflow) => workflow.workflow_uses,
+	);
 
 	const workflows: Record<DepGraphLanguage, string> = {
 		Scala: 'scalacenter/sbt-dependency-submission',
@@ -49,44 +50,18 @@ export function doesRepoHaveDepSubmissionWorkflowForLanguage(
 }
 
 export function createSnsEventsForDependencyGraphIntegration(
-	languages: github_languages[],
-	productionRepos: Repository[],
-	workflow_usages: guardian_github_actions_usage[],
-	view_repo_ownership: view_repo_ownership[],
+	reposWithoutWorkflows: RepositoryWithDepGraphLanguage[],
+	repoOwnership: view_repo_ownership[],
 ): DependencyGraphIntegratorEvent[] {
-	const depGraphLanguages: DepGraphLanguage[] = ['Scala', 'Kotlin'];
-	const eventsForAllLanguages: DependencyGraphIntegratorEvent[] = [];
-
-	depGraphLanguages.forEach((language) => {
-		let reposWithDepGraphLanguages: Repository[] = [];
-		const repos = productionRepos.filter((repo) =>
-			checkRepoForLanguage(repo, languages, language),
-		);
-		console.log(`Found ${repos.length} ${language} repos in production`);
-
-		reposWithDepGraphLanguages = reposWithDepGraphLanguages.concat(repos);
-
-		const reposWithoutWorkflows = reposWithDepGraphLanguages.filter(
-			(repo) =>
-				!doesRepoHaveDepSubmissionWorkflowForLanguage(
-					repo,
-					workflow_usages,
-					language,
-				),
-		);
-		console.log(
-			`Found ${reposWithoutWorkflows.length} production repos without ${language} dependency submission workflows`,
-		);
-		reposWithoutWorkflows.map((repo) =>
-			eventsForAllLanguages.push({
-				name: removeRepoOwner(repo.full_name),
-				language,
-				admins: findContactableOwners(repo.full_name, view_repo_ownership),
-			}),
-		);
-	});
+	const eventsForAllLanguages: DependencyGraphIntegratorEvent[] =
+		reposWithoutWorkflows.map((repo) => ({
+			name: removeRepoOwner(repo.full_name),
+			language: repo.language,
+			admins: findContactableOwners(repo.full_name, repoOwnership),
+		}));
 
 	console.log(`Found ${eventsForAllLanguages.length} events to send to SNS`);
+
 	return eventsForAllLanguages;
 }
 
@@ -110,6 +85,50 @@ async function sendOneRepoToDepGraphIntegrator(
 	}
 }
 
+export function getReposWithoutWorkflows(
+	languages: github_languages[],
+	productionRepos: Repository[],
+	productionWorkflowUsages: guardian_github_actions_usage[],
+): RepositoryWithDepGraphLanguage[] {
+	const depGraphLanguages: DepGraphLanguage[] = ['Scala', 'Kotlin'];
+	let allReposWithoutWorkflows: RepositoryWithDepGraphLanguage[] = [];
+
+	depGraphLanguages.forEach((language) => {
+		let reposWithDepGraphLanguages: Repository[] = [];
+
+		const repos = productionRepos.filter((repo) =>
+			checkRepoForLanguage(repo, languages, language),
+		);
+
+		console.log(`Found ${repos.length} ${language} repos in production`);
+
+		reposWithDepGraphLanguages = reposWithDepGraphLanguages.concat(repos);
+
+		const reposWithoutWorkflows = reposWithDepGraphLanguages
+			.filter((repo) => {
+				const workflowUsagesForRepo = productionWorkflowUsages.filter(
+					(workflow) => workflow.full_name === repo.full_name,
+				);
+				const result = !doesRepoHaveDepSubmissionWorkflowForLanguage(
+					repo,
+					workflowUsagesForRepo,
+					language,
+				);
+				return result;
+			})
+			.map((repo) => ({ ...repo, language }));
+
+		allReposWithoutWorkflows = allReposWithoutWorkflows.concat(
+			reposWithoutWorkflows,
+		);
+		console.log(
+			`Found ${reposWithoutWorkflows.length} production ${language} repos without dependency submission workflows`,
+		);
+	});
+
+	return allReposWithoutWorkflows;
+}
+
 export async function sendReposToDependencyGraphIntegrator(
 	config: Config,
 	repoLanguages: github_languages[],
@@ -118,16 +137,22 @@ export async function sendReposToDependencyGraphIntegrator(
 	repoOwners: view_repo_ownership[],
 	repoCount: number,
 ): Promise<void> {
-	const eventsToSend: DependencyGraphIntegratorEvent[] = shuffle(
-		createSnsEventsForDependencyGraphIntegration(
+	const suitableRepos: RepositoryWithDepGraphLanguage[] =
+		getReposWithoutWorkflows(
 			repoLanguages,
 			productionRepos,
 			productionWorkflowUsages,
-			repoOwners,
-		),
-	).slice(0, repoCount);
+		);
 
-	for (const event of eventsToSend) {
-		await sendOneRepoToDepGraphIntegrator(config, event);
+	if (suitableRepos.length !== 0) {
+		const eventsToSend: DependencyGraphIntegratorEvent[] = shuffle(
+			createSnsEventsForDependencyGraphIntegration(suitableRepos, repoOwners),
+		).slice(0, repoCount);
+
+		for (const event of eventsToSend) {
+			await sendOneRepoToDepGraphIntegrator(config, event);
+		}
+	} else {
+		console.log('No suitable repos found to create events for.');
 	}
 }

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -137,19 +137,22 @@ export async function sendReposToDependencyGraphIntegrator(
 	repoOwners: view_repo_ownership[],
 	repoCount: number,
 ): Promise<void> {
-	const suitableRepos: RepositoryWithDepGraphLanguage[] =
+	const reposRequiringDepGraphIntegration: RepositoryWithDepGraphLanguage[] =
 		getReposWithoutWorkflows(
 			repoLanguages,
 			productionRepos,
 			productionWorkflowUsages,
 		);
 
-	if (suitableRepos.length !== 0) {
+	if (reposRequiringDepGraphIntegration.length !== 0) {
 		console.log(
-			`Found ${suitableRepos.length} suitable repos without dependency submission workflows`,
+			`Found ${reposRequiringDepGraphIntegration.length} repos requiring dependency graph integration`,
 		);
 
-		const selectedRepos = shuffle(suitableRepos).slice(0, repoCount);
+		const selectedRepos = shuffle(reposRequiringDepGraphIntegration).slice(
+			0,
+			repoCount,
+		);
 
 		const eventsToSend: DependencyGraphIntegratorEvent[] =
 			createSnsEventsForDependencyGraphIntegration(selectedRepos, repoOwners);

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -56,7 +56,7 @@ export function createSnsEventsForDependencyGraphIntegration(
 	const eventsForAllLanguages: DependencyGraphIntegratorEvent[] =
 		reposWithoutWorkflows.map((repo) => ({
 			name: removeRepoOwner(repo.full_name),
-			language: repo.language,
+			language: repo.dependency_graph_language,
 			admins: findContactableOwners(repo.full_name, repoOwnership),
 		}));
 
@@ -116,7 +116,7 @@ export function getReposWithoutWorkflows(
 				);
 				return result;
 			})
-			.map((repo) => ({ ...repo, language }));
+			.map((repo) => ({ ...repo, dependency_graph_language: language }));
 
 		allReposWithoutWorkflows = allReposWithoutWorkflows.concat(
 			reposWithoutWorkflows,


### PR DESCRIPTION
## What does this change?

- Fixes the function (originally `createSnsEventsForDependencyGraphIntegration` ) that detected whether a repo has a dependency submission workflow. The function was erroneously reporting that no workflows were found so all repos were candidates for being selected and sent to dependency graph integrator for PRs to be raised.
- Fixes a bug in the filtering of workflows in the dependency tracking functionality (`hasDependencyTracking` which was still reporting correctly) which uses the same function as above (namely `doesRepoHaveDepSubmissionWorkflowForLanguage`).
- Refactors the sns messaging function `createSnsEventsForDependencyGraphIntegration`  to separate out the workflow check. The function was doing a lot of different things in addition to creating the events. I have pulled out the remaining functionality into a new function called `getReposWithoutWorkflows`, and created a new `RepositoryWithDepGraphLanguage` type to allow its output to be fed directly into `createSnsEventsForDependencyGraphIntegration`.
 - Refactors the `sendReposToDependencyGraphIntegrator` function to select suitable repos using the new `getReposWithoutWorkflows` function and shuffle/slice the required number of repos before sending them for message creation.
- Fixes some linting errors.

## Why?

To make the dependency graph integrator work correctly, and hopefully make the code clearer, with better separation of concerns.

## How has it been verified?

Tested by running repocop locally and observing the logs.
