### PR TITLE
chore(deps): Update `guardian/cq-source-ns1` from 0.0.4 to 0.1.1

### DIFF
--- a/.env
+++ b/.env
@@ -30,7 +30,7 @@ CQ_SNYK=5.4.0
 CQ_GITHUB_LANGUAGES=0.0.5
 
 # See https://github.com/guardian/cq-source-ns1
-CQ_NS1=0.0.4
+CQ_NS1=0.1.1
 
 # --- FOR LOCAL DEVELOPMENT ONLY ---
 STAGE=DEV

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -16329,7 +16329,7 @@ spec:
           },
           {
             "Essential": false,
-            "Image": "ghcr.io/guardian/cq-source-ns1:0.0.4",
+            "Image": "ghcr.io/guardian/cq-source-ns1:0.1.1",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {


### PR DESCRIPTION
## What does this change?
Update https://github.com/guardian/cq-source-ns1 to the latest version which includes some dependency updates, including an [update to Node 22 (LTS)](https://github.com/guardian/cq-source-ns1/releases/tag/v0.1.0). See https://github.com/guardian/cq-source-ns1/releases/tag/v0.1.1.

## Why?
Staying up to date.

## How has it been verified?
After [deploying to CODE](https://riffraff.gutools.co.uk/deployment/view/ce74f712-bae5-4070-a811-832edaf91202) and manually running the NS1 task (`npm -w cli start -- run-task --stage=CODE --name NS1`), I've observed the [logs](https://logs.gutools.co.uk/s/devx/app/r/s/djryD) showing the plugin collecting data and [Grafana CODE](https://metrics.code.dev-gutools.co.uk/goto/gIKJ2DMHg?orgId=1) showing said data (see the `_cq_sync_time` column):

<img width="465" alt="image" src="https://github.com/user-attachments/assets/96f957a1-4124-477c-98af-72b26663d7f3">
