### PR TITLE
chore(deps): Update `guardian/cq-source-ns1` from v0.1.1 to v0.1.2

### DIFF
--- a/.env
+++ b/.env
@@ -30,7 +30,7 @@ CQ_SNYK=5.4.0
 CQ_GITHUB_LANGUAGES=0.0.5
 
 # See https://github.com/guardian/cq-source-ns1
-CQ_NS1=0.1.1
+CQ_NS1=0.1.2
 
 # --- FOR LOCAL DEVELOPMENT ONLY ---
 STAGE=DEV

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -16328,7 +16328,7 @@ spec:
           },
           {
             "Essential": false,
-            "Image": "ghcr.io/guardian/cq-source-ns1:0.1.1",
+            "Image": "ghcr.io/guardian/cq-source-ns1:0.1.2",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {


### PR DESCRIPTION
## What does this change?
This version includes a vulnerability fix.

See https://github.com/guardian/cq-source-ns1/releases/tag/v0.1.2.