### PR TITLE
fix: Update docker syntax 

### DIFF
--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -60,7 +60,7 @@ start_containers() {
     echo ""
   done
 
-  docker-compose -f "${DIR}/../docker-compose.yaml" --env-file "$MAIN_ENV_FILE" --env-file "$LOCAL_ENV_FILE" up -d --build
+  docker compose -f "${DIR}/../docker-compose.yaml" --env-file "$MAIN_ENV_FILE" --env-file "$LOCAL_ENV_FILE" up -d --build
 }
 
 check_vpn_connection() {

--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -52,16 +52,15 @@ start_containers() {
   open -a Docker
   set -e
 
-while (! docker stats --no-stream ); do
-  # Docker takes a few seconds to initialize
-  sleep 5
-  echo -e "${yellow}Do you have an alternative Docker install, such as podman or minikube, aliased to 'docker'? If so, please launch it now${clear}"
-  echo "Standing by for Docker to start..."
-  echo ""
-done
+  while (! docker stats --no-stream ); do
+    # Docker takes a few seconds to initialize
+    sleep 5
+    echo -e "${yellow}Do you have an alternative Docker install, such as podman or minikube, aliased to 'docker'? If so, please launch it now${clear}"
+    echo "Standing by for Docker to start..."
+    echo ""
+  done
 
-docker-compose -f "${DIR}/../docker-compose.yaml" --env-file "$MAIN_ENV_FILE" --env-file "$LOCAL_ENV_FILE" up -d --build
-    
+  docker-compose -f "${DIR}/../docker-compose.yaml" --env-file "$MAIN_ENV_FILE" --env-file "$LOCAL_ENV_FILE" up -d --build
 }
 
 check_vpn_connection() {

--- a/packages/dev-environment/script/start-prisma-migrate-test
+++ b/packages/dev-environment/script/start-prisma-migrate-test
@@ -34,7 +34,7 @@ start_containers() {
   step "Launching Docker containers"
 
   if (docker info) 2>&1 >/dev/null; then
-    docker-compose -f "${DIR}/../docker-compose-prisma-migrate.yaml" --env-file "$MAIN_ENV_FILE" --env-file "$LOCAL_ENV_FILE" up -d --build
+    docker compose -f "${DIR}/../docker-compose-prisma-migrate.yaml" --env-file "$MAIN_ENV_FILE" --env-file "$LOCAL_ENV_FILE" up -d --build
   else
     echo "Docker is not running. Please start Docker."
     exit 1


### PR DESCRIPTION
## What does this change?
Updates how we invoke docker; the `docker-compose` command has been replaced with `docker compose`.

I've also corrected some indentation levels, so it might be easier to [review w/out whitespace](https://github.com/guardian/service-catalogue/pull/1336/files?diff=split&w=1).