### PR TITLE
feat: add Github custom properties table to cloudquery

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ CQ_POSTGRES_SOURCE=3.0.7
 CQ_AWS=27.5.0
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/github/versions
-CQ_GITHUB=10.0.1
+CQ_GITHUB=11.11.1
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/fastly/versions
 CQ_FASTLY=3.0.7

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -13582,7 +13582,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v10.0.1
+  version: v11.11.1
   tables:
     - github_issues
   destinations:
@@ -14707,7 +14707,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v10.0.1
+  version: v11.11.1
   tables:
     - github_repositories
     - github_repository_branches
@@ -15422,7 +15422,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v10.0.1
+  version: v11.11.1
   tables:
     - github_organizations
     - github_organization_members

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -156,7 +156,7 @@ spec:
 		spec:
 		  name: github
 		  path: cloudquery/github
-		  version: v10.0.1
+		  version: v11.11.1
 		  tables:
 		    - github_repositories
 		  destinations:

--- a/packages/common/prisma/migrations/20241128170250_github_repository_custom_properties/migration.sql
+++ b/packages/common/prisma/migrations/20241128170250_github_repository_custom_properties/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "github_repository_custom_properties" (
+    "_cq_sync_time" TIMESTAMP(6),
+    "_cq_source_name" TEXT,
+    "_cq_id" UUID NOT NULL,
+    "_cq_parent_id" UUID,
+    "org" TEXT NOT NULL,
+    "property_name" TEXT NOT NULL,
+    "repository_id" BIGINT NOT NULL,
+    "value" TEXT
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "github_repository_custom_properties__cq_id_key" ON "github_repository_custom_properties"("_cq_id");

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -380,6 +380,19 @@ model github_repository_branches {
   @@id([org, repository_id, name], map: "github_repository_branches_cqpk")
 }
 
+model github_repository_custom_properties {
+  cq_sync_time   DateTime? @map("_cq_sync_time") @db.Timestamp(6)
+  cq_source_name String?   @map("_cq_source_name")
+  cq_id          String    @unique @map("_cq_id") @db.Uuid
+  cq_parent_id   String?   @map("_cq_parent_id") @db.Uuid
+  org            String
+  property_name  String
+  repository_id  BigInt
+  value          String?
+
+  @@ignore
+}
+
 model github_team_repositories {
   cq_sync_time                   DateTime? @map("_cq_sync_time") @db.Timestamp(6)
   cq_source_name                 String?   @map("_cq_source_name")

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
         - github_teams
         - github_repositories
         - github_repository_branches
+        - github_repository_custom_properties
         - github_workflows
         - github_languages
         - aws_ec2_instances


### PR DESCRIPTION
## What does this change?
- upgrades github cloudquery plugin to v11 which provides a custom properties table
- creates a `github_repository_custom_properties` table in prisma schema
- creates the sql  migration
- adds the table to the docker-compose so that it can be queried in DEV

## Why?

This follows from #1316. Using custom properties will allow us to move away from topics. Custom properties can be
 made compulsory, which means we can enforce repos to choose a property.

The `production` custom property also applies branch protection.

## How has it been verified?

- [x] Migration applied to CODE - the Github tables are copied from CODE to DEV for local testing
- [x] Tested locally - 14 rows returned
