### PR TITLE
chore: Suppress AWS Inspector FSBP findings.

### DIFF
--- a/packages/cloudbuster/src/findings.ts
+++ b/packages/cloudbuster/src/findings.ts
@@ -28,6 +28,18 @@ export function findingsToGuardianFormat(
 		};
 	});
 }
+
+export function isSuppressedFinding(
+	finding: cloudbuster_fsbp_vulnerabilities,
+): boolean {
+	// Suppress AWS Inspector findings
+	// These currently have a cost impact associated to them and has limited language support.
+	// With InfoSec at the moment to decide what we do with this control:
+	//   https://chat.google.com/room/AAAAag0I08g/5caKQThOs8Q/FHanFOG9rnw
+	return ['Inspector.1', 'Inspector.2', 'Inspector.3', 'Inspector.4'].includes(
+		finding.control_id,
+	);
+}
 /**
  * @param findings An array of FSBP findings.
  * @returns An object mapping account numbers to findings.

--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -5,7 +5,7 @@ import { getPrismaClient } from 'common/src/database-setup';
 import type { SecurityHubSeverity } from 'common/src/types';
 import { getConfig } from './config';
 import { createDigestsFromFindings, sendDigest } from './digests';
-import { findingsToGuardianFormat } from './findings';
+import { findingsToGuardianFormat, isSuppressedFinding } from './findings';
 
 export async function main() {
 	const severities: SecurityHubSeverity[] = ['CRITICAL', 'HIGH'];
@@ -23,9 +23,9 @@ export async function main() {
 		(f) => f.workflow.Status !== 'SUPPRESSED',
 	);
 
-	const tableContents: cloudbuster_fsbp_vulnerabilities[] = dbResults.flatMap(
-		findingsToGuardianFormat,
-	);
+	const tableContents: cloudbuster_fsbp_vulnerabilities[] = dbResults
+		.flatMap(findingsToGuardianFormat)
+		.filter((f) => !isSuppressedFinding(f));
 
 	console.log(
 		`${tableContents.length} high and critical FSBP findings detected`,


### PR DESCRIPTION
## What does this change?

Temporarily hide AWS Inspector findings from the FSBP dashboard.

## Why?

As far as I'm aware the guidance is to ignore this finding for now as per https://chat.google.com/room/AAAAag0I08g/5caKQThOs8Q/FHanFOG9rnw as it has a cost associated and is pending feedback from InfoSec on what to do about it.

I also want to see my accounts FSBP Dashboard drop to 0 vulnerabilities too 😅 

## How has it been verified?

Don't have credentials to test this locally unfortunately, have included tests however.
