### PR TITLE
fix: give repocop more memory

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -23907,7 +23907,7 @@ spec:
         "LoggingConfig": {
           "LogFormat": "JSON",
         },
-        "MemorySize": 1536,
+        "MemorySize": 2048,
         "Role": {
           "Fn::GetAtt": [
             "repocopServiceRole757D74E8",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -23907,7 +23907,7 @@ spec:
         "LoggingConfig": {
           "LogFormat": "JSON",
         },
-        "MemorySize": 1024,
+        "MemorySize": 1536,
         "Role": {
           "Fn::GetAtt": [
             "repocopServiceRole757D74E8",

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -44,7 +44,7 @@ export class Repocop {
 			architecture: Architecture.ARM_64,
 			fileName: 'repocop.zip',
 			handler: 'index.main',
-			memorySize: 1536,
+			memorySize: 2048,
 			monitoringConfiguration,
 			rules: [{ schedule }],
 			runtime: Runtime.NODEJS_20_X,

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -44,7 +44,7 @@ export class Repocop {
 			architecture: Architecture.ARM_64,
 			fileName: 'repocop.zip',
 			handler: 'index.main',
-			memorySize: 1024,
+			memorySize: 1536,
 			monitoringConfiguration,
 			rules: [{ schedule }],
 			runtime: Runtime.NODEJS_20_X,


### PR DESCRIPTION
## What does this change?
Allocates more memory to the repocop lambda, from 1024MB to 1536MB.

## Why?

After [this change](https://github.com/guardian/service-catalogue/commit/e8e39d17e20fe99cba20100a40f962acaba08393#diff-f1ff53a8917a7ca393cb947297fc15e40d2132865ac31f7d1013f6a3e9b3cccd) was merged on 2 December, the memory use has doubled from around ~700MB to ~1400MB. 
Not sure why a change to add a cloudquery table which we are not querying in repocop has led to this increase.

I have created [a visualisation of the memory use since 25 November](https://logs.gutools.co.uk/s/devx/app/dashboards#/view/45c689cb-0068-4d79-90ad-11b08bd21128?_g=(refreshInterval:(pause:!t,value:60000),time:(from:'2024-11-25T00:00:00.000Z',to:'2024-12-03T17:27:55.287Z'))&_a=()) (when the first data point was available).

## How has it been verified?

I increased the memory in the console to 1536MB and ran the lamdba. It executed successfully and used 1426MB of memory.
