### PR TITLE
Fix: add if not exists clause to last 2 migrations

### DIFF
--- a/packages/common/prisma/migrations/20241128170250_github_repository_custom_properties/migration.sql
+++ b/packages/common/prisma/migrations/20241128170250_github_repository_custom_properties/migration.sql
@@ -1,5 +1,5 @@
 -- CreateTable
-CREATE TABLE "github_repository_custom_properties" (
+CREATE TABLE IF NOT EXISTS "github_repository_custom_properties" (
     "_cq_sync_time" TIMESTAMP(6),
     "_cq_source_name" TEXT,
     "_cq_id" UUID NOT NULL,
@@ -11,4 +11,4 @@ CREATE TABLE "github_repository_custom_properties" (
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "github_repository_custom_properties__cq_id_key" ON "github_repository_custom_properties"("_cq_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "github_repository_custom_properties__cq_id_key" ON "github_repository_custom_properties"("_cq_id");

--- a/packages/common/prisma/migrations/20241203141400_amigo_bake_packages/migration.sql
+++ b/packages/common/prisma/migrations/20241203141400_amigo_bake_packages/migration.sql
@@ -1,5 +1,5 @@
 -- CreateTable
-CREATE TABLE "amigo_bake_packages"
+CREATE TABLE IF NOT EXISTS "amigo_bake_packages"
 (
     "_cq_sync_time"   TIMESTAMP(6),
     "_cq_source_name" TEXT,
@@ -18,4 +18,4 @@ CREATE TABLE "amigo_bake_packages"
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "amigo_bake_packages__cq_id_key" ON "amigo_bake_packages" ("_cq_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "amigo_bake_packages__cq_id_key" ON "amigo_bake_packages" ("_cq_id");


### PR DESCRIPTION
Co-authored-by: akash1810 <akash1810@users.noreply.github.com>

## What does this change?

Adds `IF NOT EXISTS` to the migrations for the `github_repository_custom_properties` and `amigo_bake_packages` tables.

## Why?

The Cloudquery tasks for these are currently failing as Cloudquery should own these tables but they are currently owned by Prisma.

## How has it been verified?

- [ ] Tested on CODE
