### PR TITLE
Configure schedule and memory for AmigoBakePackages task

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -71,7 +71,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
   "Resources": {
     "CloudquerySourceAmigoBakePackagesScheduledEventRule3FDBCEB5": {
       "Properties": {
-        "ScheduleExpression": "rate(1 day)",
+        "ScheduleExpression": "cron(0 3 * * ? *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -416,7 +416,7 @@ spec:
             "Environment": [
               {
                 "Name": "GOMEMLIMIT",
-                "Value": "409MiB",
+                "Value": "819MiB",
               },
             ],
             "Essential": true,
@@ -681,7 +681,7 @@ spec:
           ],
         },
         "Family": "ServiceCatalogueCloudquerySourceAmigoBakePackagesTaskDefinition07388B36",
-        "Memory": "512",
+        "Memory": "1024",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [
           "FARGATE",

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -626,13 +626,14 @@ export function addCloudqueryEcsCluster(
 	const amigoBakePackagesSource: CloudquerySource = {
 		name: 'AmigoBakePackages',
 		description: 'Packages installed in Amigo bakes.',
-		schedule: nonProdSchedule ?? Schedule.rate(Duration.days(1)),
+		schedule: nonProdSchedule ?? Schedule.cron({ minute: '0', hour: '3' }),
 		config: amigoBakePackagesConfig(
 			baseImagesTableName,
 			recipesTableName,
 			bakesTableName,
 			packagesBucket.bucketName,
 		),
+		memoryLimitMiB: 1024,
 		policies: [
 			readDynamoDbTablePolicy(
 				GuardianAwsAccounts.DeployTools,


### PR DESCRIPTION
## What does this change?
It gives an explicit schedule for running the task and increases memory from 512 MiB.

## Why?
We're seeing the task bump along the current memory limit of 512 MiB.

## How has it been verified?
We should see the task run successfully.
