### PR TITLE
Bump image-packages CQ plugin

### DIFF
--- a/.env
+++ b/.env
@@ -33,7 +33,7 @@ CQ_GITHUB_LANGUAGES=0.0.5
 CQ_NS1=0.1.3
 
 # See https://github.com/guardian/cq-image-packages
-CQ_IMAGE_PACKAGES=1.0.0
+CQ_IMAGE_PACKAGES=1.0.1
 
 # --- FOR LOCAL DEVELOPMENT ONLY ---
 STAGE=DEV


### PR DESCRIPTION
To use [latest release](https://github.com/guardian/cq-source-image-packages/releases/tag/v1.0.1).
