### PR TITLE
fix: log account cloudbuster messages are sent to in PROD

### DIFF
--- a/packages/cloudbuster/src/digests.ts
+++ b/packages/cloudbuster/src/digests.ts
@@ -133,8 +133,6 @@ export async function sendDigest(
 	config: Config,
 	digest: Digest,
 ): Promise<void> {
-	const target = { Stack: 'testing-alerts' };
-
 	const notifyParams: NotifyParams = {
 		subject: digest.subject,
 		message: digest.message,
@@ -150,7 +148,7 @@ export async function sendDigest(
 
 	if (enableMessaging && stage == 'PROD') {
 		console.log(
-			`Sending ${digest.accountId} digest to ${JSON.stringify(target, null, 4)}...`,
+			`Sending ${digest.accountId} digest to ${JSON.stringify(notifyParams.target, null, 4)}...`,
 		);
 		await anghammaradClient.notify(notifyParams);
 	} else if (enableMessaging) {
@@ -160,7 +158,7 @@ export async function sendDigest(
 		};
 
 		console.log(
-			`Sending ${digest.accountId} digest to ${JSON.stringify(target, null, 4)}...`,
+			`Sending ${digest.accountId} digest to ${JSON.stringify(testNotifyParams.target, null, 4)}...`,
 		);
 
 		await anghammaradClient.notify(testNotifyParams);


### PR DESCRIPTION
## What does this change?

Adds the account ID of the target account to the console.log for `cloudbuster`.

## Why?

In `PROD`, the log was still indicating that the messages were being sent to `testing-alerts`, when in fact they were going to the real accounts. 

## How has it been verified?
When this is merged, we should see real account IDs being logged out by `cloudbuster PROD`. I tested the `CODE` variant on CODE and the logging was as expected.
