### PR TITLE
refactor: use logger in cloudbuster

### DIFF
--- a/packages/cloudbuster/src/digests.ts
+++ b/packages/cloudbuster/src/digests.ts
@@ -156,10 +156,9 @@ export async function sendDigest(
 						target: { Stack: 'testing-alerts' },
 					};
 		logger.log({
-			message: `Sending ${digest.accountId} (${digest.accountName}) digest to ${JSON.stringify(notificationParameters.target, null, 4)}...`,
+			message: `Sending ${digest.accountId} (${digest.accountName}) digest...`,
 			accountName: digest.accountName,
 			target: notificationParameters.target,
-			stage,
 			enableMessaging,
 		});
 
@@ -169,7 +168,6 @@ export async function sendDigest(
 			message: `Messaging disabled. Anghammarad would have sent: ${JSON.stringify(notifyParams, null, 4)}`,
 			accountName: digest.accountName,
 			target: notifyParams.target,
-			stage,
 			enableMessaging,
 		});
 	}

--- a/packages/cloudbuster/src/digests.ts
+++ b/packages/cloudbuster/src/digests.ts
@@ -148,32 +148,22 @@ export async function sendDigest(
 	const { enableMessaging, stage } = config;
 
 	if (enableMessaging) {
-		if (stage === 'PROD') {
-			logger.log({
-				message: `Sending ${digest.accountId} (${digest.accountName}) digest to ${JSON.stringify(notifyParams.target, null, 4)}...`,
-				accountName: digest.accountName,
-				target: notifyParams.target,
-				stage,
-				enableMessaging,
-			});
+		const notificationParameters =
+			stage === 'PROD'
+				? notifyParams
+				: {
+						...notifyParams,
+						target: { Stack: 'testing-alerts' },
+					};
+		logger.log({
+			message: `Sending ${digest.accountId} (${digest.accountName}) digest to ${JSON.stringify(notificationParameters.target, null, 4)}...`,
+			accountName: digest.accountName,
+			target: notificationParameters.target,
+			stage,
+			enableMessaging,
+		});
 
-			await anghammaradClient.notify(notifyParams);
-		} else {
-			const testNotifyParams = {
-				...notifyParams,
-				target: { Stack: 'testing-alerts' },
-			};
-
-			logger.log({
-				message: `Sending ${digest.accountId} (${digest.accountName}) digest to ${JSON.stringify(testNotifyParams.target, null, 4)}...`,
-				accountName: digest.accountName,
-				target: testNotifyParams.target,
-				stage,
-				enableMessaging,
-			});
-
-			await anghammaradClient.notify(testNotifyParams);
-		}
+		await anghammaradClient.notify(notificationParameters);
 	} else {
 		logger.log({
 			message: `Messaging disabled. Anghammarad would have sent: ${JSON.stringify(notifyParams, null, 4)}`,

--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -1,5 +1,6 @@
 import { Anghammarad } from '@guardian/anghammarad';
 import type { cloudbuster_fsbp_vulnerabilities } from '@prisma/client';
+import { logger } from 'common/logs';
 import { getFsbpFindings } from 'common/src/database-queries';
 import { getPrismaClient } from 'common/src/database-setup';
 import type { SecurityHubSeverity } from 'common/src/types';
@@ -15,9 +16,9 @@ export async function main() {
 	const prisma = getPrismaClient(config);
 
 	// *** DATA GATHERING ***
-	console.log(
-		`Starting Cloudbuster. Level of severities that will be scanned: ${severities.join(', ')}`,
-	);
+	logger.log({
+		message: `Starting Cloudbuster. Level of severities that will be scanned: ${severities.join(', ')}`,
+	});
 
 	const dbResults = (await getFsbpFindings(prisma, severities)).filter(
 		(f) => f.workflow.Status !== 'SUPPRESSED',
@@ -27,9 +28,9 @@ export async function main() {
 		findingsToGuardianFormat,
 	);
 
-	console.log(
-		`${tableContents.length} high and critical FSBP findings detected`,
-	);
+	logger.log({
+		message: `${tableContents.length} high and critical FSBP findings detected`,
+	});
 
 	await prisma.cloudbuster_fsbp_vulnerabilities.deleteMany();
 	await prisma.cloudbuster_fsbp_vulnerabilities.createMany({


### PR DESCRIPTION
## What does this change?

- Uses logger in place of console.log
- Refactors the logic a little to make it clearer (is it?)

## Why?

- logger allows for markers to be added - see comment in #1355

## How has it been verified?

- [ ] Tested on CODE to verify messages are logged out as expected
