### PR TITLE
feat: allow repos to be ignored by dep graph integrator

### DIFF
--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -6,6 +6,7 @@ import {
 	getDevDatabaseConfig,
 } from 'common/src/database-setup';
 import type { DatabaseConfig, PrismaConfig } from 'common/src/database-setup';
+import type { DepGraphLanguage } from 'common/types';
 
 export interface Config extends PrismaConfig {
 	/**
@@ -59,6 +60,11 @@ export interface Config extends PrismaConfig {
 	dependencyGraphIntegratorTopic: string;
 
 	/**
+	 * A list of repos to be excluded by the dependency graph integrator, by language.
+	 */
+	dependencyGraphIgnoredRepos: Record<DepGraphLanguage, string[]>;
+
+	/**
 	 * The name of the GitHub organisation that owns the repositories.
 	 */
 	gitHubOrg: string;
@@ -92,6 +98,10 @@ export async function getConfig(): Promise<Config> {
 		dependencyGraphIntegratorTopic: getEnvOrThrow(
 			'DEPENDENCY_GRAPH_INPUT_TOPIC_ARN',
 		),
+		dependencyGraphIgnoredRepos: {
+			Scala: ['identity-platform'],
+			Kotlin: [],
+		},
 		gitHubOrg: process.env['GITHUB_ORG'] ?? 'guardian',
 	};
 }

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
@@ -20,7 +20,12 @@ import {
 
 const fullName = 'guardian/repo-name';
 const fullName2 = 'guardian/repo2';
+const ignoredRepo = 'guardian/ignore-me';
 const scalaLang = 'Scala';
+const ignoredRepos = {
+	Scala: ['ignore-me'],
+	Kotlin: [],
+};
 
 function createActionsUsage(
 	fullName: string,
@@ -144,6 +149,7 @@ describe('When getting suitable events to send to SNS', () => {
 			[repoWithTargetLanguage(fullName)],
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
+			ignoredRepos,
 		);
 		const expected = [repositoryWithDepGraphLanguage(fullName, 'Scala')];
 
@@ -154,6 +160,7 @@ describe('When getting suitable events to send to SNS', () => {
 			[repoWithTargetLanguage(fullName)],
 			[repository(fullName)],
 			[repoWithDepSubmissionWorkflow(fullName)],
+			ignoredRepos,
 		);
 		expect(result).toEqual([]);
 	});
@@ -162,14 +169,16 @@ describe('When getting suitable events to send to SNS', () => {
 			[repoWithoutTargetLanguage(fullName)],
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
+			ignoredRepos,
 		);
 		expect(result).toEqual([]);
 	});
-	test('return 2 events when 2 Scala repos are found without an existing workflow', () => {
+	test('return 2 repos when 2 Scala repos are found without an existing workflow', () => {
 		const result = getReposWithoutWorkflows(
 			[repoWithTargetLanguage(fullName), repoWithTargetLanguage(fullName2)],
 			[repository(fullName), repository(fullName2)],
 			[repoWithoutWorkflow(fullName), repoWithoutWorkflow(fullName2)],
+			ignoredRepos,
 		);
 		const expected = [
 			repositoryWithDepGraphLanguage(fullName, 'Scala'),
@@ -177,6 +186,16 @@ describe('When getting suitable events to send to SNS', () => {
 		];
 
 		expect(result).toEqual(expected);
+	});
+	test('return empty array when an ignored Scala repo is found with without an existing workflow', () => {
+		const result = getReposWithoutWorkflows(
+			[repoWithTargetLanguage(ignoredRepo)],
+			[repository(ignoredRepo)],
+			[repoWithoutWorkflow(ignoredRepo)],
+			ignoredRepos,
+		);
+
+		expect(result).toEqual([]);
 	});
 
 	const ownershipRecord1: view_repo_ownership = {


### PR DESCRIPTION
## What does this change?

- Adds a property to config for repos to be ignored by dependency graph integrator, by language (Scala or Kotlin).
- Adds a function to test a repo to see if it's in the ignored list.
- Adds a test for this function.

## Why?

There is at least one edge case where a repo contains a dependency graph integrator language, but that doesn't use sbt (it contains just one Scala file which is used in a script). We would like to allow teams to exclude these repos from the integrator so that it doesn't repeatedly raise PRs on those repos.

## How has it been verified?

- [x] Tested locally
