### PR TITLE
Reduce Likelihood of Duplicate Dependency Graph Update Workflow PRs

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -20399,9 +20399,9 @@ spec:
       },
       "Type": "AWS::IAM::Role",
     },
-    "cloudbustercloudbustercron07MONFRI028B0F781": {
+    "cloudbustercloudbustercron03MONFRI086370CEA": {
       "Properties": {
-        "ScheduleExpression": "cron(0 7 ? * MON-FRI *)",
+        "ScheduleExpression": "cron(0 3 ? * MON-FRI *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -20417,7 +20417,7 @@ spec:
       },
       "Type": "AWS::Events::Rule",
     },
-    "cloudbustercloudbustercron07MONFRI0AllowEventRuleServiceCataloguecloudbuster82FA89E4693980BB": {
+    "cloudbustercloudbustercron03MONFRI0AllowEventRuleServiceCataloguecloudbuster82FA89E47F529A44": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -20429,7 +20429,7 @@ spec:
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "cloudbustercloudbustercron07MONFRI028B0F781",
+            "cloudbustercloudbustercron03MONFRI086370CEA",
             "Arn",
           ],
         },
@@ -24221,9 +24221,28 @@ spec:
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
     },
-    "repocoprepocopcron07MONFRI08C03526D": {
+    "repocoprepocopcron03MONFRI0AllowEventRuleServiceCataloguerepocop7BEB5892318F26C8": {
       "Properties": {
-        "ScheduleExpression": "cron(0 7 ? * MON-FRI *)",
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "repocop20553EB8",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "repocoprepocopcron03MONFRI0E07FE560",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "repocoprepocopcron03MONFRI0E07FE560": {
+      "Properties": {
+        "ScheduleExpression": "cron(0 3 ? * MON-FRI *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -24238,25 +24257,6 @@ spec:
         ],
       },
       "Type": "AWS::Events::Rule",
-    },
-    "repocoprepocopcron07MONFRI0AllowEventRuleServiceCataloguerepocop7BEB58926BBB25F1": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "repocop20553EB8",
-            "Arn",
-          ],
-        },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "repocoprepocopcron07MONFRI08C03526D",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
     },
     "servicecatalogueCluster5FC34DC5": {
       "Properties": {

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -20399,9 +20399,9 @@ spec:
       },
       "Type": "AWS::IAM::Role",
     },
-    "cloudbustercloudbustercron309MONFRI0A90AE33E": {
+    "cloudbustercloudbustercron07MONFRI028B0F781": {
       "Properties": {
-        "ScheduleExpression": "cron(30 9 ? * MON-FRI *)",
+        "ScheduleExpression": "cron(0 7 ? * MON-FRI *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -20417,7 +20417,7 @@ spec:
       },
       "Type": "AWS::Events::Rule",
     },
-    "cloudbustercloudbustercron309MONFRI0AllowEventRuleServiceCataloguecloudbuster82FA89E4F5116C2E": {
+    "cloudbustercloudbustercron07MONFRI0AllowEventRuleServiceCataloguecloudbuster82FA89E4693980BB": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -20429,7 +20429,7 @@ spec:
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "cloudbustercloudbustercron309MONFRI0A90AE33E",
+            "cloudbustercloudbustercron07MONFRI028B0F781",
             "Arn",
           ],
         },
@@ -24221,9 +24221,9 @@ spec:
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
     },
-    "repocoprepocopcron309MONFRI042F648A2": {
+    "repocoprepocopcron07MONFRI08C03526D": {
       "Properties": {
-        "ScheduleExpression": "cron(30 9 ? * MON-FRI *)",
+        "ScheduleExpression": "cron(0 7 ? * MON-FRI *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -24239,7 +24239,7 @@ spec:
       },
       "Type": "AWS::Events::Rule",
     },
-    "repocoprepocopcron309MONFRI0AllowEventRuleServiceCataloguerepocop7BEB58922EC16074": {
+    "repocoprepocopcron07MONFRI0AllowEventRuleServiceCataloguerepocop7BEB58926BBB25F1": {
       "Properties": {
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
@@ -24251,7 +24251,7 @@ spec:
         "Principal": "events.amazonaws.com",
         "SourceArn": {
           "Fn::GetAtt": [
-            "repocoprepocopcron309MONFRI042F648A2",
+            "repocoprepocopcron07MONFRI08C03526D",
             "Arn",
           ],
         },

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -243,7 +243,7 @@ export class ServiceCatalogue extends GuStack {
 
 		const prodSchedule = Schedule.cron({
 			weekDay: 'MON-FRI',
-			hour: '7',
+			hour: '3',
 			minute: '0',
 		});
 

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -243,8 +243,8 @@ export class ServiceCatalogue extends GuStack {
 
 		const prodSchedule = Schedule.cron({
 			weekDay: 'MON-FRI',
-			hour: '9',
-			minute: '30',
+			hour: '7',
+			minute: '0',
 		});
 
 		const securityAlertSchedule = nonProdSchedule ?? prodSchedule;


### PR DESCRIPTION
## What does this change?
Moves schedule of [RepoCop](https://github.com/guardian/service-catalogue/blob/e38adda7ef2b1808beb613ff6d1d463cf3878f71/packages/cdk/lib/service-catalogue.ts#L252) and [CloudBuster](https://github.com/guardian/service-catalogue/blob/e38adda7ef2b1808beb613ff6d1d463cf3878f71/packages/cdk/lib/service-catalogue.ts#L297) production ECS tasks from 09:30 GMT weekdays to 07:00 GMT weekdays.

## Why?
There's a scenario we've seen in PRs https://github.com/guardian/contributions-platform/pull/551 and https://github.com/guardian/contributions-platform/pull/552 where the [dependency-graph-integrator job](https://github.com/guardian/service-catalogue/tree/7427a293ddf38ffc46c0416b318a751ec238a327/packages/dependency-graph-integrator) runs working on stale data.
The job makes decisions depending on the service catalogue `github-workflows` table, which is updated at midnight GMT.
This means that if a PR is merged between midnight and 09:30 GMT a duplicate will be created at 09:30 because the state of the repo's GHA workflows are no longer reflected in the `github-workflows` table.

This solution is the simplest possible but it doesn't eliminate the problem.  It now means that PRs merged between midnight and 07:00 GMT will be duplicated at 07:00.  There's a far lower likelihood that a PR will be merged between these hours.

## How has it been verified?
Monitor once in production:
- [ ] A successful `RepoCop` task has run at 07:00 GMT
- [ ] A successful `CloudBuster` task has run at 07:00 GMT
