### PR TITLE
Feat: allow for exemption of repos from dependency graph integrator

### DIFF
--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -389,8 +389,6 @@ model github_repository_custom_properties {
   property_name  String
   repository_id  BigInt
   value          String?
-
-  @@ignore
 }
 
 model github_team_repositories {

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -1,5 +1,6 @@
 import { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
 import type {
+	github_repository_custom_properties,
 	guardian_github_actions_usage,
 	PrismaClient,
 	repocop_github_repository_rules,
@@ -22,6 +23,7 @@ import {
 	getRepoOwnership,
 	getRepositories,
 	getRepositoryBranches,
+	getRepositoryCustomProperties,
 	getRepositoryLanguages,
 	getSnykIssues,
 	getSnykProjects,
@@ -160,6 +162,14 @@ export async function main() {
 		nonPlaygroundStacks,
 	);
 
+	const customProperties = await getRepositoryCustomProperties(prisma);
+	const customPropertiesExemptedFromDepGraphIntegration: github_repository_custom_properties[] =
+		customProperties.filter((property) => {
+			return (
+				property.property_name === 'gu_dependency_graph_integrator_ignore' &&
+				property.value
+			);
+		});
 	const dependencyGraphIntegratorRepoCount = 5;
 
 	await sendReposToDependencyGraphIntegrator(
@@ -167,6 +177,7 @@ export async function main() {
 		repoLanguages,
 		productionRepos,
 		productionWorkflowUsages,
+		customPropertiesExemptedFromDepGraphIntegration,
 		repoOwners,
 		dependencyGraphIntegratorRepoCount,
 		octokit,

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -1,6 +1,7 @@
 import type {
 	github_languages,
 	github_repository_branches,
+	github_repository_custom_properties,
 	guardian_github_actions_usage,
 	PrismaClient,
 	view_repo_ownership,
@@ -199,4 +200,12 @@ export async function getProductionWorkflowUsages(
 		},
 	});
 	return toNonEmptyArray(actions_usage);
+}
+
+export async function getRepositoryCustomProperties(
+	client: PrismaClient,
+): Promise<NonEmptyArray<github_repository_custom_properties>> {
+	const custom_properties =
+		await client.github_repository_custom_properties.findMany({});
+	return toNonEmptyArray(custom_properties);
 }

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
@@ -21,7 +21,8 @@ import {
 
 const fullName = 'guardian/repo-name';
 const fullName2 = 'guardian/repo2';
-const scalaLang = 'Scala';
+const scala = 'Scala';
+const kotlin = 'Kotlin';
 
 function createActionsUsage(
 	fullName: string,
@@ -75,8 +76,11 @@ function repositoryWithDepGraphLanguage(
 	};
 }
 
-function repoWithTargetLanguage(fullName: string): github_languages {
-	return repoWithLanguages(fullName, ['Scala', 'TypeScript']);
+function repoWithTargetLanguage(
+	fullName: string,
+	language: DepGraphLanguage,
+): github_languages {
+	return repoWithLanguages(fullName, [language, 'TypeScript']);
 }
 
 function repoWithoutTargetLanguage(fullName: string): github_languages {
@@ -104,8 +108,8 @@ describe('When trying to find repos using Scala', () => {
 	test('return true if Scala is found in the repo', () => {
 		const result = checkRepoForLanguage(
 			repository(fullName),
-			[repoWithTargetLanguage(fullName)],
-			scalaLang,
+			[repoWithTargetLanguage(fullName, scala)],
+			scala,
 		);
 
 		expect(result).toBe(true);
@@ -114,44 +118,18 @@ describe('When trying to find repos using Scala', () => {
 		const result = checkRepoForLanguage(
 			repository(fullName),
 			[repoWithoutTargetLanguage(fullName)],
-			scalaLang,
+			scala,
 		);
 		expect(result).toBe(false);
 	});
 });
-
-function exemptedCustomProperty(): github_repository_custom_properties {
-	return {
-		cq_sync_time: null,
-		cq_source_name: null,
-		cq_id: 'id1',
-		cq_parent_id: null,
-		org: 'guardian',
-		property_name: 'gu_dependency_graph_integrator_ignore',
-		repository_id: BigInt(1),
-		value: 'Scala',
-	};
-}
-
-function nonExemptedCustomProperty(): github_repository_custom_properties {
-	return {
-		cq_sync_time: null,
-		cq_source_name: null,
-		cq_id: 'id1',
-		cq_parent_id: null,
-		org: 'guardian',
-		property_name: 'gu_dependency_graph_integrator_ignore',
-		repository_id: BigInt(12345),
-		value: 'Scala',
-	};
-}
 
 describe('When checking a repo for an existing dependency submission workflow', () => {
 	test('return true if repo workflow is present', () => {
 		const result = doesRepoHaveDepSubmissionWorkflowForLanguage(
 			repository(fullName),
 			[repoWithDepSubmissionWorkflow(fullName)],
-			'Scala',
+			scala,
 		);
 		expect(result).toBe(true);
 	});
@@ -159,7 +137,7 @@ describe('When checking a repo for an existing dependency submission workflow', 
 		const result = doesRepoHaveDepSubmissionWorkflowForLanguage(
 			repository(fullName),
 			[repoWithoutWorkflow(fullName)],
-			'Scala',
+			scala,
 		);
 		expect(result).toBe(false);
 	});
@@ -168,25 +146,25 @@ describe('When checking a repo for an existing dependency submission workflow', 
 describe('When getting suitable repos to send to SNS', () => {
 	test('return the repo when a Scala repo is found without an existing workflow', () => {
 		const result = getSuitableReposWithoutWorkflows(
-			[repoWithTargetLanguage(fullName)],
+			[repoWithTargetLanguage(fullName, scala)],
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
 			[],
 		);
-		const expected = [repositoryWithDepGraphLanguage(fullName, 'Scala')];
+		const expected = [repositoryWithDepGraphLanguage(fullName, scala)];
 
 		expect(result).toEqual(expected);
 	});
 	test('return empty repo array when a Scala repo is found with an existing workflow', () => {
 		const result = getSuitableReposWithoutWorkflows(
-			[repoWithTargetLanguage(fullName)],
+			[repoWithTargetLanguage(fullName, scala)],
 			[repository(fullName)],
 			[repoWithDepSubmissionWorkflow(fullName)],
 			[],
 		);
 		expect(result).toEqual([]);
 	});
-	test('return empty array when non-Scala repo is found with without an existing workflow', () => {
+	test('return empty array when non-Scala/Kotlin repo is found with without an existing workflow', () => {
 		const result = getSuitableReposWithoutWorkflows(
 			[repoWithoutTargetLanguage(fullName)],
 			[repository(fullName)],
@@ -197,35 +175,83 @@ describe('When getting suitable repos to send to SNS', () => {
 	});
 	test('return both repos when 2 Scala repos are found without an existing workflow', () => {
 		const result = getSuitableReposWithoutWorkflows(
-			[repoWithTargetLanguage(fullName), repoWithTargetLanguage(fullName2)],
+			[
+				repoWithTargetLanguage(fullName, scala),
+				repoWithTargetLanguage(fullName2, scala),
+			],
 			[repository(fullName), repository(fullName2)],
 			[repoWithoutWorkflow(fullName), repoWithoutWorkflow(fullName2)],
 			[],
 		);
 		const expected = [
-			repositoryWithDepGraphLanguage(fullName, 'Scala'),
-			repositoryWithDepGraphLanguage(fullName2, 'Scala'),
+			repositoryWithDepGraphLanguage(fullName, scala),
+			repositoryWithDepGraphLanguage(fullName2, scala),
 		];
 
 		expect(result).toEqual(expected);
 	});
+	function exemptedCustomProperty(): github_repository_custom_properties {
+		return {
+			cq_sync_time: null,
+			cq_source_name: null,
+			cq_id: 'id1',
+			cq_parent_id: null,
+			org: 'guardian',
+			property_name: 'gu_dependency_graph_integrator_ignore',
+			repository_id: BigInt(1),
+			value: scala,
+		};
+	}
+
+	function nonExemptedCustomProperty(): github_repository_custom_properties {
+		return {
+			cq_sync_time: null,
+			cq_source_name: null,
+			cq_id: 'id1',
+			cq_parent_id: null,
+			org: 'guardian',
+			property_name: 'gu_dependency_graph_integrator_ignore',
+			repository_id: BigInt(12345),
+			value: null,
+		};
+	}
 	test('return the repo when a Scala repo is found without an existing workflow and repo is not exempt', () => {
 		const result = getSuitableReposWithoutWorkflows(
-			[repoWithTargetLanguage(fullName)],
+			[repoWithTargetLanguage(fullName, scala)],
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
 			[nonExemptedCustomProperty()],
 		);
-		const expected = [repositoryWithDepGraphLanguage(fullName, 'Scala')];
+		const expected = [repositoryWithDepGraphLanguage(fullName, scala)];
+
+		expect(result).toEqual(expected);
+	});
+	test('return the repo when a Kotlin repo is found without an existing workflow and repo is not exempt', () => {
+		const result = getSuitableReposWithoutWorkflows(
+			[repoWithTargetLanguage(fullName, kotlin)],
+			[repository(fullName)],
+			[repoWithoutWorkflow(fullName)],
+			[nonExemptedCustomProperty()],
+		);
+		const expected = [repositoryWithDepGraphLanguage(fullName, kotlin)];
 
 		expect(result).toEqual(expected);
 	});
 	test('return empty repo array when a Scala repo is found without an existing workflow but is exempt', () => {
 		const result = getSuitableReposWithoutWorkflows(
-			[repoWithTargetLanguage(fullName)],
+			[repoWithTargetLanguage(fullName, scala)],
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
 			[exemptedCustomProperty()],
+		);
+		expect(result).toEqual([]);
+	});
+	test('return empty repo array when a Kotlin repo is found without an existing workflow but is exempt', () => {
+		const result = getSuitableReposWithoutWorkflows(
+			[repoWithTargetLanguage(fullName, kotlin)],
+			[repository(fullName)],
+			[repoWithoutWorkflow(fullName)],
+			[{ ...exemptedCustomProperty(), value: kotlin }],
 		);
 		expect(result).toEqual([]);
 	});
@@ -251,13 +277,13 @@ describe('When getting suitable repos to send to SNS', () => {
 		};
 
 		const result = createSnsEventsForDependencyGraphIntegration(
-			[repositoryWithDepGraphLanguage(fullName, 'Scala')],
+			[repositoryWithDepGraphLanguage(fullName, scala)],
 			[ownershipRecord1, ownershipRecord2],
 		);
 		expect(result).toEqual([
 			{
 				name: removeRepoOwner(fullName),
-				language: 'Scala',
+				language: scala,
 				admins: ['team-slug', 'team-slug2'],
 			},
 		]);
@@ -270,13 +296,13 @@ describe('When getting suitable repos to send to SNS', () => {
 		};
 
 		const result = createSnsEventsForDependencyGraphIntegration(
-			[repositoryWithDepGraphLanguage(fullName, 'Scala')],
+			[repositoryWithDepGraphLanguage(fullName, scala)],
 			[ownershipRecord],
 		);
 		expect(result).toEqual([
 			{
 				name: removeRepoOwner(fullName),
-				language: 'Scala',
+				language: scala,
 				admins: [],
 			},
 		]);

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.test.ts
@@ -15,7 +15,7 @@ import {
 	createSnsEventsForDependencyGraphIntegration,
 	doesRepoHaveDepSubmissionWorkflowForLanguage,
 	getExistingPullRequest,
-	getReposWithoutWorkflows,
+	getSuitableReposWithoutWorkflows,
 } from './send-to-sns';
 
 const fullName = 'guardian/repo-name';
@@ -140,7 +140,7 @@ describe('When checking a repo for an existing dependency submission workflow', 
 
 describe('When getting suitable events to send to SNS', () => {
 	test('return the repo when a Scala repo is found without an existing workflow', () => {
-		const result = getReposWithoutWorkflows(
+		const result = getSuitableReposWithoutWorkflows(
 			[repoWithTargetLanguage(fullName)],
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
@@ -150,7 +150,7 @@ describe('When getting suitable events to send to SNS', () => {
 		expect(result).toEqual(expected);
 	});
 	test('return empty repo array when a Scala repo is found with an existing workflow', () => {
-		const result = getReposWithoutWorkflows(
+		const result = getSuitableReposWithoutWorkflows(
 			[repoWithTargetLanguage(fullName)],
 			[repository(fullName)],
 			[repoWithDepSubmissionWorkflow(fullName)],
@@ -158,7 +158,7 @@ describe('When getting suitable events to send to SNS', () => {
 		expect(result).toEqual([]);
 	});
 	test('return empty array when non-Scala repo is found with without an existing workflow', () => {
-		const result = getReposWithoutWorkflows(
+		const result = getSuitableReposWithoutWorkflows(
 			[repoWithoutTargetLanguage(fullName)],
 			[repository(fullName)],
 			[repoWithoutWorkflow(fullName)],
@@ -166,7 +166,7 @@ describe('When getting suitable events to send to SNS', () => {
 		expect(result).toEqual([]);
 	});
 	test('return 2 events when 2 Scala repos are found without an existing workflow', () => {
-		const result = getReposWithoutWorkflows(
+		const result = getSuitableReposWithoutWorkflows(
 			[repoWithTargetLanguage(fullName), repoWithTargetLanguage(fullName2)],
 			[repository(fullName), repository(fullName2)],
 			[repoWithoutWorkflow(fullName), repoWithoutWorkflow(fullName2)],

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -202,8 +202,6 @@ export async function sendReposToDependencyGraphIntegrator(
 
 		const selectedRepos: RepositoryWithDepGraphLanguage[] = [];
 
-		let reposWithPrs = 0;
-
 		while (selectedRepos.length < repoCount && shuffledRepos.length > 0) {
 			const repo = shuffledRepos.pop();
 			if (repo) {
@@ -221,13 +219,9 @@ export async function sendReposToDependencyGraphIntegrator(
 				);
 				if (!existingPr) {
 					selectedRepos.push(repo);
-				} else {
-					reposWithPrs++;
 				}
 			}
 		}
-
-		console.log(`Found ${reposWithPrs} repos with existing PRs`);
 
 		const eventsToSend: DependencyGraphIntegratorEvent[] =
 			createSnsEventsForDependencyGraphIntegration(selectedRepos, repoOwners);

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -126,10 +126,12 @@ export function repoIsExempted(
 	exemptedCustomProperties: github_repository_custom_properties[],
 	language: DepGraphLanguage,
 ): boolean {
-	const exemptedRepo = exemptedCustomProperties.find(
-		(property) => repo.id === property.repository_id,
-	);
-	if (exemptedRepo && exemptedRepo.value === language) {
+	const exemptedRepo: github_repository_custom_properties | undefined =
+		exemptedCustomProperties.find(
+			(property) =>
+				repo.id === property.repository_id && language === property.value,
+		);
+	if (exemptedRepo) {
 		logger.log({
 			message: `${repo.name} is exempted from dependency graph integration for ${language}`,
 			numexemptedCustomProperties: exemptedCustomProperties.length,

--- a/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
+++ b/packages/repocop/src/remediation/dependency_graph-integrator/send-to-sns.ts
@@ -123,18 +123,19 @@ async function sendOneRepoToDepGraphIntegrator(
 
 export function repoIsExempted(
 	repo: Repository,
-	exceptedCustomProperties: github_repository_custom_properties[],
+	exemptedCustomProperties: github_repository_custom_properties[],
+	language: DepGraphLanguage,
 ): boolean {
-	const repoIsExcepted = exceptedCustomProperties.find(
+	const exemptedRepo = exemptedCustomProperties.find(
 		(property) => repo.id === property.repository_id,
 	);
-	if (repoIsExcepted) {
+	if (exemptedRepo && exemptedRepo.value === language) {
 		logger.log({
-			message: `${repo.name} is excepted from dependency graph integration`,
-			numExceptedCustomProperties: exceptedCustomProperties.length,
+			message: `${repo.name} is exempted from dependency graph integration for ${language}`,
+			numexemptedCustomProperties: exemptedCustomProperties.length,
 		});
 	}
-	return repoIsExcepted !== undefined;
+	return exemptedRepo !== undefined;
 }
 
 export function getSuitableReposWithoutWorkflows(
@@ -155,7 +156,9 @@ export function getSuitableReposWithoutWorkflows(
 			);
 
 			return reposWithDepGraphLanguages
-				.filter((repo) => !repoIsExempted(repo, exemptedCustomProperties))
+				.filter(
+					(repo) => !repoIsExempted(repo, exemptedCustomProperties, language),
+				)
 				.filter((repo) => {
 					const workflowUsagesForRepo = productionWorkflowUsages.filter(
 						(workflow) => workflow.full_name === repo.full_name,

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -151,15 +151,3 @@ export interface VulnerabilityDigest {
 	message: string;
 	actions: Action[];
 }
-
-export type CustomPropertyFields = Pick<
-	github_repository_custom_properties,
-	'property_name' | 'value' | 'repository_id'
-> & {
-	repo_name: string;
-};
-
-export interface CustomProperty extends CustomPropertyFields {
-	property_name: NonNullable<CustomPropertyFields['property_name']>;
-	value: NonNullable<CustomPropertyFields['value']>;
-}

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -2,6 +2,7 @@ import type { Action } from '@guardian/anghammarad';
 import type { Endpoints } from '@octokit/types';
 import type {
 	aws_cloudformation_stacks,
+	github_repository_custom_properties,
 	github_teams,
 	repocop_github_repository_rules,
 } from '@prisma/client';
@@ -149,4 +150,16 @@ export interface VulnerabilityDigest {
 	subject: string;
 	message: string;
 	actions: Action[];
+}
+
+export type CustomPropertyFields = Pick<
+	github_repository_custom_properties,
+	'property_name' | 'value' | 'repository_id'
+> & {
+	repo_name: string;
+};
+
+export interface CustomProperty extends CustomPropertyFields {
+	property_name: NonNullable<CustomPropertyFields['property_name']>;
+	value: NonNullable<CustomPropertyFields['value']>;
 }

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -2,7 +2,6 @@ import type { Action } from '@guardian/anghammarad';
 import type { Endpoints } from '@octokit/types';
 import type {
 	aws_cloudformation_stacks,
-	github_repository_custom_properties,
 	github_teams,
 	repocop_github_repository_rules,
 } from '@prisma/client';


### PR DESCRIPTION
## What does this change?

- Repocop collects the `github_repositories_custom_properties` table.
- Adds a check for the custom property `gu_dependency_graph_integrator_ignore` and excludes any repos that have this property from dependency graph integration.
- Updates the tests and adds a couple more for the exemptions.

## Why?

There is at least one repo that we know of that contains a script written in Scala file but that doesn't use sbt. As there are no dependencies for Scala in the repo, it doesn't need to have the sbt dependency submission workflow. Currently, the dependency graph integrator will identify this repo as requiring a workflow, and continue to raise a PR against it if the existing PR is closed or if the workflow is not merged in.

## How has it been verified?

- [x] Added the custom property to the repo in question and observed the custom property appear in the Cloudquery table `github_repositories_custom_properties`.
- [x] Tested locally
- [x] Tested on CODE