### PR TITLE
refactor: explicitly add custom props table to cloudquery source

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -15382,6 +15382,7 @@ spec:
     - github_repositories
     - github_repository_branches
     - github_repository_collaborators
+    - github_repository_custom_properties
     - github_workflows
   skip_tables:
     - github_releases
@@ -15610,7 +15611,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('github_repositories', 'DAILY'),('github_repository_branches', 'DAILY'),('github_repository_collaborators', 'DAILY'),('github_workflows', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('github_repositories', 'DAILY'),('github_repository_branches', 'DAILY'),('github_repository_collaborators', 'DAILY'),('github_repository_custom_properties', 'DAILY'),('github_workflows', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -392,6 +392,7 @@ export function addCloudqueryEcsCluster(
 					'github_repositories',
 					'github_repository_branches',
 					'github_repository_collaborators',
+					'github_repository_custom_properties',
 					'github_workflows',
 				],
 


### PR DESCRIPTION
## What does this change?

Explicitly adds the `github_repository_custom_properties` table to the list of those collected by the GithubRepositories Cloudquery source.

## Why?

All child tables are automatically collected, unless we specify them in the `skipTables` property. However, for clarity it is good to explicitly say what tables we want to collect.

## How has it been verified?

- [x] CI passes
