### PR TITLE
Use Java 21 in dependency graph submission workflow

### DIFF
--- a/packages/dependency-graph-integrator/src/file-generator.test.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.test.ts
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0
         with:
           distribution: corretto
-          java-version: 17
+          java-version: 21
       - name: Install sbt
         id: sbt
         uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
@@ -65,7 +65,7 @@ jobs:
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Submit dependencies
         id: submit
         uses: gradle/actions/dependency-submission@d156388eb19639ec20ade50009f3d199ce1e2808 # v4.1.0

--- a/packages/dependency-graph-integrator/src/file-generator.ts
+++ b/packages/dependency-graph-integrator/src/file-generator.ts
@@ -24,7 +24,7 @@ function createLanguageSpecificWorkflowSteps(
 				uses: 'actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0',
 				with: {
 					distribution: 'corretto',
-					'java-version': '17',
+					'java-version': '21',
 				},
 			},
 			{
@@ -55,7 +55,7 @@ function createLanguageSpecificWorkflowSteps(
 				uses: 'actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1',
 				with: {
 					distribution: 'temurin',
-					'java-version': '17',
+					'java-version': '21',
 				},
 			},
 			{


### PR DESCRIPTION
## What does this change?
Using Java 21 to run the dependency graph submission workflow rather than Java 17.

## Why?
Java 21 is the latest LTS version.

## How has it been verified?
Several workflows have successfully run using Java 21, 
eg. https://github.com/guardian/myguardian-support-services/actions/runs/12869554808