### PR TITLE
Bump image_packages CQ plugin to latest

### DIFF
--- a/.env
+++ b/.env
@@ -33,7 +33,7 @@ CQ_GITHUB_LANGUAGES=0.0.5
 CQ_NS1=0.1.3
 
 # See https://github.com/guardian/cq-image-packages
-CQ_IMAGE_PACKAGES=1.0.1
+CQ_IMAGE_PACKAGES=1.0.2
 
 # --- FOR LOCAL DEVELOPMENT ONLY ---
 STAGE=DEV

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -368,7 +368,7 @@ spec:
   name: image-packages
   registry: github
   path: guardian/image-packages
-  version: v1.0.1
+  version: v1.0.2
   destinations:
     - postgresql
   tables:


### PR DESCRIPTION
## What does this change?
Uses latest version of plugin.

## Why?
Keep up to date and avoid large shocks.

## How has it been verified?
Tested in Code.