### PR TITLE
feat: Remove the `github_issue_pullrequest_reviews` table from the database

### DIFF
--- a/packages/common/prisma/migrations/20250131123229_drop_github_issue_pullrequest_reviews/migration.sql
+++ b/packages/common/prisma/migrations/20250131123229_drop_github_issue_pullrequest_reviews/migration.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS github_issue_pullrequest_reviews;


### PR DESCRIPTION
## What does this change?
Since #1350 we have stopped collecting this table.

## Why?
The table is redundant.

---
Co-authored by: @kelvin-chappell.