### PR TITLE
chore(deps): Update the version of `guardian/cq-source-ns1` from 0.1.3 to 0.1.4

### DIFF
--- a/.env
+++ b/.env
@@ -27,7 +27,7 @@ CQ_GUARDIAN_GALAXIES=1.1.8
 CQ_GITHUB_LANGUAGES=0.0.5
 
 # See https://github.com/guardian/cq-source-ns1
-CQ_NS1=0.1.3
+CQ_NS1=0.1.4
 
 # See https://github.com/guardian/cq-image-packages
 CQ_IMAGE_PACKAGES=1.0.1

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -17023,7 +17023,7 @@ spec:
           },
           {
             "Essential": false,
-            "Image": "ghcr.io/guardian/cq-source-ns1:0.1.3",
+            "Image": "ghcr.io/guardian/cq-source-ns1:0.1.4",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {


### PR DESCRIPTION
This version includes updates to dependencies. See https://github.com/guardian/cq-source-ns1/releases/tag/v0.1.4.