### PR TITLE
chore: Address a deprecation warning

### DIFF
--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -159,7 +159,7 @@ export class ServiceCatalogue extends GuStack {
 			This certificate supports automatic rotation.
 			See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.RegionCertificateAuthorities
 			 */
-			caCertificate: CaCertificate.RDS_CA_RDS2048_G1,
+			caCertificate: CaCertificate.RDS_CA_RSA2048_G1,
 		};
 
 		const db = new DatabaseInstance(this, 'PostgresInstance1', dbProps);


### PR DESCRIPTION
## What does this change?
Address a deprecation warning. See https://github.com/aws/aws-cdk/blob/6a77e4f5cd872b4f3b985f1ea6eebd5d54aebd70/packages/aws-cdk-lib/aws-rds/lib/ca-certificate.ts#L18-L23.

This doesn't require a snapshot update as the old and new enum evaluate to the same value. That is, this is a no-op.