### PR TITLE
feat: Change `frequency` column in `cloudquery_table_frequency` to milliseconds

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -554,7 +554,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('amigo_bake_packages', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('amigo_bake_packages', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -973,7 +973,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_costexplorer_%', 'WEEKLY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'WEEKLY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_costexplorer_%', 604800000) ON CONFLICT (table_name) DO UPDATE SET frequency = 604800000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -1640,7 +1640,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_accessanalyzer_%', 'DAILY'),('aws_securityhub_%', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_accessanalyzer_%', 86400000),('aws_securityhub_%', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -2323,7 +2323,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_lambda_%', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_lambda_%', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -2945,7 +2945,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_organization%', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_organization%', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -3598,7 +3598,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_autoscaling_groups', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_autoscaling_groups', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -4253,7 +4253,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_backup_protected_resources', 'DAILY'),('aws_backup_vaults', 'DAILY'),('aws_backup_vault_recovery_points', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_backup_protected_resources', 86400000),('aws_backup_vaults', 86400000),('aws_backup_vault_recovery_points', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -4936,7 +4936,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_acm%', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_acm%', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -5793,7 +5793,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_cloudformation_%', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_cloudformation_%', 10800000) ON CONFLICT (table_name) DO UPDATE SET frequency = 10800000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -6212,7 +6212,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_cloudwatch_alarms', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_cloudwatch_alarms', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -6865,7 +6865,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_dynamodb%', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_dynamodb%', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -7551,7 +7551,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_ec2_instances', 'DAILY'),('aws_ec2_security_groups', 'DAILY'),('aws_ec2_images', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_ec2_instances', 1800000),('aws_ec2_security_groups', 1800000),('aws_ec2_images', 1800000) ON CONFLICT (table_name) DO UPDATE SET frequency = 1800000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -8204,7 +8204,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_iam_credential_reports', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_iam_credential_reports', 14400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 14400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -8858,7 +8858,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_inspector_findings', 'DAILY'),('aws_inspector2_findings', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_inspector_findings', 86400000),('aws_inspector2_findings', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -9512,7 +9512,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_elbv1_%', 'DAILY'),('aws_elbv2_%', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_elbv1_%', 1800000),('aws_elbv2_%', 1800000) ON CONFLICT (table_name) DO UPDATE SET frequency = 1800000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -10168,7 +10168,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_rds_instances', 'DAILY'),('aws_rds_clusters', 'DAILY'),('aws_rds_db_snapshots', 'DAILY'),('aws_rds_cluster_snapshots', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_rds_instances', 86400000),('aws_rds_clusters', 86400000),('aws_rds_db_snapshots', 86400000),('aws_rds_cluster_snapshots', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -10821,7 +10821,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_s3%', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_s3%', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -11775,7 +11775,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_%', 'WEEKLY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'WEEKLY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_%', 604800000) ON CONFLICT (table_name) DO UPDATE SET frequency = 604800000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -12224,7 +12224,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_ssm_parameters', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_ssm_parameters', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -12892,7 +12892,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('fastly_services', 'DAILY'),('fastly_service_versions', 'DAILY'),('fastly_service_backends', 'DAILY'),('fastly_service_domains', 'DAILY'),('fastly_service_health_checks', 'DAILY'),('fastly_account_users', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('fastly_services', 86400000),('fastly_service_versions', 86400000),('fastly_service_backends', 86400000),('fastly_service_domains', 86400000),('fastly_service_health_checks', 86400000),('fastly_account_users', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -13554,7 +13554,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('galaxies_people_table', 'DAILY'),('galaxies_teams_table', 'DAILY'),('galaxies_streams_table', 'DAILY'),('galaxies_people_profile_info_table', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('galaxies_people_table', 86400000),('galaxies_teams_table', 86400000),('galaxies_streams_table', 86400000),('galaxies_people_profile_info_table', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -14499,7 +14499,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('github_issues', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('github_issues', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -14947,7 +14947,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('github_languages', 'WEEKLY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'WEEKLY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('github_languages', 604800000) ON CONFLICT (table_name) DO UPDATE SET frequency = 604800000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -15634,7 +15634,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('github_repositories', 'DAILY'),('github_repository_branches', 'DAILY'),('github_repository_collaborators', 'DAILY'),('github_repository_custom_properties', 'DAILY'),('github_workflows', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('github_repositories', 86400000),('github_repository_branches', 86400000),('github_repository_collaborators', 86400000),('github_repository_custom_properties', 86400000),('github_workflows', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -16349,7 +16349,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('github_organizations', 'WEEKLY'),('github_organization_members', 'WEEKLY'),('github_teams', 'WEEKLY'),('github_team_members', 'WEEKLY'),('github_team_repositories', 'WEEKLY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'WEEKLY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('github_organizations', 604800000),('github_organization_members', 604800000),('github_teams', 604800000),('github_team_members', 604800000),('github_team_repositories', 604800000) ON CONFLICT (table_name) DO UPDATE SET frequency = 604800000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -17043,7 +17043,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('ns1_%', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('ns1_%', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -17993,7 +17993,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('riffraff_%', 'DAILY') ON CONFLICT (table_name) DO UPDATE SET frequency = 'DAILY'"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('riffraff_%', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",

--- a/packages/cdk/lib/cloudquery/schedule.test.ts
+++ b/packages/cdk/lib/cloudquery/schedule.test.ts
@@ -1,52 +1,60 @@
 import { Duration } from 'aws-cdk-lib';
 import { Schedule } from 'aws-cdk-lib/aws-events';
-import { scheduleFrequency } from './schedule';
+import { scheduleFrequencyMs } from './schedule';
 
 describe('EventBridge expression parsing', () => {
 	it('should correctly identify task frequency from CRON', () => {
 		expect(
-			scheduleFrequency(
+			scheduleFrequencyMs(
 				Schedule.cron({
 					hour: '1',
 				}),
 			),
-		).toBe('DAILY');
+		).toBe(Duration.minutes(1).toMilliseconds());
 		expect(
-			scheduleFrequency(
+			scheduleFrequencyMs(
 				Schedule.cron({
 					minute: '1',
 					hour: '1',
 					weekDay: '1',
 				}),
 			),
-		).toBe('WEEKLY');
+		).toBe(Duration.days(7).toMilliseconds());
 		expect(
-			scheduleFrequency(
+			scheduleFrequencyMs(
 				Schedule.cron({
 					minute: '1',
 					hour: '1',
 					day: '1',
 				}),
 			),
-		).toBe('OTHER');
+		).toBe(Duration.days(31).toMilliseconds());
 	});
 
 	it('should correctly identify task frequency from RATE', () => {
-		expect(scheduleFrequency(Schedule.rate(Duration.days(1)))).toBe('DAILY');
-		expect(scheduleFrequency(Schedule.rate(Duration.days(7)))).toBe('WEEKLY');
-		expect(scheduleFrequency(Schedule.rate(Duration.days(30)))).toBe('OTHER');
+		expect(scheduleFrequencyMs(Schedule.rate(Duration.days(1)))).toBe(
+			Duration.days(1).toMilliseconds(),
+		);
+		expect(scheduleFrequencyMs(Schedule.rate(Duration.days(7)))).toBe(
+			Duration.days(7).toMilliseconds(),
+		);
+		expect(scheduleFrequencyMs(Schedule.rate(Duration.days(30)))).toBe(
+			Duration.days(30).toMilliseconds(),
+		);
 	});
 
 	it('should correctly identify task frequency from EXPRESSION', () => {
-		expect(scheduleFrequency(Schedule.expression('rate(1 days)'))).toBe(
-			'DAILY',
+		expect(scheduleFrequencyMs(Schedule.expression('rate(1 days)'))).toBe(
+			Duration.days(1).toMilliseconds(),
 		);
 	});
 
 	it('should throw error from invalid EXPRESSION', () => {
-		expect(() => scheduleFrequency(Schedule.expression('asdf'))).toThrow(Error);
-		expect(() => scheduleFrequency(Schedule.expression('asdf(asdf)'))).toThrow(
+		expect(() => scheduleFrequencyMs(Schedule.expression('asdf'))).toThrow(
 			Error,
 		);
+		expect(() =>
+			scheduleFrequencyMs(Schedule.expression('asdf(asdf)')),
+		).toThrow(Error);
 	});
 });

--- a/packages/cdk/lib/cloudquery/schedule.ts
+++ b/packages/cdk/lib/cloudquery/schedule.ts
@@ -5,11 +5,9 @@ import awsCronParser from 'aws-cron-parser';
  * Takes a schedule and figures out its frequency. Supports both CRON and RATE schedules.
  *
  * @param schedule - An AWS EventBridge Schedule
- * @returns an enum representing the rate at which a schedule runs
+ * @returns the duration in milliseconds between executions
  */
-export const scheduleFrequency = (
-	schedule: Schedule,
-): 'DAILY' | 'WEEKLY' | 'OTHER' => {
+export const scheduleFrequencyMs = (schedule: Schedule): number => {
 	// RATE and CRON are both 4 characters long
 	const type = schedule.expressionString.substring(0, 4);
 	const expression = schedule.expressionString.substring(
@@ -17,23 +15,13 @@ export const scheduleFrequency = (
 		schedule.expressionString.length - 1,
 	);
 
-	let frequencyInMilliseconds: number | undefined;
-
-	if (type === 'rate') {
-		frequencyInMilliseconds = scheduleFromRate(expression);
-	} else if (type === 'cron') {
-		frequencyInMilliseconds = scheduleFromCron(expression);
-	} else {
-		throw new Error(`Unexpected schedule type: ${type}`);
-	}
-
-	const DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
-	if (frequencyInMilliseconds / DAY_IN_MILLISECONDS > 7) {
-		return 'OTHER';
-	} else if (frequencyInMilliseconds / DAY_IN_MILLISECONDS > 1) {
-		return 'WEEKLY';
-	} else {
-		return 'DAILY';
+	switch (type) {
+		case 'rate':
+			return scheduleFromRate(expression);
+		case 'cron':
+			return scheduleFromCron(expression);
+		default:
+			throw new Error(`Unexpected schedule type: ${type}`);
 	}
 };
 
@@ -76,17 +64,17 @@ const scheduleFromCron = (expression: string): number => {
 	// AWS uses a non-standard CRON expression so we need to rely on a cron library specifically designed
 	// for parsing AWS cron expressions.
 	const parsedExpression = awsCronParser.parse(expression);
-	const occurence = awsCronParser.next(parsedExpression, new Date());
+	const occurrence = awsCronParser.next(parsedExpression, new Date());
 
-	if (!occurence) {
-		throw new Error(`First occurence of schedule not found: ${expression}`);
+	if (!occurrence) {
+		throw new Error(`First occurrence of schedule not found: ${expression}`);
 	}
 
-	const nextOccurrence = awsCronParser.next(parsedExpression, occurence);
+	const nextOccurrence = awsCronParser.next(parsedExpression, occurrence);
 
 	if (!nextOccurrence) {
 		throw new Error(`Second occurrence of schedule not found: ${expression}`);
 	}
 
-	return nextOccurrence.getTime() - occurence.getTime();
+	return nextOccurrence.getTime() - occurrence.getTime();
 };

--- a/packages/common/prisma/migrations/20250204123000_frequency_milliseconds/migration.sql
+++ b/packages/common/prisma/migrations/20250204123000_frequency_milliseconds/migration.sql
@@ -1,0 +1,29 @@
+/*
+ This migration converts the frequency column to store frequency in milliseconds.
+ This offers greater accuracy and flexibility in scheduling.
+ For example, it enables identification of tables that are updated multiple times a day.
+
+ To understand the daily rate:
+ ```sql
+ SELECT table_name
+        , 86400000 / frequency AS daily_rate
+ FROM   cloudquery_table_frequency;
+ ```
+ */
+BEGIN;
+
+ALTER TABLE cloudquery_table_frequency ADD COLUMN frequency_milliseconds BIGINT NULL;
+
+UPDATE cloudquery_table_frequency SET frequency_milliseconds = CASE
+    WHEN frequency = 'DAILY' THEN 86400000
+    WHEN frequency = 'WEEKLY' THEN 604800000
+    ELSE 0 -- this should never happen
+END;
+
+ALTER TABLE cloudquery_table_frequency ALTER COLUMN frequency_milliseconds SET NOT NULL;
+
+ALTER TABLE cloudquery_table_frequency DROP COLUMN frequency;
+
+ALTER TABLE cloudquery_table_frequency RENAME COLUMN frequency_milliseconds TO frequency;
+
+COMMIT;

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -636,8 +636,8 @@ model audit_results {
 }
 
 model cloudquery_table_frequency {
-  table_name String  @id
-  frequency  String?
+  table_name String @id
+  frequency  BigInt
 }
 
 model guardian_non_p_and_e_github_teams {


### PR DESCRIPTION
> [!NOTE]
> These database changes have been [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/d96682c5-edcc-438c-8014-5dbedb24175e) and therefore the database schema is only compatible with this branch. Before testing another branch on CODE, we'll need to apply another migration to revert the schema change. Or, rebase the feature branch on this one.

## What does this change and why?
Updates the `cloudquery_table_frequency` table to store frequency as milliseconds. Using milliseconds allows for a higher degree of accuracy. For example, we can identify tables that are updated multiple times a day.

To understand the daily rate, we can do:

```sql
SELECT table_name
       , 86400000 / frequency AS daily_rate -- 86400000 = milliseconds in a day
FROM   cloudquery_table_frequency;
```

## How has it been verified?
I've [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/d96682c5-edcc-438c-8014-5dbedb24175e) and seen the migration apply:

<img width="1483" alt="image" src="https://github.com/user-attachments/assets/7f69625f-3d3c-42ba-ab35-c71d2ce2f2f5" />

Using the above SQL, we can see [the effective daily rate of each table](https://metrics.code.dev-gutools.co.uk/goto/ElIX4cKHR?orgId=1):

![image](https://github.com/user-attachments/assets/7e1fb026-9a96-4516-be78-cee1d8cb411d)