### PR TITLE
fix: Install `ca-certificates` package

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,8 @@
 
 # Environment variables shared between ci and DEV.
 
+# NOTE: If you change this value remember to produce a new image by running the "CQ image" workflow.
+# See https://github.com/guardian/service-catalogue/actions/workflows/cq-image.yml
 # See https://github.com/cloudquery/cloudquery/releases?q=cli
 CQ_CLI=6.15.0
 

--- a/containers/cloudquery/Dockerfile
+++ b/containers/cloudquery/Dockerfile
@@ -4,4 +4,6 @@ FROM ghcr.io/cloudquery/cloudquery:${CQ_CLI}
 
 # Need to install RDS certs before running Cloudquery container due to
 # access to the root filesystem being restricted
-RUN wget -O /usr/local/share/ca-certificates/global-bundle.crt -q https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem && update-ca-certificates
+RUN apk add --no-cache ca-certificates
+RUN wget -O /usr/local/share/ca-certificates/global-bundle.crt -q https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+RUN update-ca-certificates


### PR DESCRIPTION
## What does this change?
It appears v6.15.0 of the CloudQuery CLI image no longer includes `ca-certificates`, which provides the `update-ca-certificates` command. Add it back!

The changes in https://github.com/guardian/service-catalogue/pull/1405 didn't actually do anything as we have to manually publish a new image. I've added a note about this as an inline comment. We should automate this process in future though.

## How has it been verified?
I've [manually run](https://github.com/guardian/service-catalogue/actions/runs/13175742340/job/36774525816) the [workflow](https://github.com/guardian/service-catalogue/blob/main/.github/workflows/cq-image.yml) to publish an image.