### PR TITLE
chore(deps): Update CloudQuery Galaxies plugin from v1.1.8 to v1.1.9

### DIFF
--- a/.env
+++ b/.env
@@ -23,7 +23,7 @@ CQ_GITHUB=11.11.1
 CQ_FASTLY=3.0.7
 
 # See https://github.com/guardian/cq-source-galaxies
-CQ_GUARDIAN_GALAXIES=1.1.8
+CQ_GUARDIAN_GALAXIES=1.1.9
 
 # See https://github.com/guardian/cq-source-github-languages
 CQ_GITHUB_LANGUAGES=0.0.5

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -13349,7 +13349,7 @@ spec:
   name: galaxies
   path: guardian/galaxies
   registry: github
-  version: v1.1.8
+  version: v1.1.9
   destinations:
     - postgresql
   tables:


### PR DESCRIPTION
## What does this change?
This version includes some dependency updates.

See https://github.com/guardian/cq-source-galaxies/releases/tag/v1.1.9.