### PR TITLE
feat: Create a new SQL view for VPC details

### DIFF
--- a/packages/common/prisma/migrations/20250212092000_aws_vpc_tables/migration.sql
+++ b/packages/common/prisma/migrations/20250212092000_aws_vpc_tables/migration.sql
@@ -1,0 +1,75 @@
+BEGIN TRANSACTION;
+    CREATE TABLE IF NOT EXISTS "aws_ec2_route_tables" (
+        "_cq_sync_time" TIMESTAMP(6),
+        "_cq_source_name" TEXT,
+        "_cq_id" UUID NOT NULL,
+        "_cq_parent_id" UUID,
+        "account_id" TEXT,
+        "region" TEXT,
+        "arn" TEXT,
+        "tags" JSONB,
+        "associations" JSONB,
+        "owner_id" TEXT,
+        "propagating_vgws" JSONB,
+        "route_table_id" TEXT,
+        "routes" JSONB,
+        "vpc_id" TEXT,
+
+        CONSTRAINT "aws_ec2_route_tables_cqpk" PRIMARY KEY ("_cq_id")
+    );
+    
+    CREATE TABLE IF NOT EXISTS "aws_ec2_subnets" (
+        "_cq_sync_time" TIMESTAMP(6),
+        "_cq_source_name" TEXT,
+        "_cq_id" UUID NOT NULL,
+        "_cq_parent_id" UUID,
+        "request_account_id" TEXT,
+        "request_region" TEXT,
+        "arn" TEXT,
+        "tags" JSONB,
+        "assign_ipv6_address_on_creation" BOOLEAN,
+        "availability_zone" TEXT,
+        "availability_zone_id" TEXT,
+        "available_ip_address_count" BIGINT,
+        "cidr_block" TEXT,
+        "customer_owned_ipv4_pool" TEXT,
+        "default_for_az" BOOLEAN,
+        "enable_dns64" BOOLEAN,
+        "enable_lni_at_device_index" BIGINT,
+        "ipv6_cidr_block_association_set" JSONB,
+        "ipv6_native" BOOLEAN,
+        "map_customer_owned_ip_on_launch" BOOLEAN,
+        "map_public_ip_on_launch" BOOLEAN,
+        "outpost_arn" TEXT,
+        "owner_id" TEXT,
+        "private_dns_name_options_on_launch" JSONB,
+        "state" TEXT,
+        "subnet_arn" TEXT,
+        "subnet_id" TEXT,
+        "vpc_id" TEXT,
+
+        CONSTRAINT "aws_ec2_subnets_cqpk" PRIMARY KEY ("_cq_id")
+    );
+
+    CREATE TABLE IF NOT EXISTS "aws_ec2_vpcs" (
+        "_cq_sync_time" TIMESTAMP(6),
+        "_cq_source_name" TEXT,
+        "_cq_id" UUID NOT NULL,
+        "_cq_parent_id" UUID,
+        "account_id" TEXT,
+        "region" TEXT,
+        "arn" TEXT,
+        "tags" JSONB,
+        "cidr_block" TEXT,
+        "cidr_block_association_set" JSONB,
+        "dhcp_options_id" TEXT,
+        "instance_tenancy" TEXT,
+        "ipv6_cidr_block_association_set" JSONB,
+        "is_default" BOOLEAN,
+        "owner_id" TEXT,
+        "state" TEXT,
+        "vpc_id" TEXT,
+
+        CONSTRAINT "aws_ec2_vpcs_cqpk" PRIMARY KEY ("_cq_id")
+    );
+COMMIT TRANSACTION;

--- a/packages/common/prisma/migrations/20250212092300_view_aws_vpcs/migration.sql
+++ b/packages/common/prisma/migrations/20250212092300_view_aws_vpcs/migration.sql
@@ -1,0 +1,170 @@
+-- @formatter:off -- this stops IntelliJ from reformatting the SQL
+begin transaction;
+    drop view if exists view_aws_vpcs;
+    drop function if exists fn_view_aws_vpcs;
+
+    create function fn_view_aws_vpcs() returns table (
+        account_id text
+        , region text
+        , vpc_id text
+        , vpc_cidr_block text
+        , is_default boolean
+        , subnet_id text
+        , subnet_type text
+        , subnet_cidr_block text
+        , subnet_total_addresses bigint
+        , subnet_remaining_addresses bigint
+        , subnet_in_use boolean
+        , subnet_route_table_id text
+    ) as $$
+        with constants as (
+            /*
+             5 addresses are reserved by AWS.
+             See https://docs.aws.amazon.com/vpc/latest/userguide/subnet-sizing.html#subnet-sizing-ipv4.
+             */
+            select  5 as unusable_addresses
+        )
+
+        /*
+         Build a list of VPC route tables and the subnet they're associated with.
+         This association can either be:
+           - Explicit: where the subnet is in the `associations` column; OR
+           - Implicit: where the `association` is `Main`
+         NOTE: Only subnets with an explict association are returned at this point.
+
+         We also determine if there is a public route (i.e. an internet gateway open to the world).
+         NOTE: As route table can have multiple routes, a subnet could appear as both public and private at this point.
+        */
+        , part1 as (
+            select  distinct rt.account_id
+                    , rt.region
+                    , rt.vpc_id
+                    , rt.route_table_id
+                    , assoc ->> 'SubnetId' as subnet_id
+                    , (assoc ->> 'Main')::boolean as is_main
+                    , case
+                        when roots ->> 'GatewayId' like 'igw-%' and roots ->> 'DestinationCidrBlock' = '0.0.0.0/0' then 'public'
+                        else 'private'
+                      end as route_type
+            from    aws_ec2_route_tables rt
+                    , jsonb_array_elements(rt.associations) AS assoc
+                    , jsonb_array_elements(rt.routes) as roots
+        )
+
+        /*
+         Build a list of subnets and the route to it (public or private).
+         Also calculate the total number of IP addresses available and the remaining number that can be allocated.
+        */
+        , part2 as (
+            select  subnet.request_account_id as account_id
+                    , subnet.request_region as region
+                    , subnet.vpc_id
+                    , subnet.subnet_id
+
+                    /*
+                     If a subnet is not explicitly associated with a route table, we look for the main route table.
+                     */
+                    , case
+                        when part1.route_table_id is null then (
+                            select      d.route_type
+                            from        part1 as d
+                            where       d.is_main = true
+                                        and subnet.vpc_id = d.vpc_id
+                                        and subnet.request_account_id = d.account_id
+                                        and subnet.request_region = d.region
+
+                            /*
+                             From `part1` we have a row for each route in a route table.
+                             By ordering by `route_type` and taking the first item, we say a subnet is public if it has a public route.
+                             This is a bit of a hack, as it relies on "public" being alphabetically before "private", but it works for now.
+                            */
+                            order by    d.route_type desc
+                            limit       1
+                          )
+                      else part1.route_type
+                    end as subnet_type
+                    , case
+                        when part1.route_table_id is null then (
+                            select      d.route_table_id
+                            from        part1 as d
+                            where       d.is_main = true
+                                        and subnet.vpc_id = d.vpc_id
+                                        and subnet.request_account_id = d.account_id
+                                        and subnet.request_region = d.region
+                            order by    d.route_type desc -- see above for an explanation of this
+                            limit       1
+                        )
+                        else part1.route_table_id
+                      end as route_table_id
+
+                    , 2^(32 - masklen(subnet.cidr_block::cidr)) - constants.unusable_addresses as subnet_total_addresses
+                    , subnet.available_ip_address_count as subnet_remaining_addresses
+                    , subnet.cidr_block
+                    , subnet.tags
+            from    constants
+                    , aws_ec2_subnets subnet
+                    left join part1 on subnet.request_account_id = part1.account_id
+                    and subnet.request_region = part1.region
+                    and subnet.vpc_id = part1.vpc_id
+                    and subnet.subnet_id = part1.subnet_id
+        )
+        , public_subnets as (
+            select  *
+                    , subnet_total_addresses - subnet_remaining_addresses - 1 > 0 as subnet_in_use -- each public subnet has 1 elastic IP associated with it
+            from    part2
+            where   part2.subnet_type = 'public'
+        )
+        , private_subnets as (
+            select  *
+                    , subnet_total_addresses - subnet_remaining_addresses > 0 as subnet_in_use
+            from    part2
+            where   part2.subnet_type = 'private'
+
+                    /*
+                     From `part1` we can have one row with a subnet being "public" and another row with it being "private".
+                     Here, we dedupe this.
+                     */
+                    and part2.subnet_id not in (select subnet_id from public_subnets)
+        )
+        , subnets as (
+            select  *
+            from    public_subnets
+            union all
+            select  *
+            from    private_subnets
+        )
+
+        /*
+         Build a list of VPCs and their associated subnets.
+         Although it is not calculated here:
+           - A VPC is unused if all its subnets are unused
+           - The total number of IP addresses available in a VPC is the sum of the total number of IP addresses available in its subnets
+         */
+        , data as (
+            select  vpc.account_id
+                    , vpc.region
+                    , vpc.vpc_id
+                    , vpc.cidr_block as vpc_cidr_block
+                    , vpc.is_default
+                    , subnets.subnet_id
+                    , subnets.subnet_type
+                    , subnets.cidr_block as subnet_cidr_block
+                    , subnets.subnet_total_addresses
+                    , subnets.subnet_remaining_addresses
+                    , subnets.subnet_in_use
+                    , subnets.route_table_id as subnet_route_table_id
+            from    aws_ec2_vpcs vpc
+                    join subnets on vpc.vpc_id = subnets.vpc_id
+                    and vpc.account_id = subnets.account_id
+                    and vpc.region = subnets.region
+        )
+
+        select  *
+        from    data;
+    $$ language sql;
+
+    create view view_aws_vpcs as (
+        select  *
+        from    fn_view_aws_vpcs()
+    );
+commit transaction;

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -795,6 +795,80 @@ model cloudquery_plugin_usage {
   @@unique([timestamp, name, metric], map: "cloudquery_plugin_usage_key")
 }
 
+model aws_ec2_route_tables {
+  cq_sync_time     DateTime? @map("_cq_sync_time") @db.Timestamp(6)
+  cq_source_name   String?   @map("_cq_source_name")
+  cq_id            String    @id(map: "aws_ec2_route_tables_cqpk") @map("_cq_id") @db.Uuid
+  cq_parent_id     String?   @map("_cq_parent_id") @db.Uuid
+  account_id       String?
+  region           String?
+  arn              String?
+  tags             Json?
+  associations     Json?
+  owner_id         String?
+  propagating_vgws Json?
+  route_table_id   String?
+  routes           Json?
+  vpc_id           String?
+
+  @@ignore
+}
+
+model aws_ec2_subnets {
+  cq_sync_time                       DateTime? @map("_cq_sync_time") @db.Timestamp(6)
+  cq_source_name                     String?   @map("_cq_source_name")
+  cq_id                              String    @id(map: "aws_ec2_subnets_cqpk") @map("_cq_id") @db.Uuid
+  cq_parent_id                       String?   @map("_cq_parent_id") @db.Uuid
+  request_account_id                 String?
+  request_region                     String?
+  arn                                String?
+  tags                               Json?
+  assign_ipv6_address_on_creation    Boolean?
+  availability_zone                  String?
+  availability_zone_id               String?
+  available_ip_address_count         BigInt?
+  cidr_block                         String?
+  customer_owned_ipv4_pool           String?
+  default_for_az                     Boolean?
+  enable_dns64                       Boolean?
+  enable_lni_at_device_index         BigInt?
+  ipv6_cidr_block_association_set    Json?
+  ipv6_native                        Boolean?
+  map_customer_owned_ip_on_launch    Boolean?
+  map_public_ip_on_launch            Boolean?
+  outpost_arn                        String?
+  owner_id                           String?
+  private_dns_name_options_on_launch Json?
+  state                              String?
+  subnet_arn                         String?
+  subnet_id                          String?
+  vpc_id                             String?
+
+  @@ignore
+}
+
+model aws_ec2_vpcs {
+  cq_sync_time                    DateTime? @map("_cq_sync_time") @db.Timestamp(6)
+  cq_source_name                  String?   @map("_cq_source_name")
+  cq_id                           String    @id(map: "aws_ec2_vpcs_cqpk") @map("_cq_id") @db.Uuid
+  cq_parent_id                    String?   @map("_cq_parent_id") @db.Uuid
+  account_id                      String?
+  region                          String?
+  arn                             String?
+  tags                            Json?
+  cidr_block                      String?
+  cidr_block_association_set      Json?
+  dhcp_options_id                 String?
+  instance_tenancy                String?
+  ipv6_cidr_block_association_set Json?
+  is_default                      Boolean?
+  owner_id                        String?
+  state                           String?
+  vpc_id                          String?
+
+  @@ignore
+}
+
 view view_repo_ownership {
   github_team_id     BigInt
   github_team_name   String

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -947,3 +947,21 @@ view aws_organizations_tree {
 
   @@ignore
 }
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+view view_aws_vpcs {
+  account_id                 String?
+  region                     String?
+  vpc_id                     String?
+  vpc_cidr_block             String?
+  is_default                 Boolean?
+  subnet_id                  String?
+  subnet_type                String?
+  subnet_cidr_block          String?
+  subnet_total_addresses     BigInt?
+  subnet_remaining_addresses BigInt?
+  subnet_in_use              Boolean?
+  subnet_route_table_id      String?
+
+  @@ignore
+}

--- a/packages/common/prisma/views/public/view_aws_vpcs.sql
+++ b/packages/common/prisma/views/public/view_aws_vpcs.sql
@@ -1,0 +1,28 @@
+SELECT
+  fn_view_aws_vpcs.account_id,
+  fn_view_aws_vpcs.region,
+  fn_view_aws_vpcs.vpc_id,
+  fn_view_aws_vpcs.vpc_cidr_block,
+  fn_view_aws_vpcs.is_default,
+  fn_view_aws_vpcs.subnet_id,
+  fn_view_aws_vpcs.subnet_type,
+  fn_view_aws_vpcs.subnet_cidr_block,
+  fn_view_aws_vpcs.subnet_total_addresses,
+  fn_view_aws_vpcs.subnet_remaining_addresses,
+  fn_view_aws_vpcs.subnet_in_use,
+  fn_view_aws_vpcs.subnet_route_table_id
+FROM
+  fn_view_aws_vpcs() fn_view_aws_vpcs(
+    account_id,
+    region,
+    vpc_id,
+    vpc_cidr_block,
+    is_default,
+    subnet_id,
+    subnet_type,
+    subnet_cidr_block,
+    subnet_total_addresses,
+    subnet_remaining_addresses,
+    subnet_in_use,
+    subnet_route_table_id
+  );

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -28,6 +28,9 @@ services:
         - github_workflows
         - github_languages
         - aws_ec2_instances
+        - aws_ec2_route_tables
+        - aws_ec2_subnets
+        - aws_ec2_vpcs
         - aws_cloudformation_stacks
         - amigo_bake_packages
   postgres:


### PR DESCRIPTION
## What does this change?
Querying a VPC and its subnets to understand which subnet is private or public and their IP space is fairly complicated.
Encapsulating this in a view means this complexity is done once.

Rather than detail the complexity in the PR description, I've attempted to explain it with inline comments.

The data in this view enables us to create a dashboard to more easily visualise the shape of a VPC. I'm not yet sure how often we'll `SELECT` from the view. If we find we're exhausting the database, we could consider making it a materialised view that's [automatically refreshed after data collection](https://github.com/guardian/service-catalogue/pull/1048).

## How has it been verified?
I've [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/dd10ec76-fb50-4677-870b-c18078a54cf3) and can now see the view in [Grafana CODE](https://metrics.code.dev-gutools.co.uk/goto/nwFrr6KNR?orgId=1).