### PR TITLE
Add performance overhead and telemetry

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -1,6 +1,7 @@
 import 'source-map-support/register';
 import { RiffRaffYamlFile } from '@guardian/cdk/lib/riff-raff-yaml-file';
 import { App, Duration } from 'aws-cdk-lib';
+import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import { ServiceCatalogue } from '../lib/service-catalogue';
 
@@ -21,6 +22,7 @@ new ServiceCatalogue(app, 'ServiceCatalogue-PROD', {
 		minute: '0',
 	}),
 	enableCloudquerySchedules: true,
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.XLARGE),
 });
 
 new ServiceCatalogue(app, 'ServiceCatalogue-CODE', {
@@ -33,6 +35,7 @@ new ServiceCatalogue(app, 'ServiceCatalogue-CODE', {
 
 	// Do not run CloudQuery tasks in CODE, preferring instead to run them manually using the CLI.
 	enableCloudquerySchedules: false,
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 });
 
 // Add an additional S3 deployment type and synth riff-raff.yaml

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19919,12 +19919,13 @@ spec:
         "AllocatedStorage": "100",
         "CACertificateIdentifier": "rds-ca-rsa2048-g1",
         "CopyTagsToSnapshot": true,
-        "DBInstanceClass": "db.t4g.small",
+        "DBInstanceClass": "db.t4g.xlarge",
         "DBSubnetGroupName": {
           "Ref": "PostgresInstance1SubnetGroupCAC045A5",
         },
         "DeletionProtection": true,
         "EnableIAMDatabaseAuthentication": true,
+        "EnablePerformanceInsights": true,
         "Engine": "postgres",
         "MasterUserPassword": {
           "Fn::Join": [
@@ -19950,11 +19951,19 @@ spec:
             ],
           ],
         },
+        "MonitoringInterval": 10,
+        "MonitoringRoleArn": {
+          "Fn::GetAtt": [
+            "PostgresInstance1MonitoringRole681B0673",
+            "Arn",
+          ],
+        },
         "MultiAZ": false,
+        "PerformanceInsightsRetentionPeriod": 7,
         "Port": "5432",
         "PubliclyAccessible": false,
         "StorageEncrypted": true,
-        "StorageType": "gp2",
+        "StorageType": "gp3",
         "Tags": [
           {
             "Key": "devx-backup-enabled",
@@ -19988,6 +19997,59 @@ spec:
       },
       "Type": "AWS::RDS::DBInstance",
       "UpdateReplacePolicy": "Snapshot",
+    },
+    "PostgresInstance1MonitoringRole681B0673": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "monitoring.rds.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
     },
     "PostgresInstance1Secret7FA1A24B": {
       "DeletionPolicy": "Delete",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19919,7 +19919,7 @@ spec:
         "AllocatedStorage": "100",
         "CACertificateIdentifier": "rds-ca-rsa2048-g1",
         "CopyTagsToSnapshot": true,
-        "DBInstanceClass": "db.t4g.xlarge",
+        "DBInstanceClass": "db.t4g.small",
         "DBSubnetGroupName": {
           "Ref": "PostgresInstance1SubnetGroupCAC045A5",
         },

--- a/packages/cdk/lib/service-catalogue.test.ts
+++ b/packages/cdk/lib/service-catalogue.test.ts
@@ -1,5 +1,6 @@
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
+import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import { CfnFunction } from 'aws-cdk-lib/aws-lambda';
 import { ServiceCatalogue } from './service-catalogue';
@@ -16,6 +17,7 @@ describe('The ServiceCatalogue stack', () => {
 				minute: '0',
 			}),
 			enableCloudquerySchedules: true,
+			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();
@@ -32,6 +34,7 @@ describe('The ServiceCatalogue stack', () => {
 				minute: '0',
 			}),
 			enableCloudquerySchedules: true,
+			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 		});
 
 		const lambdas = stack.node

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -16,13 +16,8 @@ import {
 import { GuardianPrivateNetworks } from '@guardian/private-infrastructure-config';
 import type { App } from 'aws-cdk-lib';
 import { Duration, Tags } from 'aws-cdk-lib';
-import {
-	InstanceClass,
-	InstanceSize,
-	InstanceType,
-	Peer,
-	Port,
-} from 'aws-cdk-lib/aws-ec2';
+import type { InstanceType } from 'aws-cdk-lib/aws-ec2';
+import { Peer, Port } from 'aws-cdk-lib/aws-ec2';
 import type { Schedule } from 'aws-cdk-lib/aws-events';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import type { DatabaseInstanceProps } from 'aws-cdk-lib/aws-rds';
@@ -105,6 +100,11 @@ interface ServiceCatalogueProps extends GuStackProps {
 	 * When false, the schedule will be disabled. Tasks will need to be run manually using the CLI.
 	 */
 	enableCloudquerySchedules: boolean;
+
+	/**
+	 * The instance type to be used by RDS (e.g. t4g.small)
+	 */
+	instanceType: InstanceType;
 }
 
 export class ServiceCatalogue extends GuStack {
@@ -120,6 +120,7 @@ export class ServiceCatalogue extends GuStack {
 			gitHubOrg = 'guardian',
 			securityAlertSchedule,
 			enableCloudquerySchedules,
+			instanceType,
 		} = props;
 
 		const privateSubnets = GuVpc.subnetsFromParameter(this, {
@@ -149,9 +150,9 @@ export class ServiceCatalogue extends GuStack {
 			engine: DatabaseInstanceEngine.POSTGRES,
 			port,
 			vpc,
+			instanceType,
 			vpcSubnets: { subnets: privateSubnets },
 			iamAuthentication: true, // We're not using IAM auth for ECS tasks, however we do use IAM auth when connecting to RDS locally.
-			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.XLARGE),
 			storageEncrypted: true,
 			securityGroups: [dbSecurityGroup],
 			deletionProtection: rdsDeletionProtection,

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -30,6 +30,7 @@ import {
 	CaCertificate,
 	DatabaseInstance,
 	DatabaseInstanceEngine,
+	StorageType,
 } from 'aws-cdk-lib/aws-rds';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { Topic } from 'aws-cdk-lib/aws-sns';
@@ -150,7 +151,7 @@ export class ServiceCatalogue extends GuStack {
 			vpc,
 			vpcSubnets: { subnets: privateSubnets },
 			iamAuthentication: true, // We're not using IAM auth for ECS tasks, however we do use IAM auth when connecting to RDS locally.
-			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.XLARGE),
 			storageEncrypted: true,
 			securityGroups: [dbSecurityGroup],
 			deletionProtection: rdsDeletionProtection,
@@ -160,6 +161,9 @@ export class ServiceCatalogue extends GuStack {
 			See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.RegionCertificateAuthorities
 			 */
 			caCertificate: CaCertificate.RDS_CA_RSA2048_G1,
+			storageType: StorageType.GP3,
+			enablePerformanceInsights: true,
+			monitoringInterval: Duration.seconds(10),
 		};
 
 		const db = new DatabaseInstance(this, 'PostgresInstance1', dbProps);


### PR DESCRIPTION
## What does this change?

The Service catalogue databased has started failing on and off since last week, and today it became unusable. This changed gives it more overhead in storage and compute, and enables extra monitoring features. This should enable us to inspect what is exactly has caused service catalogue to start falling over.

## Why?

## How has it been verified?
