### PR TITLE
Downgrade to t4g.large in PROD

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -22,7 +22,7 @@ new ServiceCatalogue(app, 'ServiceCatalogue-PROD', {
 		minute: '0',
 	}),
 	enableCloudquerySchedules: true,
-	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.XLARGE),
+	instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.LARGE),
 });
 
 new ServiceCatalogue(app, 'ServiceCatalogue-CODE', {


### PR DESCRIPTION
## What does this change?

We've been running xlarge for a while, but we think we can get identical levels of performance by using a large instance instead.


## Why?

This will help us decide which type of instance to reserve for the year.