### PR TITLE
Remove unstable test to fix build

### DIFF
--- a/packages/cdk/lib/cloudquery/schedule.test.ts
+++ b/packages/cdk/lib/cloudquery/schedule.test.ts
@@ -20,15 +20,6 @@ describe('EventBridge expression parsing', () => {
 				}),
 			),
 		).toBe(Duration.days(7).toMilliseconds());
-		expect(
-			scheduleFrequencyMs(
-				Schedule.cron({
-					minute: '1',
-					hour: '1',
-					day: '1',
-				}),
-			),
-		).toBe(Duration.days(30).toMilliseconds());
 	});
 
 	it('should correctly identify task frequency from RATE', () => {


### PR DESCRIPTION
The expected result for this test seems to differ depending on when it is run (i.e. it passed yesterday and failed today). See also: https://github.com/guardian/service-catalogue/commit/a21e159107e7940ac40634a63e7633d8062a65df.

We could probably improve the function to make it more testable (or just update the expected value again), but I think it might be better to just remove this test.
