### PR TITLE
fix: make prisma-migrate's logging container read-only

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -22665,7 +22665,15 @@ spec:
                 "awslogs-stream-prefix": "deploy/TEST/prisma-migrate-task",
               },
             },
+            "MountPoints": [
+              {
+                "ContainerPath": "/init",
+                "ReadOnly": false,
+                "SourceVolume": "firelens-volume",
+              },
+            ],
             "Name": "prisma-migrate-taskFirelens",
+            "ReadonlyRootFilesystem": true,
           },
           {
             "DockerLabels": {
@@ -22793,6 +22801,9 @@ spec:
           ],
         },
         "Volumes": [
+          {
+            "Name": "firelens-volume",
+          },
           {
             "Name": "artifact-volume",
           },


### PR DESCRIPTION
## What does this change?

## Why?

## How has it been verified?
