### PR TITLE
fix: Make additional CQ container read-only (NS1 task)

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -17721,6 +17721,7 @@ spec:
               },
             },
             "Name": "CloudquerySource-NS1PluginContainer",
+            "ReadonlyRootFilesystem": true,
           },
           {
             "Command": [

--- a/packages/cdk/lib/cloudquery/task.ts
+++ b/packages/cdk/lib/cloudquery/task.ts
@@ -291,6 +291,7 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 					image: dockerDistributedPluginImage,
 					logging: fireLensLogDriver,
 					essential: false,
+					readonlyRootFilesystem: true,
 				},
 			);
 


### PR DESCRIPTION
## What does this change?

This PR makes the additional CloudQuery container used by the NS1 task read-only.

## Why?

This should resolve two [high FSBP issues](https://www.google.com/url?q=https://metrics.gutools.co.uk/d/ddi3x35x70jy8d/fsbp-compliance?orgId%3D1%26var-account_name%3DDeploy%2520Tools%26var-control_id%3DAll&sa=D&source=calendar&ust=1745052925244270&usg=AOvVaw1P2gyoPxj79fTSMOoM7XBl) (one for `CODE` and one for `PROD`).

## How has it been verified?

1. [Deployed this branch to `CODE`](https://riffraff.gutools.co.uk/deployment/view/830c4399-82bf-47c5-9c45-a1a162b38feb)
1. Ran the NS1 task using `npm -w cli start run-task -- --stage CODE --name NS1`
1. Checked [the logs](https://logs.gutools.co.uk/s/devx/app/r/s/JzOZB) - there is quite a lot here, but there [don't seem to be any errors](https://logs.gutools.co.uk/s/devx/app/r/s/tghef) and it looks pretty similar to the [equivalent task running based on `main`](https://logs.gutools.co.uk/s/devx/app/r/s/5N2Ac).
1. Confirmed that the NS1 data in the `CODE` DB (queried via Grafana `CODE`) has the expected sync time:

![image](https://github.com/user-attachments/assets/fe1a3499-13c0-43de-9b46-f633c1b96abd)