### PR TITLE
feat: Alarm on `EBSByteBalance` metric anomalies

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -24,6 +24,7 @@ new ServiceCatalogue(app, 'ServiceCatalogue-PROD', {
 	databaseDeletionProtection: true,
 	databaseMultiAz: true,
 	databaseInstanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.LARGE),
+	databaseEbsByteBalanceAlarm: true,
 });
 
 new ServiceCatalogue(app, 'ServiceCatalogue-CODE', {
@@ -39,6 +40,7 @@ new ServiceCatalogue(app, 'ServiceCatalogue-CODE', {
 	databaseDeletionProtection: false,
 	databaseMultiAz: false,
 	databaseInstanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+	databaseEbsByteBalanceAlarm: false,
 });
 
 // Add an additional S3 deployment type and synth riff-raff.yaml

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19579,6 +19579,106 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
+    "EBSByteBalanceAlarm": {
+      "Properties": {
+        "ActionsEnabled": false,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":devx-alerts",
+              ],
+            ],
+          },
+        ],
+        "ComparisonOperator": "LessThanLowerOrGreaterThanUpperThreshold",
+        "DatapointsToAlarm": 1,
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "ANOMALY_DETECTION_BAND(m1, 2)",
+            "Id": "ad1",
+            "ReturnData": true,
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "DBInstanceIdentifier",
+                    "Value": {
+                      "Ref": "PostgresInstance16DE4286E",
+                    },
+                  },
+                ],
+                "MetricName": "EBSByteBalance%",
+                "Namespace": "AWS/RDS",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":devx-alerts",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "ThresholdMetricId": "ad1",
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "EBSByteBalanceAnomalyDetector": {
+      "Properties": {
+        "Dimensions": [
+          {
+            "Name": "DBInstanceIdentifier",
+            "Value": {
+              "Ref": "PostgresInstance16DE4286E",
+            },
+          },
+        ],
+        "MetricName": "EBSByteBalance%",
+        "Namespace": "AWS/RDS",
+        "Stat": "Average",
+      },
+      "Type": "AWS::CloudWatch::AnomalyDetector",
+    },
     "GithubActionsUsageAC7E0411": {
       "DependsOn": [
         "GithubActionsUsageServiceRoleDefaultPolicyBFE2CD5F",

--- a/packages/cdk/lib/service-catalogue.test.ts
+++ b/packages/cdk/lib/service-catalogue.test.ts
@@ -23,6 +23,7 @@ describe('The ServiceCatalogue stack', () => {
 				InstanceClass.T4G,
 				InstanceSize.SMALL,
 			),
+			databaseEbsByteBalanceAlarm: true,
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();
@@ -45,6 +46,7 @@ describe('The ServiceCatalogue stack', () => {
 				InstanceClass.T4G,
 				InstanceSize.SMALL,
 			),
+			databaseEbsByteBalanceAlarm: true,
 		});
 
 		const lambdas = stack.node


### PR DESCRIPTION
## What does this change?
Provisions an [anomaly detection](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Anomaly_Detection.html) alarm for the `EBSByteBalance` metric of the RDS instance. This is in reaction to a recent incident where we saw the database being unusable from Grafana. In triaging this incident, we saw the `EBSByteBalance` metric appearing to correlate with performance issues. With this alarm, we hope to catch issues earlier.

An anomaly detection alarm is chosen over a standard alarm as it wasn't immediately clear what the threshold for a standard alarm should be, as the existing metrics are quite spiky.

This changes instantiates level 1 CDK constructs as there aren't any level 2 constructs available for anomaly detection. The code was largely inspired by https://aws.amazon.com/de/blogs/networking-and-content-delivery/monitoring-load-balancers-using-amazon-cloudwatch-anomaly-detection-alarms/.

See #1471.

## How has it been verified?
[Deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/7b444714-1cad-4055-947c-0f963df27dde) and inspected the resulting alarm in the AWS console, it seems OK, or at least there are few "in alarm" times:

<img width="1759" alt="image" src="https://github.com/user-attachments/assets/f5f79cfc-32f7-4cc9-a16f-f491f8b492d7" />
