### PR TITLE
feat: Daily collection of `aws_costexplorer_cost_custom`

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -389,6 +389,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -830,6 +831,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -1497,6 +1499,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -2180,6 +2183,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -2802,6 +2806,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -3455,6 +3460,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -4110,6 +4116,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -4793,6 +4800,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -5650,6 +5658,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -6069,6 +6078,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -6722,6 +6732,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -7375,6 +7386,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -8060,6 +8072,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -8744,6 +8757,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -9398,6 +9412,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -10052,6 +10067,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -10708,6 +10724,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -11361,6 +11378,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -12315,6 +12333,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -12764,6 +12783,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -13418,6 +13438,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -14091,6 +14112,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -14997,6 +15019,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -15481,6 +15504,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -16132,6 +16156,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -16847,6 +16872,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -17547,6 +17573,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-
@@ -18492,6 +18519,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
+  write_mode: overwrite-delete-stale
   migrate_mode: forced
   spec:
     connection_string: >-

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -802,9 +802,10 @@ spec:
   otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
-    accounts:
-      - id: cq-for-000000000000
-        role_arn: arn:aws:iam::000000000000:role/cloudquery-access
+    org:
+      member_role_name: cloudquery-access
+      organization_units:
+        - ou-123
     use_paid_apis: true
     table_options:
       aws_costexplorer_cost_custom:

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -734,7 +734,7 @@ spec:
     },
     "CloudquerySourceAwsCostExplorerScheduledEventRule85BE97F8": {
       "Properties": {
-        "ScheduleExpression": "rate(7 days)",
+        "ScheduleExpression": "cron(0 0 * * ? *)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -788,23 +788,42 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "printf 'kind: source
+              "export START_DATE=$(date -d "@$(($(date +%s) - 172800))" "+%Y-%m-%d");export END_DATE=$(date -d "@$(($(date +%s) - 86400))" "+%Y-%m-%d");printf 'kind: source
 spec:
   name: aws
   path: cloudquery/aws
   version: v27.5.0
   tables:
-    - aws_costexplorer_cost_30d
+    - aws_costexplorer_cost_custom
   skip_dependent_tables: false
   destinations:
     - postgresql
   otel_endpoint: 0.0.0.0:4318
   otel_endpoint_insecure: true
   spec:
-    use_paid_apis: true
     accounts:
       - id: cq-for-000000000000
         role_arn: arn:aws:iam::000000000000:role/cloudquery-access
+    use_paid_apis: true
+    table_options:
+      aws_costexplorer_cost_custom:
+        get_cost_and_usage:
+          - TimePeriod:
+              Start: \${START_DATE}
+              End: \${END_DATE}
+            Granularity: DAILY
+            GroupBy:
+              - Type: TAG
+                Key: App
+              - Type: TAG
+                Key: Stack
+              - Type: TAG
+                Key: Stage
+            Metrics:
+              - NetUnblendedCost
+              - UnblendedCost
+              - NetAmortizedCost
+              - AmortizedCost
 ' > /usr/share/cloudquery/source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -973,7 +992,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_costexplorer_cost_30d', 604800000) ON CONFLICT (table_name) DO UPDATE SET frequency = 604800000"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_costexplorer_cost_custom', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -12257,7 +12276,7 @@ spec:
     - aws_accessanalyzer_*
     - aws_securityhub_*
     - aws_cloudformation_*
-    - aws_costexplorer_cost_30d
+    - aws_costexplorer_cost_custom
     - aws_elbv1_*
     - aws_elbv2_*
     - aws_autoscaling_groups

--- a/packages/cdk/lib/cloudquery/cluster.ts
+++ b/packages/cdk/lib/cloudquery/cluster.ts
@@ -7,6 +7,7 @@ import type { IManagedPolicy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
 import type { Secret as SecretsManager } from 'aws-cdk-lib/aws-secretsmanager';
 import type { CloudqueryConfig } from './config';
+import { CloudqueryWriteMode } from './config';
 import { ScheduledCloudqueryTask } from './task';
 
 export interface CloudquerySource {
@@ -92,6 +93,13 @@ export interface CloudquerySource {
 	 * @see https://docs.cloudquery.io/docs/reference/source-spec
 	 */
 	dockerDistributedPluginImage?: RepositoryImage;
+
+	/**
+	 * Specifies the update method to use when inserting rows to Postgres.
+	 *
+	 * @default {@link CloudqueryWriteMode.OverwriteDeleteStale}
+	 */
+	writeMode?: CloudqueryWriteMode;
 }
 
 interface CloudqueryClusterProps extends AppIdentity {
@@ -174,6 +182,7 @@ export class CloudqueryCluster extends Cluster {
 				additionalSecurityGroups,
 				runAsSingleton = false,
 				dockerDistributedPluginImage,
+				writeMode = CloudqueryWriteMode.OverwriteDeleteStale,
 			}) => {
 				new ScheduledCloudqueryTask(scope, `CloudquerySource-${name}`, {
 					...taskProps,
@@ -194,6 +203,7 @@ export class CloudqueryCluster extends Cluster {
 						'api-key',
 					),
 					dockerDistributedPluginImage,
+					writeMode,
 				});
 			},
 		);

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -3,13 +3,16 @@ import { dump } from 'js-yaml';
 import {
 	awsSourceConfigForAccount,
 	awsSourceConfigForOrganisation,
+	CloudqueryWriteMode,
 	githubSourceConfig,
 	postgresDestinationConfig,
 } from './config';
 
 describe('Config generation, and converting to YAML', () => {
 	it('Should create a destination configuration', () => {
-		const config = postgresDestinationConfig();
+		const config = postgresDestinationConfig(
+			CloudqueryWriteMode.OverwriteDeleteStale,
+		);
 		expect(dump(config)).toMatchInlineSnapshot(`
 		"kind: destination
 		spec:
@@ -17,6 +20,7 @@ describe('Config generation, and converting to YAML', () => {
 		  registry: github
 		  path: cloudquery/postgresql
 		  version: v7.2.0
+		  write_mode: overwrite-delete-stale
 		  migrate_mode: forced
 		  spec:
 		    connection_string: >-

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -13,7 +13,6 @@ interface CloudqueryTableConfig {
 	tables?: string[];
 	skipTables?: string[];
 	concurrency?: number;
-	usePaidApis?: boolean;
 }
 
 interface GitHubCloudqueryTableConfig extends CloudqueryTableConfig {
@@ -50,7 +49,7 @@ export function awsSourceConfig(
 	tableConfig: CloudqueryTableConfig,
 	extraConfig: Record<string, unknown> = {},
 ): CloudqueryConfig {
-	const { tables, skipTables, concurrency, usePaidApis } = tableConfig;
+	const { tables, skipTables, concurrency } = tableConfig;
 
 	if (!tables && !skipTables) {
 		throw new Error('Must specify either tables or skipTables');
@@ -70,7 +69,6 @@ export function awsSourceConfig(
 			otel_endpoint_insecure: true,
 			spec: {
 				concurrency,
-				use_paid_apis: usePaidApis,
 				...extraConfig,
 			},
 		},

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -103,11 +103,12 @@ export function awsSourceConfig(
 /**
  * Create a ServiceCatalogue configuration for all AWS accounts in the organisation.
  * @param tableConfig Which tables to include or exclude.
- *
+ * @param extraConfig Extra spec fields.
  * @see https://www.cloudquery.io/docs/plugins/sources/aws/configuration#org
  */
 export function awsSourceConfigForOrganisation(
 	tableConfig: CloudqueryTableConfig,
+	extraConfig: Record<string, unknown> = {},
 ): CloudqueryConfig {
 	return awsSourceConfig(tableConfig, {
 		org: {
@@ -115,6 +116,7 @@ export function awsSourceConfigForOrganisation(
 			member_role_name: 'cloudquery-access',
 			organization_units: [GuardianOrganisationalUnits.Root],
 		},
+		...extraConfig,
 	});
 }
 

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -20,9 +20,33 @@ interface GitHubCloudqueryTableConfig extends CloudqueryTableConfig {
 }
 
 /**
+ * Specifies the update method to use when inserting rows to Postgres.
+ *
+ * @see https://cli-docs.cloudquery.io/docs/reference/destination-spec#write_mode
+ */
+export enum CloudqueryWriteMode {
+	/**
+	 * Overwrite existing rows with the same primary key, and delete rows that are no longer present in the cloud.
+	 */
+	OverwriteDeleteStale = 'overwrite-delete-stale',
+
+	/**
+	 * Same as {@link CloudqueryWriteMode.OverwriteDeleteStale}, but doesn't delete stale rows from previous syncs.
+	 */
+	Overwrite = 'overwrite',
+
+	/**
+	 * Rows are never overwritten or deleted, only appended.
+	 */
+	Append = 'append',
+}
+
+/**
  * Create a ServiceCatalogue destination configuration for Postgres.
  */
-export function postgresDestinationConfig(): CloudqueryConfig {
+export function postgresDestinationConfig(
+	writeMode: CloudqueryWriteMode,
+): CloudqueryConfig {
 	return {
 		kind: 'destination',
 		spec: {
@@ -30,6 +54,7 @@ export function postgresDestinationConfig(): CloudqueryConfig {
 			registry: 'github',
 			path: 'cloudquery/postgresql',
 			version: `v${Versions.CloudqueryPostgresDestination}`,
+			write_mode: writeMode,
 			migrate_mode: 'forced',
 			spec: {
 				connection_string: [

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -17,6 +17,7 @@ import {
 	amigoBakePackagesConfig,
 	awsSourceConfigForAccount,
 	awsSourceConfigForOrganisation,
+	CloudqueryWriteMode,
 	fastlySourceConfig,
 	galaxiesSourceConfig,
 	githubLanguagesConfig,
@@ -177,7 +178,7 @@ export function addCloudqueryEcsCluster(
 				`export START_DATE=$(date -d "@$(($(date +%s) - ${Duration.days(2).toSeconds()}))" "+%Y-%m-%d")`,
 				`export END_DATE=$(date -d "@$(($(date +%s) - ${Duration.days(1).toSeconds()}))" "+%Y-%m-%d")`,
 			],
-
+			writeMode: CloudqueryWriteMode.Overwrite,
 			config: awsSourceConfigForAccount(
 				GuardianAwsAccounts.Workflow,
 				{

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -168,7 +168,7 @@ export function addCloudqueryEcsCluster(
 		{
 			name: 'AwsCostExplorer',
 			description:
-				'Collecting Cost Explorer information for the Worflow account. This requires the use of paid AWS APIs so we are trialling it in a single account first',
+				'Collects daily AWS costs (aggregated by App, Stack and Stage tags). We aim to keep historical data for this table (unlike other tables)',
 			schedule: Schedule.cron({ minute: '0', hour: '0' }),
 
 			// TODO replace with time variable substitution once it supports relative date only strings.

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -179,8 +179,7 @@ export function addCloudqueryEcsCluster(
 				`export END_DATE=$(date -d "@$(($(date +%s) - ${Duration.days(1).toSeconds()}))" "+%Y-%m-%d")`,
 			],
 			writeMode: CloudqueryWriteMode.Overwrite,
-			config: awsSourceConfigForAccount(
-				GuardianAwsAccounts.Workflow,
+			config: awsSourceConfigForOrganisation(
 				{
 					tables: ['aws_costexplorer_cost_custom'],
 				},

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -168,11 +168,49 @@ export function addCloudqueryEcsCluster(
 			name: 'AwsCostExplorer',
 			description:
 				'Collecting Cost Explorer information for the Worflow account. This requires the use of paid AWS APIs so we are trialling it in a single account first',
-			schedule: Schedule.rate(Duration.days(7)),
-			config: awsSourceConfigForAccount(GuardianAwsAccounts.Workflow, {
-				tables: ['aws_costexplorer_cost_30d'],
-				usePaidApis: true,
-			}),
+			schedule: Schedule.cron({ minute: '0', hour: '0' }),
+
+			// TODO replace with time variable substitution once it supports relative date only strings.
+			//  See https://cli-docs.cloudquery.io/docs/advanced-topics/environment-variable-substitution#time-variable-substitution-example
+			//  See https://github.com/cloudquery/cloudquery/pull/20399
+			additionalCommands: [
+				`export START_DATE=$(date -d "@$(($(date +%s) - ${Duration.days(2).toSeconds()}))" "+%Y-%m-%d")`,
+				`export END_DATE=$(date -d "@$(($(date +%s) - ${Duration.days(1).toSeconds()}))" "+%Y-%m-%d")`,
+			],
+
+			config: awsSourceConfigForAccount(
+				GuardianAwsAccounts.Workflow,
+				{
+					tables: ['aws_costexplorer_cost_custom'],
+				},
+				{
+					use_paid_apis: true,
+					table_options: {
+						aws_costexplorer_cost_custom: {
+							get_cost_and_usage: [
+								{
+									TimePeriod: {
+										Start: '${START_DATE}',
+										End: '${END_DATE}',
+									},
+									Granularity: 'DAILY',
+									GroupBy: [
+										{ Type: 'TAG', Key: 'App' },
+										{ Type: 'TAG', Key: 'Stack' },
+										{ Type: 'TAG', Key: 'Stage' },
+									],
+									Metrics: [
+										'NetUnblendedCost',
+										'UnblendedCost',
+										'NetAmortizedCost',
+										'AmortizedCost',
+									],
+								},
+							],
+						},
+					},
+				},
+			),
 			policies: [listOrgsPolicy, cloudqueryAccess('*')],
 		},
 		{


### PR DESCRIPTION
## What does this change?
Stops collecting data for the [`aws_costexplorer_cost_30d` table](https://hub.cloudquery.io/plugins/source/cloudquery/aws/latest/tables/aws_costexplorer_cost_30d), replacing it with the [`aws_costexplorer_cost_custom` table](https://hub.cloudquery.io/plugins/source/cloudquery/aws/latest/tables/aws_costexplorer_cost_custom). This table supports aggregation. We're aggregating by the `App`, `Stack` and `Stage` tags, which should allow us to understand the cost of an individual service.

Data is collected for every account in the AWS organisation. Previously only data for the Workflow account was collected.

Collection of `aws_costexplorer_cost_custom` runs daily at midnight, with a window for two days ago. That is, at midnight of 25 April 2025, we collect data the period of 23 April 2025 - 24 April 2025. Hopefully this allows us to ignore complications of timezones 🤞🏽.

CloudQuery uses the [`GetCostAndUsage`](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetCostAndUsage.html) for this table, which supports arbitrary time periods. This means, for example, we could get daily data for the year 2024. However I'm not sure yet how best to do this, so suggest solving this in a separate PR.

With 40 accounts in the AWS organisation, this task would now collect 1,200 rows a month (40 accounts * 30 days). This is within our contracted usage.

Additionally, as we're collecting a single day at a time, this task implements a [`write_mode`](https://cli-docs.cloudquery.io/docs/reference/destination-spec#write_mode) of `overwrite` so that historical data is kept. This differs from the default behaviour of `overwrite-delete-stale`:

> - `overwrite-delete-stale`: syncs overwrite existing rows with the same primary key, and delete rows that are no longer present in the cloud.
> - `overwrite`: Same as overwrite-delete-stale, but doesn't delete stale rows from previous syncs.
> - `append`: Rows are never overwritten or deleted, only appended.
>
> – https://cli-docs.cloudquery.io/docs/reference/destination-spec#write_mode

For explicitness, every task now specifies its `write_mode` too.

## How has it been verified?
[Deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/763bb307-3cd7-49ba-9f85-c9354e405512) and after running the task, there is data in the [`aws_costexplorer_cost_custom` table](https://metrics.code.dev-gutools.co.uk/goto/kCGDel1Ng?orgId=1).

To test the `write_mode` changes, the task was run twice across different days. We can see multiple [records in the table](https://metrics.code.dev-gutools.co.uk/goto/ogFAgu1NR?orgId=1) with different `_cq_sync_time` columns.

---

Closes https://github.com/guardian/service-catalogue/pull/1479.