### PR TITLE
fix: Call `GetCostAndUsage` correctly

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -819,8 +819,6 @@ spec:
                 Key: App
               - Type: TAG
                 Key: Stack
-              - Type: TAG
-                Key: Stage
             Metrics:
               - NetUnblendedCost
               - UnblendedCost

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -197,7 +197,6 @@ export function addCloudqueryEcsCluster(
 									GroupBy: [
 										{ Type: 'TAG', Key: 'App' },
 										{ Type: 'TAG', Key: 'Stack' },
-										{ Type: 'TAG', Key: 'Stage' },
 									],
 									Metrics: [
 										'NetUnblendedCost',


### PR DESCRIPTION
## What does this change?
Patches the changes in #1510, which fails to run with the follow error:

> operation error Cost Explorer: GetCostAndUsage, https response error StatusCode: 400, RequestID: 8e41a8fb-c06f-42b8-9892-6cc3f285d3bf, api error ValidationException: Only two values for GroupBy are allowed

Confession: I only tested #1510 on CODE with a group by of `App` and `Stage`, which is why I didn't see this error originally!