### PR TITLE
feat: Enable on demand backfill of `aws_costexplorer_cost_custom`

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -789,7 +789,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "export START_DATE=$(date -d "@$(($(date +%s) - 172800))" "+%Y-%m-%d");export END_DATE=$(date -d "@$(($(date +%s) - 86400))" "+%Y-%m-%d");printf 'kind: source
+              "export START_DATE=\${START_DATE:-$(date -d "@$(($(date +%s) - 172800))" "+%Y-%m-%d")};export END_DATE=\${END_DATE:-$(date -d "@$(($(date +%s) - 86400))" "+%Y-%m-%d")};printf 'kind: source
 spec:
   name: aws
   path: cloudquery/aws

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -175,8 +175,13 @@ export function addCloudqueryEcsCluster(
 			//  See https://cli-docs.cloudquery.io/docs/advanced-topics/environment-variable-substitution#time-variable-substitution-example
 			//  See https://github.com/cloudquery/cloudquery/pull/20399
 			additionalCommands: [
-				`export START_DATE=$(date -d "@$(($(date +%s) - ${Duration.days(2).toSeconds()}))" "+%Y-%m-%d")`,
-				`export END_DATE=$(date -d "@$(($(date +%s) - ${Duration.days(1).toSeconds()}))" "+%Y-%m-%d")`,
+				/*
+				START_DATE and END_DATE are only set if they're not already set.
+				This allows us to backfill data if we need to via the CLI of this project, which sets the environment variables via container overrides.
+				See https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerOverride.html.
+				 */
+				`export START_DATE=$\{START_DATE:-$(date -d "@$(($(date +%s) - ${Duration.days(2).toSeconds()}))" "+%Y-%m-%d")}`,
+				`export END_DATE=$\{END_DATE:-$(date -d "@$(($(date +%s) - ${Duration.days(1).toSeconds()}))" "+%Y-%m-%d")}`,
 			],
 			writeMode: CloudqueryWriteMode.Overwrite,
 			config: awsSourceConfigForOrganisation(

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,6 +21,23 @@ npm -w cli start list-tasks -- --stage [CODE|PROD]
 npm -w cli start run-task -- --stage [CODE|PROD] --name [TASK_NAME]
 ```
 
+Additional environment variables can be sent to the CloudQuery container via the `--env` flag.
+This is useful for providing ad-hoc configuration.
+
+For example, to backfill data for the `AwsCostExplorer` task:
+
+```bash
+npm -w cli start -- run-task \
+  --stage PROD \
+  --name AwsCostExplorer \
+  --env START_DATE=2025-02-01 \
+  --env END_DATE=2025-02-28
+```
+
+> [!NOTE]
+> The AWS API for Cost Explorer works best with small time ranges.
+> If you need to backfill a large time range, consider multiple invocations with smaller ranges.
+
 ### Database migrations
 ```bash
 npm -w cli start migrate -- --stage [DEV|CODE|PROD]


### PR DESCRIPTION
## What does this change?
Following from https://github.com/guardian/service-catalogue/pull/1510 this change updates the Service Catalogue CLI to allow setting of environment variables within the CloudQuery container. This allows us to backfill data for the `AwsCostExplorer` task by running:

```bash
npm -w cli start -- run-task \
  --stage PROD \
  --name AwsCostExplorer \
  --env START_DATE=2025-01-01 \
  --env END_DATE=2025-02-01
```

This utilises the [container overrides](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerOverride.html).

## Why?
To backfill data on demand.

## How has it been verified?
I've [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/c873a3b6-807a-43db-b492-6a54d4b94610). After running the following:

```bash
npm -w cli start -- run-task \
  --stage CODE \
  --name AwsCostExplorer \
  --env START_DATE=2025-01-01 \
  --env END_DATE=2025-01-10
```

We can see some [historical data in the `aws_costexplorer_cost_custom` table](https://metrics.code.dev-gutools.co.uk/goto/IUfGpHbNg?orgId=1).