### PR TITLE
chore(dependabot): Group eslint plugin updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,7 @@ updates:
           - '@guardian/eslint-config'
           - '@guardian/prettier'
           - 'eslint'
-          - 'eslint-plugin-prettier'
+          - 'eslint-plugin-*'
       octokit:
         patterns:
           - '@octokit/*'


### PR DESCRIPTION
## What does this change?
I was surprised to see #1519 and #1520 as separate PRs. This change updates the Dependabot configuration to bump all eslint plugins [together](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#patterns-and-exclude-patterns-groups), ensuring they're compatible with each other.