### PR TITLE
Improves the view_domain_tag performance

### DIFF
--- a/packages/common/prisma/migrations/20250519144107_view_domain_tag_fix_slow_join/migration.sql
+++ b/packages/common/prisma/migrations/20250519144107_view_domain_tag_fix_slow_join/migration.sql
@@ -1,0 +1,119 @@
+BEGIN TRANSACTION;
+    DROP VIEW IF EXISTS view_domain_tags;
+    DROP FUNCTION IF EXISTS fn_view_domain_tags;
+
+    CREATE FUNCTION fn_view_domain_tags() RETURNS TABLE (
+                                                            domain_name TEXT
+        , app TEXT
+        , stack TEXT
+        , stage TEXT
+        , tool TEXT
+        , repo TEXT
+        , riffraff_project TEXT
+        , account_name TEXT
+        , account_id TEXT
+                                                        ) as $$
+    WITH arn_tag_sets AS (
+        SELECT
+            arn,
+            tags,
+            account_id
+        FROM
+            aws_cloudfront_distributions
+        UNION
+        SELECT
+            arn,
+            tags,
+            account_id
+        FROM
+            aws_elbv1_load_balancers
+        UNION
+        SELECT
+            arn,
+            tags,
+            account_id
+        FROM
+            aws_elbv2_load_balancers
+        UNION
+        SELECT
+            arn,
+            tags,
+            account_id
+        FROM
+            aws_cloudformation_stacks
+    ),
+         domain_to_tag_sets AS (
+             SELECT
+                 COALESCE(fd.name, cert.domain_name) as domain_name,
+                 (
+                     UNNEST(
+                             ARRAY_AGG(tag_sets.tags)
+                     )
+                     ) as tags,
+                 -- Takes the fist account_id and assume they are all the same
+                 (ARRAY_AGG(cert.account_id)) [1] AS account_id
+             FROM
+                 aws_acm_certificates AS cert
+                     -- Joins on the first arn due to performance
+                     LEFT JOIN arn_tag_sets AS tag_sets ON tag_sets.arn = cert.in_use_by [1]
+                     LEFT JOIN aws_apigateway_domain_names AS agw ON agw.domain_name = cert.domain_name
+                     LEFT JOIN aws_accounts AS acc ON cert.account_id = acc.id
+                     LEFT JOIN fastly_service_backends fb ON fb.hostname = cert.domain_name
+                     LEFT JOIN fastly_service_domains fd ON fd.service_id = fb.service_id
+                     AND fd.service_version = fb.service_version
+             GROUP BY
+                 fd.name,
+                 cert.domain_name
+         ),
+         domain_to_tag_sets_filtered AS (
+             SELECT
+                 *
+             FROM
+                 domain_to_tag_sets
+             WHERE
+                 tags IS NOT NULL
+               AND tags != '{}'
+         ),
+         tool_to_tag_sets AS (
+             SELECT
+                 domain_tags.domain_name,
+                 arn_tags.tags,
+                 arn_tags.account_id
+             FROM
+                 domain_to_tag_sets domain_tags
+                     JOIN arn_tag_sets arn_tags ON domain_tags.tags ->> 'gu:tool' = arn_tags.tags ->> 'gu:tool'
+                     JOIN aws_accounts AS acc ON arn_tags.account_id = acc.id
+             WHERE
+                 domain_tags.tags ->> 'gu:tool' IS NOT NULL
+         )
+    SELECT
+        DISTINCT domain_name,
+                 tags ->> 'App' AS app,
+                 tags ->> 'Stack' AS stack,
+                 tags ->> 'Stage' AS stage,
+                 tags ->> 'gu:tool' AS tool,
+                 COALESCE(tags ->> 'gu:application-repo', tags ->> 'gu:repo') AS repo,
+                 tags ->> 'gu:riff-raff:project' AS riffraff_project,
+                 acc.name,
+                 account_id
+    FROM
+        (
+            SELECT
+                *
+            FROM
+                domain_to_tag_sets_filtered
+            UNION
+            SELECT
+                *
+            FROM
+                tool_to_tag_sets
+        ) all_tags
+            LEFT JOIN aws_accounts AS acc ON all_tags.account_id = acc.id;
+    $$ language sql;
+
+    CREATE VIEW view_domain_tags AS (
+                                    SELECT  *
+                                    FROM    fn_view_domain_tags()
+                                        );
+
+COMMIT TRANSACTION;

--- a/packages/common/prisma/migrations/20250519144107_view_domain_tag_fix_slow_join/migration.sql
+++ b/packages/common/prisma/migrations/20250519144107_view_domain_tag_fix_slow_join/migration.sql
@@ -1,9 +1,11 @@
+-- @formatter:off -- this stops IntelliJ from reformatting the SQL
+
 BEGIN TRANSACTION;
     DROP VIEW IF EXISTS view_domain_tags;
     DROP FUNCTION IF EXISTS fn_view_domain_tags;
 
     CREATE FUNCTION fn_view_domain_tags() RETURNS TABLE (
-                                                            domain_name TEXT
+        domain_name TEXT
         , app TEXT
         , stack TEXT
         , stage TEXT
@@ -12,7 +14,7 @@ BEGIN TRANSACTION;
         , riffraff_project TEXT
         , account_name TEXT
         , account_id TEXT
-                                                        ) as $$
+    ) as $$
     WITH arn_tag_sets AS (
         SELECT
             arn,
@@ -86,16 +88,16 @@ BEGIN TRANSACTION;
              WHERE
                  domain_tags.tags ->> 'gu:tool' IS NOT NULL
          )
-    SELECT
-        DISTINCT domain_name,
-                 tags ->> 'App' AS app,
-                 tags ->> 'Stack' AS stack,
-                 tags ->> 'Stage' AS stage,
-                 tags ->> 'gu:tool' AS tool,
-                 COALESCE(tags ->> 'gu:application-repo', tags ->> 'gu:repo') AS repo,
-                 tags ->> 'gu:riff-raff:project' AS riffraff_project,
-                 acc.name,
-                 account_id
+    SELECT DISTINCT
+        domain_name,
+        tags ->> 'App' AS app,
+        tags ->> 'Stack' AS stack,
+        tags ->> 'Stage' AS stage,
+        tags ->> 'gu:tool' AS tool,
+        COALESCE(tags ->> 'gu:application-repo', tags ->> 'gu:repo') AS repo,
+        tags ->> 'gu:riff-raff:project' AS riffraff_project,
+        acc.name,
+        account_id
     FROM
         (
             SELECT
@@ -112,8 +114,8 @@ BEGIN TRANSACTION;
     $$ language sql;
 
     CREATE VIEW view_domain_tags AS (
-                                    SELECT  *
-                                    FROM    fn_view_domain_tags()
-                                        );
+        SELECT  *
+        FROM    fn_view_domain_tags()
+    );
 
 COMMIT TRANSACTION;

--- a/packages/common/prisma/migrations/20250519144107_view_domain_tag_fix_slow_join/migration.sql
+++ b/packages/common/prisma/migrations/20250519144107_view_domain_tag_fix_slow_join/migration.sql
@@ -49,7 +49,7 @@ BEGIN TRANSACTION;
                  COALESCE(fd.name, cert.domain_name) as domain_name,
                  (
                      UNNEST(
-                             ARRAY_AGG(tag_sets.tags)
+                             ARRAY_AGG(cert.tags || tag_sets.tags)
                      )
                      ) as tags,
                  -- Takes the fist account_id and assume they are all the same

--- a/packages/common/prisma/views/public/view_domain_tags.sql
+++ b/packages/common/prisma/views/public/view_domain_tags.sql
@@ -5,7 +5,7 @@ SELECT
   fn_view_domain_tags.stage,
   fn_view_domain_tags.tool,
   fn_view_domain_tags.repo,
-  fn_view_domain_tags.riffraff,
+  fn_view_domain_tags.riffraff_project,
   fn_view_domain_tags.account_name,
   fn_view_domain_tags.account_id
 FROM
@@ -16,7 +16,7 @@ FROM
     stage,
     tool,
     repo,
-    riffraff,
+    riffraff_project,
     account_name,
     account_id
   );


### PR DESCRIPTION
## What does this change?

Improves performance by adjusting the join between `aws_acm_certificates` and `arn_tag_sets`. 

### Before:
```SQL
= ANY(cert.in_use_by)
```
Total request time: 10.7 s

### After:
```SQL
= cert.in_use_by [1]
```
Total request time: 468 ms

## Why?

To improve performance of the [Tools Audit dashboard ](https://metrics.gutools.co.uk/d/aegzv59r9eghsd/tool-audit).

## How has it been verified?
This change has been run into PROD for testing and to unblock a demo. 
