### PR TITLE
test: Mock the date

### DIFF
--- a/packages/cdk/lib/service-catalogue.test.ts
+++ b/packages/cdk/lib/service-catalogue.test.ts
@@ -6,6 +6,25 @@ import { CfnFunction } from 'aws-cdk-lib/aws-lambda';
 import { ServiceCatalogue } from './service-catalogue';
 
 describe('The ServiceCatalogue stack', () => {
+	beforeAll(() => {
+		/*
+		Each CloudQuery task generates a SQL statement to insert its cadence into the `cloudquery_table_frequency` database table.
+		This value can change depending on how many days there are in the current month.
+
+		For example, for a task that runs on the first of every month (` Schedule.cron({ day: '1', hour: '0', minute: '0' })`):
+		- In May the value will be 2678400000 (31 days)
+		- In June the value will be 2592000000 (30 days)
+
+		Mock the current date to ensure the Jest snapshot is stable.
+		 */
+		const date = new Date('2025-05-01');
+		jest.useFakeTimers().setSystemTime(date);
+	});
+
+	afterAll(() => {
+		jest.useRealTimers();
+	});
+
 	it('matches the snapshot', () => {
 		const app = new App();
 		const stack = new ServiceCatalogue(app, 'ServiceCatalogue', {


### PR DESCRIPTION
## What does this change?
Mock the date to ensure stability of the `cloudquery_table_frequency` insert statements.

## Why?
We have a few open Dependabot PRs raised on 1 June 2025 that are failing CI due to May and June having a different number of days:

![image](https://github.com/user-attachments/assets/3bbc9ea8-9b9f-4cc7-8fdf-d83a965468b3)

## How has it been verified?
Observe CI and the tests passing.