### PR TITLE
chore(deps): Update `guardian/cq-source-ns1` from 0.1.4 to 0.1.6

### DIFF
--- a/.env
+++ b/.env
@@ -29,7 +29,7 @@ CQ_GUARDIAN_GALAXIES=1.1.9
 CQ_GITHUB_LANGUAGES=0.0.5
 
 # See https://github.com/guardian/cq-source-ns1
-CQ_NS1=0.1.4
+CQ_NS1=0.1.6
 
 # See https://github.com/guardian/cq-image-packages
 CQ_IMAGE_PACKAGES=1.0.1

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -18398,7 +18398,7 @@ spec:
           },
           {
             "Essential": false,
-            "Image": "ghcr.io/guardian/cq-source-ns1:0.1.4",
+            "Image": "ghcr.io/guardian/cq-source-ns1:0.1.6",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {


### PR DESCRIPTION
## What does this change?
The 0.1.5 and 0.1.6 patch versions include dependency updates. See also https://github.com/guardian/cq-source-ns1/releases.