### PR TITLE
feat: use a Github App to authenticate the github languages cloudquery task

### DIFF
--- a/.env
+++ b/.env
@@ -26,7 +26,7 @@ CQ_FASTLY=3.0.7
 CQ_GUARDIAN_GALAXIES=1.1.9
 
 # See https://github.com/guardian/cq-source-github-languages
-CQ_GITHUB_LANGUAGES=0.0.5
+CQ_GITHUB_LANGUAGES=0.0.7
 
 # See https://github.com/guardian/cq-source-ns1
 CQ_NS1=0.1.6

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -15511,8 +15511,6 @@ spec:
     - github_languages
   registry: github
   spec:
-    orgs:
-      - guardian
     app_auth:
       - org: guardian
         private_key_path: /usr/share/cloudquery/github-private-key

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -15511,11 +15511,10 @@ spec:
     - github_languages
   registry: github
   spec:
-    app_auth:
-      org: guardian
-      private_key_path: /usr/share/cloudquery/github-private-key
-      app_id: \${file:/usr/share/cloudquery/github-app-id}
-      installation_id: \${file:/usr/share/cloudquery/github-installation-id}
+    org: guardian
+    private_key_path: /usr/share/cloudquery/github-private-key
+    app_id: \${file:/usr/share/cloudquery/github-app-id}
+    installation_id: \${file:/usr/share/cloudquery/github-installation-id}
 ' > /usr/share/cloudquery/source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -15500,7 +15500,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "printf 'kind: source
+              "echo -n $GITHUB_PRIVATE_KEY | base64 -d > /usr/share/cloudquery/github-private-key;echo -n $GITHUB_APP_ID >  /usr/share/cloudquery/github-app-id;echo -n $GITHUB_INSTALLATION_ID >  /usr/share/cloudquery/github-installation-id;printf 'kind: source
 spec:
   name: github-languages
   path: guardian/github-languages
@@ -15510,6 +15510,15 @@ spec:
   tables:
     - github_languages
   registry: github
+  spec:
+    orgs:
+      - guardian
+    app_auth:
+      - org: guardian
+        private_key_path: /usr/share/cloudquery/github-private-key
+        app_id: \${file:/usr/share/cloudquery/github-app-id}
+        installation_id: \${file:/usr/share/cloudquery/github-installation-id}
+    include_archived_repos: false
 ' > /usr/share/cloudquery/source.yaml;printf 'kind: destination
 spec:
   name: postgresql
@@ -15581,9 +15590,45 @@ spec:
             "ReadonlyRootFilesystem": true,
             "Secrets": [
               {
-                "Name": "GITHUB_ACCESS_TOKEN",
+                "Name": "GITHUB_PRIVATE_KEY",
                 "ValueFrom": {
-                  "Ref": "githublanguages5093EDEC",
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "githubcredentialsAF453741",
+                      },
+                      ":private-key::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "GITHUB_APP_ID",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "githubcredentialsAF453741",
+                      },
+                      ":app-id::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "GITHUB_INSTALLATION_ID",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "githubcredentialsAF453741",
+                      },
+                      ":installation-id::",
+                    ],
+                  ],
                 },
               },
               {
@@ -16029,7 +16074,7 @@ spec:
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "githublanguages5093EDEC",
+                "Ref": "githubcredentialsAF453741",
               },
             },
             {
@@ -21620,33 +21665,6 @@ spec:
       "Properties": {
         "GenerateSecretString": {},
         "Name": "/TEST/deploy/service-catalogue/github-credentials",
-        "Tags": [
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/service-catalogue",
-          },
-          {
-            "Key": "Stack",
-            "Value": "deploy",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::SecretsManager::Secret",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "githublanguages5093EDEC": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "GenerateSecretString": {},
-        "Name": "/TEST/deploy/service-catalogue/github-languages",
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -15512,11 +15512,10 @@ spec:
   registry: github
   spec:
     app_auth:
-      - org: guardian
-        private_key_path: /usr/share/cloudquery/github-private-key
-        app_id: \${file:/usr/share/cloudquery/github-app-id}
-        installation_id: \${file:/usr/share/cloudquery/github-installation-id}
-    include_archived_repos: false
+      org: guardian
+      private_key_path: /usr/share/cloudquery/github-private-key
+      app_id: \${file:/usr/share/cloudquery/github-app-id}
+      installation_id: \${file:/usr/share/cloudquery/github-installation-id}
 ' > /usr/share/cloudquery/source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -15504,7 +15504,7 @@ spec:
 spec:
   name: github-languages
   path: guardian/github-languages
-  version: v0.0.5
+  version: v0.0.7
   destinations:
     - postgresql
   tables:

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -306,7 +306,11 @@ export function riffraffSourcesConfig(): CloudqueryConfig {
 	};
 }
 
-export function githubLanguagesConfig(): CloudqueryConfig {
+export function githubLanguagesConfig(
+	tableConfig: GitHubCloudqueryTableConfig,
+): CloudqueryConfig {
+	const { org } = tableConfig;
+
 	return {
 		kind: 'source',
 		spec: {
@@ -316,6 +320,24 @@ export function githubLanguagesConfig(): CloudqueryConfig {
 			destinations: ['postgresql'],
 			tables: ['github_languages'],
 			registry: 'github',
+			spec: {
+				orgs: [org],
+				app_auth: [
+					{
+						org,
+						private_key_path: `${serviceCatalogueConfigDirectory}/github-private-key`,
+						app_id:
+							'${' +
+							`file:${serviceCatalogueConfigDirectory}/github-app-id` +
+							'}',
+						installation_id:
+							'${' +
+							`file:${serviceCatalogueConfigDirectory}/github-installation-id` +
+							'}',
+					},
+				],
+				include_archived_repos: true,
+			},
 		},
 	};
 }

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -336,7 +336,7 @@ export function githubLanguagesConfig(
 							'}',
 					},
 				],
-				include_archived_repos: true,
+				include_archived_repos: false,
 			},
 		},
 	};

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -321,7 +321,6 @@ export function githubLanguagesConfig(
 			tables: ['github_languages'],
 			registry: 'github',
 			spec: {
-				orgs: [org],
 				app_auth: [
 					{
 						org,

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -320,19 +320,17 @@ export function githubLanguagesConfig(
 			destinations: ['postgresql'],
 			tables: ['github_languages'],
 			registry: 'github',
-			spec: {
-				app_auth: {
-						org,
-						private_key_path: `${serviceCatalogueConfigDirectory}/github-private-key`,
-						app_id:
-							'${' +
-							`file:${serviceCatalogueConfigDirectory}/github-app-id` +
-							'}',
-						installation_id:
-							'${' +
-							`file:${serviceCatalogueConfigDirectory}/github-installation-id` +
-							'}',
-					},
+			spec: {				
+					org,
+					private_key_path: `${serviceCatalogueConfigDirectory}/github-private-key`,
+					app_id:
+						'${' +
+						`file:${serviceCatalogueConfigDirectory}/github-app-id` +
+						'}',
+					installation_id:
+						'${' +
+						`file:${serviceCatalogueConfigDirectory}/github-installation-id` +
+						'}',
 			},
 		},
 	};

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -321,8 +321,7 @@ export function githubLanguagesConfig(
 			tables: ['github_languages'],
 			registry: 'github',
 			spec: {
-				app_auth: [
-					{
+				app_auth: {
 						org,
 						private_key_path: `${serviceCatalogueConfigDirectory}/github-private-key`,
 						app_id:
@@ -334,8 +333,6 @@ export function githubLanguagesConfig(
 							`file:${serviceCatalogueConfigDirectory}/github-installation-id` +
 							'}',
 					},
-				],
-				include_archived_repos: false,
 			},
 		},
 	};

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -568,19 +568,14 @@ export function addCloudqueryEcsCluster(
 		},
 	};
 
-	const githubLanguagesSecret = new SecretsManager(scope, 'github-languages', {
-		secretName: `/${stage}/${stack}/${app}/github-languages`,
-	});
-
 	const githubLanguagesSource: CloudquerySource = {
 		name: 'GitHubLanguages',
 		description: 'Collect GitHub languages data',
 		schedule: Schedule.rate(Duration.days(7)),
-		config: githubLanguagesConfig(),
-		secrets: {
-			GITHUB_ACCESS_TOKEN: Secret.fromSecretsManager(githubLanguagesSecret),
-		},
-		// additionalCommands: additionalGithubCommands,
+		config: githubLanguagesConfig({org: gitHubOrgName}),
+		secrets: githubSecrets,
+		additionalCommands: additionalGithubCommands
+
 	};
 
 	const ns1ApiKey = new SecretsManager(scope, 'ns1-credentials', {


### PR DESCRIPTION
## What does this change?

- Uses a Github App to authenticate the collection of the github_languages table by the custom Cloudquery plugin.
- Removes the creation of a PAT token which we should no longer need.

Replaces the use of a single GitHub access token with app-based authentication. It also updates related configurations, secrets management, and infrastructure definitions to align with this new authentication method.

### Authentication Updates:
* Replaced the use of the `GITHUB_ACCESS_TOKEN` secret with three new secrets: `GITHUB_PRIVATE_KEY`, `GITHUB_APP_ID`, and `GITHUB_INSTALLATION_ID`, for GitHub app-based authentication. (`packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap`: [packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snapL16237-R16281](diffhunk://#diff-f1ff53a8917a7ca393cb947297fc15e40d2132865ac31f7d1013f6a3e9b3cccdL16237-R16281))
* Updated the `githubLanguagesConfig` function to include app authentication details (`org`, `private_key_path`, `app_id`, and `installation_id`) in the configuration. (`packages/cdk/lib/cloudquery/config.ts`: [[1]](diffhunk://#diff-9918e771ea5ffb426ab72daf9e9b526ec0c100df8a56f73625803a672b87d252L309-R313) [[2]](diffhunk://#diff-9918e771ea5ffb426ab72daf9e9b526ec0c100df8a56f73625803a672b87d252R323-R336)

### Configuration Changes:
* Added `app_auth` configuration under the `spec` section for GitHub sources, specifying paths to the private key, app ID, and installation ID. (`packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap`: [packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snapR16166-R16171](diffhunk://#diff-f1ff53a8917a7ca393cb947297fc15e40d2132865ac31f7d1013f6a3e9b3cccdR16166-R16171))

### Secrets Management:
* Removed the `githublanguages5093EDEC` secret, which was previously used for storing the GitHub access token. (`packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap`: [packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snapL22298-L22324](diffhunk://#diff-f1ff53a8917a7ca393cb947297fc15e40d2132865ac31f7d1013f6a3e9b3cccdL22298-L22324))
* Updated the `addCloudqueryEcsCluster` function to use the new secrets (`githubSecrets`) instead of the removed `github-languages` secret. (`packages/cdk/lib/cloudquery/index.ts`: [packages/cdk/lib/cloudquery/index.tsL654-R661](diffhunk://#diff-d03c4b415fc8a678f92000e3f6ad81d811bc669e02e8c9de6a523c943e4be6bfL654-R661))

### Infrastructure Updates:
* Updated IAM resource references to use the new `githubcredentialsAF453741` resource instead of the old `githublanguages5093EDEC` resource. (`packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap`: [packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snapL16685-R16727](diffhunk://#diff-f1ff53a8917a7ca393cb947297fc15e40d2132865ac31f7d1013f6a3e9b3cccdL16685-R16727))

## Why?

It is brittle to use a PAT token tied to an individual for authentication. 

## How has it been verified?

- [x] Tested in CODE once https://github.com/guardian/cq-source-github-languages/pull/26 has been merged and the new version released