### PR TITLE
Enable actions for RDS alarm

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -20274,7 +20274,7 @@ spec:
     },
     "EBSByteBalanceAlarm": {
       "Properties": {
-        "ActionsEnabled": false,
+        "ActionsEnabled": true,
         "AlarmActions": [
           {
             "Fn::Join": [
@@ -20284,7 +20284,7 @@ spec:
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":devx-alerts",
+                ":devx-sec-ops-reliability-alerts",
               ],
             ],
           },
@@ -20328,7 +20328,7 @@ spec:
                 {
                   "Ref": "AWS::AccountId",
                 },
-                ":devx-alerts",
+                ":devx-sec-ops-reliability-alerts",
               ],
             ],
           },

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -137,7 +137,7 @@ export class ServiceCatalogue extends GuStack {
 			databaseEbsByteBalanceAlarm,
 		} = props;
 
-		const alertTopicName = 'devx-alerts';
+		const alertTopicName = 'devx-sec-ops-reliability-alerts';
 
 		const alertTopic = Topic.fromTopicArn(
 			this,
@@ -214,14 +214,7 @@ export class ServiceCatalogue extends GuStack {
 				treatMissingData: TreatMissingData.BREACHING,
 				datapointsToAlarm: 1,
 				evaluationPeriods: 1,
-
-				/*
-				This alarms is using anomaly detection which we're not too familiar with yet.
-				A disabled alarm will provide an activity history we can use to fine-tune the alarm.
-				TODO Enable this once we're confident the alarm is working as we'd like.
-				 */
-				actionsEnabled: false,
-
+				actionsEnabled: true,
 				alarmActions: [alertTopic.topicArn],
 				okActions: [alertTopic.topicArn],
 				thresholdMetricId: 'ad1',


### PR DESCRIPTION
I noticed that the alarm introduced in https://github.com/guardian/service-catalogue/pull/1498 was not configured to notify the team yet.

We wanted to check that it wasn't going to be too noisy before switching the alerts on and now we have data which seems to confirm that this won't be too much of an issue:

![image](https://github.com/user-attachments/assets/fa3564c5-d982-4240-95d1-e6bc9883f710)

I've also updated the SNS topic used so that notifications are sent to the Security and Reliability & Operations teams only (rather than the whole DevX stream). I think this smaller audience is more appropriate as the [EndToEnd team](https://galaxies.gutools.co.uk/?selectedNode=endToEndToolsAndInfrastructure) are not responsible for maintaining this service.