### PR TITLE
Filter inspector findings

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -9405,6 +9405,16 @@ spec:
       member_role_name: cloudquery-access
       organization_units:
         - ou-123
+    table_options:
+      aws_inspector2_findings:
+        list_findings:
+          - filter_criteria:
+              finding_status:
+                - comparison: EQUALS
+                  value: ACTIVE
+              severity:
+                - comparison: Gte
+                  value: '7'
 ' > /usr/share/cloudquery/source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -9412,9 +9412,6 @@ spec:
               finding_status:
                 - comparison: EQUALS
                   value: ACTIVE
-              severity:
-                - comparison: Gte
-                  value: '7'
 ' > /usr/share/cloudquery/source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -53,16 +53,6 @@ interface CloudqueryEcsClusterProps {
 	enableCloudquerySchedules: boolean;
 }
 
-interface Comparison {
-	comparison: string;
-	value: string;
-}
-
-const HighOrCritical: Comparison = {
-	comparison: 'Gte',
-	value: '7',
-};
-
 export function addCloudqueryEcsCluster(
 	scope: GuStack,
 	props: CloudqueryEcsClusterProps,
@@ -296,10 +286,6 @@ export function addCloudqueryEcsCluster(
 				},
 				{
 					table_options: {
-						// For more information on how security hub filtering works, see the following links:
-						// # https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_AwsSecurityFindingFilters.html
-						// # https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_StringFilter.html
-						//https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_NumberFilter.html
 						aws_inspector2_findings: {
 							list_findings: [
 								{
@@ -309,9 +295,6 @@ export function addCloudqueryEcsCluster(
 												comparison: 'EQUALS',
 												value: 'ACTIVE',
 											},
-										],
-										severity: [
-											HighOrCritical,
 										],
 									},
 								},
@@ -410,12 +393,12 @@ export function addCloudqueryEcsCluster(
 	];
 
 	/*
-  This is a catch-all task, collecting all other AWS data.
-  Although we're not using the data for any particular reason, it is still useful to have.
-
-  It runs once a week because there is a lot of data, and we need to avoid overlapping invocations.
-  If we identify a table that needs to be updated more often, we should create a dedicated task for it.
-   */
+	This is a catch-all task, collecting all other AWS data.
+	Although we're not using the data for any particular reason, it is still useful to have.
+	
+	It runs once a week because there is a lot of data, and we need to avoid overlapping invocations.
+	If we identify a table that needs to be updated more often, we should create a dedicated task for it.
+	*/
 	const remainingAwsSources: CloudquerySource = {
 		name: 'AwsRemainingData',
 		description: 'Data fetched across all accounts in the organisation.',


### PR DESCRIPTION
## What does this change?

Reduces the amount if inspector findings we ingest

It would be nice to get the severity filter in the first commit working, but CloudQuery is extremely grumpy about how to get a number into its table spec, and I haven't worked that out yet.

## Why?

Currently our daily findings our 500k. Collecting only active findings cuts that number in half, which is particularly useful when you're about to scale up your use of inspector massively.

## How has it been verified?

Deployed to CODE, verified execution and reduction in size of dataset
