### PR TITLE
modify the securityhub_findings filter to reduce data collected

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -1489,9 +1489,16 @@ spec:
               compliance_status:
                 - comparison: NOT_EQUALS
                   value: PASSED
-              workflow_status:
+              product_name:
+                - comparison: EQUALS
+                  value: GuardDuty
+                - comparison: EQUALS
+                  value: Inspector
+                - comparison: EQUALS
+                  value: Security Hub
+              severity_label:
                 - comparison: NOT_EQUALS
-                  value: RESOLVED
+                  value: MEDIUM
 ' > /usr/share/cloudquery/source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -138,10 +138,27 @@ export function addCloudqueryEcsCluster(
 												value: 'PASSED',
 											},
 										],
-										workflow_status: [
+										product_name: [
 											{
+												comparison: 'EQUALS',
+												value: 'GuardDuty',
+											},
+											{
+												comparison: 'EQUALS',
+												value: 'Inspector',
+											},
+											{
+												comparison: 'EQUALS',
+												value: 'Security Hub',
+											},
+										],
+										severity_label: [
+											{
+												//tagging standard uses 'LOW' and 'INFORMATIONAL'.
+												// For security standards, we are only interested in 'HIGH' and 'CRITICAL'
+												//It may seem unnecessary, but this cuts our row count in half.
 												comparison: 'NOT_EQUALS',
-												value: 'RESOLVED',
+												value: 'MEDIUM',
 											},
 										],
 									},
@@ -405,7 +422,7 @@ export function addCloudqueryEcsCluster(
 	/*
 	This is a catch-all task, collecting all other AWS data.
 	Although we're not using the data for any particular reason, it is still useful to have.
-	
+		
 	It runs once a week because there is a lot of data, and we need to avoid overlapping invocations.
 	If we identify a table that needs to be updated more often, we should create a dedicated task for it.
 	*/


### PR DESCRIPTION
## What does this change?

Rolling out inspector and guard duty more widely means that we are collecting much more data in security hub. This PR brings the row count down to a sustainable (but still elevated) level

## Why?

We have a limit on the number of CQ rows we can sync every month

## How has it been verified?

Tested on CODE. In terms of row count, we have gone from x -> 5x -> 2x

In the future, if we turn off the tagging data, we could eliminate the `LOW` and `INFORMATIONAL` severity levels, and significantly reduce the amount of data we collect again, potentially to below our original level.
