### PR TITLE
add indexes to common filters in fsbp data

### DIFF
--- a/packages/common/prisma/migrations/20250619133153_fsbp_idx/migration.sql
+++ b/packages/common/prisma/migrations/20250619133153_fsbp_idx/migration.sql
@@ -1,0 +1,9 @@
+CREATE INDEX IF NOT EXISTS "account_id_idx"   ON "aws_securityhub_findings" ("aws_account_id");
+CREATE INDEX IF NOT EXISTS "region_idx"       ON "aws_securityhub_findings" ("request_region");
+CREATE INDEX IF NOT EXISTS "product_name_idx" ON "aws_securityhub_findings" ("product_name");
+
+CREATE INDEX IF NOT EXISTS "account_name_idx" ON "cloudbuster_fsbp_vulnerabilities" ("aws_account_name");
+CREATE INDEX IF NOT EXISTS "account_id_idx"   ON "cloudbuster_fsbp_vulnerabilities" ("aws_account_id");
+CREATE INDEX IF NOT EXISTS "aws_region"       ON "cloudbuster_fsbp_vulnerabilities" ("aws_region");
+CREATE INDEX IF NOT EXISTS "control_id_idx"   ON "cloudbuster_fsbp_vulnerabilities" ("control_id");
+CREATE INDEX IF NOT EXISTS "within_sla_idx"   ON "cloudbuster_fsbp_vulnerabilities" ("within_sla");


### PR DESCRIPTION
## What does this change?

Indexing on commonly used filters in fsbp-related tables

## Why?

The FSBP compliance dashboard loads quite slowly. By indexing on fields commonly used in Grafana query filters, we can reduce the amount of time it takes to retrieve data from the DB

## How has it been verified?

Ran the migration locally without issue. Once approved, I'll run it on `CODE`. Once merged, it'll run automatically on `PROD`
