### PR TITLE
show affected regions in cloudbuster digest

### DIFF
--- a/packages/cloudbuster/src/digests.ts
+++ b/packages/cloudbuster/src/digests.ts
@@ -103,8 +103,9 @@ function formatFindings(
 	const remediation = findings[0]?.remediation;
 	const title = findings[0]?.title;
 	const findingsString = findingsCount === 1 ? 'finding' : 'findings';
+	const regions = [...new Set(findings.map((f) => f.aws_region))].join(', ');
 	const url = `https://metrics.gutools.co.uk/d/ddi3x35x70jy8d?var-account_name=${encodeURIComponent(account_name)}&var-control_id=${control_id}`;
-	return `[${findingsCount} ${findingsString}](${url}) in app: **${app}**, for control [${control_id}](${remediation}), (${title})`;
+	return `[${findingsCount} ${findingsString}](${url}) in app: **${app}**, for control [${control_id}](${remediation}), in ${regions}, (${title})`;
 }
 
 function createEmailBody(
@@ -152,9 +153,9 @@ export async function sendDigest(
 			stage === 'PROD'
 				? notifyParams
 				: {
-						...notifyParams,
-						target: { Stack: 'testing-alerts' },
-					};
+					...notifyParams,
+					target: { Stack: 'testing-alerts' },
+				};
 		logger.log({
 			message: `Sending ${digest.accountId} (${digest.accountName}) digest...`,
 			accountName: digest.accountName,


### PR DESCRIPTION
## What does this change?

The region that the vulnerabilities exist in are now shown in the cloudbuster digest

## Why?

Makes it easier for teams to find their vulnerabilities.

## How has it been verified?

Unit tests have been updated to reflect new message. Added a new test to verify behaviour.
