### PR TITLE
Fix aws_inspector2_findings table options

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -1503,16 +1503,16 @@ spec:
                   value: MEDIUM
       aws_inspector2_findings:
         aws_inspector2_findings:
-          list_findings:
-            - filter_criteria:
-                finding_status:
-                  - comparison: EQUALS
-                    value: ACTIVE
-                severity:
-                  - comparison: EQUALS
-                    value: CRITICAL
-                  - comparison: EQUALS
-                    value: HIGH
+          - list_findings:
+              - filter_criteria:
+                  finding_status:
+                    - comparison: EQUALS
+                      value: ACTIVE
+                  severity:
+                    - comparison: EQUALS
+                      value: CRITICAL
+                    - comparison: EQUALS
+                      value: HIGH
 ' > /usr/share/cloudquery/source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/cloudquery/table-options.ts
+++ b/packages/cdk/lib/cloudquery/table-options.ts
@@ -49,17 +49,19 @@ export const securityHubTableOptions = {
 
 // https://docs.aws.amazon.com/inspector/v2/APIReference/API_FilterCriteria.html
 export const inspector2TableOptions = {
-    aws_inspector2_findings: {
-        list_findings: [
-            {
-                filter_criteria: {
-                    finding_status: [stringFilter(AwsComparison.Equals, 'ACTIVE')],
-                    severity: [
-                        stringFilter(AwsComparison.Equals, 'CRITICAL'),
-                        stringFilter(AwsComparison.Equals, 'HIGH'),
-                    ],
+    aws_inspector2_findings: [
+        {
+            list_findings: [
+                {
+                    filter_criteria: {
+                        finding_status: [stringFilter(AwsComparison.Equals, 'ACTIVE')],
+                        severity: [
+                            stringFilter(AwsComparison.Equals, 'CRITICAL'),
+                            stringFilter(AwsComparison.Equals, 'HIGH'),
+                        ],
+                    },
                 },
-            },
-        ],
-    },
+            ],
+        },
+    ],
 }


### PR DESCRIPTION
## What does this change?

Uses the correct schema for filteriing inspector findings

## Why?

This is one of our largest tables, and it syncs every day.

## How has it been verified?

TODO: Deploy to CODE