### PR TITLE
update some deps dependabot can't manage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3808,80 +3808,73 @@
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.2.tgz",
-      "integrity": "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==",
-      "dev": true,
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.1.tgz",
+      "integrity": "sha512-j1nQNU1ZxNFx2ZtKmL4sMrs4egy5h65OMDmSbVyuCzjOcwsHq6EaYjOTGXPQxgfiN8dJ4CriYHk6zF050WEULg==",
       "dependencies": {
-        "@octokit/request": "^9.2.3",
+        "@octokit/request": "^10.0.2",
         "@octokit/types": "^14.0.0",
         "universal-user-agent": "^7.0.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@octokit/graphql/node_modules/@octokit/endpoint": {
-      "version": "10.1.4",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.4.tgz",
-      "integrity": "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==",
-      "dev": true,
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.0.tgz",
+      "integrity": "sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ==",
       "dependencies": {
         "@octokit/types": "^14.0.0",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.0.0.tgz",
-      "integrity": "sha512-FZvktFu7HfOIJf2BScLKIEYjDsw6RKc7rBJCdvCTfKsVnx2GEB/Nbzjr29DUdb7vQhlzS/j8qDzdditP0OC6aw==",
-      "dev": true
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-25.1.0.tgz",
+      "integrity": "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="
     },
     "node_modules/@octokit/graphql/node_modules/@octokit/request": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.3.tgz",
-      "integrity": "sha512-Ma+pZU8PXLOEYzsWf0cn/gY+ME57Wq8f49WTXA8FMHp2Ps9djKw//xYJ1je8Hm0pR2lU9FUGeJRWOtxq6olt4w==",
-      "dev": true,
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.3.tgz",
+      "integrity": "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA==",
       "dependencies": {
-        "@octokit/endpoint": "^10.1.4",
-        "@octokit/request-error": "^6.1.8",
+        "@octokit/endpoint": "^11.0.0",
+        "@octokit/request-error": "^7.0.0",
         "@octokit/types": "^14.0.0",
-        "fast-content-type-parse": "^2.0.0",
+        "fast-content-type-parse": "^3.0.0",
         "universal-user-agent": "^7.0.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@octokit/graphql/node_modules/@octokit/request-error": {
-      "version": "6.1.8",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.8.tgz",
-      "integrity": "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==",
-      "dev": true,
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.0.tgz",
+      "integrity": "sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg==",
       "dependencies": {
         "@octokit/types": "^14.0.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@octokit/graphql/node_modules/@octokit/types": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.0.0.tgz",
-      "integrity": "sha512-VVmZP0lEhbo2O1pdq63gZFiGCKkm8PPp8AUOijlwPO6hojEVjspA0MWKP7E4hbvGxzFKNqKr6p0IYtOH/Wf/zA==",
-      "dev": true,
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-14.1.0.tgz",
+      "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
       "dependencies": {
-        "@octokit/openapi-types": "^25.0.0"
+        "@octokit/openapi-types": "^25.1.0"
       }
     },
     "node_modules/@octokit/graphql/node_modules/universal-user-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
-      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
-      "dev": true
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="
     },
     "node_modules/@octokit/oauth-app": {
       "version": "6.1.0",
@@ -8593,10 +8586,9 @@
       }
     },
     "node_modules/fast-content-type-parse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
-      "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
       "funding": [
         {
           "type": "github",
@@ -14342,15 +14334,26 @@
         "@aws-sdk/rds-signer": "^3.835.0",
         "@guardian/anghammarad": "^1.8.3",
         "@octokit/auth-app": "^6.1.2",
+        "@octokit/graphql": "^9.0.1",
         "@prisma/client": "^6.10.1",
         "octokit": "^3.2.1",
-        "octokit-plugin-create-pull-request": "^5.1.1"
+        "octokit-plugin-create-pull-request": "^6.0.1"
       },
       "devDependencies": {
-        "@octokit/graphql": "^8.1.1",
         "@octokit/types": "^13.6.1",
         "@types/aws-lambda": "^8.10.147",
         "prisma": "^6.10.1"
+      }
+    },
+    "packages/common/node_modules/octokit-plugin-create-pull-request": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/octokit-plugin-create-pull-request/-/octokit-plugin-create-pull-request-6.0.1.tgz",
+      "integrity": "sha512-bxNPhWMwQOBrwS/z76ST6/wg/pIo7y+ZpA6X6+gRH6NTvMU6NhVmx5WyMAMD7Agx1lQenQevZO8ovOVh2Q2dzw==",
+      "dependencies": {
+        "@octokit/types": "^13.5.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "packages/data-audit": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -13,13 +13,13 @@
 		"@aws-sdk/credential-providers": "^3.835.0",
 		"@aws-sdk/rds-signer": "^3.835.0",
 		"@octokit/auth-app": "^6.1.2",
+		"@octokit/graphql": "^9.0.1",
 		"octokit": "^3.2.1",
-		"octokit-plugin-create-pull-request": "^5.1.1",
+		"octokit-plugin-create-pull-request": "^6.0.1",
 		"@prisma/client": "^6.10.1"
 	},
 	"devDependencies": {
 		"prisma": "^6.10.1",
-		"@octokit/graphql": "^8.1.1",
 		"@octokit/types": "^13.6.1",
 		"@types/aws-lambda": "^8.10.147"
 	},


### PR DESCRIPTION
## What does this change?

Dependabot's octokit upgrades have been failing for months. Let's update the ones we can now, and figure the rest out later.
