### PR TITLE
Integrate zizmor with service catalogue

### DIFF
--- a/.github/actions/npm-run/action.yml
+++ b/.github/actions/npm-run/action.yml
@@ -31,6 +31,6 @@ runs:
 
     - name: Run script
       shell: bash
-      run: npm run ${{ env.SCRIPT }}
+      run: npm run "${SCRIPT}"
       env:
         SCRIPT: ${{ inputs.script }}

--- a/.github/actions/npm-run/action.yml
+++ b/.github/actions/npm-run/action.yml
@@ -21,7 +21,9 @@ runs:
 
     - uses: guardian/actions-read-private-repos@8792b5279dc2e6dfb6b9aa6ba2f26b6226be444c # v0.1.1
       with:
-        private-ssh-keys: ${{ inputs.deployment_key }}
+        private-ssh-keys: ${{ env.KEY }}
+      env:
+        KEY: ${{ inputs.deployment_key }}
 
     - name: install dependencies
       shell: bash
@@ -29,4 +31,6 @@ runs:
 
     - name: Run script
       shell: bash
-      run: npm run ${{ inputs.script }}
+      run: npm run ${{ env.SCRIPT }}
+      env:
+        SCRIPT: ${{ inputs.script }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 # Find full documentation here https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   merge_group:
@@ -23,10 +26,10 @@ jobs:
   lint:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/npm-run
         with:
           script: lint
@@ -35,10 +38,10 @@ jobs:
   test:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/npm-run
         with:
           script: test
@@ -47,10 +50,10 @@ jobs:
   typecheck:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/npm-run
         with:
           script: typecheck
@@ -61,8 +64,6 @@ jobs:
     runs-on: ubuntu-latest
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
-    permissions:
-      contents: read
 
     env:
       NODE_OPTIONS: '--max_old_space_size=4096'
@@ -88,6 +89,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -129,10 +132,11 @@ jobs:
     permissions:
       # required by aws-actions/configure-aws-credentials
       id-token: write
-      contents: read
       pull-requests: write # required by guardian/actions-riff-raff
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     services:
       # See https://docs.github.com/en/actions/using-containerized-services/creating-postgresql-service-containers
       postgres:
-        image: postgres:14.6-alpine
+        image: postgres:14.6-alpine@sha256:a0f7890719c3c42b9f78f1ad98b2cd45aa2ee3472da12f9d2d3bfbc07f421146
 
         # Keep these in sync with `.env` file at the repository root
         env:

--- a/.github/workflows/cq-image.yml
+++ b/.github/workflows/cq-image.yml
@@ -30,6 +30,7 @@ concurrency:
 
 jobs:
   CQ_CLI:
+    name: 'Set CQ version'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/cq-image.yml
+++ b/.github/workflows/cq-image.yml
@@ -1,6 +1,9 @@
 # Find full documentation here https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
 name: CQ image
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:
@@ -27,12 +30,12 @@ concurrency:
 
 jobs:
   CQ_CLI:
-    permissions:
-      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set CQ_CLI
         run: |
@@ -49,5 +52,4 @@ jobs:
       IMAGE_NAME: cloudquery
       BUILD_ARGS: CQ_CLI=${{ needs.CQ_CLI.outputs.CQ_CLI }}
     permissions:
-      contents: read
       packages: write

--- a/.github/workflows/prisma-migrate-image.yml
+++ b/.github/workflows/prisma-migrate-image.yml
@@ -1,6 +1,9 @@
 # Find full documentation here https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
 name: prisma-migrate image
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:
@@ -27,5 +30,4 @@ jobs:
     with:
       IMAGE_NAME: prisma-migrate
     permissions:
-      contents: read
       packages: write

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -22,6 +22,7 @@ env:
 
 jobs:
   build-and-push:
+    name: Build and push Docker image
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,6 +1,9 @@
 # Find full documentation here https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
 name: Release image
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:
@@ -21,12 +24,13 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       packages: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -51,10 +51,14 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
-          context: ./containers/${{ inputs.IMAGE_NAME }}
-          file: containers/${{ inputs.IMAGE_NAME }}/Dockerfile
+          context: ./containers/${IMAGE_NAME}
+          file: containers/${IMAGE_NAME}/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: ${{ inputs.BUILD_ARGS }}
+          build-args: ${BUILD_ARGS}
+
+        env:
+          IMAGE_NAME: ${{ inputs.IMAGE_NAME }}
+          BUILD_ARGS: ${{ inputs.BUILD_ARGS }}

--- a/.github/workflows/singleton.yml
+++ b/.github/workflows/singleton.yml
@@ -1,6 +1,9 @@
 # Find full documentation here https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
 name: Singleton image
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:
@@ -31,5 +34,4 @@ jobs:
     with:
       IMAGE_NAME: singleton
     permissions:
-      contents: read
       packages: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,7 +3,7 @@
 name: 'Stale PR Handler'
 
 #no permissions by default
-permissions:
+permissions: {}
 
 on:
   schedule:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,12 +8,11 @@ on:
     # Don't check on Fridays as it wouldn't be very nice to have a bot mark your PR as Stale on Friday and then close it on Monday morning!
     - cron: '0 6 * * MON-THU'
 
-permissions:
-  pull-requests: write
-
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         id: stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,6 +2,9 @@
 # then close them 3 days later if there is still no activity.
 name: 'Stale PR Handler'
 
+#no permissions by default
+permissions:
+
 on:
   schedule:
     # Check for Stale PRs every Monday to Thursday morning

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,5 +1,8 @@
 name: 'CI security checks'
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   # Manual invocation.
@@ -21,9 +24,9 @@ jobs:
   action-check:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: pip install zizmor
       - run: zizmor . --format=github --persona=pedantic --offline

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: 'CI security checks'
+
+on:
+  pull_request:
+  # Manual invocation.
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+      - nt/zizmor
+
+# Ensure we only ever have one build running at a time.
+# If we push twice in quick succession, the first build will be stopped once the second starts.
+# This avoids any race conditions.
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  action-check:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - run: pip install zizmor
+      - run: zizmor . --format=github --persona=pedantic --offline

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@f52a838cfabf134edcbaa7c8b3677dde20045018 # v0.1.1
+        with:
+          persona: pedantic
+          min-severity: medium

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   action-check:
+    name: 'Run Zizmor'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,4 @@
-name: 'CI security checks'
+name: GitHub Actions Security Analysis
 
 permissions:
   contents: read
@@ -13,21 +13,18 @@ on:
       - main
       - nt/zizmor
 
-# Ensure we only ever have one build running at a time.
-# If we push twice in quick succession, the first build will be stopped once the second starts.
-# This avoids any race conditions.
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  action-check:
-    name: 'Run Zizmor'
-    timeout-minutes: 15
+  zizmor:
+    name: Run zizmor 🌈
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - run: pip install zizmor
-      - run: zizmor . --format=github --persona=pedantic --offline
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@f52a838cfabf134edcbaa7c8b3677dde20045018 # v0.1.1

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+          sparse-checkout: .github
 
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@f52a838cfabf134edcbaa7c8b3677dde20045018 # v0.1.1


### PR DESCRIPTION
## What does this change?

Integrate the service catalogue with [Zizmor](https://docs.zizmor.sh/). Zizmor is a tool that performs static analysis on GitHub actions. It seems to be named after a still-living [New York dermatologist](https://www.bbc.co.uk/news/blogs-trending-35226720), who was famous for his subway adverts?

When integrated with a repo for the first time, This action will not fail when issues are detected - it will instead generate issues in the Security tab of the repo, so teams can deal with them as and when they have time. This mimics the behaviour of dependabot, and you can see an example of existing issues [here](https://github.com/guardian/service-catalogue/security/code-scanning?query=is%3Aopen+branch%3Ant%2Fzizmor-high+).

However, if a _new_ issue is added to the repo, CI will fail. You can see an example of what that looks like in the `Checks` section of this [test PR](https://github.com/guardian/service-catalogue/pull/1555/checks?check_run_id=44909339610)

I think this might be useful to roll out more widely, as GHA is used all the way across the org, and permissions management in actions is not something that most developers are actively thinking about. Let's do some of that thinking for them.

The most important file in this PR is [zizmor.yml](https://github.com/guardian/service-catalogue/pull/1554/files#diff-8e6408444d2bf2bed6f02c5dc62a7f1f6ab7337eae098d332986e6a81411aeb7). The others are just fixing issues that this new action raised

## Why?

Supposedly, CodeQL [supports GitHub Actions](https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/). However, it's never raised any issues. I was curious to see if another tool might be more useful.

CI environment security is important for the provenance of our software. We should limit the ability of these systems to tamper with our projects wherever possible. Zizmor makes that easier by highlighting low-hanging fruit, such as permissions issues and version pinning.

## How has it been verified?

If you want to know more about how zizmor works, you can [read the docs](https://docs.zizmor.sh/) of the tool, and the [github action](https://github.com/zizmorcore/zizmor-action).

But to see how it interacts with this repo in particular, please see the following links

- Notification of existing issues [example](https://github.com/guardian/service-catalogue/security/code-scanning?query=is%3Aopen+branch%3Ant%2Fzizmor-high+)
- Rejection of new issues [example](https://github.com/guardian/service-catalogue/pull/1555/checks?check_run_id=44909339610)

## Due diligence

Zizmor is open source, and looks quite active, with a healthy contributor count. It uses an MIT licence, which is very permissive. It doesn't require any permission beyond the ability to read the repo (which is public), and create security issues (which is optional), so I'm not too concerned about its security threat.

It's also [used](https://docs.zizmor.sh/trophy-case/) by some quite big names, including Apache (Airflow), Canonical, curl, Docker Grafana, and Homebrew, all of which we use ourselves.


