### PR TITLE
Cloudbuster should skip the app tag if none are found

### DIFF
--- a/packages/cloudbuster/src/digests.test.ts
+++ b/packages/cloudbuster/src/digests.test.ts
@@ -95,6 +95,15 @@ describe('createDigestForAccount', () => {
 		const actual = createDigestForAccount([vuln]);
 		expect(actual).toBeUndefined();
 	});
+	it('should not include the app tag in the message if app is null', () => {
+		const vuln = { ...testVuln, app: null };
+		const actual = createDigestForAccount([vuln]);
+		expect(actual?.message).not.toContain('in app:');
+	})
+	it('should include the app tag in the message if app exists', () => {
+		const actual = createDigestForAccount([testVuln]);
+		expect(actual?.message).toContain(`in app: **${testVuln.app}**,`);
+	})
 });
 
 function mockFinding(

--- a/packages/cloudbuster/src/digests.ts
+++ b/packages/cloudbuster/src/digests.ts
@@ -99,13 +99,13 @@ function formatFindings(
 ) {
 	const findingsCount = findings.length;
 	const control_id = findings[0]?.control_id;
-	const app = findings[0]?.app ?? 'unknown';
+	const app = findings[0]?.app ? ` in app: **${findings[0]?.app}**,` : '';
 	const remediation = findings[0]?.remediation;
 	const title = findings[0]?.title;
 	const findingsString = findingsCount === 1 ? 'finding' : 'findings';
 	const regions = [...new Set(findings.map((f) => f.aws_region))].join(', ');
 	const url = `https://metrics.gutools.co.uk/d/ddi3x35x70jy8d?var-account_name=${encodeURIComponent(account_name)}&var-control_id=${control_id}`;
-	return `[${findingsCount} ${findingsString}](${url}) in app: **${app}**, for control [${control_id}](${remediation}), in ${regions}, (${title})`;
+	return `[${findingsCount} ${findingsString}](${url})${app} for control [${control_id}](${remediation}), in ${regions}, (${title})`;
 }
 
 function createEmailBody(


### PR DESCRIPTION
## What does this change?

Cloudbuster displays the app tag as `unknown` if it can't find one. If we can't find one, let's skip it.

## Why?

This shortens the message for users, and makes it easier for teams outside P&E (who may not use Stack/Stage/App notation as standard) to understand their messages

## How has it been verified?

Added unit tests to verify behaviour. Tested message contents locally.
