### PR TITLE
Fix filtering for aws_inspector2_findings

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
 {
@@ -1502,17 +1502,16 @@ spec:
                 - comparison: NOT_EQUALS
                   value: MEDIUM
       aws_inspector2_findings:
-        aws_inspector2_findings:
-          list_findings:
-            - filter_criteria:
-                finding_status:
-                  - comparison: EQUALS
-                    value: ACTIVE
-                severity:
-                  - comparison: EQUALS
-                    value: CRITICAL
-                  - comparison: EQUALS
-                    value: HIGH
+        list_findings:
+          - filter_criteria:
+              finding_status:
+                - comparison: EQUALS
+                  value: ACTIVE
+              severity:
+                - comparison: EQUALS
+                  value: CRITICAL
+                - comparison: EQUALS
+                  value: HIGH
 ' > /usr/share/cloudquery/source.yaml;printf 'kind: destination
 spec:
   name: postgresql

--- a/packages/cdk/lib/cloudquery/table-options.ts
+++ b/packages/cdk/lib/cloudquery/table-options.ts
@@ -49,17 +49,15 @@ export const securityHubTableOptions = {
 
 // https://docs.aws.amazon.com/inspector/v2/APIReference/API_FilterCriteria.html
 export const inspector2TableOptions = {
-    aws_inspector2_findings: {
-        list_findings: [
-            {
-                filter_criteria: {
-                    finding_status: [stringFilter(AwsComparison.Equals, 'ACTIVE')],
-                    severity: [
-                        stringFilter(AwsComparison.Equals, 'CRITICAL'),
-                        stringFilter(AwsComparison.Equals, 'HIGH'),
-                    ],
-                },
+    list_findings: [
+        {
+            filter_criteria: {
+                finding_status: [stringFilter(AwsComparison.Equals, 'ACTIVE')],
+                severity: [
+                    stringFilter(AwsComparison.Equals, 'CRITICAL'),
+                    stringFilter(AwsComparison.Equals, 'HIGH'),
+                ],
             },
-        ],
-    },
+        },
+    ],
 }


### PR DESCRIPTION
## What does this change?

There was a small issue with the table options for [`aws_inspector2_findings`](https://hub.cloudquery.io/plugins/source/cloudquery/aws/latest/tables/aws_inspector2_findings).

This meant that the filtering wasn't being applied, so we were pulling in a lot more data than we actually need.

This PR fixes the table options which allows the filtering to work as expected. 

## Why?

This will help us to reduce the amount of rows that we're using, which will help us to stay within our quota. It also seems to make the task much faster.

## How has it been verified?

I've deployed the change to `CODE` and run the `AwsDelegatedToSecurityAccount` task. The logs confirm that we are now syncing significantly fewer rows (see [old](https://logs.gutools.co.uk/s/devx/app/r/s/R8epd) vs [new](https://logs.gutools.co.uk/s/devx/app/r/s/6bUFy)).