### PR TITLE
fix: Update S3 event pattern for Prisma migrate task to use 'Object Created' detail type

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -20433,25 +20433,21 @@ spec:
       "Properties": {
         "EventPattern": {
           "detail": {
-            "eventName": [
-              "PutObject",
-            ],
-            "eventSource": [
-              "s3.amazonaws.com",
-            ],
-            "requestParameters": {
-              "bucketName": [
+            "bucket": {
+              "name": [
                 {
                   "Ref": "SsmParameterValueaccountservicesartifactbucketC96584B6F00A464EAD1953AFF4B05118Parameter",
                 },
               ],
+            },
+            "object": {
               "key": [
                 "deploy/TEST/service-catalogue-prisma-migrations/prisma.zip",
               ],
             },
           },
           "detail-type": [
-            "AWS API Call via CloudTrail",
+            "Object Created",
           ],
           "source": [
             "aws.s3",

--- a/packages/cdk/lib/prisma-migrate-task.ts
+++ b/packages/cdk/lib/prisma-migrate-task.ts
@@ -167,15 +167,15 @@ export function addPrismaMigrateTask(
 	const rule = new Rule(scope, 'PrismaMigrateArtifactPutRule', {
 		eventPattern: {
 			source: ['aws.s3'],
-			detailType: ['AWS API Call via CloudTrail'],
+			detailType: ['Object Created'],
 			detail: {
-				eventSource: ['s3.amazonaws.com'],
-				eventName: ['PutObject'],
-				requestParameters: {
-					bucketName: [artifactBucketName],
-					key: [prismaArtifactKey],
-				},
-			},
+                bucket: {
+                    name: [artifactBucketName],
+                },
+                object: {
+                    key: [prismaArtifactKey],
+                },
+            },
 		},
 	});
 


### PR DESCRIPTION
Co-authored-by: Natasha <67543397+NovemberTang@users.noreply.github.com>

## What does this change?

Changes the event type for the prisma migrate trigger from Cloudtrail to S3 bucket.

## Why?

## How has it been verified?
