### PR TITLE
upgrade cq_aws to v32

### DIFF
--- a/.env
+++ b/.env
@@ -14,7 +14,7 @@ CQ_POSTGRES_DESTINATION=7.2.0
 CQ_POSTGRES_SOURCE=3.0.7
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/aws/versions
-CQ_AWS=27.5.0
+CQ_AWS=32.32.0
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/github/versions
 CQ_GITHUB=11.11.1

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -793,7 +793,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_costexplorer_cost_custom
   skip_dependent_tables: false
@@ -1465,7 +1465,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_accessanalyzer_*
     - aws_securityhub_*
@@ -2183,7 +2183,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_lambda_*
   skip_dependent_tables: false
@@ -2807,7 +2807,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_organization*
   skip_dependent_tables: false
@@ -3460,7 +3460,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_autoscaling_groups
   skip_dependent_tables: false
@@ -4114,7 +4114,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_backup_protected_resources
     - aws_backup_vaults
@@ -4800,7 +4800,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_acm*
   skip_dependent_tables: false
@@ -5658,7 +5658,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_cloudformation_*
   skip_dependent_tables: false
@@ -6078,7 +6078,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_cloudwatch_alarms
   skip_dependent_tables: false
@@ -6732,7 +6732,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_dynamodb*
   skip_dependent_tables: false
@@ -7386,7 +7386,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_ec2_images
   skip_dependent_tables: false
@@ -8071,7 +8071,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_ec2_instances
     - aws_ec2_security_groups
@@ -8757,7 +8757,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_iam_credential_reports
   skip_dependent_tables: false
@@ -9411,7 +9411,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_elbv1_*
     - aws_elbv2_*
@@ -10066,7 +10066,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_rds_instances
     - aws_rds_clusters
@@ -10723,7 +10723,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_s3*
   skip_dependent_tables: false
@@ -11611,7 +11611,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_*
   skip_dependent_tables: false
@@ -12128,7 +12128,7 @@ spec:
 spec:
   name: aws
   path: cloudquery/aws
-  version: v27.5.0
+  version: v32.32.0
   tables:
     - aws_ssm_parameters
   skip_dependent_tables: false

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -35,25 +35,25 @@ describe('Config generation, and converting to YAML', () => {
 			tables: ['aws_s3_buckets'],
 		});
 		expect(dump(config)).toMatchInlineSnapshot(`
-"kind: source
-spec:
-  name: aws
-  path: cloudquery/aws
-  version: v27.5.0
-  tables:
-    - aws_s3_buckets
-  skip_dependent_tables: false
-  destinations:
-    - postgresql
-  otel_endpoint: 0.0.0.0:4318
-  otel_endpoint_insecure: true
-  spec:
-    org:
-      member_role_name: cloudquery-access
-      organization_units:
-        - ou-123
-"
-`);
+		"kind: source
+		spec:
+		  name: aws
+		  path: cloudquery/aws
+		  version: v32.32.0
+		  tables:
+		    - aws_s3_buckets
+		  skip_dependent_tables: false
+		  destinations:
+		    - postgresql
+		  otel_endpoint: 0.0.0.0:4318
+		  otel_endpoint_insecure: true
+		  spec:
+		    org:
+		      member_role_name: cloudquery-access
+		      organization_units:
+		        - ou-123
+		"
+	`);
 	});
 
 	it('Should create an AWS source configuration with skipped tables for the organisation', () => {
@@ -62,27 +62,27 @@ spec:
 			skipTables: ['aws_s3_buckets'],
 		});
 		expect(dump(config)).toMatchInlineSnapshot(`
-"kind: source
-spec:
-  name: aws
-  path: cloudquery/aws
-  version: v27.5.0
-  tables:
-    - '*'
-  skip_dependent_tables: false
-  skip_tables:
-    - aws_s3_buckets
-  destinations:
-    - postgresql
-  otel_endpoint: 0.0.0.0:4318
-  otel_endpoint_insecure: true
-  spec:
-    org:
-      member_role_name: cloudquery-access
-      organization_units:
-        - ou-123
-"
-`);
+		"kind: source
+		spec:
+		  name: aws
+		  path: cloudquery/aws
+		  version: v32.32.0
+		  tables:
+		    - '*'
+		  skip_dependent_tables: false
+		  skip_tables:
+		    - aws_s3_buckets
+		  destinations:
+		    - postgresql
+		  otel_endpoint: 0.0.0.0:4318
+		  otel_endpoint_insecure: true
+		  spec:
+		    org:
+		      member_role_name: cloudquery-access
+		      organization_units:
+		        - ou-123
+		"
+	`);
 	});
 
 	it('Should create an AWS source configuration for a single account', () => {
@@ -94,26 +94,26 @@ spec:
 			],
 		});
 		expect(dump(config)).toMatchInlineSnapshot(`
-"kind: source
-spec:
-  name: aws
-  path: cloudquery/aws
-  version: v27.5.0
-  tables:
-    - aws_accessanalyzer_analyzers
-    - aws_accessanalyzer_analyzer_archive_rules
-    - aws_accessanalyzer_analyzer_findings
-  skip_dependent_tables: false
-  destinations:
-    - postgresql
-  otel_endpoint: 0.0.0.0:4318
-  otel_endpoint_insecure: true
-  spec:
-    accounts:
-      - id: cq-for-000000000015
-        role_arn: arn:aws:iam::000000000015:role/cloudquery-access
-"
-`);
+		"kind: source
+		spec:
+		  name: aws
+		  path: cloudquery/aws
+		  version: v32.32.0
+		  tables:
+		    - aws_accessanalyzer_analyzers
+		    - aws_accessanalyzer_analyzer_archive_rules
+		    - aws_accessanalyzer_analyzer_findings
+		  skip_dependent_tables: false
+		  destinations:
+		    - postgresql
+		  otel_endpoint: 0.0.0.0:4318
+		  otel_endpoint_insecure: true
+		  spec:
+		    accounts:
+		      - id: cq-for-000000000015
+		        role_arn: arn:aws:iam::000000000015:role/cloudquery-access
+		"
+	`);
 	});
 
 	it('Should create an AWS source configuration for a single account with table options', () => {
@@ -131,27 +131,27 @@ spec:
 			},
 		);
 		expect(dump(config)).toMatchInlineSnapshot(`
-"kind: source
-spec:
-  name: aws
-  path: cloudquery/aws
-  version: v27.5.0
-  tables:
-    - aws_securityhub_findings
-  skip_dependent_tables: false
-  destinations:
-    - postgresql
-  otel_endpoint: 0.0.0.0:4318
-  otel_endpoint_insecure: true
-  spec:
-    accounts:
-      - id: cq-for-000000000015
-        role_arn: arn:aws:iam::000000000015:role/cloudquery-access
-    table_options:
-      securityhub_findings:
-        record_state: ACTIVE
-"
-`);
+		"kind: source
+		spec:
+		  name: aws
+		  path: cloudquery/aws
+		  version: v32.32.0
+		  tables:
+		    - aws_securityhub_findings
+		  skip_dependent_tables: false
+		  destinations:
+		    - postgresql
+		  otel_endpoint: 0.0.0.0:4318
+		  otel_endpoint_insecure: true
+		  spec:
+		    accounts:
+		      - id: cq-for-000000000015
+		        role_arn: arn:aws:iam::000000000015:role/cloudquery-access
+		    table_options:
+		      securityhub_findings:
+		        record_state: ACTIVE
+		"
+	`);
 	});
 
 	it('Should create a GitHub source configuration', () => {


### PR DESCRIPTION
## What does this change?

Upgrades the CloudQuery AWS plugin version from v27 to v32. I've reviewed the changelog for each major version, and there are no breaking changes to tables that we are using.

## Why?

Keeping dependencies up to date.

## How has it been verified?

We should deploy this change to CODE, then introspect the changes to the DB to create a schema migration, as we don't currently have a way to perform a sync locally. If there is a simpler way to do this, please let me know
