### PR TITLE
only active findings should count towards obligatron metrics

### DIFF
--- a/packages/obligatron/src/obligations/aws-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/aws-vulnerabilities.ts
@@ -84,18 +84,16 @@ export async function evaluateFsbpVulnerabilities(
 ): Promise<ObligationResult[]> {
 	const findings = (await getFsbpFindings(client, ['CRITICAL', 'HIGH'])).map(
 		(v) => v as unknown as SecurityHubFinding,
-	);
+	).filter((f) => f.workflow.Status !== 'SUPPRESSED');
 
-	console.log(`Found ${findings.length} FSBP findings`);
+	console.log(`Found ${findings.length} active FSBP findings`);
 
 	const outOfSlaFindings = findings.filter(
 		(f) =>
 			!isWithinSlaTime(f.first_observed_at, stringToSeverity(f.severity.Label)),
 	);
 
-	console.log(`Found ${findings.length} FSBP findings`);
-
-	console.log(`Found ${outOfSlaFindings.length} findings out of SLA`);
+	console.log(`Found ${outOfSlaFindings.length} active findings out of SLA`);
 
 	const results = fsbpFindingsToObligatronResults(outOfSlaFindings);
 


### PR DESCRIPTION
## What does this change?

Filters suppressed security hub findings

## Why?

Teams are not obligated to fix these, as they have been recorded in the risk register

## How has it been verified?

TODO deploy to code, a small dip in obligation count should be recorded
