### PR TITLE
Notify the security team when an interactive is found

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -21695,6 +21695,9 @@ spec:
         },
         "Environment": {
           "Variables": {
+            "ANGHAMMARAD_SNS_ARN": {
+              "Ref": "AnghammaradSnsArn",
+            },
             "APP": "interactive-monitor",
             "GITHUB_APP_SECRET": {
               "Fn::Join": [

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -29,7 +29,6 @@ export class InteractiveMonitor {
 			runtime: Runtime.NODEJS_20_X,
 			environment: {
 				ANGHAMMARAD_SNS_ARN: anghammaradTopic.topicArn,
-				APP: app,
 				GITHUB_APP_SECRET: githubCredentials.secretName,
 				GITHUB_ORG: gitHubOrg,
 			},

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -3,13 +3,14 @@ import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Architecture, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
+import type { ITopic } from 'aws-cdk-lib/aws-sns';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { LambdaSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 
 const service = 'interactive-monitor';
 export class InteractiveMonitor {
 	public readonly topic: Topic;
-	constructor(guStack: GuStack, gitHubOrg: string) {
+	constructor(guStack: GuStack, gitHubOrg: string, anghammaradTopic: ITopic,) {
 		const app = guStack.app ?? 'service-catalogue'; //shouldn't be undefined, but make linter happy
 		const { stage, stack } = guStack;
 		const topic = new Topic(guStack, 'Topic', {
@@ -27,6 +28,8 @@ export class InteractiveMonitor {
 			handler: 'index.handler',
 			runtime: Runtime.NODEJS_20_X,
 			environment: {
+				ANGHAMMARAD_SNS_ARN: anghammaradTopic.topicArn,
+				APP: app,
 				GITHUB_APP_SECRET: githubCredentials.secretName,
 				GITHUB_ORG: gitHubOrg,
 			},

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -315,13 +315,13 @@ export class ServiceCatalogue extends GuStack {
 		const anghammaradTopicParameter =
 			GuAnghammaradTopicParameter.getInstance(this);
 
-		const interactiveMonitor = new InteractiveMonitor(this, gitHubOrg);
-
 		const anghammaradTopic = Topic.fromTopicArn(
 			this,
 			'anghammarad-arn',
 			anghammaradTopicParameter.valueAsString,
 		);
+
+		const interactiveMonitor = new InteractiveMonitor(this, gitHubOrg, anghammaradTopic);
 
 		const repocopGithubCredentials = new Secret(
 			this,

--- a/packages/cloudbuster/src/run-locally.ts
+++ b/packages/cloudbuster/src/run-locally.ts
@@ -5,6 +5,6 @@ import { main } from './index.js';
 config({ path: `../../.env` }); // Load `.env` file at the root of the repository
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
-if (require.main === module) {
+if (import.meta.url === `file://${process.argv[1]}`) {
 	void main();
 }

--- a/packages/interactive-monitor/package.json
+++ b/packages/interactive-monitor/package.json
@@ -1,12 +1,13 @@
 {
 	"name": "interactive-monitor",
 	"version": "1.0.0",
+	"type": "module",
 	"description": "A lambda which applies branch protection to repos that are passed to it via an SQS topic",
 	"exports": "./index.ts",
 	"scripts": {
 		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@aws-sdk",
 		"test": "node --import tsx --test \"**/*.test.ts\"",
-		"start": "tsx src/run-locally.ts",
+		"start": "APP=interactive-monitor tsx src/run-locally.ts",
 		"typecheck": "tsc --noEmit"
 	},
 	"author": "guardian",

--- a/packages/interactive-monitor/src/config.ts
+++ b/packages/interactive-monitor/src/config.ts
@@ -1,4 +1,10 @@
+import { getEnvOrThrow } from "common/functions.js";
+
 export interface Config {
+	/**
+	 * The name of this application.
+	 */
+	app: string;
 	/**
 	 * The stage to run in.
 	 */
@@ -8,11 +14,17 @@ export interface Config {
 	 * The GitHub org to use
 	 */
 	owner: string;
+	/**
+	 * The ARN of the Anghammarad SNS topic.
+	 */
+	anghammaradSnsTopic: string;
 }
 
 export function getConfig(): Config {
 	return {
+		app: getEnvOrThrow('APP'),
 		stage: process.env['STAGE'] ?? 'DEV',
 		owner: process.env['GITHUB_ORG'] ?? 'guardian',
+		anghammaradSnsTopic: getEnvOrThrow('ANGHAMMARAD_SNS_ARN'),
 	};
 }

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -42,8 +42,10 @@ export async function assessRepos(events: string[], config: Config) {
 	const results: InteractiveRepoAssessment[] = await Promise.all(events.map(async (repo) => await isInteractive(repo, owner, octokit)));
 	const interactives = results.filter((result) => result.isInteractive);
 	if (interactives.length > 0) {
-		await Promise.all(interactives.map((repo) => applyTopics(repo.repo, owner, octokit, 'interactive')));
 		await notify(onProd, interactives, config);
+		if (onProd) {
+			await Promise.all(interactives.map((repo) => applyTopics(repo.repo, owner, octokit, 'interactive')));
+		}
 	} else {
 		console.log('No interactives found');
 	}

--- a/packages/interactive-monitor/src/run-locally.ts
+++ b/packages/interactive-monitor/src/run-locally.ts
@@ -1,13 +1,11 @@
 import { homedir } from 'os';
 import { config } from 'dotenv';
 import { getConfig } from './config.js';
-import { assessRepo } from './index.js';
+import { assessRepos } from './index.js';
 
 config({ path: `../../.env` }); // Load `.env` file at the root of the repository
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
-const testRepo1 = 'ofm-awards-label-2019-atom';
-const testRepo2 = 'oz-230101-wildfires';
+const testRepos = ['ofm-awards-label-2019-atom', 'oz-230101-wildfires'];
 const devConfig = getConfig();
-void assessRepo(testRepo1, devConfig);
-void assessRepo(testRepo2, devConfig);
+void assessRepos(testRepos, devConfig);

--- a/packages/interactive-monitor/src/run-locally.ts
+++ b/packages/interactive-monitor/src/run-locally.ts
@@ -8,4 +8,6 @@ config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
 const testRepos = ['ofm-awards-label-2019-atom', 'oz-230101-wildfires'];
 const devConfig = getConfig();
-void assessRepos(testRepos, devConfig);
+if (import.meta.url === `file://${process.argv[1]}`) {
+    void assessRepos(testRepos, devConfig);
+}


### PR DESCRIPTION
## What does this change?

Sends a notification to the security team when a new interactive has been labelled, so we can do a quick accuracy assessment.

## Why?

I think it would be useful to get an idea of how well the interactive monitor is working. For example, how often it catches something, how accurate it is, etc.

## How has it been verified?

The lambda has been run locally, and produces the expected output.
