### PR TITLE
fix: local running of packages

### DIFF
--- a/packages/cloudbuster/src/run-locally.ts
+++ b/packages/cloudbuster/src/run-locally.ts
@@ -1,10 +1,19 @@
 import { homedir } from 'os';
+import { fileURLToPath } from 'url';
 import { config } from 'dotenv';
 import { main } from './index.js';
 
 config({ path: `../../.env` }); // Load `.env` file at the root of the repository
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * checks if the current module is the entry point script - replaces the CommonJs `require.main === module` check
+ * `import.meta.url` represents the URL of the current module file, e.g. run-locally.ts
+ * `process.argv[1]` represents the path to the script that was executed - it's the second 
+argument in the process's argument vector (the first being the Node executable).
+*/ 
+const isMain = fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
     void main();
 }

--- a/packages/cloudbuster/src/run-locally.ts
+++ b/packages/cloudbuster/src/run-locally.ts
@@ -5,6 +5,6 @@ import { main } from './index.js';
 config({ path: `../../.env` }); // Load `.env` file at the root of the repository
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
-if (require.main === module) {
-	void main();
+if (import.meta.url === `file://${process.argv[1]}`) {
+    void main();
 }

--- a/packages/data-audit/package.json
+++ b/packages/data-audit/package.json
@@ -2,6 +2,7 @@
   "name": "data-audit",
   "version": "0.0.0",
   "description": "Checking data accuracy",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\"",
     "start": "APP=data-audit tsx src/run-locally.ts",

--- a/packages/data-audit/src/index.ts
+++ b/packages/data-audit/src/index.ts
@@ -5,10 +5,10 @@ import {
 } from '@aws-sdk/client-organizations';
 import { awsClientConfig } from 'common/aws.js';
 import { getPrismaClient } from 'common/src/database-setup.js';
-import { auditAwsAccounts } from './audit/aws-accounts';
-import { auditLambdaFunctions } from './audit/aws-lambda';
-import { auditS3Buckets } from './audit/aws-s3-buckets';
-import { saveAudits } from './audit/database';
+import { auditAwsAccounts } from './audit/aws-accounts.js';
+import { auditLambdaFunctions } from './audit/aws-lambda.js';
+import { auditS3Buckets } from './audit/aws-s3-buckets.js';
+import { saveAudits } from './audit/database.js';
 import { getConfig } from './config.js';
 
 async function getAwsAccounts(stage: string) {

--- a/packages/data-audit/src/run-locally.ts
+++ b/packages/data-audit/src/run-locally.ts
@@ -1,9 +1,18 @@
+import { fileURLToPath } from 'url';
 import { config } from 'dotenv';
 import { main } from './index.js';
 
 // Read the .env file from the repository root
 config({ path: `../../.env` });
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * checks if the current module is the entry point script - replaces the CommonJs `require.main === module` check
+ * `import.meta.url` represents the URL of the current module file, e.g. run-locally.ts
+ * `process.argv[1]` represents the path to the script that was executed - it's the second 
+argument in the process's argument vector (the first being the Node executable).
+*/ 
+const isMain = fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
     void main();
 }

--- a/packages/data-audit/src/run-locally.ts
+++ b/packages/data-audit/src/run-locally.ts
@@ -4,6 +4,6 @@ import { main } from './index.js';
 // Read the .env file from the repository root
 config({ path: `../../.env` });
 
-if (require.main === module) {
-	void main();
+if (import.meta.url === `file://${process.argv[1]}`) {
+    void main();
 }

--- a/packages/dependency-graph-integrator/src/run-locally.ts
+++ b/packages/dependency-graph-integrator/src/run-locally.ts
@@ -5,10 +5,10 @@ import { main } from './index.js';
 config({ path: `../../.env` }); // Load `.env` file at the root of the repository
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
-if (require.main === module) {
-	void main({
-		name: 'service-catalogue',
-		language: 'Scala',
-		admins: ['devx-security'],
-	});
+if (import.meta.url === `file://${process.argv[1]}`) {
+    void main({
+        name: 'service-catalogue',
+        language: 'Scala',
+        admins: ['devx-security'],
+    });
 }

--- a/packages/dependency-graph-integrator/src/run-locally.ts
+++ b/packages/dependency-graph-integrator/src/run-locally.ts
@@ -1,11 +1,20 @@
 import { homedir } from 'os';
+import { fileURLToPath } from 'url';
 import { config } from 'dotenv';
 import { main } from './index.js';
 
 config({ path: `../../.env` }); // Load `.env` file at the root of the repository
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * checks if the current module is the entry point script - replaces the CommonJs `require.main === module` check
+ * `import.meta.url` represents the URL of the current module file, e.g. run-locally.ts
+ * `process.argv[1]` represents the path to the script that was executed - it's the second 
+argument in the process's argument vector (the first being the Node executable).
+*/ 
+const isMain = fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
     void main({
         name: 'service-catalogue',
         language: 'Scala',

--- a/packages/interactive-monitor/package.json
+++ b/packages/interactive-monitor/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "interactive-monitor",
 	"version": "1.0.0",
+	"type": "module",
 	"description": "A lambda which applies branch protection to repos that are passed to it via an SQS topic",
 	"exports": "./index.ts",
 	"scripts": {

--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -3,7 +3,7 @@ import { applyTopics, parseEvent, stageAwareOctokit } from 'common/functions.js'
 import type { Octokit } from 'octokit';
 import type { Config } from './config.js';
 import { getConfig } from './config.js';
-import { tryToParseJsConfig } from './js-parser';
+import { tryToParseJsConfig } from './js-parser.js';
 import type { ConfigJsonFile, ContentResponse, FileMetadata } from './types.js';
 
 async function isFromInteractiveTemplate(

--- a/packages/interactive-monitor/src/js-parser.test.ts
+++ b/packages/interactive-monitor/src/js-parser.test.ts
@@ -1,6 +1,6 @@
 import  assert from 'assert';
 import { describe, it } from 'node:test';
-import { getPathFromConfigFile, parseFileToJS } from './js-parser';
+import { getPathFromConfigFile, parseFileToJS } from './js-parser.js';
 
 void describe('getPathFromConfigFile', () => {
 	void it('should return a valid path from a valid js file', () => {

--- a/packages/repocop/src/run-locally.ts
+++ b/packages/repocop/src/run-locally.ts
@@ -1,10 +1,19 @@
 import { homedir } from 'os';
+import { fileURLToPath } from 'url';
 import { config } from 'dotenv';
 import { main } from './index.js';
 
 config({ path: `../../.env` }); // Load `.env` file at the root of the repository
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * checks if the current module is the entry point script - replaces the CommonJs `require.main === module` check
+ * `import.meta.url` represents the URL of the current module file, e.g. run-locally.ts
+ * `process.argv[1]` represents the path to the script that was executed - it's the second 
+argument in the process's argument vector (the first being the Node executable).
+*/ 
+const isMain = fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
     void main();
 }

--- a/packages/repocop/src/run-locally.ts
+++ b/packages/repocop/src/run-locally.ts
@@ -5,6 +5,6 @@ import { main } from './index.js';
 config({ path: `../../.env` }); // Load `.env` file at the root of the repository
 config({ path: `${homedir()}/.gu/service_catalogue/.env.local` });
 
-if (require.main === module) {
-	void main();
+if (import.meta.url === `file://${process.argv[1]}`) {
+    void main();
 }


### PR DESCRIPTION
## What does this change?

- Updates the run-locally scripts in various packages to use ESM syntax rather than CommonJS. ESM modules don’t expose a concept of 'main module' like CommonJS does, so Node.js can’t natively tell if a module is the entry point. Instead, we use a comparison of the URL of the current module file with the path of the script. See comments in the `run-locally.ts` files for more information.

- Adds `"type":"module"` to `package.json`s that were missing it.

## Why?

Running locally for several packages was broken after the recent bump to ESM.

## How has it been verified?

Running locally works now for all packages that were broken. 
