### PR TITLE
set non-prod obligatron frequency to every 30 days

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -22201,7 +22201,7 @@ spec:
     "obligatronAWSVULNERABILITIES8E81FCF9": {
       "Properties": {
         "Description": "Daily execution of Obligatron lambda for 'AWS_VULNERABILITIES' obligation",
-        "ScheduleExpression": "cron(0 11 * * ? *)",
+        "ScheduleExpression": "rate(30 days)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -22385,7 +22385,7 @@ spec:
     "obligatronPRODUCTIONDEPENDENCIESC26096F0": {
       "Properties": {
         "Description": "Daily execution of Obligatron lambda for 'PRODUCTION_DEPENDENCIES' obligation",
-        "ScheduleExpression": "cron(0 10 * * ? *)",
+        "ScheduleExpression": "rate(30 days)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -22601,7 +22601,7 @@ spec:
     "obligatronTAGGING3F8E9BB2": {
       "Properties": {
         "Description": "Daily execution of Obligatron lambda for 'TAGGING' obligation",
-        "ScheduleExpression": "cron(0 9 * * ? *)",
+        "ScheduleExpression": "rate(30 days)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/packages/cdk/lib/obligatron.ts
+++ b/packages/cdk/lib/obligatron.ts
@@ -52,7 +52,7 @@ export class Obligatron {
 			const startTime = (9 + index).toString();
 			new Rule(stack, `obligatron-${obligation}`, {
 				description: `Daily execution of Obligatron lambda for '${obligation}' obligation`,
-				schedule: Schedule.cron({ minute: '0', hour: startTime }),
+				schedule: stack.stage == 'PROD' ? Schedule.cron({ minute: '0', hour: startTime }) : Schedule.rate(Duration.days(30)),
 				targets: [
 					new LambdaFunction(lambda, {
 						event: RuleTargetInput.fromText(obligation),


### PR DESCRIPTION
## What does this change?

Typically, we only run service catalogue jobs once a month on CODE to verify that they are still working. There is no need to run obligatron lambdas every day, so let's reduce their frequency

## Why?

Running them every day is not necessary

## How has it been verified?

Snapshots show the correct schedule