### PR TITLE
allow interactive monitor to publish to anghammarad

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -22031,6 +22031,13 @@ spec:
               ],
             },
             {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "AnghammaradSnsArn",
+              },
+            },
+            {
               "Action": [
                 "secretsmanager:GetSecretValue",
                 "secretsmanager:DescribeSecret",

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -42,6 +42,7 @@ export class InteractiveMonitor {
 		});
 
 		lambda.addToRolePolicy(policyStatement);
+		anghammaradTopic.grantPublish(lambda);
 		githubCredentials.grantRead(lambda);
 		topic.addSubscription(new LambdaSubscription(lambda, {}));
 		this.topic = topic;


### PR DESCRIPTION
## What does this change?

Allows interactive-monitor to publish to anghammarad

## Why?

interactive-monitor is identifying australian interactives, but is failing to apply the topics to them. This is because anghammarad sends out a notification just before the topic is applied, and this lambda does not currently have permission to publish to anghammarad.

Allowing us to notify users means we can move on to the next stage of the process, which is applying the new tags
