### PR TITLE
chore(deps): Update NS1 plugin to 0.1.7

### DIFF
--- a/.env
+++ b/.env
@@ -29,7 +29,7 @@ CQ_GUARDIAN_GALAXIES=1.1.9
 CQ_GITHUB_LANGUAGES=0.0.7
 
 # See https://github.com/guardian/cq-source-ns1
-CQ_NS1=0.1.6
+CQ_NS1=0.1.7
 
 # See https://github.com/guardian/cq-image-packages
 CQ_IMAGE_PACKAGES=1.0.1

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -17804,7 +17804,7 @@ spec:
           },
           {
             "Essential": false,
-            "Image": "ghcr.io/guardian/cq-source-ns1:0.1.6",
+            "Image": "ghcr.io/guardian/cq-source-ns1:0.1.7",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {


### PR DESCRIPTION
## What does this change?
Updates the version of https://github.com/guardian/cq-source-ns1 used to the latest (0.1.7). See https://github.com/guardian/cq-source-ns1/releases/tag/v0.1.7.