### PR TITLE
chore(deps): Update End Of Life CloudQuery plugin to 1.4.0

### DIFF
--- a/.env
+++ b/.env
@@ -35,7 +35,7 @@ CQ_NS1=0.1.7
 CQ_IMAGE_PACKAGES=1.0.1
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/endoflife/latest/versions
-CQ_ENDOFLIFE=1.2.7
+CQ_ENDOFLIFE=1.4.0
 
 # --- FOR LOCAL DEVELOPMENT ONLY ---
 STAGE=DEV

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -12753,7 +12753,7 @@ spec:
   name: endoflife
   path: cloudquery/endoflife
   registry: cloudquery
-  version: v1.2.7
+  version: v1.4.0
   tables:
     - endoflife_products
   destinations:


### PR DESCRIPTION
## What does this change?
Updates the [End Of Life CloudQuery plugin](https://hub.cloudquery.io/plugins/source/cloudquery/endoflife/latest/versions) to the current latest.