### PR TITLE
Track the number of repos that do not have a valid production status

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -22412,6 +22412,45 @@ spec:
       },
       "Type": "AWS::Events::Rule",
     },
+    "obligatronREPOSITORYSTATUSAllowEventRuleServiceCatalogueobligatron5BD5033EE0DF9501": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "obligatronA58CFCF1",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "obligatronREPOSITORYSTATUSD313E655",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "obligatronREPOSITORYSTATUSD313E655": {
+      "Properties": {
+        "Description": "Daily execution of Obligatron lambda for 'REPOSITORY_STATUS' obligation",
+        "ScheduleExpression": "rate(30 days)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "obligatronA58CFCF1",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+            "Input": ""REPOSITORY_STATUS"",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
     "obligatronServiceRole1E85277A": {
       "Properties": {
         "AssumeRolePolicyDocument": {

--- a/packages/common/src/database-queries.ts
+++ b/packages/common/src/database-queries.ts
@@ -1,5 +1,6 @@
 import type { aws_securityhub_findings, PrismaClient } from '@prisma/client';
-import type { SecurityHubFinding, SecurityHubSeverity } from './types.js';
+import { toNonEmptyArray } from './functions.js';
+import type { Repository, SecurityHubFinding, SecurityHubSeverity } from './types.js';
 /**
  * Queries the database for FSBP findings
  */
@@ -23,4 +24,25 @@ export async function getFsbpFindings(
 		});
 
 	return findings as unknown as SecurityHubFinding[];
+}
+
+export async function getRepositories(
+	client: PrismaClient,
+	ignoredRepositoryPrefixes: string[],
+): Promise<Repository[]> {
+	console.debug('Discovering repositories');
+	const repositories = await client.github_repositories.findMany({
+		where: {
+			NOT: [
+				{
+					OR: ignoredRepositoryPrefixes.map((prefix) => {
+						return { full_name: { startsWith: prefix } };
+					}),
+				},
+			],
+		},
+	});
+
+	console.debug(`Found ${repositories.length} repositories`);
+	return toNonEmptyArray(repositories.map((r) => r as Repository));
 }

--- a/packages/obligatron/src/index.ts
+++ b/packages/obligatron/src/index.ts
@@ -5,6 +5,7 @@ import { config } from 'dotenv';
 import { getConfig } from './config.js';
 import { evaluateFsbpVulnerabilities } from './obligations/aws-vulnerabilities.js';
 import { evaluateDependencyVulnerabilityObligation } from './obligations/dependency-vulnerabilities.js';
+import { evaluateRepoTopics } from './obligations/github-topics.js';
 import {
 	type Obligation,
 	type ObligationResult,
@@ -34,6 +35,9 @@ async function getResults(
 		}
 		case 'AWS_VULNERABILITIES': {
 			return await evaluateFsbpVulnerabilities(db);
+		}
+		case 'REPOSITORY_STATUS': {
+			return await evaluateRepoTopics(db);
 		}
 	}
 }

--- a/packages/obligatron/src/obligations/github-topics.test.ts
+++ b/packages/obligatron/src/obligations/github-topics.test.ts
@@ -55,13 +55,11 @@ void describe('repoToObligationResult', () => {
         updated_at: new Date('2020-01-01'),
     };
 
-
-
     void it('should convert a repository to an obligation result', () => {
         const result = repoToObligationResult(repo);
         const expectedResult = {
             resource: 'some/repo',
-            reason: 'Repository does not have topics indicating production status: ',
+            reason: 'Repository does not have topics indicating production status. Topics: ',
             url: 'https://github.com/some/repo',
             contacts: undefined,
         };
@@ -71,6 +69,6 @@ void describe('repoToObligationResult', () => {
     void it('should include topics in the reason', () => {
         const repoWithTopics = { ...repo, topics: ['topic1', 'topic2'] };
         const result = repoToObligationResult(repoWithTopics);
-        assert.strictEqual(result.reason, 'Repository does not have topics indicating production status: topic1, topic2');
+        assert.strictEqual(result.reason, 'Repository does not have topics indicating production status. Topics: topic1, topic2');
     });
 });

--- a/packages/obligatron/src/obligations/github-topics.test.ts
+++ b/packages/obligatron/src/obligations/github-topics.test.ts
@@ -1,0 +1,76 @@
+import assert from 'assert';
+import { describe, it } from 'node:test';
+import type { Repository } from 'common/types.js';
+import { repoToObligationResult, topicsIncludesProductionStatus } from './github-topics.js';
+
+void describe('topicsIncludesProductionStatus', () => {
+    const productionStatuses = ['production', 'testing', 'documentation', 'prototype', 'hackday', 'learning', 'interactive'];
+    void it('returns true when topics include a production status', () => {
+        const topics = ['production', 'blah'];
+        assert.strictEqual(topicsIncludesProductionStatus(topics, productionStatuses), true);
+    });
+
+    void it('returns false when topics do not include any production status', () => {
+        const topics = ['https'];
+        assert.strictEqual(topicsIncludesProductionStatus(topics, productionStatuses), false);
+    });
+
+    void it('returns false when topics is empty', () => {
+        const topics: string[] = [];
+        assert.strictEqual(topicsIncludesProductionStatus(topics, productionStatuses), false);
+    });
+
+    void it('returns false when productionStatuses is empty', () => {
+        const topics = ['production'];
+        const emptyProductionStatuses: string[] = [];
+        assert.strictEqual(topicsIncludesProductionStatus(topics, emptyProductionStatuses), false);
+    });
+
+    void it('returns false when both topics and productionStatuses are empty', () => {
+        assert.strictEqual(topicsIncludesProductionStatus([], []), false);
+    });
+
+    void it('returns true when multiple production statuses are present in topics', () => {
+        const topics = ['production', 'staging', 'testing'];
+        assert.strictEqual(topicsIncludesProductionStatus(topics, productionStatuses), true);
+    });
+
+    void it('is case sensitive', () => {
+        const topics = ['Production', 'scala'];
+        const caseSensitiveProductionStatuses = ['production'];
+        assert.strictEqual(topicsIncludesProductionStatus(topics, caseSensitiveProductionStatuses), false);
+    })
+});
+
+void describe('repoToObligationResult', () => {
+    const repo: Repository = {
+        archived: false,
+        full_name: 'some/repo',
+        topics: [],
+        id: BigInt(1),
+        default_branch: 'main',
+        name: 'repo',
+        created_at: new Date('2020-01-01'),
+        pushed_at: new Date('2020-01-01'),
+        updated_at: new Date('2020-01-01'),
+    };
+
+
+
+    void it('should convert a repository to an obligation result', () => {
+        const result = repoToObligationResult(repo);
+        const expectedResult = {
+            resource: 'some/repo',
+            reason: 'Repository does not have topics indicating production status: ',
+            url: 'https://github.com/some/repo',
+            contacts: undefined,
+        };
+        assert.deepStrictEqual(result, expectedResult);
+    });
+
+    void it('should include topics in the reason', () => {
+        const repoWithTopics = { ...repo, topics: ['topic1', 'topic2'] };
+        const result = repoToObligationResult(repoWithTopics);
+        assert.strictEqual(result.reason, 'Repository does not have topics indicating production status: topic1, topic2');
+    });
+});

--- a/packages/obligatron/src/obligations/github-topics.ts
+++ b/packages/obligatron/src/obligations/github-topics.ts
@@ -1,0 +1,35 @@
+import type { PrismaClient } from '@prisma/client';
+import { getRepositories } from 'common/src/database-queries.js';
+import type {
+    Repository,
+} from 'common/src/types.js';
+import type { ObligationResult } from './index.js';
+
+export function topicsIncludesProductionStatus(topics: string[], productionStatuses: string[]): boolean {
+    return productionStatuses.some(status => topics.includes(status));
+}
+
+export function repoToObligationResult(repo: Repository): ObligationResult {
+    return {
+        resource: repo.full_name,
+        reason: `Repository does not have topics indicating production status: ${repo.topics.join(', ')}`,
+        url: `https://github.com/${repo.full_name}`,
+        contacts: undefined,
+    };
+}
+
+async function evaluateRepoTopics(prisma: PrismaClient): Promise<ObligationResult[]> {
+
+    const productionStatuses: string[] = (await prisma.guardian_production_status.findMany({
+        select: {
+            status: true,
+        },
+    })).map((status) => status.status);
+
+
+    const repositories = (await getRepositories(prisma, []))
+        .filter((repo) => !repo.archived && !topicsIncludesProductionStatus(repo.topics, productionStatuses));
+
+    return repositories.map((repo) => repoToObligationResult(repo));
+
+}

--- a/packages/obligatron/src/obligations/github-topics.ts
+++ b/packages/obligatron/src/obligations/github-topics.ts
@@ -18,7 +18,7 @@ export function repoToObligationResult(repo: Repository): ObligationResult {
     };
 }
 
-async function evaluateRepoTopics(prisma: PrismaClient): Promise<ObligationResult[]> {
+export async function evaluateRepoTopics(prisma: PrismaClient): Promise<ObligationResult[]> {
 
     const productionStatuses: string[] = (await prisma.guardian_production_status.findMany({
         select: {

--- a/packages/obligatron/src/obligations/github-topics.ts
+++ b/packages/obligatron/src/obligations/github-topics.ts
@@ -12,7 +12,7 @@ export function topicsIncludesProductionStatus(topics: string[], productionStatu
 export function repoToObligationResult(repo: Repository): ObligationResult {
     return {
         resource: repo.full_name,
-        reason: `Repository does not have topics indicating production status: ${repo.topics.join(', ')}`,
+        reason: `Repository does not have topics indicating production status. Topics: ${repo.topics.join(', ')}`,
         url: `https://github.com/${repo.full_name}`,
         contacts: undefined,
     };

--- a/packages/obligatron/src/obligations/index.ts
+++ b/packages/obligatron/src/obligations/index.ts
@@ -4,6 +4,7 @@ export const Obligations = [
 	'TAGGING',
 	'PRODUCTION_DEPENDENCIES',
 	'AWS_VULNERABILITIES',
+	'REPOSITORY_STATUS',
 ] as const;
 export type Obligation = (typeof Obligations)[number];
 

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -7,6 +7,7 @@ import type {
 	view_repo_ownership,
 } from '@prisma/client';
 import { awsClientConfig } from 'common/aws.js';
+import { getRepositories } from 'common/database-queries.js';
 import { partition, stageAwareOctokit } from 'common/functions.js';
 import { getPrismaClient } from 'common/src/database-setup.js';
 import type { RepocopVulnerability } from 'common/src/types.js';
@@ -21,7 +22,6 @@ import {
 	getDependabotVulnerabilities,
 	getProductionWorkflowUsages,
 	getRepoOwnership,
-	getRepositories,
 	getRepositoryBranches,
 	getRepositoryCustomProperties,
 	getRepositoryLanguages,

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -21,27 +21,6 @@ import type {
 	Team,
 } from './types.js';
 
-export async function getRepositories(
-	client: PrismaClient,
-	ignoredRepositoryPrefixes: string[],
-): Promise<Repository[]> {
-	console.debug('Discovering repositories');
-	const repositories = await client.github_repositories.findMany({
-		where: {
-			NOT: [
-				{
-					OR: ignoredRepositoryPrefixes.map((prefix) => {
-						return { full_name: { startsWith: prefix } };
-					}),
-				},
-			],
-		},
-	});
-
-	console.debug(`Found ${repositories.length} repositories`);
-	return toNonEmptyArray(repositories.map((r) => r as Repository));
-}
-
 // We only care about branches from repos we've selected, so lets only pull those to save us some time/memory
 export async function getRepositoryBranches(
 	client: PrismaClient,


### PR DESCRIPTION
## What does this change?

- Moves `getRepositories` to common
- Creates a new `REPOSITORY_STATUS` obligation that checks for the existence of particular topics

## What does this not change

At the moment, this code does not attempt to find the repo owner. It only performs the evaluation. This is because it is an MVP, and adding the logic to find the owner would increase the complexity of this PR. This is addressed in #1594 

It also does not find interactives, as `guardian_production_status` doesn't currently include  `interactive` as a value. This will be fixed in #1593 

## Why?

All unarchived repositories should have a valid production status, so that its security obligations can be evaluated accurately. Tracking the number of repos that do not have one of these statuses means we have a ceiling of how many repos are not being tracked by repocop, that should be.

The obligation has been named `REPOSITORY_STATUS` rather than `REPOSITORY_TOPIC` so we can be flexible with the implementation. We may not always rely on GitHub topics to tell us what a repo is doing, and the name reflects that.

## How has it been verified?

Unit tests have been added to verify functionality.
This PR has been tested on CODE, and seems to be running correctly.
