### PR TITLE
Link to newly tagged interactives

### DIFF
--- a/packages/interactive-monitor/src/index.ts
+++ b/packages/interactive-monitor/src/index.ts
@@ -21,11 +21,11 @@ async function isInteractive(repo: string, owner: string, octokit: Octokit): Pro
 async function notify(onProd: boolean, interactives: InteractiveRepoAssessment[], config: Config) {
 	const client = new Anghammarad();
 	const today = new Date().toDateString();
-	const msg = `The following repositories have been assessed as interactives:\n${interactives.map((r) => r.repo).join('\n')}`;
+	const message = `The following repositories have been assessed as interactives:\n${interactives.map((r) => `[${r.repo}](https://github.com/${config.owner}/${r.repo})`).join('\n')}`;
 	await client.notify({
 		subject: 'Interactive Monitor',
 		actions: [],
-		message: msg,
+		message,
 		target: onProd ? { GithubTeamSlug: 'devx-security' } : { Stack: 'testing-alerts' },
 		channel: RequestedChannel.PreferHangouts,
 		sourceSystem: `interactive-monitor ${config.stage}`,


### PR DESCRIPTION
## What does this change?

When the interactive-monitor notification goes out, allow the user to click a link, taking them to the repo on GitHub

## Why?

Better user experience

## How has it been verified?

Verified behaviour on CODE
