### PR TITLE
Make maximum vulnerability age for digest common

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -22210,6 +22210,7 @@ spec:
               "Ref": "AnghammaradSnsArn",
             },
             "APP": "cloudbuster",
+            "CUT_OFF_IN_DAYS": "60",
             "DATABASE_HOSTNAME": {
               "Fn::GetAtt": [
                 "PostgresInstance16DE4286E",
@@ -26069,6 +26070,7 @@ spec:
               "Ref": "AnghammaradSnsArn",
             },
             "APP": "repocop",
+            "CUT_OFF_IN_DAYS": "60",
             "DATABASE_HOSTNAME": {
               "Fn::GetAtt": [
                 "PostgresInstance16DE4286E",

--- a/packages/cdk/lib/cloudbuster.ts
+++ b/packages/cdk/lib/cloudbuster.ts
@@ -18,9 +18,10 @@ type CloudBusterProps = {
 	db: DatabaseInstance;
 	anghammaradTopic: ITopic;
 	monitoringConfiguration:
-		| NoMonitoring
-		| GuLambdaErrorPercentageMonitoringProps;
+	| NoMonitoring
+	| GuLambdaErrorPercentageMonitoringProps;
 	schedule: Schedule;
+	digestCutOffInDays: number;
 };
 
 export class CloudBuster {
@@ -32,6 +33,7 @@ export class CloudBuster {
 			anghammaradTopic,
 			monitoringConfiguration,
 			schedule,
+			digestCutOffInDays,
 		} = props;
 		const app = 'cloudbuster';
 
@@ -47,6 +49,8 @@ export class CloudBuster {
 				ANGHAMMARAD_SNS_ARN: anghammaradTopic.topicArn,
 				DATABASE_HOSTNAME: db.dbInstanceEndpointAddress,
 				QUERY_LOGGING: 'false',
+				CUT_OFF_IN_DAYS: digestCutOffInDays.toString(),
+
 			},
 			timeout: Duration.minutes(2),
 			memorySize: 512,

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -30,6 +30,7 @@ export class Repocop {
 		dbSecurityGroup: SecurityGroup,
 		repocopGithubSecret: Secret,
 		gitHubOrg: string,
+		digestCutOffInDays: number
 	) {
 		const dependencyGraphIntegratorInputTopic = new Topic(
 			guStack,
@@ -58,6 +59,7 @@ export class Repocop {
 				DEPENDENCY_GRAPH_INPUT_TOPIC_ARN:
 					dependencyGraphIntegratorInputTopic.topicArn,
 				GITHUB_ORG: gitHubOrg,
+				CUT_OFF_IN_DAYS: digestCutOffInDays.toString(),
 			},
 			vpc,
 			securityGroups: [dbSecurityGroup],

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -331,6 +331,8 @@ export class ServiceCatalogue extends GuStack {
 			},
 		);
 
+		const digestCutOffInDays = 60;
+
 		new Repocop(
 			this,
 			securityAlertSchedule,
@@ -342,6 +344,7 @@ export class ServiceCatalogue extends GuStack {
 			applicationToPostgresSecurityGroup,
 			repocopGithubCredentials,
 			gitHubOrg,
+			digestCutOffInDays
 		);
 
 		addDataAuditLambda(this, {
@@ -386,6 +389,7 @@ export class ServiceCatalogue extends GuStack {
 				'cloudbuster',
 			),
 			schedule: securityAlertSchedule,
+			digestCutOffInDays,
 		});
 	}
 }

--- a/packages/cloudbuster/package.json
+++ b/packages/cloudbuster/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@aws-sdk --external:@prisma/client --external:prisma",
-		"start": "APP=cloudbuster tsx src/run-locally.ts",
+		"start": "APP=cloudbuster CUT_OFF_IN_DAYS=60 tsx src/run-locally.ts",
 		"test": "node --import tsx --test \"**/*.test.ts\"",
 		"typecheck": "tsc --noEmit"
 	}

--- a/packages/cloudbuster/src/config.ts
+++ b/packages/cloudbuster/src/config.ts
@@ -19,6 +19,10 @@ export interface Config extends PrismaConfig {
 	 * Anghammarad's topic ARN
 	 */
 	anghammaradSnsTopic: string;
+	/**
+	 * The number of days we report on vulnerabilities for.
+	 */
+	cutOffInDays: number;
 }
 
 export async function getConfig(): Promise<Config> {
@@ -36,5 +40,6 @@ export async function getConfig(): Promise<Config> {
 		withQueryLogging: isDev,
 		enableMessaging: !isDev,
 		anghammaradSnsTopic,
+		cutOffInDays: Number(getEnvOrThrow('CUT_OFF_IN_DAYS'))
 	};
 }

--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -58,11 +58,13 @@ export async function main() {
 	const activeFindings = uniqueTableContents.filter(
 		(row) => !row.suppressed,
 	);
-	const digests = createDigestsFromFindings(activeFindings, 'CRITICAL');
+
+	const digestCutOffInDays = 60;
+	const digests = createDigestsFromFindings(activeFindings, 'CRITICAL', digestCutOffInDays);
 
 	const isTuesday = new Date().getDay() === 2;
 	if (isTuesday) {
-		digests.push(...createDigestsFromFindings(activeFindings, 'HIGH'));
+		digests.push(...createDigestsFromFindings(activeFindings, 'HIGH', digestCutOffInDays));
 	}
 	// *** NOTIFICATION SENDING ***
 	const anghammaradClient = new Anghammarad();

--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -59,12 +59,11 @@ export async function main() {
 		(row) => !row.suppressed,
 	);
 
-	const digestCutOffInDays = 60;
-	const digests = createDigestsFromFindings(activeFindings, 'CRITICAL', digestCutOffInDays);
+	const digests = createDigestsFromFindings(activeFindings, 'CRITICAL', config.cutOffInDays);
 
 	const isTuesday = new Date().getDay() === 2;
 	if (isTuesday) {
-		digests.push(...createDigestsFromFindings(activeFindings, 'HIGH', digestCutOffInDays));
+		digests.push(...createDigestsFromFindings(activeFindings, 'HIGH', config.cutOffInDays));
 	}
 	// *** NOTIFICATION SENDING ***
 	const anghammaradClient = new Anghammarad();

--- a/packages/repocop/package.json
+++ b/packages/repocop/package.json
@@ -8,7 +8,7 @@
 	},
 	"scripts": {
 		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@aws-sdk --external:@prisma/client --external:prisma",
-		"start": "APP=repocop tsx src/run-locally.ts",
+		"start": "APP=repocop CUT_OFF_IN_DAYS=60 tsx src/run-locally.ts",
 		"test": "node --import tsx --test \"**/*.test.ts\"",
 		"typecheck": "tsc --noEmit"
 	},

--- a/packages/repocop/src/config.ts
+++ b/packages/repocop/src/config.ts
@@ -62,6 +62,11 @@ export interface Config extends PrismaConfig {
 	 * The name of the GitHub organisation that owns the repositories.
 	 */
 	gitHubOrg: string;
+
+	/**
+	 * The number of days we report on vulnerabilities for.
+	 */
+	cutOffInDays: number;
 }
 
 export async function getConfig(): Promise<Config> {
@@ -93,5 +98,6 @@ export async function getConfig(): Promise<Config> {
 			'DEPENDENCY_GRAPH_INPUT_TOPIC_ARN',
 		),
 		gitHubOrg: process.env['GITHUB_ORG'] ?? 'guardian',
+		cutOffInDays: Number(getEnvOrThrow('CUT_OFF_IN_DAYS'))
 	};
 }

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -188,11 +188,14 @@ export async function main() {
 			octokit,
 		);
 
+		const vulnCutOffInDays = 60;
+
 		await createAndSendVulnerabilityDigests(
 			config,
 			teams,
 			repoOwners,
 			evaluationResults,
+			vulnCutOffInDays
 		);
 
 		await applyProductionTopicAndMessageTeams(

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -188,14 +188,11 @@ export async function main() {
 			octokit,
 		);
 
-		const vulnCutOffInDays = 60;
-
 		await createAndSendVulnerabilityDigests(
 			config,
 			teams,
 			repoOwners,
 			evaluationResults,
-			vulnCutOffInDays
 		);
 
 		await applyProductionTopicAndMessageTeams(

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -140,7 +140,7 @@ export async function createAndSendVulnDigestsForSeverity(
 	repoOwners: view_repo_ownership[],
 	results: EvaluationResult[],
 	severity: 'critical' | 'high',
-	maxVulnAgeInDays: number = 60,
+	maxVulnAgeInDays: number,
 ) {
 	const digests = teams
 		.map((t) =>
@@ -166,6 +166,7 @@ export async function createAndSendVulnerabilityDigests(
 	teams: Team[],
 	repoOwners: view_repo_ownership[],
 	evaluationResults: EvaluationResult[],
+	cutOffInDays: number,
 ) {
 	await createAndSendVulnDigestsForSeverity(
 		config,
@@ -173,6 +174,7 @@ export async function createAndSendVulnerabilityDigests(
 		repoOwners,
 		evaluationResults,
 		'critical',
+		cutOffInDays
 	);
 
 	const isTuesday = new Date().getDay() === 2;
@@ -183,6 +185,7 @@ export async function createAndSendVulnerabilityDigests(
 			repoOwners,
 			evaluationResults,
 			'high',
+			cutOffInDays
 		);
 	}
 }

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -140,7 +140,6 @@ export async function createAndSendVulnDigestsForSeverity(
 	repoOwners: view_repo_ownership[],
 	results: EvaluationResult[],
 	severity: 'critical' | 'high',
-	maxVulnAgeInDays: number,
 ) {
 	const digests = teams
 		.map((t) =>
@@ -149,7 +148,7 @@ export async function createAndSendVulnDigestsForSeverity(
 				severity,
 				repoOwners,
 				results,
-				maxVulnAgeInDays,
+				config.cutOffInDays,
 			),
 		)
 		.filter((d): d is VulnerabilityDigest => d !== undefined);
@@ -166,7 +165,6 @@ export async function createAndSendVulnerabilityDigests(
 	teams: Team[],
 	repoOwners: view_repo_ownership[],
 	evaluationResults: EvaluationResult[],
-	cutOffInDays: number,
 ) {
 	await createAndSendVulnDigestsForSeverity(
 		config,
@@ -174,7 +172,6 @@ export async function createAndSendVulnerabilityDigests(
 		repoOwners,
 		evaluationResults,
 		'critical',
-		cutOffInDays
 	);
 
 	const isTuesday = new Date().getDay() === 2;
@@ -185,7 +182,6 @@ export async function createAndSendVulnerabilityDigests(
 			repoOwners,
 			evaluationResults,
 			'high',
-			cutOffInDays
 		);
 	}
 }


### PR DESCRIPTION
## What does this change?

Allows the cutoff date for vulnerability digest notification to be common between repocop and cloudbuster

## Why?

They use the same vulnerability reporting schedule. Typically when we want to change one, we also want to change the other.

## How has it been verified?

Unit tests have been updated
Tested on CODE
