### PR TITLE
reduce maximum age for digest inclusion

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -22210,7 +22210,7 @@ spec:
               "Ref": "AnghammaradSnsArn",
             },
             "APP": "cloudbuster",
-            "CUT_OFF_IN_DAYS": "60",
+            "CUT_OFF_IN_DAYS": "45",
             "DATABASE_HOSTNAME": {
               "Fn::GetAtt": [
                 "PostgresInstance16DE4286E",
@@ -26070,7 +26070,7 @@ spec:
               "Ref": "AnghammaradSnsArn",
             },
             "APP": "repocop",
-            "CUT_OFF_IN_DAYS": "60",
+            "CUT_OFF_IN_DAYS": "45",
             "DATABASE_HOSTNAME": {
               "Fn::GetAtt": [
                 "PostgresInstance16DE4286E",

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -331,7 +331,7 @@ export class ServiceCatalogue extends GuStack {
 			},
 		);
 
-		const digestCutOffInDays = 60;
+		const digestCutOffInDays = 45
 
 		new Repocop(
 			this,


### PR DESCRIPTION
## What does this change?

Reduces the window for teams to be alerted about new issues from 60 to 45 days.

## Why?

Reducing the number of times we notify teams about an issue will help teams deal with alert fatigue. 60 days was chosen as an arbitrary number longer than the SLA period - 45 also meets that brief.

## How has it been verified?

CI passes
