### PR TITLE
Attempt to fix GitHub releases task

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -16836,8 +16836,6 @@ spec:
   tables:
     - github_releases
   skip_dependent_tables: false
-  skip_tables:
-    - github_repositories
   destinations:
     - postgresql
   spec:
@@ -16855,7 +16853,7 @@ spec:
   registry: github
   path: cloudquery/postgresql
   version: v7.2.0
-  write_mode: overwrite-delete-stale
+  write_mode: overwrite
   migrate_mode: forced
   spec:
     connection_string: >-

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -16836,6 +16836,8 @@ spec:
   tables:
     - github_releases
   skip_dependent_tables: false
+  skip_tables:
+    - github_repositories
   destinations:
     - postgresql
   spec:

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -1,18 +1,18 @@
-import type { GuStack } from '@guardian/cdk/lib/constructs/core';
-import { GuStringParameter } from '@guardian/cdk/lib/constructs/core';
-import { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
-import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
-import { GuardianAwsAccounts } from '@guardian/private-infrastructure-config';
-import { Aws, Duration } from 'aws-cdk-lib';
-import type { IVpc } from 'aws-cdk-lib/aws-ec2';
-import { Secret } from 'aws-cdk-lib/aws-ecs';
-import { Schedule } from 'aws-cdk-lib/aws-events';
-import type { PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
-import { Secret as SecretsManager } from 'aws-cdk-lib/aws-secretsmanager';
-import { StringParameter } from 'aws-cdk-lib/aws-ssm';
-import type { CloudquerySource } from './cluster';
-import { CloudqueryCluster } from './cluster';
+import type { GuStack } from "@guardian/cdk/lib/constructs/core";
+import { GuStringParameter } from "@guardian/cdk/lib/constructs/core";
+import { GuSecurityGroup } from "@guardian/cdk/lib/constructs/ec2";
+import { GuS3Bucket } from "@guardian/cdk/lib/constructs/s3";
+import { GuardianAwsAccounts } from "@guardian/private-infrastructure-config";
+import { Aws, Duration } from "aws-cdk-lib";
+import type { IVpc } from "aws-cdk-lib/aws-ec2";
+import { Secret } from "aws-cdk-lib/aws-ecs";
+import { Schedule } from "aws-cdk-lib/aws-events";
+import type { PolicyStatement } from "aws-cdk-lib/aws-iam";
+import type { DatabaseInstance } from "aws-cdk-lib/aws-rds";
+import { Secret as SecretsManager } from "aws-cdk-lib/aws-secretsmanager";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
+import type { CloudquerySource } from "./cluster";
+import { CloudqueryCluster } from "./cluster";
 import {
 	amigoBakePackagesConfig,
 	awsSourceConfigForAccount,
@@ -27,19 +27,11 @@ import {
 	ns1SourceConfig,
 	riffraffSourcesConfig,
 	serviceCatalogueConfigDirectory,
-	skipTables,
-} from './config';
-import { Images } from './images';
-import {
-	cloudqueryAccess,
-	listOrgsPolicy,
-	readBucketPolicy,
-	readDynamoDbTablePolicy,
-} from './policies';
-import {
-	inspector2TableOptions,
-	securityHubTableOptions,
-} from './table-options';
+	skipTables
+} from "./config";
+import { Images } from "./images";
+import { cloudqueryAccess, listOrgsPolicy, readBucketPolicy, readDynamoDbTablePolicy } from "./policies";
+import { inspector2TableOptions, securityHubTableOptions } from "./table-options";
 
 interface CloudqueryEcsClusterProps {
 	vpc: IVpc;
@@ -455,8 +447,8 @@ export function addCloudqueryEcsCluster(
 				org: gitHubOrgName,
 				repositories: ['guardian/cdk'],
 				tables: ['github_releases'],
-				skipTables: ['github_repositories'],
 			}),
+			writeMode: CloudqueryWriteMode.Overwrite,
 			secrets: githubSecrets,
 			additionalCommands: additionalGithubCommands,
 		},

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -455,6 +455,7 @@ export function addCloudqueryEcsCluster(
 				org: gitHubOrgName,
 				repositories: ['guardian/cdk'],
 				tables: ['github_releases'],
+				skipTables: ['github_repositories'],
 			}),
 			secrets: githubSecrets,
 			additionalCommands: additionalGithubCommands,

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -1,18 +1,18 @@
-import type { GuStack } from "@guardian/cdk/lib/constructs/core";
-import { GuStringParameter } from "@guardian/cdk/lib/constructs/core";
-import { GuSecurityGroup } from "@guardian/cdk/lib/constructs/ec2";
-import { GuS3Bucket } from "@guardian/cdk/lib/constructs/s3";
-import { GuardianAwsAccounts } from "@guardian/private-infrastructure-config";
-import { Aws, Duration } from "aws-cdk-lib";
-import type { IVpc } from "aws-cdk-lib/aws-ec2";
-import { Secret } from "aws-cdk-lib/aws-ecs";
-import { Schedule } from "aws-cdk-lib/aws-events";
-import type { PolicyStatement } from "aws-cdk-lib/aws-iam";
-import type { DatabaseInstance } from "aws-cdk-lib/aws-rds";
-import { Secret as SecretsManager } from "aws-cdk-lib/aws-secretsmanager";
-import { StringParameter } from "aws-cdk-lib/aws-ssm";
-import type { CloudquerySource } from "./cluster";
-import { CloudqueryCluster } from "./cluster";
+import type { GuStack } from '@guardian/cdk/lib/constructs/core';
+import { GuStringParameter } from '@guardian/cdk/lib/constructs/core';
+import { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
+import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
+import { GuardianAwsAccounts } from '@guardian/private-infrastructure-config';
+import { Aws, Duration } from 'aws-cdk-lib';
+import type { IVpc } from 'aws-cdk-lib/aws-ec2';
+import { Secret } from 'aws-cdk-lib/aws-ecs';
+import { Schedule } from 'aws-cdk-lib/aws-events';
+import type { PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
+import { Secret as SecretsManager } from 'aws-cdk-lib/aws-secretsmanager';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import type { CloudquerySource } from './cluster';
+import { CloudqueryCluster } from './cluster';
 import {
 	amigoBakePackagesConfig,
 	awsSourceConfigForAccount,
@@ -27,11 +27,19 @@ import {
 	ns1SourceConfig,
 	riffraffSourcesConfig,
 	serviceCatalogueConfigDirectory,
-	skipTables
-} from "./config";
-import { Images } from "./images";
-import { cloudqueryAccess, listOrgsPolicy, readBucketPolicy, readDynamoDbTablePolicy } from "./policies";
-import { inspector2TableOptions, securityHubTableOptions } from "./table-options";
+	skipTables,
+} from './config';
+import { Images } from './images';
+import {
+	cloudqueryAccess,
+	listOrgsPolicy,
+	readBucketPolicy,
+	readDynamoDbTablePolicy,
+} from './policies';
+import {
+	inspector2TableOptions,
+	securityHubTableOptions,
+} from './table-options';
 
 interface CloudqueryEcsClusterProps {
 	vpc: IVpc;


### PR DESCRIPTION
## What does this change?

This PR updates the write mode for the new GitHub releases task, which was introduced in https://github.com/guardian/service-catalogue/pull/1600. By using `overwrite` instead of `overwrite-delete-stale`, we can collect release information for the `cdk` repository without accidentally clearing rows for all other repos from the `github_repositories` table.

## Why?

Prior to this PR, the new releases task was overwriting all data in the `github_repositories` table (which is a [dependency for the `github_releases` table](https://hub.cloudquery.io/plugins/source/cloudquery/github/v14.1.1/tables/github_releases)). Because we are [limiting the releases task to a single repository (`cdk`)](https://github.com/guardian/service-catalogue/blob/e7c21a85c3788bbd143b00303180110b17e20e46/packages/cdk/lib/cloudquery/index.ts#L456) in practice this meant that we ended up with a single row in the `github_repositories` table when we should have over 4000. This broke various dashboards which rely on `github_repositories` ([example](https://metrics.gutools.co.uk/d/aeub22vwdhb7ka/aws-java-sdk-v1?orgId=1&from=now-6h&to=now&timezone=browser&var-github_team=$__all)).

We run the new releases task once a week (Mondays at 10:00), so the old behaviour will break the `github_repositories` table every Monday unless we merge a fix.

## How has it been verified?

I've [deployed this to `CODE`](https://riffraff.gutools.co.uk/deployment/view/1e3dc127-a298-4d78-bd4a-4704510880c3) and run the releases task (with `npm -w cli start run-task -- --stage CODE --name GitHubReleases`). 

I can see that the `github_repositories` table still contains the correct number of rows. Sync times for the majority of rows are not updated whereas the row for the `cdk` repository is synced again / updated as part of the releases task.

Interestingly, all releases are also synced again (which is not what I was expecting when I added [this comment](https://github.com/guardian/service-catalogue/pull/1600#pullrequestreview-3155398515)!).