### PR TITLE
Exclude repos from REPOSITORY_STATUS obligation if they do not belong to P&E

### DIFF
--- a/packages/obligatron/src/obligations/github-topics.ts
+++ b/packages/obligatron/src/obligations/github-topics.ts
@@ -1,4 +1,5 @@
 import type { PrismaClient, view_repo_ownership } from '@prisma/client';
+import { toNonEmptyArray } from 'common/functions.js';
 import { getRepoOwnership, getRepositories } from 'common/src/database-queries.js';
 import type {
     Repository,
@@ -20,6 +21,27 @@ export function repoToObligationResult(repo: Repository, allOwners: view_repo_ow
     };
 }
 
+const getExternalTeams = async (prisma: PrismaClient): Promise<string[]> => {
+    const teams = await prisma.guardian_non_p_and_e_github_teams.findMany();
+    return toNonEmptyArray(teams.map(t => t.team_name));
+}
+
+// This function filters out repos that are owned exclusively by teams outsude of P&E.
+// It will keep repos that have no owners, or have at least one owning team inside the department
+export function removeExternallyOwnedRepos(
+    repos: Repository[],
+    repoOwners: view_repo_ownership[],
+    externalTeams: string[]
+): Repository[] {
+    const externalTeamSlugs = new Set(externalTeams);
+    return repos.filter(repo => {
+        const owners = repoOwners.filter(owner => owner.full_repo_name === repo.full_name);
+        console.log(`Repo ${repo.full_name} has owners: ${owners.map(o => o.github_team_slug).join(', ')}`);
+        // Include repos with no owners, or with at least one non-external owner
+        return owners.length === 0 || owners.some(owner => !externalTeamSlugs.has(owner.github_team_slug));
+    });
+}
+
 export async function evaluateRepoTopics(prisma: PrismaClient): Promise<ObligationResult[]> {
 
     const productionStatuses: string[] = (await prisma.guardian_production_status.findMany({
@@ -28,16 +50,19 @@ export async function evaluateRepoTopics(prisma: PrismaClient): Promise<Obligati
         },
     })).map((status) => status.status);
 
-
-    const repositories = (await getRepositories(prisma, []))
+    const reposWithNoStatus = (await getRepositories(prisma, []))
         .filter((repo) => !repo.archived && !topicsIncludesProductionStatus(repo.topics, productionStatuses));
 
 
-    //prefilter to only repos that don't have production topics. At a minimum, this will reduce the size of the list by 90%
-    const owners = (await getRepoOwnership(prisma)).filter((record) =>
-        repositories.some((repo) => repo.full_name === record.full_repo_name),
+    const repoOwners = await getRepoOwnership(prisma);
+    const externalTeams = await getExternalTeams(prisma);
+
+    const internalReposWithoutProductionStatus = removeExternallyOwnedRepos(
+        reposWithNoStatus,
+        repoOwners,
+        externalTeams
     );
 
-    return repositories.map((repo) => repoToObligationResult(repo, owners));
+    return internalReposWithoutProductionStatus.map((repo) => repoToObligationResult(repo, repoOwners));
 
 }


### PR DESCRIPTION
## What does this change?

We have a table, called `guardian_non_p_and_e_github_teams`, that enumerates teams outside of the department. Repos owned by these teams are not required to use production statuses listed in `guardian_production_status`. This PR excludes repositories owned exclusively by external teams from this obligation

## Why?

Only teams inside P&E are required to use topics as a production status

## How has it been verified?

The new code has been unit tested. It has also been deployed to CODE, where we see a 30% reduction in repos breaking the rule