### PR TITLE
chore(deps): Update Galaxies CloudQuery plugin from 1.1.9 to 1.1.10

### DIFF
--- a/.env
+++ b/.env
@@ -23,7 +23,7 @@ CQ_GITHUB=11.11.1
 CQ_FASTLY=3.0.7
 
 # See https://github.com/guardian/cq-source-galaxies
-CQ_GUARDIAN_GALAXIES=1.1.9
+CQ_GUARDIAN_GALAXIES=1.1.10
 
 # See https://github.com/guardian/cq-source-github-languages
 CQ_GITHUB_LANGUAGES=0.0.7

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -14738,7 +14738,7 @@ spec:
   name: galaxies
   path: guardian/galaxies
   registry: github
-  version: v1.1.9
+  version: v1.1.10
   destinations:
     - postgresql
   tables:


### PR DESCRIPTION
## What does this change?
Updates Galaxies plugin for CloudQuery to 1.1.10, which includes various dependency updates. See https://github.com/guardian/cq-source-galaxies/releases/tag/v1.1.10.

## How to test?
After [deploying to CODE](https://riffraff.gutools.co.uk/deployment/view/5f3fe90b-fefc-488e-8225-eb467375a280), we can run the Galaxies task via:

```bash
npm -w cli start -- run-task --stage CODE --name Galaxies
```

We can then query the data in Grafana, observing [the `_cq_sync_time` column](https://metrics.code.dev-gutools.co.uk/goto/U1CznTrNg?orgId=1):

<img width="498" height="508" alt="image" src="https://github.com/user-attachments/assets/6346bd59-dcfd-4f17-a18e-c6cc7dee05b2" />
