### PR TITLE
Move to allow list for more control of tables collected, start with riffraff

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19921,7 +19921,8 @@ spec:
   destinations:
     - postgresql
   tables:
-    - riffraff_*
+    - riffraff_authorized_users
+    - riffraff_deploys
   skip_tables:
     - riffraff_deploy_logs
   spec:
@@ -20139,7 +20140,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('riffraff_%', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('riffraff_authorized_users', 86400000),('riffraff_deploys', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",

--- a/packages/cdk/lib/cloudquery/allow-list-tables/riffraff-table-list.ts
+++ b/packages/cdk/lib/cloudquery/allow-list-tables/riffraff-table-list.ts
@@ -1,0 +1,1 @@
+export const riffraffTables = ['riffraff_authorized_users', 'riffraff_deploys'];

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -1,4 +1,5 @@
 import { GuardianOrganisationalUnits } from '@guardian/private-infrastructure-config';
+import { riffraffTables } from './allow-list-tables/riffraff-table-list';
 import { Versions } from './versions';
 
 export type CloudqueryConfig = {
@@ -348,7 +349,7 @@ export function riffraffSourcesConfig(): CloudqueryConfig {
 			path: 'cloudquery/postgresql',
 			version: `v${Versions.CloudqueryPostgresSource}`,
 			destinations: ['postgresql'],
-			tables: ['riffraff_*'],
+			tables: riffraffTables,
 			skip_tables: ['riffraff_deploy_logs'],
 			spec: {
 				connection_string: [

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "test": "jest --detectOpenHandles --config ./jest.config.js --selectProjects cdk",
+    "test-update": "jest --detectOpenHandles --config ./jest.config.js --selectProjects cdk -u",
     "synth": "cdk synth --path-metadata false --version-reporting false",
     "build": "npm run synth",
     "diff:code": "cdk diff --path-metadata false --version-reporting false --profile deployTools ServiceCatalogue-CODE",


### PR DESCRIPTION
We decided to split the [move to allow list PR](https://github.com/guardian/service-catalogue/pull/1601) into smaller steps to be better able to check the impact of the changes

## What does this change?
Collect riffraff tables from an allow list instead of collecting list with a wildcard

## Why?
Cloudquery bills by row collected and frequently add new tables in updates so we want to move to an allow list based approach to manage the risk of collecting more tables than our allowance allows us to.

## How has it been verified?
