### PR TITLE
Revert "chore(deps): bump the prisma group with 2 updates"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4466,9 +4466,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.16.1.tgz",
-      "integrity": "sha512-QaBCOY29lLAxEFFJgBPyW3WInCW52fJeQTmWx/h6YsP5u0bwuqP51aP0uhqFvhK9DaZPwvai/M4tSDYLVE9vRg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.15.0.tgz",
+      "integrity": "sha512-wR2LXUbOH4cL/WToatI/Y2c7uzni76oNFND7+23ypLllBmIS8e3ZHhO+nud9iXSXKFt1SoM3fTZvHawg63emZw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4488,9 +4488,9 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.16.1.tgz",
-      "integrity": "sha512-sz3uxRPNL62QrJ0EYiujCFkIGZ3hg+9hgC1Ae1HjoYuj0BxCqHua4JNijYvYCrh9LlofZDZcRBX3tHBfLvAngA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.15.0.tgz",
+      "integrity": "sha512-KMEoec9b2u6zX0EbSEx/dRpx1oNLjqJEBZYyK0S3TTIbZ7GEGoVyGyFRk4C72+A38cuPLbfQGQvgOD+gBErKlA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4501,53 +4501,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.16.1.tgz",
-      "integrity": "sha512-RWv/VisW5vJE4cDRTuAHeVedtGoItXTnhuLHsSlJ9202QKz60uiXWywBlVcqXVq8bFeIZoCoWH+R1duZJPwqLw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.15.0.tgz",
+      "integrity": "sha512-y7cSeLuQmyt+A3hstAs6tsuAiVXSnw9T55ra77z0nbNkA8Lcq9rNcQg6PI00by/+WnE/aMRJ/W7sZWn2cgIy1g==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.16.1.tgz",
-      "integrity": "sha512-EOnEM5HlosPudBqbI+jipmaW/vQEaF0bKBo4gVkGabasINHR6RpC6h44fKZEqx4GD8CvH+einD2+b49DQrwrAg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.15.0.tgz",
+      "integrity": "sha512-opITiR5ddFJ1N2iqa7mkRlohCZqVSsHhRcc29QXeldMljOf4FSellLT0J5goVb64EzRTKcIDeIsJBgmilNcKxA==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.16.1",
-        "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
-        "@prisma/fetch-engine": "6.16.1",
-        "@prisma/get-platform": "6.16.1"
+        "@prisma/debug": "6.15.0",
+        "@prisma/engines-version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
+        "@prisma/fetch-engine": "6.15.0",
+        "@prisma/get-platform": "6.15.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43.tgz",
-      "integrity": "sha512-ThvlDaKIVrnrv97ujNFDYiQbeMQpLa0O86HFA2mNoip4mtFqM7U5GSz2ie1i2xByZtvPztJlNRgPsXGeM/kqAA==",
+      "version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb.tgz",
+      "integrity": "sha512-a/46aK5j6L3ePwilZYEgYDPrhBQ/n4gYjLxT5YncUTJJNRnTCVjPF86QdzUOLRdYjCLfhtZp9aum90W0J+trrg==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.16.1.tgz",
-      "integrity": "sha512-fl/PKQ8da5YTayw86WD3O9OmKJEM43gD3vANy2hS5S1CnfW2oPXk+Q03+gUWqcKK306QqhjjIHRFuTZ31WaosQ==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.15.0.tgz",
+      "integrity": "sha512-xcT5f6b+OWBq6vTUnRCc7qL+Im570CtwvgSj+0MTSGA1o9UDSKZ/WANvwtiRXdbYWECpyC3CukoG3A04VTAPHw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.16.1",
-        "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
-        "@prisma/get-platform": "6.16.1"
+        "@prisma/debug": "6.15.0",
+        "@prisma/engines-version": "6.15.0-5.85179d7826409ee107a6ba334b5e305ae3fba9fb",
+        "@prisma/get-platform": "6.15.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.16.1.tgz",
-      "integrity": "sha512-kUfg4vagBG7dnaGRcGd1c0ytQFcDj2SUABiuveIpL3bthFdTLI6PJeLEia6Q8Dgh+WhPdo0N2q0Fzjk63XTyaA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.15.0.tgz",
+      "integrity": "sha512-Jbb+Xbxyp05NSR1x2epabetHiXvpO8tdN2YNoWoA/ZsbYyxxu/CO/ROBauIFuMXs3Ti+W7N7SJtWsHGaWte9Rg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.16.1"
+        "@prisma/debug": "6.15.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -13156,15 +13156,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.16.1.tgz",
-      "integrity": "sha512-MFkMU0eaDDKAT4R/By2IA9oQmwLTxokqv2wegAErr9Rf+oIe7W2sYpE/Uxq0H2DliIR7vnV63PkC1bEwUtl98w==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.15.0.tgz",
+      "integrity": "sha512-E6RCgOt+kUVtjtZgLQDBJ6md2tDItLJNExwI0XJeBc1FKL+Vwb+ovxXxuok9r8oBgsOXBA33fGDuE/0qDdCWqQ==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.16.1",
-        "@prisma/engines": "6.16.1"
+        "@prisma/config": "6.15.0",
+        "@prisma/engines": "6.15.0"
       },
       "bin": {
         "prisma": "build/index.js"
@@ -15522,14 +15522,14 @@
         "@guardian/anghammarad": "^1.8.3",
         "@octokit/auth-app": "^8.1.0",
         "@octokit/graphql": "^9.0.1",
-        "@prisma/client": "^6.16.1",
+        "@prisma/client": "^6.15.0",
         "octokit": "^5.0.3",
         "octokit-plugin-create-pull-request": "^6.0.1"
       },
       "devDependencies": {
         "@octokit/types": "^14.1.0",
         "@types/aws-lambda": "^8.10.152",
-        "prisma": "^6.16.1"
+        "prisma": "^6.15.0"
       },
       "engines": {
         "node": ">=18"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,10 +19,10 @@
 		"@octokit/graphql": "^9.0.1",
 		"octokit": "^5.0.3",
 		"octokit-plugin-create-pull-request": "^6.0.1",
-		"@prisma/client": "^6.16.1"
+		"@prisma/client": "^6.15.0"
 	},
 	"devDependencies": {
-		"prisma": "^6.16.1",
+		"prisma": "^6.15.0",
 		"@octokit/types": "^14.1.0",
 		"@types/aws-lambda": "^8.10.152"
 	}


### PR DESCRIPTION
Reverts guardian/service-catalogue#1624 as the lambda artifact created in CI is now exceeding the AWS lambda file-size limit, with the latest [PROD deployment of `main`](https://riffraff.gutools.co.uk/deployment/view/63432a50-af6f-4485-90db-6befb4ad0e77) failing with:

> Unzipped size must be smaller than 262144000 bytes (Service: Lambda, Status Code: 400

This has [successfully deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/107666e1-aac5-4ea5-b4aa-8d7aeadc03a3).

Interestingly the size difference isn't that big, which suggest something else might trip the size limit soon. The table below shows the size of the zipped files.

| File | [`main`](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=deploy%3A%3Aservice-catalogue&id=7353) (bytes) | [This branch](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=deploy%3A%3Aservice-catalogue&id=7361) (bytes) |
|--------|--------|--------|
| cloudbuster/cloudbuster.zip | 95470431 | 94481830 |
| cloudquery-usage/cloudquery-usage.zip | 93796811 | 92808210 |
| data-audit/data-audit.zip | 93606826 | 92618225 |
| dependency-graph-integrator/dependency-graph-integrator.zip | 117876 | 117876 |
| github-actions-usage/github-actions-usage.zip | 93888264 | 92899663 | 
| interactive-monitor/interactive-monitor.zip | 3550751 | 3550751 | 
| obligatron/obligatron.zip | 93793053 | 92804452 | 
| prisma/prisma.zip | 83109 | 83109 | 
| refresh-materialized-view/refresh-materialized-view.zip | 93785101 | 92796500 | 
| repocop/repocop.zip | 95532674 | 94544073 | 