### PR TITLE
Indicate vulnerability scope

### DIFF
--- a/packages/common/prisma/migrations/20250922134600_repocop_vulns_update/migration.sql
+++ b/packages/common/prisma/migrations/20250922134600_repocop_vulns_update/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE repocop_vulnerabilities ADD COLUMN scope TEXT NOT NULL DEFAULT 'runtime';
+

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -676,6 +676,7 @@ model repocop_vulnerabilities {
   repo_owner       String
   id               String   @id @default(uuid())
   within_sla       Boolean
+  scope            String   @default("runtime")
 }
 
 /// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.

--- a/packages/common/src/types.test.ts
+++ b/packages/common/src/types.test.ts
@@ -1,0 +1,19 @@
+import assert from 'assert';
+import { describe, it } from 'node:test';
+import { chooseScope } from './types.js';
+
+void describe('chooseScope', () => {
+    void it('should return the correct scope for a valid input', () => {
+        assert.strictEqual(chooseScope('runtime'), 'runtime');
+        assert.strictEqual(chooseScope('development'), 'development');
+    });
+
+    void it('should return "runtime" for an invalid input', () => {
+        assert.strictEqual(chooseScope('unknown'), 'runtime');
+    });
+
+    void it('should return "runtime" for undefined input', () => {
+        assert.strictEqual(chooseScope(undefined), 'runtime');
+        assert.strictEqual(chooseScope(null), 'runtime');
+    });
+});

--- a/packages/common/src/types.test.ts
+++ b/packages/common/src/types.test.ts
@@ -3,17 +3,17 @@ import { describe, it } from 'node:test';
 import { chooseScope } from './types.js';
 
 void describe('chooseScope', () => {
-    void it('should return the correct scope for a valid input', () => {
-        assert.strictEqual(chooseScope('runtime'), 'runtime');
-        assert.strictEqual(chooseScope('development'), 'development');
-    });
+	void it('should return the correct scope for a valid input', () => {
+		assert.strictEqual(chooseScope('runtime'), 'runtime');
+		assert.strictEqual(chooseScope('development'), 'development');
+	});
 
-    void it('should return "runtime" for an invalid input', () => {
-        assert.strictEqual(chooseScope('unknown'), 'runtime');
-    });
+	void it('should return "runtime" for an invalid input', () => {
+		assert.strictEqual(chooseScope('unknown'), 'runtime');
+	});
 
-    void it('should return "runtime" for undefined input', () => {
-        assert.strictEqual(chooseScope(undefined), 'runtime');
-        assert.strictEqual(chooseScope(null), 'runtime');
-    });
+	void it('should return "runtime" for undefined input', () => {
+		assert.strictEqual(chooseScope(undefined), 'runtime');
+		assert.strictEqual(chooseScope(null), 'runtime');
+	});
 });

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -67,9 +67,10 @@ export type Severity = Lowercase<SecurityHubSeverity> | 'unknown';
 
 export type RepocopVulnerability = Omit<
 	repocop_vulnerabilities,
-	'id' | 'repo_owner' | 'severity'
+	'id' | 'repo_owner' | 'severity' | 'scope'
 > & {
 	severity: Severity;
+	scope: 'runtime' | 'development';
 };
 
 type RepositoryFields = Pick<

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -65,6 +65,17 @@ export interface ProjectId {
 
 export type Severity = Lowercase<SecurityHubSeverity> | 'unknown';
 
+export function chooseScope(
+	scope: string | null | undefined,
+): 'runtime' | 'development' {
+	if (scope === 'runtime' || scope === 'development') {
+		return scope;
+	} else {
+		console.log(`Unknown scope: ${scope}`);
+		return 'runtime'; // default to runtime if unknown
+	}
+}
+
 export type RepocopVulnerability = Omit<
 	repocop_vulnerabilities,
 	'id' | 'repo_owner' | 'severity' | 'scope'

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.test.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.test.ts
@@ -32,6 +32,7 @@ void describe('The dependency vulnerabilities obligation', () => {
 		repo_owner: 'owner1',
 		source: 'Dependabot',
 		within_sla: false,
+		scope: 'runtime',
 	};
 
 	void it('should return something if it finds a vulnerability on a repo', () => {

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -1,10 +1,11 @@
 import type { PrismaClient, repocop_vulnerabilities } from '@prisma/client';
 import { stringToSeverity, toNonEmptyArray } from 'common/src/functions.js';
 import { logger } from 'common/src/logs.js';
-import type {
-	NonEmptyArray,
-	RepocopVulnerability,
-	Repository,
+import {
+	chooseScope,
+	type NonEmptyArray,
+	type RepocopVulnerability,
+	type Repository,
 } from 'common/src/types.js';
 import type { ObligationResult } from './index.js';
 
@@ -18,6 +19,7 @@ function prismaToCustomType(
 	return {
 		...vuln,
 		severity: stringToSeverity(vuln.severity),
+		scope: chooseScope(vuln.scope as string | null | undefined), // This is safe as the type is string.
 	};
 }
 

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -19,7 +19,7 @@ function prismaToCustomType(
 	return {
 		...vuln,
 		severity: stringToSeverity(vuln.severity),
-		scope: chooseScope(vuln.scope as string | null | undefined), // This is safe as the type is string.
+		scope: chooseScope(vuln.scope as string | null | undefined), // This is safe as the type of vuln.scope is string.
 	};
 }
 

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -570,6 +570,7 @@ const oldCriticalDependabotVuln: RepocopVulnerability = {
 	is_patchable: true,
 	cves: ['CVE-2021-1234'],
 	within_sla: false,
+	scope: 'runtime',
 };
 
 const newCriticalDependabotVuln: RepocopVulnerability = {
@@ -652,6 +653,7 @@ void describe('NO RULE - Vulnerabilities from Dependabot', () => {
 			is_patchable: true,
 			cves: ['CVE-2018-6188'],
 			within_sla: false,
+			scope: 'runtime',
 		};
 
 		const expected2: RepocopVulnerability = {
@@ -670,6 +672,7 @@ void describe('NO RULE - Vulnerabilities from Dependabot', () => {
 			is_patchable: true,
 			cves: ['CVE-2021-20191'],
 			within_sla: false,
+			scope: 'runtime',
 		};
 
 		assert.deepStrictEqual(result, [expected1, expected2]);
@@ -695,6 +698,7 @@ void describe('Deduplication of repocop vulnerabilities', () => {
 		is_patchable: true,
 		cves: ['CVE-2018-6188'],
 		within_sla: false,
+		scope: 'runtime',
 	};
 	const vuln2: RepocopVulnerability = {
 		full_name: fullName,
@@ -708,6 +712,7 @@ void describe('Deduplication of repocop vulnerabilities', () => {
 		is_patchable: true,
 		cves: ['CVE-2018-6188'],
 		within_sla: false,
+		scope: 'runtime',
 	};
 	const actual = deduplicateVulnerabilitiesByCve([vuln1, vuln2]);
 	void test('Should happen if two vulnerabilities share the same CVEs', () => {

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -6,7 +6,7 @@ import type {
 	view_repo_ownership,
 } from '@prisma/client';
 import { isWithinSlaTime, partition } from 'common/src/functions.js';
-import { SLAs } from 'common/src/types.js';
+import { chooseScope, SLAs } from 'common/src/types.js';
 import type {
 	DepGraphLanguage,
 	RepocopVulnerability,

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -411,17 +411,6 @@ const urlSortPredicate = (maybeUrl: string) => {
 	}
 };
 
-function chooseScope(
-	scope: string | null | undefined,
-): 'runtime' | 'development' {
-	if (scope === 'runtime' || scope === 'development') {
-		return scope;
-	} else {
-		console.log(`Unknown scope: ${scope}`);
-		return 'runtime'; // default to runtime if unknown
-	}
-}
-
 export function dependabotAlertToRepocopVulnerability(
 	fullName: string,
 	alert: Alert,

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -411,6 +411,17 @@ const urlSortPredicate = (maybeUrl: string) => {
 	}
 };
 
+function chooseScope(
+	scope: string | null | undefined,
+): 'runtime' | 'development' {
+	if (scope === 'runtime' || scope === 'development') {
+		return scope;
+	} else {
+		console.log(`Unknown scope: ${scope}`);
+		return 'runtime'; // default to runtime if unknown
+	}
+}
+
 export function dependabotAlertToRepocopVulnerability(
 	fullName: string,
 	alert: Alert,
@@ -437,7 +448,7 @@ export function dependabotAlertToRepocopVulnerability(
 		is_patchable: !!alert.security_vulnerability.first_patched_version,
 		cves: CVEs,
 		within_sla: isWithinSlaTime(alertIssueDate, severity),
-		scope: alert.dependency.scope ?? 'runtime', //assume runtime if unknown
+		scope: chooseScope(alert.dependency.scope),
 	};
 }
 

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -437,6 +437,7 @@ export function dependabotAlertToRepocopVulnerability(
 		is_patchable: !!alert.security_vulnerability.first_patched_version,
 		cves: CVEs,
 		within_sla: isWithinSlaTime(alertIssueDate, severity),
+		scope: alert.dependency.scope ?? 'runtime', //assume runtime if unknown
 	};
 }
 

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -92,7 +92,14 @@ export async function main() {
 			octokit,
 		);
 
-	console.log(productionDependabotVulnerabilities);
+	const [runtimeVulns, devVulns] = partition(
+		productionDependabotVulnerabilities,
+		(vuln) => vuln.scope === 'runtime',
+	);
+
+	console.log(
+		`Found ${runtimeVulns.length} runtime vulnerabilities and ${devVulns.length} dev dependencies vulnerabilities in production repositories.`,
+	);
 
 	const productionWorkflowUsages: guardian_github_actions_usage[] =
 		await getProductionWorkflowUsages(prisma, productionRepos);
@@ -102,7 +109,7 @@ export async function main() {
 		branches,
 		repoOwners,
 		repoLanguages,
-		productionDependabotVulnerabilities,
+		runtimeVulns,
 		productionWorkflowUsages,
 	);
 

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -95,10 +95,7 @@ async function getAlertsForRepo(
 				direction: 'asc', //retrieve oldest vulnerabilities first
 			});
 
-		const openRuntimeDependencies = alert.data.filter(
-			(a) => a.dependency.scope !== 'development',
-		);
-		return openRuntimeDependencies;
+		return alert.data;
 	} catch (error) {
 		console.debug(
 			`Dependabot - ${repoName}: Could not get alerts. Dependabot may not be enabled.`,

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -84,6 +84,7 @@ const highRecentVuln: RepocopVulnerability = {
 	is_patchable: true,
 	cves: ['CVE-123'],
 	within_sla: true,
+	scope: 'runtime',
 };
 
 void describe('createDigest', () => {
@@ -155,6 +156,7 @@ void describe('createDigest', () => {
 			is_patchable: true,
 			cves: ['CVE-123'],
 			within_sla: true,
+			scope: 'runtime',
 		};
 		const anotherResultWithVuln: EvaluationResult = {
 			...anotherResult,

--- a/packages/repocop/src/utils.test.ts
+++ b/packages/repocop/src/utils.test.ts
@@ -40,6 +40,7 @@ void describe('vulnSortingPredicate', () => {
 			alert_issue_date: new Date(),
 			cves: [],
 			within_sla: true,
+			scope: 'runtime',
 		};
 		const criticalNotPatchable: RepocopVulnerability = {
 			...criticalPatchable,


### PR DESCRIPTION
## What does this change?

The first in a sequence of PRs to provide runtime dependencies to the repocop dashboard.

This PR:

- Adds a `scope` column to the repocop vulnerabilities table
- Partitions the vulnerabilities based on scope, rather than filtering them, so we can use the development vulnerabilities later

Technically, the `scope` value is optional, according to the Octokit API. In the (unusual) case the GitHub can't tell whether a dependency is runtime or development, the safest option is to assume that it _is_ being used at runtime, and include it in the SLA requirement as a precaution. This also keeps the data model a bit simpler for grafana purposes. If a new type of scope is created, repocop will start logging this.

## Why?

So the service catalogue can store and display information about dev vulnerabilities, even though we don't expect teams to actively keep on top of them

## How has it been verified?

The `partition` function has already been unit tested. I've deployed this to CODE and verified that the same number of vulns exists before and after deployment
