### PR TITLE
Increase frequency for cloudwatch table

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -5912,7 +5912,7 @@ spec:
     },
     "CloudquerySourceAwsOrgWideCloudwatchAlarmsScheduledEventRule443F1BD5": {
       "Properties": {
-        "ScheduleExpression": "cron(0 2 * * ? *)",
+        "ScheduleExpression": "rate(30 minutes)",
         "State": "ENABLED",
         "Targets": [
           {
@@ -6148,7 +6148,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_cloudwatch_alarms', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_cloudwatch_alarms', 1800000) ON CONFLICT (table_name) DO UPDATE SET frequency = 1800000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -259,7 +259,7 @@ export function addCloudqueryEcsCluster(
 			name: 'AwsOrgWideCloudwatchAlarms',
 			description:
 				'Collecting CloudWatch Alarm data across the organisation. Uses include building SLO dashboards.',
-			schedule: Schedule.cron({ minute: '0', hour: '2' }),
+			schedule: Schedule.rate(Duration.minutes(30)),
 			config: awsSourceConfigForOrganisation({
 				tables: ['aws_cloudwatch_alarms'],
 			}),


### PR DESCRIPTION
## What does this change?

This makes the scheduling of `aws_cloudwatch_alarms` match `aws_elbv1_load_balancers` and `aws_elbv2_load_balancers`.

## Why?

We get alerts for when a cloudwatch alarm references a non-existing LB. The frequency of the load balancer tables means we can detect when a LB disappears quite quickly, but detecting the fixed cloudwatch alarm only happens over night.

## How has it been verified?
I think this change is low risk from a code perspective, so I haven't validated it.

The question that worries me is if the increased row consumption is going to be a problem? The table currently has `3520` rows, so with this change I think it means 168,960 rows a day or ~5M/month?