### PR TITLE
Remove unused riffraff_authorized_users table

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19580,7 +19580,6 @@ spec:
   destinations:
     - postgresql
   tables:
-    - riffraff_authorized_users
     - riffraff_deploys
   skip_tables:
     - riffraff_deploy_logs
@@ -19795,7 +19794,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('riffraff_authorized_users', 86400000),('riffraff_deploys', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('riffraff_deploys', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",

--- a/packages/cdk/lib/cloudquery/allow-list-tables/riffraff-table-list.ts
+++ b/packages/cdk/lib/cloudquery/allow-list-tables/riffraff-table-list.ts
@@ -1,1 +1,1 @@
-export const riffraffTables = ['riffraff_authorized_users', 'riffraff_deploys'];
+export const riffraffTables = ['riffraff_deploys'];

--- a/packages/common/prisma/migrations/20250930121946_drop_riffraff_authorized_users_table/migration.sql
+++ b/packages/common/prisma/migrations/20250930121946_drop_riffraff_authorized_users_table/migration.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS riffraff_authorized_users;


### PR DESCRIPTION
## What does this change?

This PR removes the unused `riffraff_authorized_users` table and prevents further attempts to sync this table. As a follow-up to this, we'll also deploy https://github.com/guardian/riff-raff/pull/1475, which will remove the resources on the Riff-Raff side.

This table was originally added in https://github.com/guardian/riff-raff/pull/1273 and https://github.com/guardian/service-catalogue/pull/424.

## Why?

This list of users has been irrelevant since https://github.com/guardian/riff-raff/pull/1464 was merged, so there is no value in keeping this table in Service Catalogue.

We don't believe that this table was ever really used so there are no current plans to sync the up-to-date list of users to Service Catalogue as a replacement.

## How has it been verified?

Prior to deploying this branch to `CODE`, I confirmed that it was possible to query data in the `riffraff_authorized_users` table using Grafana's `CODE` environment (which is connected to `CODE` Service Catalogue)

I've [deployed this branch](https://riffraff.gutools.co.uk/deployment/view/c774035a-515a-4aef-a238-70588553621e) and the [logs show that the migration ran successfully](https://logs.gutools.co.uk/s/devx/app/r/s/7qjwr).

I've also confirmed that the table no longer exists using `CODE` Grafana:

<img width="710" height="299" alt="image" src="https://github.com/user-attachments/assets/d9d63d04-70f3-4695-b528-3d3295c4da90" />