### PR TITLE
Remove outdated docs

### DIFF
--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -1,8 +1,5 @@
 # Database Migrations
 
-> **Note**
-> The migration process is currently manual.
-
 ## What are they?
 
 Service Catalogue uses the [Prisma](https://www.prisma.io) ORM for database migrations,


### PR DESCRIPTION
The deployment process for migrations is now automated; see https://github.com/guardian/service-catalogue/pull/882 for more details.
