### PR TITLE
Group Dependabot GHA bumps into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,3 +42,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+    groups:
+      all:
+        patterns:
+          - '*'


### PR DESCRIPTION
## What does this change?
Should give us a single PR including all outstanding GHA upgrades.

## Why?
Easier to review.

## How has it been verified?
Will see what happens when it's merged.