### PR TITLE
Fix: update ignored languages

### DIFF
--- a/packages/repocop/src/languages.ts
+++ b/packages/repocop/src/languages.ts
@@ -26,6 +26,7 @@ export const ignoredLanguages = [
 	'Apex', // only runs inside Salesforce which manages its dependencies
 	'SaltStack', // OS-level dependencies
 	'RenderScript', // Rust files are being misattributed to this due to .rs extension
+	'ObjectScript', // Apex files are being misattributed to this due to the .cls extension
 ];
 
 const commonSupportedLanguages = [

--- a/packages/repocop/src/languages.ts
+++ b/packages/repocop/src/languages.ts
@@ -25,7 +25,7 @@ export const ignoredLanguages = [
 	'Awk', // interpreter, no dependencies
 	'Apex', // only runs inside Salesforce which manages its dependencies
 	'SaltStack', // OS-level dependencies
-	'Renderscript', // Rust files are mistaken for this due to .rs extension
+	'RenderScript', // Rust files are being misattributed to this due to .rs extension
 ];
 
 const commonSupportedLanguages = [


### PR DESCRIPTION
## What does this change?

Fixes a typo in RenderScript which is case-sensitive.
Adds ObjectScript to the ignore list.

## Why?
Repos were still being reported as not having vulnerability tracking based on these languages which should be ignored.

