### PR TITLE
chore(deps): Update CloudQuery plugins for NS1 and Galaxies

### DIFF
--- a/.env
+++ b/.env
@@ -23,7 +23,7 @@ CQ_GITHUB=11.11.1
 CQ_FASTLY=3.0.7
 
 # See https://github.com/guardian/cq-source-galaxies
-CQ_GUARDIAN_GALAXIES=1.1.10
+CQ_GUARDIAN_GALAXIES=1.1.11
 
 # See https://github.com/guardian/cq-source-github-languages
 CQ_GITHUB_LANGUAGES=0.0.7

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -14900,7 +14900,7 @@ spec:
   name: galaxies
   path: guardian/galaxies
   registry: github
-  version: v1.1.10
+  version: v1.1.11
   destinations:
     - postgresql
   tables:


### PR DESCRIPTION
## What does this change?
These updates include dependency updates. See:
- [NS1 v0.1.8](https://github.com/guardian/cq-source-ns1/releases/tag/v0.1.8)
- [Galaxies v1.1.11](https://github.com/guardian/cq-source-galaxies/releases/tag/v1.1.11)
