### PR TITLE
feat: Switch to enhanced container insights in PROD

### DIFF
--- a/packages/cdk/bin/cdk.ts
+++ b/packages/cdk/bin/cdk.ts
@@ -2,6 +2,7 @@ import 'source-map-support/register';
 import { RiffRaffYamlFile } from '@guardian/cdk/lib/riff-raff-yaml-file';
 import { App, Duration } from 'aws-cdk-lib';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
+import { ContainerInsights } from 'aws-cdk-lib/aws-ecs';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import type { ServiceCatalogueProps } from '../lib/service-catalogue';
 import { ServiceCatalogue } from '../lib/service-catalogue';
@@ -26,6 +27,7 @@ export const serviceCataloguePRODProperties: ServiceCatalogueProps = {
 	databaseMultiAz: true,
 	databaseInstanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.LARGE),
 	databaseEbsByteBalanceAlarm: true,
+	containerInsights: ContainerInsights.ENHANCED,
 };
 
 new ServiceCatalogue(
@@ -48,6 +50,7 @@ new ServiceCatalogue(app, 'ServiceCatalogue-CODE', {
 	databaseMultiAz: false,
 	databaseInstanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
 	databaseEbsByteBalanceAlarm: false,
+	containerInsights: ContainerInsights.DISABLED,
 });
 
 // Add an additional S3 deployment type and synth riff-raff.yaml

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -29074,7 +29074,7 @@ spec:
         "ClusterSettings": [
           {
             "Name": "containerInsights",
-            "Value": "enabled",
+            "Value": "enhanced",
           },
         ],
         "Tags": [

--- a/packages/cdk/lib/cloudquery/cluster.ts
+++ b/packages/cdk/lib/cloudquery/cluster.ts
@@ -147,8 +147,6 @@ interface CloudqueryClusterProps extends AppIdentity {
  * created in the private subnets of the VPC provided.
  */
 export class CloudqueryCluster extends Cluster {
-	//aws-cdk-lib.aws_ecs.ClusterProps#containerInsights is deprecated.
-	//moved to containerInsightsV2
 	constructor(scope: GuStack, id: string, props: CloudqueryClusterProps) {
 		super(scope, id, {
 			vpc: props.vpc,

--- a/packages/cdk/lib/cloudquery/cluster.ts
+++ b/packages/cdk/lib/cloudquery/cluster.ts
@@ -1,12 +1,8 @@
 import type { AppIdentity, GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
 import type { ISecurityGroup, IVpc } from 'aws-cdk-lib/aws-ec2';
-import {
-	Cluster,
-	ContainerInsights,
-	type RepositoryImage,
-	Secret,
-} from 'aws-cdk-lib/aws-ecs';
+import type { ContainerInsights } from 'aws-cdk-lib/aws-ecs';
+import { Cluster, type RepositoryImage, Secret } from 'aws-cdk-lib/aws-ecs';
 import type { Schedule } from 'aws-cdk-lib/aws-events';
 import type { IManagedPolicy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
@@ -140,6 +136,8 @@ interface CloudqueryClusterProps extends AppIdentity {
 	 * When false, the schedule will be disabled. Tasks will need to be run manually using the CLI.
 	 */
 	enableCloudquerySchedules: boolean;
+
+	containerInsights: ContainerInsights;
 }
 
 /**
@@ -151,7 +149,7 @@ export class CloudqueryCluster extends Cluster {
 		super(scope, id, {
 			vpc: props.vpc,
 			enableFargateCapacityProviders: true,
-			containerInsightsV2: ContainerInsights.ENABLED,
+			containerInsightsV2: props.containerInsights,
 		});
 
 		const {

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -5,6 +5,7 @@ import { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import { Duration } from 'aws-cdk-lib';
 import type { IVpc } from 'aws-cdk-lib/aws-ec2';
+import type { ContainerInsights } from 'aws-cdk-lib/aws-ecs';
 import { Secret } from 'aws-cdk-lib/aws-ecs';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import type { PolicyStatement } from 'aws-cdk-lib/aws-iam';
@@ -59,6 +60,8 @@ interface CloudqueryEcsClusterProps {
 	 * When false, the schedule will be disabled. Tasks will need to be run manually using the CLI.
 	 */
 	enableCloudquerySchedules: boolean;
+
+	containerInsights: ContainerInsights;
 }
 
 export function addCloudqueryEcsCluster(
@@ -75,6 +78,7 @@ export function addCloudqueryEcsCluster(
 		gitHubOrg: gitHubOrgName,
 		cloudqueryApiKey,
 		enableCloudquerySchedules,
+		containerInsights,
 	} = props;
 
 	const riffRaffDatabaseAccessSecurityGroupParam =
@@ -677,5 +681,6 @@ export function addCloudqueryEcsCluster(
 			endOfLifeSource,
 		],
 		cloudqueryApiKey,
+		containerInsights,
 	});
 }

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -24,6 +24,7 @@ import {
 } from 'aws-cdk-lib/aws-cloudwatch';
 import type { InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { Peer, Port } from 'aws-cdk-lib/aws-ec2';
+import type { ContainerInsights } from 'aws-cdk-lib/aws-ecs';
 import type { Schedule } from 'aws-cdk-lib/aws-events';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import type { DatabaseInstanceProps } from 'aws-cdk-lib/aws-rds';
@@ -118,6 +119,8 @@ export interface ServiceCatalogueProps extends GuStackProps {
 	 * Should the EBS byte balance metric of the database be monitored?
 	 */
 	databaseEbsByteBalanceAlarm: boolean;
+
+	containerInsights: ContainerInsights;
 }
 
 export class ServiceCatalogue extends GuStack {
@@ -135,6 +138,7 @@ export class ServiceCatalogue extends GuStack {
 			databaseMultiAz,
 			databaseInstanceType,
 			databaseEbsByteBalanceAlarm,
+			containerInsights,
 		} = props;
 
 		const alertTopicName = 'devx-sec-ops-reliability-alerts';
@@ -303,6 +307,7 @@ export class ServiceCatalogue extends GuStack {
 			logShippingPolicy,
 			gitHubOrg,
 			cloudqueryApiKey,
+			containerInsights,
 		});
 
 		addCloudqueryUsageLambda(this, {


### PR DESCRIPTION
## What does this change?
Enhanced monitoring in PROD should provide more information about performance, and help us right-size the containers.

See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-enhanced-observability-metrics-ECS.html.

To somewhat mitigate the increased cost, disable container insights in CODE.

## How has it been verified?
As this switches container insights off in CODE, we'll have to test in PROD. Alternatively we could have enhanced monitoring in CODE to see what it provides, and then switch it off in a follow-up PR.