### PR TITLE
feat!: Drop `guardian_non_p_and_e_github_teams` table 

### DIFF
--- a/packages/common/prisma/migrations/20260127091000_guardian_non_p_and_e_github_teams_view/migration.sql
+++ b/packages/common/prisma/migrations/20260127091000_guardian_non_p_and_e_github_teams_view/migration.sql
@@ -1,0 +1,4 @@
+-- @formatter:off -- this stops IntelliJ from reformatting the SQL
+BEGIN TRANSACTION;
+    DROP TABLE IF EXISTS guardian_non_p_and_e_github_teams;
+COMMIT TRANSACTION;

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -633,10 +633,6 @@ model cloudquery_table_frequency {
   frequency  BigInt
 }
 
-model guardian_non_p_and_e_github_teams {
-  team_name String @id
-}
-
 model guardian_production_status {
   status   String @id
   priority Int
@@ -1418,12 +1414,10 @@ view github_organization_tree {
 }
 
 view github_teams_tree {
-  id                         String?
-  org                        String?
-  slug                       String?
-  name                       String?
+  id                         String
+  org                        String
+  slug                       String
+  name                       String
   ancestors                  String[]
-  is_product_and_engineering Boolean?
-
-  @@ignore
+  is_product_and_engineering Boolean
 }

--- a/packages/obligatron/src/obligations/github-topics.ts
+++ b/packages/obligatron/src/obligations/github-topics.ts
@@ -31,8 +31,16 @@ export function repoToObligationResult(
 }
 
 const getExternalTeams = async (prisma: PrismaClient): Promise<string[]> => {
-	const teams = await prisma.guardian_non_p_and_e_github_teams.findMany();
-	return toNonEmptyArray(teams.map((t) => t.team_name));
+	const teams = await prisma.github_teams_tree.findMany({
+		select: {
+			slug: true,
+		},
+		where: {
+			is_product_and_engineering: false,
+		},
+	});
+
+	return toNonEmptyArray(teams.map((t) => t.slug));
 };
 
 // This function filters out repos that are owned exclusively by teams outsude of P&E.


### PR DESCRIPTION
## What does this change?
The contents of `guardian_non_p_and_e_github_teams` is manually maintained. This change removes it in favour of querying the `github_teams_tree` view introduced in https://github.com/guardian/service-catalogue/pull/1807.

Whilst this is a breaking change, there are no [dashboards using `guardian_non_p_and_e_github_teams`](https://metrics.gutools.co.uk/goto/vN9t4WNvR?orgId=1). That is, no comms are needed.

> [!NOTE]
> This change increases the number of teams [from 18 to 107](https://metrics.code.dev-gutools.co.uk/goto/8Qzs47NDg?orgId=1).

## How has it been verified?
TBD.