### PR TITLE
fix(migrations): make compatible with v17 postgres

### DIFF
--- a/packages/common/prisma/migrations/20240412103300_aws_resources/migration.sql
+++ b/packages/common/prisma/migrations/20240412103300_aws_resources/migration.sql
@@ -131,6 +131,7 @@ SET search_path FROM CURRENT;
 DROP INDEX IF EXISTS idx_aws_resources_account_id;
 DROP INDEX IF EXISTS idx_aws_resources_arn;
 DROP VIEW IF EXISTS aws_resources;
+DROP MATERIALIZED VIEW IF EXISTS aws_resources;
 CREATE MATERIALIZED VIEW aws_resources AS
 SELECT
     partition,

--- a/packages/common/prisma/migrations/20240412103300_aws_resources/migration.sql
+++ b/packages/common/prisma/migrations/20240412103300_aws_resources/migration.sql
@@ -5,8 +5,9 @@ DROP FUNCTION IF EXISTS aws_resources;
 
 -- Check if a table has a given column
 CREATE OR REPLACE FUNCTION table_has_column(table_to_check text, column_to_check text) RETURNS boolean AS $$
-    SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name = table_has_column.column_to_check AND table_name = table_has_column.table_to_check)
+    SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name = column_to_check AND table_name = table_to_check)
 $$ LANGUAGE SQL;
+SET search_path FROM CURRENT;
 
 -- Extract partition from ARN
 -- arn:PARTITION:service:region:account-id:resource-id
@@ -15,6 +16,7 @@ BEGIN
     RETURN SPLIT_PART(arn, ':', 2);
 END
 $$ LANGUAGE plpgsql;
+SET search_path FROM CURRENT;
 
 -- Extract service from ARN
 -- arn:partition:SERVICE:region:account-id:resource-id
@@ -23,6 +25,7 @@ BEGIN
     RETURN SPLIT_PART(arn, ':', 3);
 END
 $$ LANGUAGE plpgsql;
+SET search_path FROM CURRENT;
 
 -- Extract region from ARN
 -- arn:partition:service:REGION:account-id:resource-id
@@ -31,6 +34,8 @@ BEGIN
     RETURN SPLIT_PART(arn, ':', 4);
 END
 $$ LANGUAGE plpgsql;
+SET search_path FROM CURRENT;
+
 
 -- Extract account ID from ARN
 -- arn:partition:service:region:ACCOUNT-ID:resource-id
@@ -39,6 +44,7 @@ BEGIN
     RETURN SPLIT_PART(arn, ':', 5);
 END
 $$ LANGUAGE plpgsql;
+SET search_path FROM CURRENT;
 
 -- Extract resource type from ARN
 -- arn:partition:service:region:account-id:RESOURCE-TYPE/resource-id OR
@@ -49,6 +55,7 @@ BEGIN
                 ELSE SPLIT_PART(SPLIT_PART(arn, ':', 6), '/', 1) END;
 END
 $$ LANGUAGE plpgsql;
+SET search_path FROM CURRENT;
 
 -- Aggregate rows from all AWS Cloudquery tables
 CREATE OR REPLACE FUNCTION aws_resources_raw()
@@ -76,47 +83,50 @@ DECLARE
     taggable           text;
 BEGIN
     FOR cloudquery_table IN
-            -- Find all base tables (no views allowed)
-            SELECT DISTINCT table_name
-            FROM information_schema.tables
-            WHERE table_type = 'BASE TABLE'
-            -- find the intersection of tables that have an ARN column
-            INTERSECT
-            SELECT DISTINCT table_name
-            FROM information_schema.columns
-            WHERE table_name LIKE 'aws_%s'
-            and COLUMN_NAME IN ('arn')
+        -- Find all base tables (no views allowed) that look like aws_*
+        SELECT DISTINCT t.table_schema, t.table_name
+        FROM information_schema.tables t
+        WHERE t.table_type = 'BASE TABLE'
+          AND t.table_name LIKE 'aws_%'
+          AND EXISTS (
+            SELECT 1
+            FROM information_schema.columns c
+            WHERE c.table_schema = t.table_schema
+              AND c.table_name = t.table_name
+              AND c.column_name = 'arn'
+        )
         LOOP
             -- Check if table has an account_id column, or default to NULL
-            account_id := CASE WHEN table_has_column(cloudquery_table.table_name, 'account_id') THEN 'account_id' ELSE 'NULL' END;
+            account_id := CASE WHEN public.table_has_column(cloudquery_table.table_name::text, 'account_id') THEN 'account_id' ELSE 'NULL' END;
             -- Check if table has an owner_id column, or default to NULL
-            owner_id := CASE WHEN table_has_column(cloudquery_table.table_name, 'owner_id') THEN 'owner_id' ELSE 'NULL' END;
+            owner_id := CASE WHEN public.table_has_column(cloudquery_table.table_name::text, 'owner_id') THEN 'owner_id' ELSE 'NULL' END;
             -- Check if table has an request_account_id column, or default to NULL
-            request_account_id := CASE WHEN table_has_column(cloudquery_table.table_name, 'request_account_id') THEN 'request_account_id' ELSE 'NULL' END;
+            request_account_id := CASE WHEN public.table_has_column(cloudquery_table.table_name::text, 'request_account_id') THEN 'request_account_id' ELSE 'NULL' END;
             -- Check if table has an region column, or default to NULL
-            region := CASE WHEN table_has_column(cloudquery_table.table_name, 'region') THEN 'region' ELSE 'NULL' END;
+            region := CASE WHEN public.table_has_column(cloudquery_table.table_name::text, 'region') THEN 'region' ELSE 'NULL' END;
             -- Check if table has an tags column, or default to an empty object
-            taggable := CASE WHEN table_has_column(cloudquery_table.table_name, 'tags') THEN 'true' ELSE 'false' END;
+            taggable := CASE WHEN public.table_has_column(cloudquery_table.table_name::text, 'tags') THEN 'true' ELSE 'false' END;
             tags := CASE WHEN taggable = 'true' THEN 'tags' ELSE '''{}''::jsonb' END;
 
             -- Fetch rows of table and append to function output
             RETURN QUERY EXECUTE FORMAT(E'
                     SELECT
                         %L as cq_table,
-                        arn_to_partition(arn) as partition,
-                        arn_to_service(arn) as service,
-                        COALESCE(%s, arn_to_region(arn)) AS region,
-                        COALESCE(%s, %s, %s, arn_to_account_id(arn)) AS account_id,
-                        arn_to_resource_type(arn) as resource_type,
+                        public.arn_to_partition(arn) as partition,
+                        public.arn_to_service(arn) as service,
+                        COALESCE(%s, public.arn_to_region(arn)) AS region,
+                        COALESCE(%s, %s, %s, public.arn_to_account_id(arn)) AS account_id,
+                        public.arn_to_resource_type(arn) as resource_type,
                         arn,
                         %s as taggable,
                         %s as tags
-                    FROM %s',
-                    cloudquery_table.table_name, region, account_id, owner_id, request_account_id,
-                    taggable, tags, cloudquery_table.table_name);
+                    FROM %I.%I',
+                                        cloudquery_table.table_name, region, account_id, owner_id, request_account_id,
+                                        taggable, tags, cloudquery_table.table_schema, cloudquery_table.table_name);
         END LOOP;
 END
 $$ LANGUAGE plpgsql;
+SET search_path FROM CURRENT;
 
 DROP INDEX IF EXISTS idx_aws_resources_account_id;
 DROP INDEX IF EXISTS idx_aws_resources_arn;
@@ -131,7 +141,7 @@ SELECT
     arn,
     bool_or(taggable) as taggable,
     jsonb_aggregate(tags) as tags
-FROM aws_resources_raw()
+FROM public.aws_resources_raw()
 GROUP BY 
     partition,
     service,
@@ -139,6 +149,7 @@ GROUP BY
     account_id,
     resource_type,
     arn;
+SET search_path FROM CURRENT;
 
 CREATE INDEX idx_aws_resources_account_id ON aws_resources (account_id);
 CREATE INDEX idx_aws_resources_arn ON aws_resources (arn);
@@ -149,24 +160,24 @@ $$
 DECLARE
     arn text = 'arn:aws:iam:eu-west-1:123456789012:user/johndoe';
 BEGIN
-    CASE WHEN arn_to_partition(arn) <> 'aws'
-    THEN RAISE EXCEPTION 'expected aws, got %', arn_to_partition(arn);
+    CASE WHEN public.arn_to_partition(arn::text) <> 'aws'
+    THEN RAISE EXCEPTION 'expected aws, got %', public.arn_to_partition(arn::text);
     ELSE END CASE;
 
-    CASE WHEN arn_to_service(arn) <> 'iam'
-    THEN RAISE EXCEPTION 'expected iam, got %', arn_to_partition(arn);
+    CASE WHEN public.arn_to_service(arn) <> 'iam'
+    THEN RAISE EXCEPTION 'expected iam, got %', public.arn_to_partition(arn::text);
     ELSE END CASE;
 
-    CASE WHEN arn_to_region(arn) <> 'eu-west-1'
-    THEN RAISE EXCEPTION 'expected eu-west-1, got %', arn_to_region(arn);
+    CASE WHEN public.arn_to_region(arn) <> 'eu-west-1'
+    THEN RAISE EXCEPTION 'expected eu-west-1, got %', public.arn_to_region(arn);
     ELSE END CASE;
 
-    CASE WHEN arn_to_account_id(arn) <> '123456789012'
-    THEN RAISE EXCEPTION 'expected 123456789012, got %', arn_to_region(arn);
+    CASE WHEN public.arn_to_account_id(arn) <> '123456789012'
+    THEN RAISE EXCEPTION 'expected 123456789012, got %', public.arn_to_region(arn);
     ELSE END CASE;
 
-    CASE WHEN arn_to_resource_type(arn) <> 'user'
-    THEN RAISE EXCEPTION 'expected user, got %', arn_to_region(arn);
+    CASE WHEN public.arn_to_resource_type(arn) <> 'user'
+    THEN RAISE EXCEPTION 'expected user, got %', public.arn_to_region(arn);
     ELSE END CASE;
 
     CASE WHEN (SELECT jsonb_aggregate(a) FROM (VALUES ('{"TagA": "ValueA"}'::jsonb), ('{"TagB": "ValueB"}'::jsonb)) data(a)) <> '{"TagA": "ValueA", "TagB": "ValueB"}'

--- a/packages/common/prisma/migrations/20240614140600_dataaudit_user/migration.sql
+++ b/packages/common/prisma/migrations/20240614140600_dataaudit_user/migration.sql
@@ -24,6 +24,12 @@ $do$
         GRANT SELECT ON public.aws_accounts TO dataaudit;
 
         -- The dataaudit user owns this table, so can do full CRUD operations
-        GRANT ALL ON public.audit_results TO dataaudit;
+        IF EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = 'public' AND table_name = 'audit_results'
+        ) THEN
+            EXECUTE 'GRANT ALL ON public.audit_results TO dataaudit';
+        END IF;
     END
 $do$;

--- a/packages/common/prisma/migrations/20250204123000_frequency_milliseconds/migration.sql
+++ b/packages/common/prisma/migrations/20250204123000_frequency_milliseconds/migration.sql
@@ -18,7 +18,9 @@ UPDATE cloudquery_table_frequency SET frequency_milliseconds = CASE
     WHEN frequency = 'DAILY' THEN 86400000
     WHEN frequency = 'WEEKLY' THEN 604800000
     ELSE 0 -- this should never happen
-END;
+END
+-- intentional full-table update
+WHERE frequency IS NOT NULL;
 
 ALTER TABLE cloudquery_table_frequency ALTER COLUMN frequency_milliseconds SET NOT NULL;
 


### PR DESCRIPTION
## What does this change?

Updates existing migrations to allow for upgrade from postgres v16 to v17.

## Why has this change been made?

Currently, we cannot upgrade to v17 of postgres because breaking changes have been made to the migrations.

## Why was this approach chosen?

Modifying existing migrations, while not ideal, is the only way to apply the patches that works in CI.

Release notes: https://www.postgresql.org/docs/release/17.0/, in particular:
- Change functions to use a safe [search_path](https://www.postgresql.org/docs/17/runtime-config-client.html#GUC-SEARCH-PATH) during maintenance operations (Jeff Davis) [§](https://postgr.es/c/2af07e2f7) [§](https://postgr.es/c/b4da732fd64)
- Remove server variable old_snapshot_threshold (Thomas Munro) [§](https://postgr.es/c/f691f5b80) 

## How has it been verified?

- [x] Ran the cli migrate command on the CODE DB successfully. 
- [x] Deployed to CODE and observed the prisma migrate task complete successfully. 
- [x] Deployed `main` to CODE to ensure the prisma migrate task still completes successfully.