### PR TITLE
Move prisma generated code to own directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Created by https://www.toptal.com/developers/gitignore/api/node,macos,intellij,visualstudiocode,go
 # Edit at https://www.toptal.com/developers/gitignore?templates=node,macos,intellij,visualstudiocode,go
 
-packages/common/src/prisma-client
+packages/common/prisma-client
 ### Go ###
 # If you prefer the allow list template instead of the deny list, see community template:
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,7 @@ import eslintPluginUnicorn from 'eslint-plugin-unicorn';
 
 export default [
 	{
-		ignores: ['**/*/dist/**', 'packages/common/src/prisma-client/**'],
+		ignores: ['**/*/dist/**', 'packages/common/prisma-client/**'],
 	},
 	...guardian.configs.recommended,
 	...guardian.configs.jest,

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider        = "prisma-client"
-  output          = "../src/prisma-client"
+  output          = "../prisma-client"
   previewFeatures = ["views"]
   binaryTargets   = ["native", "linux-arm64-openssl-3.0.x"]
 }

--- a/packages/common/src/prisma-client-setup.ts
+++ b/packages/common/src/prisma-client-setup.ts
@@ -1,6 +1,6 @@
 import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from 'common/prisma-client/client.js';
 import type { PrismaConfig } from 'common/src/database-setup.js';
-import { PrismaClient } from 'common/src/prisma-client/client.js';
 
 export function getPrismaClient(config: PrismaConfig): PrismaClient {
 	const adapter = new PrismaPg({

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "prisma.config.ts"],
+  "include": ["src", "prisma-client", "prisma.config.ts"],
   "compilerOptions": {
     "target": "ES2023",
     "module": "ESNext",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,18 @@
 {
-  "extends": "@guardian/tsconfig/tsconfig.json",
-  "compilerOptions": {
-    "esModuleInterop": true,
-    "baseUrl": ".",
-    "paths": {
-      "common": ["packages/common/src"],
-      "common/*": ["packages/common/src/*"],
-      "cloudquery-tables": ["packages/cloudquery-tables/src"],
-      "cloudquery-tables/*": ["packages/cloudquery-tables/src/*"]
-    },
-    "skipLibCheck": true,
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-  }
+	"extends": "@guardian/tsconfig/tsconfig.json",
+	"compilerOptions": {
+		"esModuleInterop": true,
+		"baseUrl": ".",
+		"paths": {
+			"common": ["packages/common/src"],
+			"common/*": ["packages/common/src/*"],
+			"common/prisma-client": ["packages/common/prisma-client"],
+			"common/prisma-client/*": ["packages/common/prisma-client/*"],
+			"cloudquery-tables": ["packages/cloudquery-tables/src"],
+			"cloudquery-tables/*": ["packages/cloudquery-tables/src/*"]
+		},
+		"skipLibCheck": true,
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext"
+	}
 }


### PR DESCRIPTION
## What does this change?

Moves generated prisma code out of src, and into its own directory

## Why has this change been made?

To split hand-written and generated code.

## How has it been verified?

- [x] deploy to CODE and test lambdas
- [x] verify CLI tool still works