### PR TITLE
fix: update prisma in migrate container to match

### DIFF
--- a/containers/prisma-migrate/Dockerfile
+++ b/containers/prisma-migrate/Dockerfile
@@ -10,7 +10,7 @@ RUN apk --no-cache add aws-cli
 # This will allow us to use the prisma migrate deploy command
 RUN npm init -y
 # TODO: Keep the version automatically in sync with common/package.json
-RUN npm install prisma@5.11.0
+RUN npm install prisma@7.3.0
 
 COPY ./run-prisma-migrate.sh /usr/src/app/run-prisma-migrate.sh
 RUN chmod +x /usr/src/app/run-prisma-migrate.sh

--- a/containers/prisma-migrate/Dockerfile
+++ b/containers/prisma-migrate/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.11.1-alpine
+FROM node:22.17.0-alpine
 
 WORKDIR /usr/src/app
 

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -26481,7 +26481,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/prisma-migrate:stable",
+            "Image": "ghcr.io/guardian/service-catalogue/prisma-migrate:sha256:883595fbd03a69689cb41b726a1b4e92a4c85ec3a04655e698941800dcefa9bb",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -26481,7 +26481,7 @@ spec:
               },
             ],
             "Essential": true,
-            "Image": "ghcr.io/guardian/service-catalogue/prisma-migrate:sha256:883595fbd03a69689cb41b726a1b4e92a4c85ec3a04655e698941800dcefa9bb",
+            "Image": "ghcr.io/guardian/service-catalogue/prisma-migrate:sha-2646d0b70ed6ffa24b504b0912403b99e4e0a3c8",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {

--- a/packages/cdk/lib/cloudquery/images.ts
+++ b/packages/cdk/lib/cloudquery/images.ts
@@ -25,7 +25,7 @@ export const Images = {
 	 * 	https://github.com/guardian/service-catalogue/pkgs/container/service-catalogue%2Fprisma-migrate
 	 */
 	prismaMigrate: ContainerImage.fromRegistry(
-		'ghcr.io/guardian/service-catalogue/prisma-migrate:stable',
+		'ghcr.io/guardian/service-catalogue/prisma-migrate:sha256:883595fbd03a69689cb41b726a1b4e92a4c85ec3a04655e698941800dcefa9bb',
 	),
 	otelCollector: ContainerImage.fromRegistry(
 		'public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0',

--- a/packages/cdk/lib/cloudquery/images.ts
+++ b/packages/cdk/lib/cloudquery/images.ts
@@ -25,7 +25,7 @@ export const Images = {
 	 * 	https://github.com/guardian/service-catalogue/pkgs/container/service-catalogue%2Fprisma-migrate
 	 */
 	prismaMigrate: ContainerImage.fromRegistry(
-		'ghcr.io/guardian/service-catalogue/prisma-migrate:sha256:883595fbd03a69689cb41b726a1b4e92a4c85ec3a04655e698941800dcefa9bb',
+		'ghcr.io/guardian/service-catalogue/prisma-migrate:sha-2646d0b70ed6ffa24b504b0912403b99e4e0a3c8',
 	),
 	otelCollector: ContainerImage.fromRegistry(
 		'public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0',


### PR DESCRIPTION
## What does this change?

Updates prisma to v7 to match the recent upgrade.
