### PR TITLE
No longer ignore CDK depenedencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,6 @@ updates:
       interval: 'monthly'
     cooldown:
       default-days: 7
-    ignore:
-      # The version of AWS CDK libraries must match those from @guardian/cdk.
-      # We'd never be able to update them here independently, so just ignore them.
-      - dependency-name: 'aws-cdk'
-      - dependency-name: 'aws-cdk-lib'
-      - dependency-name: 'constructs'
-
     groups:
       aws-sdk:
         patterns:


### PR DESCRIPTION
## What does this change?

Allows dependabot to bump cdk

## Why has this change been made?

We no longer have to do dependency matching in the way we used to to make the update work