### PR TITLE
fix: update prisma version to match client

### DIFF
--- a/containers/prisma-migrate/Dockerfile
+++ b/containers/prisma-migrate/Dockerfile
@@ -10,7 +10,7 @@ RUN apk --no-cache add aws-cli
 # This will allow us to use the prisma migrate deploy command
 RUN npm init -y
 # TODO: Keep the version automatically in sync with common/package.json
-RUN npm install prisma@5.11.0
+RUN npm install prisma@7.6.0
 
 COPY ./run-prisma-migrate.sh /usr/src/app/run-prisma-migrate.sh
 RUN chmod +x /usr/src/app/run-prisma-migrate.sh

--- a/containers/prisma-migrate/Dockerfile
+++ b/containers/prisma-migrate/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.11.1-alpine
+FROM node:20.20.2-alpine
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## What does this change?

Updates the version of prisma in the prisma-migrate task to the same version as used in `packages/common`.

## Why has this change been made?

The prisma-migrate task is currently broken.

## Why was this approach chosen?

This is a quick fix while we look at migrating to a lambda  (see #1883 ) or find a way to keep the versions synced across ecs and the prisma client. 

## How has it been verified?
