### PR TITLE
Upgrade node version from 20 to 22

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -22417,7 +22417,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",
@@ -22751,7 +22751,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",
@@ -23164,7 +23164,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",
@@ -23894,7 +23894,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",
@@ -24318,7 +24318,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",
@@ -24785,7 +24785,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",
@@ -25420,7 +25420,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",
@@ -25743,7 +25743,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",
@@ -28663,7 +28663,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",

--- a/packages/cdk/lib/cloudbuster.ts
+++ b/packages/cdk/lib/cloudbuster.ts
@@ -41,7 +41,7 @@ export class CloudBuster {
 			app,
 			vpc,
 			architecture: Architecture.ARM_64,
-			runtime: Runtime.NODEJS_20_X,
+			runtime: Runtime.NODEJS_22_X,
 			securityGroups: [dbAccess],
 			fileName: `${app}.zip`,
 			handler: 'index.main',

--- a/packages/cdk/lib/cloudquery-usage.ts
+++ b/packages/cdk/lib/cloudquery-usage.ts
@@ -29,7 +29,7 @@ export function addCloudqueryUsageLambda(
 		handler: 'index.main',
 		monitoringConfiguration: { noMonitoring: true },
 		architecture: Architecture.ARM_64,
-		runtime: Runtime.NODEJS_20_X,
+		runtime: Runtime.NODEJS_22_X,
 		securityGroups: [dbAccess],
 		environment: {
 			DATABASE_HOSTNAME: db.dbInstanceEndpointAddress,

--- a/packages/cdk/lib/data-audit.ts
+++ b/packages/cdk/lib/data-audit.ts
@@ -76,7 +76,7 @@ export function addDataAuditLambda(scope: GuStack, props: DataAuditProps) {
 				schedule: Schedule.rate(Duration.days(1)),
 			},
 		],
-		runtime: Runtime.NODEJS_20_X,
+		runtime: Runtime.NODEJS_22_X,
 		timeout: Duration.minutes(10),
 	});
 

--- a/packages/cdk/lib/github-actions-usage.ts
+++ b/packages/cdk/lib/github-actions-usage.ts
@@ -35,7 +35,7 @@ export function addGithubActionsUsageLambda(
 			QUERY_LOGGING: 'false', // Set this to 'true' to enable SQL query logging
 			NODE_EXTRA_CA_CERTS: '/var/runtime/ca-cert.pem',
 		},
-		runtime: Runtime.NODEJS_20_X,
+		runtime: Runtime.NODEJS_22_X,
 		timeout: Duration.minutes(10),
 	});
 

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -26,7 +26,7 @@ export class InteractiveMonitor {
 			architecture: Architecture.ARM_64,
 			fileName: `${service}.zip`,
 			handler: 'index.handler',
-			runtime: Runtime.NODEJS_20_X,
+			runtime: Runtime.NODEJS_22_X,
 			environment: {
 				ANGHAMMARAD_SNS_ARN: anghammaradTopic.topicArn,
 				GITHUB_APP_SECRET: githubCredentials.secretName,

--- a/packages/cdk/lib/obligatron.ts
+++ b/packages/cdk/lib/obligatron.ts
@@ -24,7 +24,7 @@ export class Obligatron {
 			app,
 			vpc,
 			architecture: Architecture.ARM_64,
-			runtime: Runtime.NODEJS_20_X,
+			runtime: Runtime.NODEJS_22_X,
 			securityGroups: [dbAccess],
 			fileName: `${app}.zip`,
 			handler: 'index.main',

--- a/packages/cdk/lib/refresh-materialized-view.ts
+++ b/packages/cdk/lib/refresh-materialized-view.ts
@@ -35,7 +35,7 @@ export function addRefreshMaterializedViewLambda(
 			QUERY_LOGGING: 'false', // Set this to 'true' to enable SQL query logging
 			NODE_EXTRA_CA_CERTS: '/var/runtime/ca-cert.pem',
 		},
-		runtime: Runtime.NODEJS_20_X,
+		runtime: Runtime.NODEJS_22_X,
 		timeout: Duration.minutes(10),
 	});
 

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -48,7 +48,7 @@ export class Repocop {
 			memorySize: 2048,
 			monitoringConfiguration,
 			rules: [{ schedule }],
-			runtime: Runtime.NODEJS_20_X,
+			runtime: Runtime.NODEJS_22_X,
 			environment: {
 				ANGHAMMARAD_SNS_ARN: anghammaradTopic.topicArn,
 				DATABASE_HOSTNAME: cloudqueryDB.dbInstanceEndpointAddress,
@@ -117,7 +117,7 @@ function stageAwareIntegratorLambda(
 		fileName: `${app}.zip`,
 		handler: 'index.handler',
 		memorySize: 1024,
-		runtime: Runtime.NODEJS_20_X,
+		runtime: Runtime.NODEJS_22_X,
 		vpc,
 		timeout: Duration.minutes(5),
 		environment: {


### PR DESCRIPTION
## What does this change?

Upgrade Lambdas using nodejs20.x to 22.

## Why has this change been made?

We should upgrade Lambdas using nodejs20.x before AWS blocks updates to functions which use the nodejs20.x runtime (Jul 1, 2026). At this point using this runtime becomes risky because deploying these applications will no longer be possible. This means that:

We cannot fix bugs or reliability issues affecting users

We will find it much harder to meet other security obligations, such as [fixing critical dependency vulnerabilities within 2 days](https://docs.google.com/document/d/1Q_ts5mbRvASCGo3UfsPHwUVvSXc3f2fkK2Fwp6N9Pxc/edit?tab=t.0#bookmark=id.vogwkng6po4g)

We lose our ability to rollback to the old runtime if the app behaves unexpectedly after an attempted upgrade

