### PR TITLE
Rename dependabot group from all to gh-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,6 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      all:
+      gh-actions:
         patterns:
           - '*'


### PR DESCRIPTION
I think the name `all` is misleading, as when I see it pop up, I assume it bumps all dependencies, not just GHA related ones, so I've renamed it
