### PR TITLE
fix: get the ECS container running on Prisma v7

### DIFF
--- a/containers/prisma-migrate/Dockerfile
+++ b/containers/prisma-migrate/Dockerfile
@@ -6,14 +6,10 @@ WORKDIR /usr/src/app
 # This is used to fetch the prisma directory from S3
 RUN apk --no-cache add aws-cli
 
-# Install the Prisma NPM package
-# This will allow us to use the prisma migrate deploy command
-RUN npm init -y
-# TODO: Keep the version automatically in sync with common/package.json
-RUN npm install prisma@7.6.0
-
 COPY ./run-prisma-migrate.sh /usr/src/app/run-prisma-migrate.sh
 RUN chmod +x /usr/src/app/run-prisma-migrate.sh
+
+COPY ./prisma.config.ts /usr/src/app/prisma.config.ts
 
 # The default entrypoint for the node image is `node ...`
 # Switch it back here so we can run a .sh script

--- a/containers/prisma-migrate/prisma.config.ts
+++ b/containers/prisma-migrate/prisma.config.ts
@@ -1,0 +1,9 @@
+import path from 'node:path';
+import { defineConfig } from 'prisma/config';
+
+export default defineConfig({
+	schema: path.join('prisma', 'schema.prisma'),
+	datasource: {
+		url: process.env.DATABASE_URL as string,
+	},
+});

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -58,6 +58,11 @@ createPrismaZip() {
     cd "$ROOT_DIR/packages/common"
     zip -qr prisma.zip ./prisma
   )
+  echo "Adding Prisma CLI to prisma zip"
+  (
+    cd "$ROOT_DIR"
+    zip -qr "$ROOT_DIR/packages/common/prisma.zip" node_modules/prisma node_modules/@prisma
+  )
 }
 
 verify() {


### PR DESCRIPTION
## What does this change?

Updates the Prisma migration container and build process:
* removes the direct installation of Prisma in the Dockerfile
* bundles the Prisma CLI with the schema during packaging
* removes the installation of the Prisma NPM package from the `prisma-migrate` Dockerfile
* adds a new `prisma.config.ts` file that defines the Prisma schema location and datasource URL using env vars
* updates the `build.sh` script to include the Prisma CLI 

## Why has this change been made?

This addresses two issues. 

1. the migration task currently fails with `Error: The datasource.url property is required in your Prisma config file when using prisma migrate deploy.`
2. The Dockerfile required its own version of Prisma which would have to be kept up-to-date manually and could easily fall out of sync with the version used on the database.

## Why was this approach chosen?

This is one of two approachs to solving this issue. The other is to migrate the task to a lambda: #1883 

## How has it been verified?

Build the container locally and ran it against a test db. 

Before: 
`Error: The datasource.url property is required in your Prisma config file when using prisma migrate deploy.`

After:
`All migrations have been successfully applied.`