### PR TITLE
fix: Use a writable directory for prisma migrate ECS task

### DIFF
--- a/containers/prisma-migrate/prisma.config.ts
+++ b/containers/prisma-migrate/prisma.config.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { defineConfig } from 'prisma/config';
 
 export default defineConfig({
-	schema: path.join('prisma', 'schema.prisma'),
+	schema: path.join('prisma', 'prisma', 'schema.prisma'),
 	datasource: {
 		url: process.env.DATABASE_URL as string,
 	},

--- a/containers/prisma-migrate/run-prisma-migrate.sh
+++ b/containers/prisma-migrate/run-prisma-migrate.sh
@@ -11,10 +11,11 @@ echo 'Retrieving Prisma artifact from S3'
 aws s3 cp "s3://$ARTIFACT_BUCKET/$PRISMA_ARTIFACT_KEY" "${ARTIFACT_FILE}"
 
 echo 'Unzipping Prisma artifact'
-unzip -q "${ARTIFACT_FILE}"
+unzip -q "${ARTIFACT_FILE}" -d "${ROOT_DIR}/prisma"
+
 
 DB_PORT=5432
 export DATABASE_URL=postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/postgres
 
 echo 'Running prisma migrate deploy'
-"${ROOT_DIR}/node_modules/.bin/prisma" migrate deploy
+"${ROOT_DIR}/prisma/node_modules/.bin/prisma" migrate deploy


### PR DESCRIPTION
## What does this change?

* Modifies the unzip command in `run-prisma-migrate.sh` to extract the Prisma artifact into the `prisma` subdirectory within the root directory so that it is not read-only.
* Changes the path to the Prisma CLI binary in `run-prisma-migrate.sh` to use the one located in `prisma/node_modules/.bin/prisma`, matching the new directory structure.
* Updates the schema path in `prisma.config.ts` to point to the correct path.

## Why has this change been made?

When the last PR was merged, the log showed: `unzip: can't create directory 'node_modules': Read-only file system`. This is the attempt to fix the issue and allow the prisma migrations to be applied.

## How has it been verified?

Checked the updated paths locally.