### PR TITLE
fix: include prisma binary in ECS migrate task

### DIFF
--- a/containers/prisma-migrate/run-prisma-migrate.sh
+++ b/containers/prisma-migrate/run-prisma-migrate.sh
@@ -18,4 +18,4 @@ DB_PORT=5432
 export DATABASE_URL=postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/postgres
 
 echo 'Running prisma migrate deploy'
-"${ROOT_DIR}/prisma/node_modules/.bin/prisma" migrate deploy
+"${ROOT_DIR}/prisma/node_modules/.bin/prisma" migrate deploy --config "${ROOT_DIR}/prisma.config.ts"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -61,7 +61,7 @@ createPrismaZip() {
   echo "Adding Prisma CLI to prisma zip"
   (
     cd "$ROOT_DIR"
-    zip -qr "$ROOT_DIR/packages/common/prisma.zip" node_modules/prisma node_modules/@prisma
+    zip -qr "$ROOT_DIR/packages/common/prisma.zip" node_modules/prisma node_modules/@prisma node_modules/.bin/prisma
   )
 }
 


### PR DESCRIPTION
## What does this change?

* Modifies the `build.sh` script to include the `prisma` CLI binary  in the `prisma.zip`. 
* Also updates the migrate script to explicitly pass the prisma config when running `prisma migrate deploy`.

## Why has this change been made?

To fix the error on the last run which was `/usr/src/app/prisma/node_modules/.bin/prisma: not found`.

## How has it been verified?

Built the zip locally and confirmed that the binary was present after the change (and not before).