### PR TITLE
fix: Update prisma migrate command to use the correct binary path

### DIFF
--- a/containers/prisma-migrate/run-prisma-migrate.sh
+++ b/containers/prisma-migrate/run-prisma-migrate.sh
@@ -18,4 +18,4 @@ DB_PORT=5432
 export DATABASE_URL=postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/postgres
 
 echo 'Running prisma migrate deploy'
-"${ROOT_DIR}/prisma/node_modules/prisma/build/index.js" migrate deploy --config "${ROOT_DIR}/prisma.config.ts"
+node "${ROOT_DIR}/prisma/node_modules/prisma/build/index.js" migrate deploy --config "${ROOT_DIR}/prisma.config.ts"

--- a/containers/prisma-migrate/run-prisma-migrate.sh
+++ b/containers/prisma-migrate/run-prisma-migrate.sh
@@ -18,4 +18,4 @@ DB_PORT=5432
 export DATABASE_URL=postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/postgres
 
 echo 'Running prisma migrate deploy'
-"${ROOT_DIR}/prisma/node_modules/.bin/prisma" migrate deploy --config "${ROOT_DIR}/prisma.config.ts"
+"${ROOT_DIR}/prisma/node_modules/prisma/build/index.js" migrate deploy --config "${ROOT_DIR}/prisma.config.ts"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -61,7 +61,7 @@ createPrismaZip() {
   echo "Adding Prisma CLI to prisma zip"
   (
     cd "$ROOT_DIR"
-    zip -qr "$ROOT_DIR/packages/common/prisma.zip" node_modules/prisma node_modules/@prisma node_modules/.bin/prisma
+    zip -qr "$ROOT_DIR/packages/common/prisma.zip" node_modules/prisma node_modules/@prisma
   )
 }
 


### PR DESCRIPTION
## What does this change?

* Changes the command in `run-prisma-migrate.sh` to use `prisma/build/index.js` for running `migrate deploy` instead of the CLI binary.

## Why has this change been made?

To fix the error in the last run: `Error: ENOENT: no such file or directory, open '/usr/src/app/prisma/node_modules/.bin/prisma_schema_build_bg.wasm'`
