### PR TITLE
fix: include all prisma dependencies in ECS migrate container

### DIFF
--- a/containers/prisma-migrate/run-prisma-migrate.sh
+++ b/containers/prisma-migrate/run-prisma-migrate.sh
@@ -16,6 +16,8 @@ unzip -q "${ARTIFACT_FILE}" -d "${ROOT_DIR}/prisma"
 
 DB_PORT=5432
 export DATABASE_URL=postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/postgres
+export NODE_PATH="${ROOT_DIR}/prisma/node_modules"
+
 
 echo 'Running prisma migrate deploy'
 node "${ROOT_DIR}/prisma/node_modules/prisma/build/index.js" migrate deploy --config "${ROOT_DIR}/prisma.config.ts"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -54,15 +54,34 @@ createZip() {
 
 createPrismaZip() {
   echo "Creating zip of Prisma files"
+  
+  TEMP_DIR=$(mktemp -d)
+  
+  # Copy prisma schema
+  cp -r "$ROOT_DIR/packages/common/prisma" "$TEMP_DIR/prisma"
+  
+  # Create a minimal package.json and install prisma deps
+  cat > "$TEMP_DIR/package.json" <<EOF
+{
+  "dependencies": {
+    "prisma": "$(node -e "console.log(require('./node_modules/prisma/package.json').version)")",
+    "@prisma/client": "$(node -e "console.log(require('./node_modules/@prisma/client/package.json').version)")"
+  }
+}
+EOF
+
   (
-    cd "$ROOT_DIR/packages/common"
-    zip -qr prisma.zip ./prisma
+    cd "$TEMP_DIR"
+    npm install --omit=dev --quiet
   )
-  echo "Adding Prisma CLI to prisma zip"
+  
+  # Zip everything
   (
-    cd "$ROOT_DIR"
-    zip -qr "$ROOT_DIR/packages/common/prisma.zip" node_modules/prisma node_modules/@prisma
+    cd "$TEMP_DIR"
+    zip -qr "$ROOT_DIR/packages/common/prisma.zip" .
   )
+  
+  rm -rf "$TEMP_DIR"
 }
 
 verify() {


### PR DESCRIPTION
## What does this change?

* Refactors the `createPrismaZip` function to build a temporary directory containing the Prisma schema and a minimal `package.json`, install only production Prisma dependencies, and package everything into the zip artifact. This ensures all necessary files and dependencies are included for deployment.
* Adds export of the `NODE_PATH` environment variable to point to the Prisma artifact’s `node_modules`, ensuring Node.js can resolve Prisma dependencies during migration.

## Why has this change been made?

To fix errors with this task.

## How has it been verified?

I ran before and after using a local container, local db and local prisma.zip, deleting node_modules (and prisma.zip) between runs. I replicated the original error, then there was another error about finding the local config file, and when this was fixed, the migrations ran successfully. 