### PR TITLE
chore(deps): Update CQ source for Galaxies from 2.1.6 to 2.1.7

### DIFF
--- a/.env
+++ b/.env
@@ -23,7 +23,7 @@ CQ_GITHUB=14.2.0
 CQ_FASTLY=4.10.3
 
 # See https://github.com/guardian/cq-source-galaxies
-CQ_GUARDIAN_GALAXIES=2.1.6
+CQ_GUARDIAN_GALAXIES=2.1.7
 
 # See https://github.com/guardian/cq-source-github-languages
 CQ_GITHUB_LANGUAGES=0.0.7

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -15758,7 +15758,7 @@ spec:
   name: galaxies
   path: guardian/galaxies
   registry: github
-  version: v2.1.6
+  version: v2.1.7
   destinations:
     - postgresql
   tables:


### PR DESCRIPTION
## What does this change?
Updates the CQ Galaxies plugin. This version includes dependency updates. See https://github.com/guardian/cq-source-galaxies/releases/tag/v2.1.7.