### PR TITLE
Group non-breaking npm updates not included in other dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,12 @@ updates:
       grafana:
         patterns:
           - '@grafana/*'
+      nonbreaking-npm:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION

## What does this change?

Adds a further group to npm dependabot updates, grouping all minor and patch versions not covered by previous groups

## Why has this change been made?

Reducing PR overhead
