### PR TITLE
Update node to version 22 in github-action-usage lambda

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -23164,7 +23164,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",

--- a/packages/cdk/lib/github-actions-usage.ts
+++ b/packages/cdk/lib/github-actions-usage.ts
@@ -35,7 +35,7 @@ export function addGithubActionsUsageLambda(
 			QUERY_LOGGING: 'false', // Set this to 'true' to enable SQL query logging
 			NODE_EXTRA_CA_CERTS: '/var/runtime/ca-cert.pem',
 		},
-		runtime: Runtime.NODEJS_20_X,
+		runtime: Runtime.NODEJS_22_X,
 		timeout: Duration.minutes(10),
 	});
 

--- a/packages/github-actions-usage/README.md
+++ b/packages/github-actions-usage/README.md
@@ -14,7 +14,7 @@ This app, deployed as an AWS Lambda, tracks which GitHub Actions are in use acro
 
 ## Querying the data
 
-The Lambda writes to the [`github_actions_usage` table](../common/prisma/migrations/20240222201635_guardian_github_actions_usage/migration.sql).
+The Lambda writes to the [`guardian_github_actions_usage` table](../common/prisma/migrations/20240222201635_guardian_github_actions_usage/migration.sql).
 
 The [`view_github_actions` SQL view](../common/prisma/migrations/20240222201635_guardian_github_actions_usage/migration.sql) also exists
 to make it easier to query the data.

--- a/packages/github-actions-usage/package.json
+++ b/packages/github-actions-usage/package.json
@@ -5,7 +5,7 @@
     "test": "node --import tsx --test \"**/*.test.ts\"",
     "start": "APP=github-actions-usage tsx src/run-locally.ts",
     "prebuild": "rm -rf dist",
-    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@prisma/client --external:prisma  --format=esm --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node22 --outdir=dist --external:@prisma/client --external:prisma  --format=esm --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
 		"postbuild": "cp package.json dist/package.json",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## What does this change?

Upgrade Lambdas using nodejs20.x to 22.

## Why has this change been made?

We should upgrade Lambdas using nodejs20.x before AWS blocks updates to functions which use the nodejs20.x runtime (Jul 1, 2026). At this point using this runtime becomes risky because deploying these applications will no longer be possible. This means that:

We cannot fix bugs or reliability issues affecting users

We will find it much harder to meet other security obligations, such as [fixing critical dependency vulnerabilities within 2 days](https://docs.google.com/document/d/1Q_ts5mbRvASCGo3UfsPHwUVvSXc3f2fkK2Fwp6N9Pxc/edit?tab=t.0#bookmark=id.vogwkng6po4g)

We lose our ability to rollback to the old runtime if the app behaves unexpectedly after an attempted upgrade

## How has it been verified?

- Deployed to code
- Checked guardian_github_actions_usage table evaluated_on 2026-03-10
- ran lambda
-  guardian_github_actions_usage table evaluated_on now 2026-04-22, same number of rows as before
- checked metrics, Duration went up from 13.8K Milliseconds to 25.45K Milliseconds (but since that is roughly the time it takes on PROD and the last run was a month ago, decided this is fine

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214114050146834