### PR TITLE
Update node to version 24 for refresh materialized view lambda

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -24254,7 +24254,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs24.x",
         "Tags": [
           {
             "Key": "App",

--- a/packages/cdk/lib/refresh-materialized-view.ts
+++ b/packages/cdk/lib/refresh-materialized-view.ts
@@ -35,7 +35,7 @@ export function addRefreshMaterializedViewLambda(
 			QUERY_LOGGING: 'false', // Set this to 'true' to enable SQL query logging
 			NODE_EXTRA_CA_CERTS: '/var/runtime/ca-cert.pem',
 		},
-		runtime: Runtime.NODEJS_20_X,
+		runtime: Runtime.NODEJS_24_X,
 		timeout: Duration.minutes(10),
 	});
 

--- a/packages/refresh-materialized-view/package.json
+++ b/packages/refresh-materialized-view/package.json
@@ -5,7 +5,7 @@
     "test": "echo \"Error: no test specified\"",
     "start": "APP=refresh-materialized-view tsx src/run-locally.ts",
     "prebuild": "rm -rf dist",
-		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@prisma/client --external:prisma  --format=esm --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
+		"build": "esbuild src/index.ts --bundle --platform=node --target=node24 --outdir=dist --external:@prisma/client --external:prisma  --format=esm --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
 		"postbuild": "cp package.json dist/package.json",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## What does this change?

Upgrade Lambda using nodejs20.x to 24.

## Why has this change been made?

See first such [Upgrade](https://github.com/guardian/service-catalogue/pull/1912) 

## How has this been tested

Locally: 

Started local environment
Created materialized view with
`npm -w refresh-materialized-view start`
Deleted resource relating to first entry
Refreshed materialized view and confirmed change

On Code:
Deployed this branch to CODE
`npm -w cli start run-task -- --stage CODE --name AwsListOrgs`
View the logs of this lambda

<img width="1824" height="738" alt="Screenshot 2026-05-05 at 16 23 36" src="https://github.com/user-attachments/assets/3eaa26b5-f15f-4f63-a994-ed8076ca8a39" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214192791416722