### PR TITLE
chore: Remove stage from developer policy friendly name

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -24147,7 +24147,7 @@ spec:
     },
     "ServiceCatalogueCliPolicy7789F330": {
       "Properties": {
-        "Description": "Service Catalogue CLI PROD",
+        "Description": "Service Catalogue CLI",
         "Path": "/developer-policy/guardian/service-catalogue/deploy/PROD/service-catalogue-cli/",
         "PolicyDocument": {
           "Statement": [

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -772,7 +772,7 @@ export function addCloudqueryEcsCluster(
 
 	const cliPolicyProps: GuDeveloperPolicyExperimentalProps = {
 		grantId: 'service-catalogue-cli',
-		friendlyName: `Service Catalogue CLI ${stage}`,
+		friendlyName: 'Service Catalogue CLI',
 		statements: [
 			SSMPolicy,
 			dbSecretPolicy,


### PR DESCRIPTION
## What does this change?
It removes the stage name suffix from the friendly name of the developer policy.

## Why has this change been made?
Now that the UI shows the deployment stage separately, it's redundant to include it in the policy friendly name.
