### PR TITLE
specify a GH api version in all requests

### DIFF
--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -1,8 +1,8 @@
 import { SecretsManager } from '@aws-sdk/client-secrets-manager';
 import type { Action } from '@guardian/anghammarad';
 import { createAppAuth } from '@octokit/auth-app';
+import { Octokit } from '@octokit/core';
 import type { SNSEvent } from 'aws-lambda';
-import { Octokit } from 'octokit';
 import {
 	type GitHubAppConfig,
 	type GithubAppSecret,
@@ -12,6 +12,12 @@ import {
 } from 'common/src/types.js';
 /* eslint-disable @typescript-eslint/no-unsafe-assignment  -- this is not unsafe */
 /* eslint-disable @typescript-eslint/no-unsafe-call  -- this is not unsafe */
+
+const apiVersion = '2022-11-28';
+const ServiceCatalogueOctokit = Octokit.defaults({
+	headers: { 'X-GitHub-Api-Version': apiVersion },
+});
+
 export async function getGithubClient(
 	githubAppConfig: GitHubAppConfig,
 ): Promise<Octokit> {
@@ -22,10 +28,25 @@ export async function getGithubClient(
 		installationId: githubAppConfig.installationId,
 	});
 
-	const octokit: Octokit = new Octokit({
+	const octokit = new ServiceCatalogueOctokit({
 		auth: installationAuthentication.token,
 	});
+
 	return octokit;
+}
+
+export async function stageAwareOctokit(stage: string): Promise<Octokit> {
+	if (stage === 'CODE' || stage === 'PROD') {
+		const githubAppConfig: GitHubAppConfig = await getGitHubAppConfig();
+		const octokit: Octokit = await getGithubClient(githubAppConfig);
+		return octokit;
+	} else {
+		const token = getEnvOrThrow('GITHUB_ACCESS_TOKEN');
+
+		new ServiceCatalogueOctokit({
+			auth: token,
+		});
+	}
 }
 
 export function getEnvOrThrow(key: string): string {
@@ -64,18 +85,6 @@ export async function getGitHubAppConfig(): Promise<GitHubAppConfig> {
 	const secretString = await getGithubAppSecret();
 	const githubAppConfig = parseSecretJson(secretString);
 	return githubAppConfig;
-}
-
-export async function stageAwareOctokit(stage: string): Promise<Octokit> {
-	if (stage === 'CODE' || stage === 'PROD') {
-		const githubAppConfig: GitHubAppConfig = await getGitHubAppConfig();
-		const octokit: Octokit = await getGithubClient(githubAppConfig);
-		return octokit;
-	} else {
-		const token = getEnvOrThrow('GITHUB_ACCESS_TOKEN');
-
-		return new Octokit({ auth: token });
-	}
 }
 
 export function parseEvent<T>(event: SNSEvent): T[] {

--- a/packages/common/src/projects-graphql.ts
+++ b/packages/common/src/projects-graphql.ts
@@ -40,16 +40,12 @@ export function addToProjectQuery(
 	  }`;
 }
 
-/* eslint-disable @typescript-eslint/no-unsafe-assignment  -- this is not unsafe */
-/* eslint-disable @typescript-eslint/no-unsafe-call  -- this is not unsafe */
-
 export async function addPrToProject(
 	stage: string,
 	shortRepoName: string,
 	boardNumber: number,
 	author: string,
 ) {
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access  -- this is not unsafe
 	const graphqlWithAuth = (await stageAwareOctokit(stage)).graphql;
 
 	const projectDetails: ProjectId = await graphqlWithAuth(
@@ -78,5 +74,3 @@ export async function addPrToProject(
 		}),
 	);
 }
-/* eslint-enable @typescript-eslint/no-unsafe-assignment */
-/* eslint-enable @typescript-eslint/no-unsafe-call */

--- a/packages/dependency-graph-integrator/src/repo-functions.ts
+++ b/packages/dependency-graph-integrator/src/repo-functions.ts
@@ -1,8 +1,6 @@
 import type { Octokit } from 'octokit';
 import type { StatusCode } from './types.js';
 
-const ghHeaders = { 'X-GitHub-Api-Version': '2022-11-28' };
-
 export async function enableDependabotAlerts(
 	repo: string,
 	octokit: Octokit,
@@ -14,7 +12,6 @@ export async function enableDependabotAlerts(
 		{
 			owner,
 			repo,
-			headers: ghHeaders,
 		},
 	);
 	return enableResponse.status;


### PR DESCRIPTION
## What does this change?

Explicitly sets the GitHub API version in all requests

## Why has this change been made?

In the interactive monitor logs, I spotted the following

```
[@octokit/request] "GET https://api.github.com/repos/<ORG>/<REPO>/contents/<FILE>" is deprecated.
It is scheduled to be removed on Fri, 10 Mar 2028 00:00:00 GMT.
See https://docs.github.com/en/rest/about-the-rest-api/api-versions
```
From what I can tell, this refers to GitHub's API version `2022-11-28`. They recently released `2026-03-10`, which we should migrate to at some point in the future. To make the migration easier, I've set the API version explicitly in Octokit, preserving the [current behaviour](Requests without the X-GitHub-Api-Version header will default to use the 2022-11-28 version.) of using the 2022 API (we can then override it in subsequent requests if we wish).

## Why was this approach chosen?

Setting the API version now means we get deterministic behaviour, and will not be surprised when the default API version switches. We can test this migration in our own time

## How has it been verified?

TODO: deploy and test all lambdas that call the GH API in CODE