### PR TITLE
Update interactive monitor lambda to node version 22

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -25483,7 +25483,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",

--- a/packages/cdk/lib/interactive-monitor.ts
+++ b/packages/cdk/lib/interactive-monitor.ts
@@ -26,7 +26,7 @@ export class InteractiveMonitor {
 			architecture: Architecture.ARM_64,
 			fileName: `${service}.zip`,
 			handler: 'index.handler',
-			runtime: Runtime.NODEJS_20_X,
+			runtime: Runtime.NODEJS_22_X,
 			environment: {
 				ANGHAMMARAD_SNS_ARN: anghammaradTopic.topicArn,
 				GITHUB_APP_SECRET: githubCredentials.secretName,

--- a/packages/interactive-monitor/package.json
+++ b/packages/interactive-monitor/package.json
@@ -5,7 +5,7 @@
 	"description": "A lambda which applies branch protection to repos that are passed to it via an SQS topic",
 	"exports": "./index.ts",
 	"scripts": {
-		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@aws-sdk",
+		"build": "esbuild src/index.ts --bundle --platform=node --target=node22 --outdir=dist --external:@aws-sdk",
 		"test": "node --import tsx --test \"**/*.test.ts\"",
 		"start": "APP=interactive-monitor tsx src/run-locally.ts",
 		"typecheck": "tsc --noEmit"


### PR DESCRIPTION
## What does this change?

Upgrade Lambda using nodejs20.x to 22.

## Why has this change been made?

See first [upgrade of a lambda](https://github.com/guardian/service-catalogue/pull/1893)

## How has it been verified?

- Deployed to CODE
- Started repocop
- Checked logs
- Checked logs for interactive monitor
- All looked fine

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214136814237959