### PR TITLE
Update the cloudquery usage lambda to node version 22

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -23037,7 +23037,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",

--- a/packages/cdk/lib/cloudquery-usage.ts
+++ b/packages/cdk/lib/cloudquery-usage.ts
@@ -29,7 +29,7 @@ export function addCloudqueryUsageLambda(
 		handler: 'index.main',
 		monitoringConfiguration: { noMonitoring: true },
 		architecture: Architecture.ARM_64,
-		runtime: Runtime.NODEJS_20_X,
+		runtime: Runtime.NODEJS_22_X,
 		securityGroups: [dbAccess],
 		environment: {
 			DATABASE_HOSTNAME: db.dbInstanceEndpointAddress,

--- a/packages/cloudquery-usage/README.md
+++ b/packages/cloudquery-usage/README.md
@@ -1,5 +1,6 @@
 # CloudQuery Usage
 Tracks the number of rows collected with [CloudQuery plugin, per day](https://api-docs.cloudquery.io/#tag/teams/operation/GetGroupedTeamUsageSummary).
+The resulting table `cloudquery_plugin_usage` powers the Grafana dashboard CloudQuery paid usage.
 
 By default, yesterday's data is collected. To customise this, set the `START_DATE` and `END_DATE` environment variables.
 

--- a/packages/cloudquery-usage/package.json
+++ b/packages/cloudquery-usage/package.json
@@ -5,7 +5,7 @@
     "test": "node --import tsx --test \"**/*.test.ts\"",
     "start": "APP=cloudquery-usage tsx src/run-locally.ts",
     "prebuild": "rm -rf dist",
-		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@prisma/client --external:prisma  --format=esm --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
+		"build": "esbuild src/index.ts --bundle --platform=node --target=node22 --outdir=dist --external:@prisma/client --external:prisma  --format=esm --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
 		"postbuild": "cp package.json dist/package.json",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## What does this change?

Upgrade Lambda using nodejs20.x to 22.

## Why has this change been made?

See first such [Upgrade](https://github.com/guardian/service-catalogue/pull/1912) 

## How can this be tested


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214114330377302