### PR TITLE
Update data-audit lambda to note version 22

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -23383,7 +23383,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",

--- a/packages/cdk/lib/data-audit.ts
+++ b/packages/cdk/lib/data-audit.ts
@@ -76,7 +76,7 @@ export function addDataAuditLambda(scope: GuStack, props: DataAuditProps) {
 				schedule: Schedule.rate(Duration.days(1)),
 			},
 		],
-		runtime: Runtime.NODEJS_20_X,
+		runtime: Runtime.NODEJS_22_X,
 		timeout: Duration.minutes(10),
 	});
 

--- a/packages/data-audit/README.md
+++ b/packages/data-audit/README.md
@@ -1,4 +1,5 @@
 # Data Audit
+Writes to table `audit_results`.
 
 ## Logs
 The logs can be [found in Central ELK](<https://logs.gutools.co.uk/s/devx/app/discover#/?_g=(filters:!((query:(match_phrase:(stack:'deploy'))),(query:(match_phrase:(app:'data-audit')))))&_a=(columns:!(stage,message))>).

--- a/packages/data-audit/package.json
+++ b/packages/data-audit/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\"",
     "start": "APP=data-audit tsx src/run-locally.ts",
     "prebuild": "rm -rf dist",
-		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@aws-sdk --external:@prisma/client --external:prisma  --format=esm --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
+		"build": "esbuild src/index.ts --bundle --platform=node --target=node22 --outdir=dist --external:@aws-sdk --external:@prisma/client --external:prisma  --format=esm --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
 		"postbuild": "cp package.json dist/package.json",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## What does this change?

Upgrade Lambda using nodejs20.x to 22.

## Why has this change been made?

See first such [Upgrade](https://github.com/guardian/service-catalogue/pull/1912) 

## How can this be tested
Run in CODE (failed)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214114330421843