### PR TITLE
fix: AWS credentials validation in migration test script

### DIFF
--- a/packages/dev-environment/script/start-prisma-migrate-test
+++ b/packages/dev-environment/script/start-prisma-migrate-test
@@ -17,10 +17,12 @@ step() {
 
 check_aws_credentials() {
   step "Checking AWS credentials"
-
   STATUS=$(aws sts get-caller-identity --profile deployTools 2>&1 || true)
   if [[ ${STATUS} =~ (ExpiredToken) ]]; then
     echo "Credentials for the deployTools profile have expired. Please fetch new credentials, and run this script again."
+    exit 1
+  elif [[ ${STATUS} =~ (InvalidClientTokenId) ]]; then
+    echo "Credentials for the deployTools profile are invalid. Please fetch new credentials, and run this script again."
     exit 1
   elif [[ ${STATUS} =~ ("could not be found") ]]; then
     echo "Credentials for the deployTools profile are missing. Please fetch some, and run this script again."


### PR DESCRIPTION
## What does this change?

Adds another condition to the AWS credentials check function for the `InvalidClientTokenId` case to the prisma migration test script.

## Why has this change been made?

When I ran the script locally before fetching credentials, the container failed to start but I got the message "AWS credentials are valid" in the terminal output, which was confusing. When I echoed out the status, it was clear that it was an `InvalidClientTokenId` error.

## How has it been verified?

I ran the script again and observed the error message being output.