### PR TITLE
fix: add volume for prisma engine and add writeable mount point

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -27034,6 +27034,11 @@ spec:
                 "ReadOnly": false,
                 "SourceVolume": "artifact-volume",
               },
+              {
+                "ContainerPath": "/tmp",
+                "ReadOnly": false,
+                "SourceVolume": "engine-volume",
+              },
             ],
             "Name": "prisma-migrate-taskContainer",
             "ReadonlyRootFilesystem": true,
@@ -27134,6 +27139,9 @@ spec:
           },
           {
             "Name": "artifact-volume",
+          },
+          {
+            "Name": "engine-volume",
           },
         ],
       },

--- a/packages/cdk/lib/prisma-migrate-task.ts
+++ b/packages/cdk/lib/prisma-migrate-task.ts
@@ -160,13 +160,24 @@ export function addPrismaMigrateTask(
 	const prismaArtifactVolume: Volume = {
 		name: 'artifact-volume',
 	};
+	const prismaEngineVolume: Volume = {
+		name: 'engine-volume',
+	};
 
 	taskDefinition.addVolume(prismaArtifactVolume);
+	taskDefinition.addVolume(prismaEngineVolume);
 
 	prismaTask.addMountPoints({
 		// So that we can download the prisma.zip from the artifact bucket
 		containerPath: '/usr/src/app/prisma',
 		sourceVolume: prismaArtifactVolume.name,
+		readOnly: false,
+	});
+
+	prismaTask.addMountPoints({
+		// So that we can write Prisma engine binary at runtime
+		containerPath: '/tmp',
+		sourceVolume: prismaEngineVolume.name,
 		readOnly: false,
 	});
 


### PR DESCRIPTION
## What does this change?

* Adds a new prisma binary volume to the `addPrismaMigrateTask` task definition.

* Mounts the new `engine-volume` at `/tmp` in the container, allowing the Prisma engine binary to be written at runtime.

## Why has this change been made?

Currently the migration container doesn't work - it fails with the error: `Error: EROFS: read-only file system, mkdir '/tmp/xxx'`

## How has it been verified?

I first recreated the error locally by making the test container (`/packages/dev-environment/docker-compose-prisma-migrate.yaml`) read-only, then mirrored the fix as below and observed the migrations running successfully.
```read_only: true
    tmpfs:
      - /usr/src/app/prisma:exec
      - /tmp
```

I have not committed these changes to the test container, but maybe they should be added, to keep the two more in line. WDYT? 