### PR TITLE
chore: Update CloudQuery GitHub source plugin from 14.2.0 to 15.2.0

### DIFF
--- a/.env
+++ b/.env
@@ -17,7 +17,7 @@ CQ_POSTGRES_SOURCE=3.0.7
 CQ_AWS=32.47.1
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/github/versions
-CQ_GITHUB=14.2.0
+CQ_GITHUB=15.2.0
 
 # See https://hub.cloudquery.io/plugins/source/cloudquery/fastly/versions
 CQ_FASTLY=4.10.3

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -17195,7 +17195,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v14.2.0
+  version: v15.2.0
   tables:
     - github_issues
   skip_dependent_tables: true
@@ -18440,7 +18440,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v14.2.0
+  version: v15.2.0
   tables:
     - github_releases
   skip_dependent_tables: true
@@ -19197,7 +19197,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v14.2.0
+  version: v15.2.0
   tables:
     - github_repositories
     - github_repository_branches
@@ -19960,7 +19960,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v14.2.0
+  version: v15.2.0
   tables:
     - github_secret_scanning_alerts
   skip_dependent_tables: true
@@ -20718,7 +20718,7 @@ spec:
 spec:
   name: github
   path: cloudquery/github
-  version: v14.2.0
+  version: v15.2.0
   tables:
     - github_organization_members
     - github_organizations

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -134,7 +134,7 @@ describe('Config generation, and converting to YAML', () => {
 		spec:
 		  name: github
 		  path: cloudquery/github
-		  version: v14.2.0
+		  version: v15.2.0
 		  tables:
 		    - github_repositories
 		  skip_dependent_tables: true


### PR DESCRIPTION
## What does this change?
Updates the CloudQuery GitHub source plugin. Whilst there are [breaking changes in this version](https://www.cloudquery.io/hub/plugins/source/cloudquery/github/v15.0.0/versions), we're not [collecting](https://github.com/guardian/service-catalogue/blob/010d068964ef63ae5572ce24f574484e08f021ba/packages/cloudquery-tables/src/github.ts#L1-L20) any impacted tables. That is, this is a no-op.

This change enables https://github.com/guardian/service-catalogue/pull/1928.