### PR TITLE
Upversion node for obligatron

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -26576,7 +26576,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs22.x",
         "Tags": [
           {
             "Key": "App",

--- a/packages/cdk/lib/obligatron.ts
+++ b/packages/cdk/lib/obligatron.ts
@@ -24,7 +24,7 @@ export class Obligatron {
 			app,
 			vpc,
 			architecture: Architecture.ARM_64,
-			runtime: Runtime.NODEJS_20_X,
+			runtime: Runtime.NODEJS_22_X,
 			securityGroups: [dbAccess],
 			fileName: `${app}.zip`,
 			handler: 'index.main',


### PR DESCRIPTION
## What does this change?

This change upversions node.

Node is currently specified at 22 in .nvmrc, which applies to the entire repo, and 22 in obligatron in this PR, and  interactive-monitor and github-actions-usage.  The remainder are all 20.

We should discuss if everything should be upversioned in one go

## Why has this change been made?

<!-- A statement of the problem this PR is solving. Please include a reference to any relevant issues or discussions. Don't link directly to chats or tickets, as these are ephemeral. -->

## Why was this approach chosen?

<!-- If the change is non-trivial, please discuss why this approach was chosen over alternatives, and any trade-offs considered. If it's very large, consider an ADR instead. -->

## How has it been verified?
