### PR TITLE
fix: bundle package.json into dist for dependency graph integrator

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -25244,7 +25244,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs24.x",
         "Tags": [
           {
             "Key": "App",

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -117,7 +117,7 @@ function stageAwareIntegratorLambda(
 		fileName: `${app}.zip`,
 		handler: 'index.handler',
 		memorySize: 1024,
-		runtime: Runtime.NODEJS_20_X,
+		runtime: Runtime.NODEJS_24_X,
 		vpc,
 		timeout: Duration.minutes(5),
 		environment: {

--- a/packages/dependency-graph-integrator/package.json
+++ b/packages/dependency-graph-integrator/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"copy-templates": "cp ../../.github/workflows/template_dep_submission_gradle.yaml src/template_dep_submission_gradle.yaml && cp ../../.github/workflows/template_dep_submission_sbt.yaml src/template_dep_submission_sbt.yaml",
 		"copy-templates:dist": "cp ../../.github/workflows/template_dep_submission_gradle.yaml dist/template_dep_submission_gradle.yaml && cp ../../.github/workflows/template_dep_submission_sbt.yaml dist/template_dep_submission_sbt.yaml",
-		"build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20  --outdir=dist --external:@aws-sdk --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\" && npm run copy-templates:dist",
+		"build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node24  --outdir=dist --external:@aws-sdk --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\" && npm run copy-templates:dist",
 		"postbuild": "cp package.json dist/package.json",
 		"prestart": "npm run copy-templates",
 		"start": "tsx src/run-locally.ts",

--- a/packages/dependency-graph-integrator/package.json
+++ b/packages/dependency-graph-integrator/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"copy-templates": "cp ../../.github/workflows/template_dep_submission_gradle.yaml src/template_dep_submission_gradle.yaml && cp ../../.github/workflows/template_dep_submission_sbt.yaml src/template_dep_submission_sbt.yaml",
 		"copy-templates:dist": "cp ../../.github/workflows/template_dep_submission_gradle.yaml dist/template_dep_submission_gradle.yaml && cp ../../.github/workflows/template_dep_submission_sbt.yaml dist/template_dep_submission_sbt.yaml",
-		"build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outdir=dist --external:@aws-sdk &&  npm run copy-templates:dist",
+		"build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.mjs --external:@aws-sdk && npm run copy-templates:dist",
 		"prestart": "npm run copy-templates",
 		"start": "tsx src/run-locally.ts",
 		"pretest": "npm run copy-templates",

--- a/packages/dependency-graph-integrator/package.json
+++ b/packages/dependency-graph-integrator/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"copy-templates": "cp ../../.github/workflows/template_dep_submission_gradle.yaml src/template_dep_submission_gradle.yaml && cp ../../.github/workflows/template_dep_submission_sbt.yaml src/template_dep_submission_sbt.yaml",
 		"copy-templates:dist": "cp ../../.github/workflows/template_dep_submission_gradle.yaml dist/template_dep_submission_gradle.yaml && cp ../../.github/workflows/template_dep_submission_sbt.yaml dist/template_dep_submission_sbt.yaml",
-		"build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.mjs --external:@aws-sdk && npm run copy-templates:dist",
+		"build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.mjs --external:@aws-sdk --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\" && npm run copy-templates:dist",
 		"prestart": "npm run copy-templates",
 		"start": "tsx src/run-locally.ts",
 		"pretest": "npm run copy-templates",

--- a/packages/dependency-graph-integrator/package.json
+++ b/packages/dependency-graph-integrator/package.json
@@ -8,7 +8,8 @@
 	"scripts": {
 		"copy-templates": "cp ../../.github/workflows/template_dep_submission_gradle.yaml src/template_dep_submission_gradle.yaml && cp ../../.github/workflows/template_dep_submission_sbt.yaml src/template_dep_submission_sbt.yaml",
 		"copy-templates:dist": "cp ../../.github/workflows/template_dep_submission_gradle.yaml dist/template_dep_submission_gradle.yaml && cp ../../.github/workflows/template_dep_submission_sbt.yaml dist/template_dep_submission_sbt.yaml",
-		"build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/index.mjs --external:@aws-sdk --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\" && npm run copy-templates:dist",
+		"build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20  --outdir=dist --external:@aws-sdk --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\" && npm run copy-templates:dist",
+		"postbuild": "cp package.json dist/package.json",
 		"prestart": "npm run copy-templates",
 		"start": "tsx src/run-locally.ts",
 		"pretest": "npm run copy-templates",


### PR DESCRIPTION
## What does this change?

* Adds a `postbuild` script to copy `package.json` into the `dist` directory after building, to ensure the lambda knows this is ESM.
* Adds a `--banner:js` flag to inject `createRequire` from the Node.js `module` package to resolve a compatibility error.

## Why has this change been made?

The lambda has been failing with the error `ERROR","message":"(node:2) Warning: To load an ES module, set \"type\": \"module\" in the package.json or use the .mjs extension.`

## How has it been verified?

- [x] Tested on CODE