### PR TITLE
Upgrade node version of cloudbuster to node 24

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -24790,7 +24790,7 @@ spec:
             "Arn",
           ],
         },
-        "Runtime": "nodejs20.x",
+        "Runtime": "nodejs24.x",
         "Tags": [
           {
             "Key": "App",

--- a/packages/cdk/lib/cloudbuster.ts
+++ b/packages/cdk/lib/cloudbuster.ts
@@ -41,7 +41,7 @@ export class CloudBuster {
 			app,
 			vpc,
 			architecture: Architecture.ARM_64,
-			runtime: Runtime.NODEJS_20_X,
+			runtime: Runtime.NODEJS_24_X,
 			securityGroups: [dbAccess],
 			fileName: `${app}.zip`,
 			handler: 'index.main',

--- a/packages/cloudbuster/package.json
+++ b/packages/cloudbuster/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"type": "module",
 	"scripts": {
-		"build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outdir=dist --external:@aws-sdk --external:@prisma/client --external:prisma  --format=esm --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
+		"build": "esbuild src/index.ts --bundle --platform=node --target=node24 --outdir=dist --external:@aws-sdk --external:@prisma/client --external:prisma  --format=esm --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
 		"postbuild": "cp package.json dist/package.json",
 		"start": "APP=cloudbuster CUT_OFF_IN_DAYS=60 tsx src/run-locally.ts",
 		"test": "node --import tsx --test \"**/*.test.ts\"",

--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -48,7 +48,7 @@ export async function main() {
 
 	if (tableContents.length !== uniqueTableContents.length) {
 		logger.warn({
-			message: `${tableContents.length - uniqueTableContents.length} duplicate FSBP findings detected with control IDs and resource ARNs: ${duplicateControlIdArns.join(', ')}`,
+			message: `${tableContents.length - uniqueTableContents.length} duplicate FSBP findings detected with control IDs and resource ARNs, including: ${duplicateControlIdArns.slice(0, 10).join(', ')}`,
 		});
 	}
 
@@ -57,7 +57,14 @@ export async function main() {
 		data: uniqueTableContents,
 	});
 
-	const activeFindings = uniqueTableContents.filter((row) => !row.suppressed);
+	const activeFindings: cloudbuster_fsbp_vulnerabilities[] =
+		uniqueTableContents.filter((row) => !row.suppressed);
+
+	logger.log({ message: `${activeFindings.length} active FSBP findings.` });
+
+	logger.log({
+		message: `Creating digests for 'CRITICAL' severity findings.`,
+	});
 
 	const digests = createDigestsFromFindings(
 		activeFindings,
@@ -67,6 +74,7 @@ export async function main() {
 
 	const isTuesday = new Date().getDay() === 2;
 	if (isTuesday) {
+		logger.log({ message: "Creating digests for 'HIGH' severity findings." });
 		digests.push(
 			...createDigestsFromFindings(activeFindings, 'HIGH', config.cutOffInDays),
 		);
@@ -78,9 +86,12 @@ export async function main() {
 		config.anghammaradSnsTopic,
 	);
 
+	logger.log({ message: `Sending ${digests.length} digests.` });
 	await Promise.all(
 		digests.map(
 			async (digest) => await sendDigest(anghammaradClient, config, digest),
 		),
 	);
+
+	logger.log({ message: 'Cloudbuster run completed.' });
 }


### PR DESCRIPTION
## What does this change?
Upgrade node version of cloudbuster to node 24

## Why has this change been made?
Support for node 20 is running out very soon

## How was this tested
No success yet,
tried to start local environment with only table aws_securityhub_findings
but that failed.

Deployed to CODE and ran the lambda with test, with supposedly succeeded, but the lambda stopped in the middle and no message appeared in the test chanel.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214114336301774