### PR TITLE
docs: Add CODEOWNERS file for devx-reliability-and-ops team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @guardian/devx-security @guardian/devx-operations
+* @guardian/devx-reliability-and-ops


### PR DESCRIPTION
Adds a CODEOWNERS file to assign @guardian/devx-reliability-and-ops as code owners for the repository.