### PR TITLE
feat: Add monitoring for Dependency Graph Integrator

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19,6 +19,7 @@ exports[`The ServiceCatalogue stack matches the snapshot 1`] = `
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm",
       "GuLambdaFunction",
+      "GuLambdaErrorPercentageAlarm",
       "GuLambdaFunction",
       "GuLambdaFunction",
       "GuLambdaFunction",
@@ -25303,6 +25304,133 @@ spec:
         },
       },
       "Type": "AWS::Lambda::Permission",
+    },
+    "dependencygraphintegratorErrorPercentageAlarmForLambda7FC01BC5": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":devx-alerts",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "dependencygraphintegrator508B46FC",
+              },
+              " exceeded 0% error rate",
+            ],
+          ],
+        },
+        "AlarmName": {
+          "Fn::Join": [
+            "",
+            [
+              "High error percentage from ",
+              {
+                "Ref": "dependencygraphintegrator508B46FC",
+              },
+              " lambda in PROD",
+            ],
+          ],
+        },
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "dependencygraphintegrator508B46FC",
+                  },
+                ],
+              ],
+            },
+            "ReturnData": true,
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "dependencygraphintegrator508B46FC",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "dependencygraphintegrator508B46FC",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "deploy::service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "dependencygraphintegratorSecurityGroupC8A882C0": {
       "Properties": {

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -40,7 +40,7 @@ export class Repocop {
 			},
 		);
 
-		const repocopLampdaProps: GuScheduledLambdaProps = {
+		const repocopLambdaProps: GuScheduledLambdaProps = {
 			app: 'repocop',
 			architecture: Architecture.ARM_64,
 			fileName: 'repocop.zip',
@@ -71,7 +71,7 @@ export class Repocop {
 		const repocopLambda = new GuScheduledLambda(
 			guStack,
 			'repocop',
-			repocopLampdaProps,
+			repocopLambdaProps,
 		);
 
 		const policyStatement = new PolicyStatement({

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -92,7 +92,8 @@ export class Repocop {
 		dependencyGraphIntegratorInputTopic.grantPublish(repocopLambda);
 		repocopLambda.addToRolePolicy(policyStatement);
 
-		const dependencyGraphIntegratorLambda = stageAwareIntegratorLambda(
+		const dependencyGraphIntegratorLambda =
+			createDependencyGraphIntegratorLambda(
 			guStack,
 			vpc,
 			'dependency-graph-integrator',
@@ -105,7 +106,7 @@ export class Repocop {
 	}
 }
 
-function stageAwareIntegratorLambda(
+function createDependencyGraphIntegratorLambda(
 	guStack: GuStack,
 	vpc: IVpc,
 	app: `${string}-integrator`,

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -126,7 +126,7 @@ function createDependencyGraphIntegratorLambda(
 		},
 	};
 
-	if (guStack.stage === 'PROD' || guStack.stage === 'TEST') {
+	if (guStack.stage === 'PROD') {
 		const githubAppSecret = new Secret(guStack, `${app}-github-app-auth`, {
 			secretName: `/${guStack.stage}/${guStack.stack}/service-catalogue/${app}-github-app-secret`,
 		});

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -112,7 +112,7 @@ function createDependencyGraphIntegratorLambda(
 	app: `${string}-integrator`,
 	gitHubOrg: string,
 ): GuLambdaFunction {
-	const nonProdLambdaProps = {
+	const baseLambdaProps = {
 		app,
 		architecture: Architecture.ARM_64,
 		fileName: `${app}.zip`,
@@ -132,9 +132,9 @@ function createDependencyGraphIntegratorLambda(
 		});
 
 		const lambda = new GuLambdaFunction(guStack, app, {
-			...nonProdLambdaProps,
+			...baseLambdaProps,
 			environment: {
-				...nonProdLambdaProps.environment,
+				...baseLambdaProps.environment,
 				GITHUB_APP_SECRET: githubAppSecret.secretArn,
 			},
 		});
@@ -143,6 +143,6 @@ function createDependencyGraphIntegratorLambda(
 
 		return lambda;
 	} else {
-		return new GuLambdaFunction(guStack, app, nonProdLambdaProps);
+		return new GuLambdaFunction(guStack, app, baseLambdaProps);
 	}
 }

--- a/packages/cdk/lib/repocop.ts
+++ b/packages/cdk/lib/repocop.ts
@@ -94,11 +94,11 @@ export class Repocop {
 
 		const dependencyGraphIntegratorLambda =
 			createDependencyGraphIntegratorLambda(
-			guStack,
-			vpc,
-			'dependency-graph-integrator',
-			gitHubOrg,
-		);
+				guStack,
+				vpc,
+				'dependency-graph-integrator',
+				gitHubOrg,
+			);
 
 		dependencyGraphIntegratorInputTopic.addSubscription(
 			new LambdaSubscription(dependencyGraphIntegratorLambda, {}),
@@ -136,6 +136,10 @@ function createDependencyGraphIntegratorLambda(
 			environment: {
 				...baseLambdaProps.environment,
 				GITHUB_APP_SECRET: githubAppSecret.secretArn,
+			},
+			errorPercentageMonitoring: {
+				toleratedErrorPercentage: 0,
+				snsTopicName: 'devx-alerts',
 			},
 		});
 


### PR DESCRIPTION
## What does this change?

- Adds monitoring for the dependency graph integrator.
- Renames the lambda as it is only used by the integrator.
- Renames the props as it was slightly confusing to me that 'non-prod' props were being used in the PROD lambda.
- Fixes a typo in the repocop lambda props.
- Removes the `TEST` stage from the code as this doesn't exist.

## Why has this change been made?

We recently discovered that the integrator had been failing for some months and only discovered this by chance. 

## Why was this approach chosen?

This follows the pattern used by Obligatron.

## How has it been verified?

- [x] Deploy broken version of lambda to CODE (pre-fix error) to ensure it is broken!
- [x] Redeploy broken version with monitoring in base props to CODE and observe alerting (no alerting observed - maybe only happens on PROD?)
- [x] Deploy fixed version and ensure it still works with monitoring in place
- [x] After merge test broken version on PROD and observe alerting