### PR TITLE
Add read-only user

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -23342,6 +23342,38 @@ spec:
       },
       "Type": "AWS::IAM::Role",
     },
+    "DevReadonlyPassword82519B98": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Description": "Password for the devreadonly Postgres user (readonly access)",
+        "GenerateSecretString": {},
+        "Name": "/PROD/deploy/service-catalogue/devreadonly-password",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "gu:riff-raff-project",
+            "Value": "deploy::service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
+    },
     "EBSByteBalanceAlarm": {
       "Properties": {
         "ActionsEnabled": true,

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -23342,12 +23342,12 @@ spec:
       },
       "Type": "AWS::IAM::Role",
     },
-    "DevReadonlyPassword82519B98": {
+    "DevReadOnlyPostgresPassword4318B657": {
       "DeletionPolicy": "Delete",
       "Properties": {
         "Description": "Password for the devreadonly Postgres user (readonly access)",
         "GenerateSecretString": {},
-        "Name": "/PROD/deploy/service-catalogue/devreadonly-password",
+        "Name": "/PROD/deploy/service-catalogue/devreadonly-postgres-password",
         "Tags": [
           {
             "Key": "gu:cdk:version",

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -279,8 +279,8 @@ export class ServiceCatalogue extends GuStack {
 			dataType: ParameterDataType.TEXT,
 		});
 
-		new Secret(this, 'DevReadonlyPassword', {
-			secretName: `/${stage}/${stack}/${app}/devreadonly-password`,
+		new Secret(this, 'DevReadOnlyPostgresPassword', {
+			secretName: `/${stage}/${stack}/${app}/devreadonly-postgres-password`,
 			description:
 				'Password for the devreadonly Postgres user (readonly access)',
 		});

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -279,6 +279,12 @@ export class ServiceCatalogue extends GuStack {
 			dataType: ParameterDataType.TEXT,
 		});
 
+		new Secret(this, 'DevReadonlyPassword', {
+			secretName: `/${stage}/${stack}/${app}/devreadonly-password`,
+			description:
+				'Password for the devreadonly Postgres user (readonly access)',
+		});
+
 		const loggingStreamName =
 			GuLoggingStreamNameParameter.getInstance(this).valueAsString;
 

--- a/packages/common/prisma/migrations/20260415162625_devreadonly_user/migration.sql
+++ b/packages/common/prisma/migrations/20260415162625_devreadonly_user/migration.sql
@@ -1,0 +1,7 @@
+CREATE USER devreadonly;
+GRANT USAGE ON SCHEMA public TO devreadonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO devreadonly;
+
+SET ROLE cloudquery;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO devreadonly;
+RESET ROLE;

--- a/packages/common/prisma/migrations/20260415162625_devreadonly_user/migration.sql
+++ b/packages/common/prisma/migrations/20260415162625_devreadonly_user/migration.sql
@@ -1,7 +1,19 @@
-CREATE USER devreadonly;
-GRANT USAGE ON SCHEMA public TO devreadonly;
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO devreadonly;
+DO
+$do$
+    BEGIN
+        -- Create the `devreadonly` user if it doesn't exist
+        IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE  rolname = 'devreadonly') THEN
+            CREATE USER devreadonly;
+        END IF;
 
-SET ROLE cloudquery;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO devreadonly;
-RESET ROLE;
+        GRANT USAGE ON SCHEMA public TO devreadonly;
+        GRANT SELECT ON ALL TABLES IN SCHEMA public TO devreadonly;
+
+        -- Grant read access to all future tables created by the cloudquery user
+        IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE  rolname = 'cloudquery') THEN
+            SET ROLE cloudquery;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO devreadonly;
+            RESET ROLE;
+        END IF;
+    END
+$do$;

--- a/sql/ci.sql
+++ b/sql/ci.sql
@@ -107,5 +107,10 @@ DELETE FROM guardian_github_actions_usage
 WHERE full_name = 'guardian/service-catalogue';
 
 
+-- Switch to the `devreadonly` user and test read access
+SET ROLE devreadonly;
+SELECT * FROM github_repositories LIMIT 1;
+SELECT * FROM view_repo_ownership LIMIT 1;
+
 -- Switch back to the original user
 RESET role;

--- a/sql/ci.sql
+++ b/sql/ci.sql
@@ -109,8 +109,36 @@ WHERE full_name = 'guardian/service-catalogue';
 
 -- Switch to the `devreadonly` user and test read access
 SET ROLE devreadonly;
+-- It should be able to read from cloudquery tables
 SELECT * FROM github_repositories LIMIT 1;
+SELECT * FROM aws_cloudformation_stacks LIMIT 1;
+-- It should be able to read from views
 SELECT * FROM view_repo_ownership LIMIT 1;
+
+-- It should NOT be able to write to any table
+DO
+$do$
+    BEGIN
+        INSERT INTO github_repositories (_cq_id, _cq_sync_time) VALUES (gen_random_uuid(), NOW());
+        RAISE EXCEPTION 'devreadonly should not be able to insert into github_repositories';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            -- Expected: write access denied
+            NULL;
+    END
+$do$;
+
+DO
+$do$
+    BEGIN
+        DELETE FROM aws_cloudformation_stacks WHERE FALSE;
+        RAISE EXCEPTION 'devreadonly should not be able to delete from aws_cloudformation_stacks';
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            -- Expected: write access denied
+            NULL;
+    END
+$do$;
 
 -- Switch back to the original user
 RESET role;


### PR DESCRIPTION
## What does this change?

This adds a new user with simple read-only permissions and a secret to hold the password of that user (the password will be set manually, after the prisma migration creates the user).

## Why has this change been made?

For developers to access the database from an IDE, without having perms to make changes. This is also useful for AI agents to run queries safely.

## Why was this approach chosen?

Identical to what's documented as the process to create the read-only user grafana user
https://github.com/guardian/service-catalogue/blob/0331ce144829447d8020ec55deb007f962918605/docs/cloudquery-implementation.md?plain=1#L60-L69

And also uses patterns similar to the creation to the repocop user creation (i.e. guard clauses)

https://github.com/guardian/service-catalogue/blob/0331ce144829447d8020ec55deb007f962918605/packages/common/prisma/migrations/20240614105000_repocop_user/migration.sql#L1-L7

<!-- If the change is non-trivial, please discuss why this approach was chosen over alternatives, and any trade-offs considered. If it's very large, consider an ADR instead. -->

## How has it been verified?

I've ran this locally on dev.

I've also included extra tests to check that the new user cannot write or delete tables.