### PR TITLE
fix: set Prisma environment variables in cli migrate function

### DIFF
--- a/packages/cli/src/database.ts
+++ b/packages/cli/src/database.ts
@@ -51,6 +51,11 @@ export async function migrateRdsDatabase(
 	const dbConfig = await getRdsConfig(client, stage);
 	const connectionString = getDatabaseConnectionString(dbConfig);
 
+	console.log('Setting Prisma env vars');
+	process.env.STAGE = stage;
+	process.env.DATABASE_HOSTNAME = dbConfig.hostname;
+	process.env.DATABASE_USER = dbConfig.user;
+	process.env.DATABASE_PASSWORD = dbConfig.password;
 	console.log('Setting DATABASE_URL');
 	process.env.DATABASE_URL = connectionString;
 


### PR DESCRIPTION
## What does this change?

Explicitly sets the environment variables for the postgres database in the cli migrate function.

## Why has this change been made?

Currently, when the user tries to run the command `npm -w cli start migrate -- --stage [CODE | PROD]` without the local `dev-environment` postgres database up and running, the following error is emitted: 
```
Error: P1001: Can't reach database server at `localhost:5432`

Please make sure your database server is running at `localhost:5432`.
```
Adding these in fixes the issue and the user can run the command without having to start the `dev-environment` first.

## How has it been verified?

- [x] Tested using the command `npm -w cli start migrate -- --stage CODE`  before and after the addition of the env vars and observed the migrate command completing successfuly after the addition.