### PR TITLE
temp: break dep graph integrator

### DIFF
--- a/packages/dependency-graph-integrator/package.json
+++ b/packages/dependency-graph-integrator/package.json
@@ -8,8 +8,7 @@
 	"scripts": {
 		"copy-templates": "cp ../../.github/workflows/template_dep_submission_gradle.yaml src/template_dep_submission_gradle.yaml && cp ../../.github/workflows/template_dep_submission_sbt.yaml src/template_dep_submission_sbt.yaml",
 		"copy-templates:dist": "cp ../../.github/workflows/template_dep_submission_gradle.yaml dist/template_dep_submission_gradle.yaml && cp ../../.github/workflows/template_dep_submission_sbt.yaml dist/template_dep_submission_sbt.yaml",
-		"build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node24  --outdir=dist --external:@aws-sdk --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\" && npm run copy-templates:dist",
-		"postbuild": "cp package.json dist/package.json",
+		"build": "esbuild src/index.ts --bundle --platform=node --format=esm --target=node20 --outdir=dist --external:@aws-sdk &&  npm run copy-templates:dist",
 		"prestart": "npm run copy-templates",
 		"start": "tsx src/run-locally.ts",
 		"pretest": "npm run copy-templates",


### PR DESCRIPTION
## What does this change?

Breaks the dependency graph integrator (see #1931) to enable testing of the recently-added monitoring (see #1940).

Once deployed, I will run the lambda and see if an alert is triggered. Then I will revert this PR.

