### PR TITLE
feat: add migrate resolve to cli

### DIFF
--- a/packages/cli/src/database.ts
+++ b/packages/cli/src/database.ts
@@ -78,6 +78,44 @@ export async function migrateRdsDatabase(
 	return Promise.resolve(0);
 }
 
+type ResolveState = 'rolled-back' | 'applied';
+
+export async function resolveRdsMigration(
+	stage: string,
+	client: SecretsManagerClient,
+	migration: string,
+	state: ResolveState,
+): Promise<number> {
+	console.log(`Resolving migration in ${stage}: ${migration} (${state})`);
+
+	const connectedToVpn = await isConnectedToVpn();
+	if (!connectedToVpn) {
+		throw new Error('Not connected to VPN');
+	}
+
+	console.log('Fetching database connection details from AWS Secrets Manager');
+	const dbConfig = await getRdsConfig(client, stage);
+	const connectionString = getDatabaseConnectionString(dbConfig);
+
+	console.log('Setting Prisma env vars');
+	process.env.STAGE = stage;
+	process.env.DATABASE_HOSTNAME = dbConfig.hostname;
+	process.env.DATABASE_USER = dbConfig.user;
+	process.env.DATABASE_PASSWORD = dbConfig.password;
+
+	console.log('Setting DATABASE_URL');
+	process.env.DATABASE_URL = connectionString;
+
+	const flag = state === 'rolled-back' ? '--rolled-back' : '--applied';
+
+	console.log(`Running prisma migrate resolve ${flag} ${migration}`);
+	const { stdout } =
+		await $`npx -w common prisma migrate resolve ${flag} ${migration}`;
+	console.log(stdout);
+
+	return Promise.resolve(0);
+}
+
 async function isConnectedToVpn(): Promise<boolean> {
 	console.log('Checking if connected to VPN');
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,13 +7,18 @@ import {
 	runAllTasks,
 	runOneTask,
 } from './aws.js';
-import { migrateDevDatabase, migrateRdsDatabase } from './database.js';
+import {
+	migrateDevDatabase,
+	migrateRdsDatabase,
+	resolveRdsMigration,
+} from './database.js';
 
 const Commands = {
 	list: 'list-tasks',
 	run: 'run-task',
 	runAll: 'run-all-tasks',
 	migrate: 'migrate',
+	migrateResolve: 'migrate-resolve',
 };
 
 const parseCommandLineArguments = () => {
@@ -126,6 +131,33 @@ const parseCommandLineArguments = () => {
 						default: false,
 					});
 			})
+			.command(
+				Commands.migrateResolve,
+				'Resolve a failed Prisma migration',
+				(yargs) => {
+					yargs
+						.option('stage', {
+							description: 'Target stage',
+							choices: ['CODE', 'PROD'],
+							demandOption: true,
+						})
+						.option('migration', {
+							description: 'Migration folder name',
+							type: 'string',
+							demandOption: true,
+						})
+						.option('state', {
+							description: 'Resolution state',
+							choices: ['rolled-back', 'applied'],
+							default: 'rolled-back',
+						})
+						.option('confirm', {
+							description: 'Confirm that you want to resolve this migration',
+							type: 'boolean',
+							default: false,
+						});
+				},
+			)
 			.demandCommand(1, '') // just print help
 			.help()
 			.alias('h', 'help').argv,
@@ -214,6 +246,19 @@ parseCommandLineArguments()
 					default:
 						throw new Error(`Unsupported stage: ${stage as string}`);
 				}
+			}
+			case Commands.migrateResolve: {
+				const { stage, migration, state, confirm } = argv;
+				if (!confirm) {
+					throw new Error('Refusing to resolve migration without --confirm');
+				}
+				const secretsManagerClient = getSecretsManagerClient();
+				return resolveRdsMigration(
+					stage as string,
+					secretsManagerClient,
+					migration as string,
+					state as 'rolled-back' | 'applied',
+				);
 			}
 			default:
 				throw new Error(`Unknown command ${command ?? ''}`);


### PR DESCRIPTION
## What does this change?

Adds the functionality to run prisma migrate resolve through the cli package.

## Why has this change been made?

I found this useful when needing to resolve a failed migration on CODE.

## Why was this approach chosen?

It follows the same pattern as the migrate function.

## How has it been verified?

- [x] Tested on the CODE database by running 
```
npm -w cli start migrate-resolve -- \
  --stage CODE \
  --migration 20240412103300_aws_resources \
  --state rolled-back \
  --confirm
``` 
and observed the command being executed and resolving the migration failure.
Also tested without the `--confirm` flag and observed the 'Refusing... ' message.