### PR TITLE
New migration drop_table_and_user_for_data_audit_lambda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     services:
       # See https://docs.github.com/en/actions/using-containerized-services/creating-postgresql-service-containers
       postgres:
-        image: postgres:17.9-alpine@sha256:6f30057d31f5861b66f3545d4821f987aacf1dd920765f0acadea0c58ff975b1
+        image: postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba
 
         # Keep these in sync with `.env` file at the repository root
         env:

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -615,7 +615,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -1080,7 +1080,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -1825,7 +1825,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -2571,7 +2571,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -3248,7 +3248,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -3951,7 +3951,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -4656,7 +4656,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -5393,7 +5393,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -6326,7 +6326,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -6773,7 +6773,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -7481,7 +7481,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -8213,7 +8213,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -8946,7 +8946,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -9649,7 +9649,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -10361,7 +10361,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -11067,7 +11067,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -11785,7 +11785,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -12522,7 +12522,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -13818,7 +13818,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -14299,7 +14299,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -14961,7 +14961,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -15713,7 +15713,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -16421,7 +16421,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -17435,7 +17435,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -17956,7 +17956,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -18679,7 +18679,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -19442,7 +19442,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -20200,7 +20200,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -20963,7 +20963,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -21707,7 +21707,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -22727,7 +22727,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -23830,7 +23830,7 @@ spec:
         "EnableIAMDatabaseAuthentication": true,
         "EnablePerformanceInsights": true,
         "Engine": "postgres",
-        "EngineVersion": "17",
+        "EngineVersion": "18.3",
         "MasterUserPassword": {
           "Fn::Join": [
             "",

--- a/packages/cdk/lib/cloudquery/images.ts
+++ b/packages/cdk/lib/cloudquery/images.ts
@@ -14,7 +14,7 @@ export const Images = {
 		`ghcr.io/guardian/cq-source-ns1:${CloudQueryPluginVersions.CloudqueryNs1}`,
 	),
 	postgres: ContainerImage.fromRegistry(
-		'public.ecr.aws/docker/library/postgres:17-alpine',
+		'public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba',
 	),
 	/**
 	 * This image is built in CI by the service-catalogue, and tagged with the

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -171,7 +171,7 @@ export class ServiceCatalogue extends GuStack {
 
 		const dbProps: DatabaseInstanceProps = {
 			engine: DatabaseInstanceEngine.postgres({
-				version: PostgresEngineVersion.VER_17,
+				version: PostgresEngineVersion.of('18.3', '18'),
 			}),
 			port,
 			vpc,

--- a/packages/common/prisma/migrations/20260506172625_drop_table_and_user_for_data_audit_lambda/migration.sql
+++ b/packages/common/prisma/migrations/20260506172625_drop_table_and_user_for_data_audit_lambda/migration.sql
@@ -1,0 +1,21 @@
+-- Remove table and user for data audit lambda
+BEGIN TRANSACTION;
+
+DO $$
+    BEGIN
+        IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'dataaudit') THEN
+            REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM dataaudit;
+            REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM dataaudit;
+            REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM dataaudit;
+            REVOKE ALL PRIVILEGES ON SCHEMA public FROM dataaudit;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM dataaudit;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON SEQUENCES FROM dataaudit;
+            ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON FUNCTIONS FROM dataaudit;
+            DROP USER IF EXISTS dataaudit;
+        END IF;
+    END
+$$;
+
+  DROP TABLE IF EXISTS "audit_results";
+
+COMMIT TRANSACTION;

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -620,14 +620,6 @@ model aws_s3_buckets {
   tags           Json?
 }
 
-model audit_results {
-  evaluated_on     DateTime
-  name             String   @id
-  success          Boolean
-  cloudquery_total Int
-  vendor_total     Int
-}
-
 model cloudquery_table_frequency {
   table_name String @id
   frequency  BigInt

--- a/packages/dev-environment/docker-compose-prisma-migrate.yaml
+++ b/packages/dev-environment/docker-compose-prisma-migrate.yaml
@@ -21,7 +21,7 @@ services:
 
   postgres:
     container_name: postgres-prisma-migrate-test
-    image: postgres:17.9
+    image: postgres:18.3
     ports:
       - '5433:5433'
     environment:

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -5,10 +5,10 @@ services:
     build:
       context: ../../containers/db-copy
       args:
-        alpine_version: 3.21.6
+        alpine_version: 3.23.4
     volumes:
       - ~/.aws/credentials:/.aws/credentials
-      - ./sql:/sql 
+      - ./sql:/sql
     environment:
       AWS_CONFIG_FILE: /.aws/config
       AWS_SHARED_CREDENTIALS_FILE: /.aws/credentials
@@ -44,7 +44,7 @@ services:
         - aws_autoscaling_groups
         - aws_elbv2_target_groups
   postgres:
-    image: postgres:17.9
+    image: postgres:18.3
     ports:
       - '${DATABASE_PORT}:${DATABASE_PORT}'
     environment:

--- a/sql/ci.sql
+++ b/sql/ci.sql
@@ -55,33 +55,6 @@ VALUES (
 DELETE FROM cloudbuster_fsbp_vulnerabilities
 WHERE arn = 'arn:aws:securityhub:eu-west-1:123456789012:product/aws/securityhub/finding/12345678901234567890123456789012';
 
-
--- Switch to the `dataaudit` user and test access to the tables/views used in the data-audit app
-SET ROLE dataaudit;
--- It should be able to read from these tables
-SELECT * FROM aws_s3_buckets LIMIT 1;
-SELECT * FROM aws_lambda_functions LIMIT 1;
-SELECT * FROM aws_accounts LIMIT 1;
-
--- It should be able to read/write from the table audit_results
-INSERT INTO audit_results (
-    evaluated_on
-    , name
-    , success
-    , cloudquery_total
-    , vendor_total
-) VALUES (
-    NOW()
-    , 'test'
-    , TRUE
-    , 1
-    , 1
-);
-SELECT * FROM audit_results LIMIT 1;
-
-DELETE FROM audit_results
-WHERE name = 'test';
-
 -- The user github_actions_usage...
 SET ROLE github_actions_usage;
 


### PR DESCRIPTION
## What does this change?

Create new migration drop_table_and_user_for_data_audit_lambda
Removes test for this user from ci

## Why has this change been made?

To clean up db after [deleting data audit lambda](https://github.com/guardian/service-catalogue/pull/1933)

## How has it been verified?
In dev:
started local environment and ran the following successfully:
`prisma migrate reset`
`prisma migrate dev`

on code:
deployed to code
checked prisma-migrate-task logs

<img width="1317" height="731" alt="Screenshot 2026-05-08 at 12 32 15" src="https://github.com/user-attachments/assets/1d404ebc-4a90-454e-b0d3-a047f27690a3" />

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214357303046637