### PR TITLE
ci: Update guardian/actions-riff-raff to v4.3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         run: ./scripts/build.sh
 
       - name: Upload to riff-raff
-        uses: guardian/actions-riff-raff@13ced2bc56d837683b64d5c8384cf08dfb6d626e # v4.2.6
+        uses: guardian/actions-riff-raff@581c043714b5b8353d5a23d79b958cd416c996e0 # v4.3.2
         with:
           app: service-catalogue
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}


### PR DESCRIPTION
## What does this change?
This version has a small DX improvement. See https://github.com/guardian/actions-riff-raff/pull/322 and https://github.com/guardian/actions-riff-raff/releases/tag/v4.3.2.

## How has it been verified?
I've [deployed](https://riffraff.gutools.co.uk/deployment/view/b0c738fa-a398-41f4-afe7-a9fd5b299a8d) and confirmed the [commit link offered by RIff-Raff](https://github.com/guardian/service-catalogue/commit/1444e6f6b85fa6a7aa6fdec6e484e9075aca96c8) is [correct](https://github.com/guardian/service-catalogue/pull/1952/commits):

<img width="803" height="264" alt="image" src="https://github.com/user-attachments/assets/f0d34cf5-7e29-456e-a914-382f81b2a121" />
