### PR TITLE
only collect critical and high severity findings

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -1630,8 +1630,10 @@ spec:
                 - comparison: EQUALS
                   value: Security Hub
               severity_label:
-                - comparison: NOT_EQUALS
-                  value: MEDIUM
+                - comparison: EQUALS
+                  value: CRITICAL
+                - comparison: EQUALS
+                  value: HIGH
       aws_inspector2_findings:
         list_findings:
           - filter_criteria:

--- a/packages/cdk/lib/cloudquery/table-options.ts
+++ b/packages/cdk/lib/cloudquery/table-options.ts
@@ -37,10 +37,8 @@ export const securityHubTableOptions = {
 					stringFilter(AwsComparison.Equals, 'Security Hub'),
 				],
 				severity_label: [
-					//tagging standard uses 'LOW' and 'INFORMATIONAL'.
-					// For security standards, we are only interested in 'HIGH' and 'CRITICAL'
-					//It may seem unnecessary, but this cuts our row count in half.
-					stringFilter(AwsComparison.NotEquals, 'MEDIUM'),
+					stringFilter(AwsComparison.Equals, 'CRITICAL'),
+					stringFilter(AwsComparison.Equals, 'HIGH'),
 				],
 			},
 		},


### PR DESCRIPTION
## What does this change?

Stop collecting`LOW`/`INFORMATIONAL` level data in securityhub. This will save nearly 4 million rows a month

## Why has this change been made?

The AWS tagging standard is no longer enabled, so we don't need to collect these severity levels.

## Why was this approach chosen?

The securityhub table is large, and using the unfiltered version would drive us over our usage limits quite quickly, so we need to be judicious about what information we collect

## How has it been verified?

This has been run on code and resulted in a 30% reduction in row count. This is probably only accurate to 1 sig fig as the fluctuations are quite large day to day