### PR TITLE
feat: upgrade postgres to v18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     services:
       # See https://docs.github.com/en/actions/using-containerized-services/creating-postgresql-service-containers
       postgres:
-        image: postgres:17.9-alpine@sha256:6f30057d31f5861b66f3545d4821f987aacf1dd920765f0acadea0c58ff975b1
+        image: postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba
 
         # Keep these in sync with `.env` file at the repository root
         env:

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -615,7 +615,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -1080,7 +1080,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -1825,7 +1825,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -2571,7 +2571,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -3248,7 +3248,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -3951,7 +3951,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -4656,7 +4656,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -5393,7 +5393,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -6326,7 +6326,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -6773,7 +6773,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -7481,7 +7481,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -8213,7 +8213,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -8946,7 +8946,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -9649,7 +9649,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -10361,7 +10361,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -11067,7 +11067,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -11785,7 +11785,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -12522,7 +12522,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -13818,7 +13818,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -14299,7 +14299,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -14961,7 +14961,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -15713,7 +15713,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -16421,7 +16421,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -17435,7 +17435,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -17956,7 +17956,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -18679,7 +18679,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -19442,7 +19442,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -20200,7 +20200,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -20963,7 +20963,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -21707,7 +21707,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -22727,7 +22727,7 @@ spec:
               "",
             ],
             "Essential": false,
-            "Image": "public.ecr.aws/docker/library/postgres:17-alpine",
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {
@@ -23830,7 +23830,7 @@ spec:
         "EnableIAMDatabaseAuthentication": true,
         "EnablePerformanceInsights": true,
         "Engine": "postgres",
-        "EngineVersion": "17",
+        "EngineVersion": "18.3",
         "MasterUserPassword": {
           "Fn::Join": [
             "",

--- a/packages/cdk/lib/cloudquery/images.ts
+++ b/packages/cdk/lib/cloudquery/images.ts
@@ -14,7 +14,7 @@ export const Images = {
 		`ghcr.io/guardian/cq-source-ns1:${CloudQueryPluginVersions.CloudqueryNs1}`,
 	),
 	postgres: ContainerImage.fromRegistry(
-		'public.ecr.aws/docker/library/postgres:17-alpine',
+		'public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba',
 	),
 	/**
 	 * This image is built in CI by the service-catalogue, and tagged with the

--- a/packages/cdk/lib/service-catalogue.ts
+++ b/packages/cdk/lib/service-catalogue.ts
@@ -171,7 +171,7 @@ export class ServiceCatalogue extends GuStack {
 
 		const dbProps: DatabaseInstanceProps = {
 			engine: DatabaseInstanceEngine.postgres({
-				version: PostgresEngineVersion.VER_17,
+				version: PostgresEngineVersion.of('18.3', '18'),
 			}),
 			port,
 			vpc,

--- a/packages/dev-environment/docker-compose-prisma-migrate.yaml
+++ b/packages/dev-environment/docker-compose-prisma-migrate.yaml
@@ -21,7 +21,7 @@ services:
 
   postgres:
     container_name: postgres-prisma-migrate-test
-    image: postgres:17.9
+    image: postgres:18.3
     ports:
       - '5433:5433'
     environment:

--- a/packages/dev-environment/docker-compose.yaml
+++ b/packages/dev-environment/docker-compose.yaml
@@ -5,10 +5,10 @@ services:
     build:
       context: ../../containers/db-copy
       args:
-        alpine_version: 3.21.6
+        alpine_version: 3.23.4
     volumes:
       - ~/.aws/credentials:/.aws/credentials
-      - ./sql:/sql 
+      - ./sql:/sql
     environment:
       AWS_CONFIG_FILE: /.aws/config
       AWS_SHARED_CREDENTIALS_FILE: /.aws/credentials
@@ -44,7 +44,7 @@ services:
         - aws_autoscaling_groups
         - aws_elbv2_target_groups
   postgres:
-    image: postgres:17.9
+    image: postgres:18.3
     ports:
       - '${DATABASE_PORT}:${DATABASE_PORT}'
     environment:


### PR DESCRIPTION
## What does this change?

Upgrades the postgres database to v18.3 which is the latest. Follows #1835.

## Why has this change been made?

To ensure we're up-to-date and making use of security patches and performance enhancements, especially now that [AI is detecting long-standing vulnerabilities](https://www.csoonline.com/article/4167137/ai-finds-20-year-old-bugs-in-postgresql-and-mariadb.html).

Release notes:
- [v18.0](https://www.postgresql.org/docs/release/18.0/)
- [v18.3](https://www.postgresql.org/docs/release/18.3/)

## Why was this approach chosen?

This is almost a like-for-like upgrade from postgres v17, but where it is appropriate to pin the version to a SHA, it has been. I have also included the alpine version in the postgres image tag, which makes it easier for us to use the right alpine version in `docker-compose.yaml`.

## How has it been verified?

- [x] Tested migration locally by running `./packages/dev-environment/script/start-prisma-migrate-test`
- [x] Tested upgrade locally 
- [x] Tested on CODE and observed migrate container complete successfully (after approval)