### PR TITLE
docs: Update documentation for database migrations command

### DIFF
--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -79,13 +79,7 @@ Prerequisite:
 You can apply a migration to CODE or PROD using the [CLI](../packages/cli)):
 
 ```bash
-npm -w cli start migrate -- --stage [CODE|PROD]
-```
-
-The command above will not apply the migration without a `--confirm` flag. If satisfied with the output of the above, you can run:
-
-```bash
-npm -w cli start migrate -- --stage [CODE|PROD] --confirm
+npm -w cli start run-task -- --stage [CODE|PROD] --name prisma-migrate-task
 ```
 
 See also:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -56,6 +56,4 @@ This sets the CloudQuery log level to `debug`, providing more detailed output fo
 
 ### Database migrations
 
-```bash
-npm -w cli start migrate -- --stage [DEV|CODE|PROD]
-```
+See [Database migrations](../../docs/database-migrations.md)


### PR DESCRIPTION
## What does this change?

- Updates the documentation to reflect the fact the `migrate` cli tasks for CODE and PROD were removed in #1960.

- Removes duplication by linking from the cli README to the database-migrations one.