### PR TITLE
add maintenance label to dependency graph integrator PRs

### DIFF
--- a/packages/dependency-graph-integrator/src/pull-requests.ts
+++ b/packages/dependency-graph-integrator/src/pull-requests.ts
@@ -54,6 +54,7 @@ export async function createPullRequest(
 		body,
 		head: branchName,
 		base: baseBranch,
+		labels: ['maintenance'],
 		changes: changes.map(({ commitMessage, files }) => ({
 			commit: commitMessage,
 			files,


### PR DESCRIPTION
## What does this change?

Add a maintenance label to PRs raised by the dependency graph integrator

## Why has this change been made?

So we can be core4 compliant

## Why was this approach chosen?

This seemed like the simplest way to do it

## How has it been verified?

Tested on PROD, see the resulting PR with correct label [here](https://github.com/guardian/service-catalogue/pull/1968)
