### PR TITLE
feat: add alert_type column to repocop_vulnerabilities table

### DIFF
--- a/packages/common/prisma/migrations/20260527164433_repocop_vulnerabilities_classification_column/migration.sql
+++ b/packages/common/prisma/migrations/20260527164433_repocop_vulnerabilities_classification_column/migration.sql
@@ -1,0 +1,7 @@
+-- Add classification column to repocop_vulnerabilities table. This will enable us to differentiate Dependabot malware alerts from vulnerability alerts.
+BEGIN TRANSACTION;
+
+ALTER TABLE IF EXISTS repocop_vulnerabilities
+  ADD COLUMN IF NOT EXISTS classification text;
+
+COMMIT;

--- a/packages/common/prisma/migrations/20260527164433_repocop_vulnerabilities_classification_column/migration.sql
+++ b/packages/common/prisma/migrations/20260527164433_repocop_vulnerabilities_classification_column/migration.sql
@@ -1,5 +1,19 @@
 -- Add alert_type column to repocop_vulnerabilities table. This will enable us to differentiate Dependabot malware alerts from vulnerability alerts.
 
+BEGIN;
+
 ALTER TABLE IF EXISTS repocop_vulnerabilities
   ADD COLUMN IF NOT EXISTS alert_type text;
 
+UPDATE repocop_vulnerabilities
+SET alert_type = 'general'
+WHERE alert_type IS NULL;
+
+ALTER TABLE repocop_vulnerabilities
+  ALTER COLUMN alert_type SET NOT NULL;
+
+ALTER TABLE repocop_vulnerabilities
+  ADD CONSTRAINT repocop_vulnerabilities_alert_type_check
+  CHECK (alert_type IN ('general', 'malware'));
+
+COMMIT;

--- a/packages/common/prisma/migrations/20260527164433_repocop_vulnerabilities_classification_column/migration.sql
+++ b/packages/common/prisma/migrations/20260527164433_repocop_vulnerabilities_classification_column/migration.sql
@@ -1,7 +1,5 @@
--- Add classification column to repocop_vulnerabilities table. This will enable us to differentiate Dependabot malware alerts from vulnerability alerts.
-BEGIN TRANSACTION;
+-- Add alert_type column to repocop_vulnerabilities table. This will enable us to differentiate Dependabot malware alerts from vulnerability alerts.
 
 ALTER TABLE IF EXISTS repocop_vulnerabilities
-  ADD COLUMN IF NOT EXISTS classification text;
+  ADD COLUMN IF NOT EXISTS alert_type text;
 
-COMMIT;

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -671,7 +671,7 @@ model repocop_vulnerabilities {
   id               String   @id @default(uuid())
   within_sla       Boolean
   scope            String   @default("runtime")
-  classification   String?
+  alert_type       String
 }
 
 /// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -671,6 +671,7 @@ model repocop_vulnerabilities {
   id               String   @id @default(uuid())
   within_sla       Boolean
   scope            String   @default("runtime")
+  classification   String?
 }
 
 /// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -67,6 +67,8 @@ export type Severity = Lowercase<SecurityHubSeverity> | 'unknown';
 
 export type DependencyScope = 'runtime' | 'development';
 
+export type AlertType = 'general' | 'malware';
+
 export function chooseDependencyScope(
 	scope: string | null | undefined,
 	dependency: string,
@@ -84,10 +86,11 @@ export function chooseDependencyScope(
 
 export type RepocopVulnerability = Omit<
 	repocop_vulnerabilities,
-	'id' | 'repo_owner' | 'severity' | 'scope'
+	'id' | 'repo_owner' | 'severity' | 'scope' | 'alert_type'
 > & {
 	severity: Severity;
 	scope: DependencyScope;
+	alert_type: AlertType;
 };
 
 type RepositoryFields = Pick<

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.test.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.test.ts
@@ -33,6 +33,7 @@ void describe('The dependency vulnerabilities obligation', () => {
 		source: 'Dependabot',
 		within_sla: false,
 		scope: 'runtime',
+		alert_type: 'general',
 	};
 
 	void it('should return something if it finds a vulnerability on a repo', () => {

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -4,6 +4,7 @@ import type {
 } from 'common/prisma-client/client.js';
 import { stringToSeverity, toNonEmptyArray } from 'common/src/functions.js';
 import { logger } from 'common/src/logs.js';
+import type { AlertType } from 'common/src/types.js';
 import {
 	chooseDependencyScope,
 	type NonEmptyArray,
@@ -22,6 +23,7 @@ function prismaToCustomType(
 	return {
 		...vuln,
 		severity: stringToSeverity(vuln.severity),
+		alert_type: vuln.alert_type as AlertType,
 		scope: chooseDependencyScope(
 			vuln.scope as string | null | undefined, // This is safe as the type of vuln.scope is string.
 			vuln.package,
@@ -34,7 +36,7 @@ async function getRepocopVulnerabilities(
 	client: PrismaClient,
 ): Promise<NonEmptyArray<ObligatronRepocopVulnerability>> {
 	const rawResponse = await client.repocop_vulnerabilities.findMany({});
-
+	// TODO:  filter for alert_type 'general' only
 	return toNonEmptyArray(rawResponse.map(prismaToCustomType));
 }
 

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -571,6 +571,7 @@ const oldCriticalDependabotVuln: RepocopVulnerability = {
 	cves: ['CVE-2021-1234'],
 	within_sla: false,
 	scope: 'runtime',
+	alert_type: 'general',
 };
 
 const newCriticalDependabotVuln: RepocopVulnerability = {
@@ -654,6 +655,7 @@ void describe('NO RULE - Vulnerabilities from Dependabot', () => {
 			cves: ['CVE-2018-6188'],
 			within_sla: false,
 			scope: 'runtime',
+			alert_type: 'general',
 		};
 
 		const expected2: RepocopVulnerability = {
@@ -673,6 +675,7 @@ void describe('NO RULE - Vulnerabilities from Dependabot', () => {
 			cves: ['CVE-2021-20191'],
 			within_sla: false,
 			scope: 'runtime',
+			alert_type: 'general',
 		};
 
 		assert.deepStrictEqual(result, [expected1, expected2]);
@@ -699,6 +702,7 @@ void describe('Deduplication of repocop vulnerabilities', () => {
 		cves: ['CVE-2018-6188'],
 		within_sla: false,
 		scope: 'runtime',
+		alert_type: 'general',
 	};
 	const vuln2: RepocopVulnerability = {
 		full_name: fullName,
@@ -713,6 +717,7 @@ void describe('Deduplication of repocop vulnerabilities', () => {
 		cves: ['CVE-2018-6188'],
 		within_sla: false,
 		scope: 'runtime',
+		alert_type: 'general',
 	};
 	const actual = deduplicateVulnerabilitiesByCve([vuln1, vuln2]);
 	void test('Should happen if two vulnerabilities share the same CVEs', () => {

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -493,6 +493,10 @@ export function dependabotAlertToRepocopVulnerability(
 	const alertIssueDate = new Date(alert.created_at);
 
 	const severity = alert.security_advisory.severity;
+	const alert_type: RepocopVulnerability['alert_type'] =
+		alert.security_advisory.classification === 'malware'
+			? 'malware'
+			: 'general';
 
 	return {
 		open: alert.state === 'open',
@@ -513,6 +517,7 @@ export function dependabotAlertToRepocopVulnerability(
 			alert.security_vulnerability.package.name,
 			fullName,
 		),
+		alert_type,
 	};
 }
 

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -95,7 +95,7 @@ async function getAlertsForRepo(
 				direction: 'asc', //retrieve oldest vulnerabilities first
 			});
 
-		return alert.data;
+		return alert.data as Alert[];
 	} catch (error) {
 		console.debug(
 			`Dependabot - ${repoName}: Could not get alerts. Dependabot may not be enabled.`,

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -88,6 +88,7 @@ const highRecentVuln: RepocopVulnerability = {
 	cves: ['CVE-123'],
 	within_sla: true,
 	scope: 'runtime',
+	alert_type: 'general',
 };
 
 void describe('createDigest', () => {
@@ -240,6 +241,7 @@ void describe('createDigest', () => {
 			cves: ['CVE-123'],
 			within_sla: true,
 			scope: 'runtime',
+			alert_type: 'general',
 		};
 		const anotherResultWithVuln: EvaluationResult = {
 			...anotherResult,

--- a/packages/repocop/src/test-data/example-dependabot-alerts.ts
+++ b/packages/repocop/src/test-data/example-dependabot-alerts.ts
@@ -83,6 +83,7 @@ export const exampleDependabotAlert: Alert[] = [
 			published_at: '2018-10-03T21:13:54Z',
 			updated_at: '2022-04-26T18:35:37Z',
 			withdrawn_at: null,
+			classification: 'general',
 		},
 		security_vulnerability: {
 			package: {
@@ -214,6 +215,7 @@ export const exampleDependabotAlert: Alert[] = [
 			published_at: '2021-06-01T17:38:00Z',
 			updated_at: '2021-08-12T23:06:00Z',
 			withdrawn_at: null,
+			classification: 'general',
 		},
 		security_vulnerability: {
 			package: {

--- a/packages/repocop/src/types.ts
+++ b/packages/repocop/src/types.ts
@@ -43,7 +43,13 @@ export interface AwsCloudFormationStack extends StackFields {
 export type DependabotVulnResponse =
 	Endpoints['GET /repos/{owner}/{repo}/dependabot/alerts']['response'];
 
-export type Alert = DependabotVulnResponse['data'][number];
+export type BaseAlert = DependabotVulnResponse['data'][number];
+
+export type Alert = BaseAlert & {
+	security_advisory: BaseAlert['security_advisory'] & {
+		classification: 'general' | 'malware' | null;
+	};
+};
 
 export interface RepoAndAlerts {
 	shortName: string;

--- a/packages/repocop/src/utils.test.ts
+++ b/packages/repocop/src/utils.test.ts
@@ -41,6 +41,7 @@ void describe('vulnSortingPredicate', () => {
 			cves: [],
 			within_sla: true,
 			scope: 'runtime',
+			alert_type: 'general',
 		};
 		const criticalNotPatchable: RepocopVulnerability = {
 			...criticalPatchable,


### PR DESCRIPTION
## What does this change?

- Adds a 'alert_type' column to the `repocop_vulnerabilities` table, which reflects the 'classification' of the advisory - whether it's 'general' or 'malware'.
- Adds a type and updates test cases to allow test and typecheck to pass.

## Why has this change been made?

To enable us to differentiate between malware alerts ('malware') and vulnerabilities ('general').

- [x] Tested on CODE