### PR TITLE
chore(ci): Remove redundant configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,6 @@ jobs:
       - name: Upload to riff-raff
         uses: guardian/actions-riff-raff@581c043714b5b8353d5a23d79b958cd416c996e0 # v4.3.2
         with:
-          app: service-catalogue
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           buildNumber: ${{ env.GITHUB_RUN_NUMBER }}


### PR DESCRIPTION
## What does this change?
Update the configuration of `guardian/actions-riff-raff`; when `projectName` is provided, `app` is ignored.

## How has it been verified?
The action should continue to work as normal. For example, it should add a comment to this PR with quick links to deploy the project to CODE.

---

See also https://github.com/guardian/service-catalogue/pull/64.