### PR TITLE
feat: add malware alerts

### DIFF
--- a/packages/common/src/functions.test.ts
+++ b/packages/common/src/functions.test.ts
@@ -281,6 +281,24 @@ void describe('daysLeftToFix', () => {
 		assert.strictEqual(isSunday, true);
 		assert.strictEqual(daysLeftToFix(sunday, 'critical'), 2);
 	});
+	void it('should reset malware SLA to 1 day remaining when raised on Friday, Saturday, or Sunday', () => {
+		const friday = new Date('2024-10-04'); // Friday
+		const saturday = new Date('2024-10-05'); // Saturday
+		const sunday = new Date('2024-10-06'); // Sunday
+
+		assert.strictEqual(daysLeftToFix(friday, 'critical', 'malware'), 1);
+		assert.strictEqual(daysLeftToFix(saturday, 'critical', 'malware'), 1);
+		assert.strictEqual(daysLeftToFix(sunday, 'critical', 'malware'), 1);
+	});
+
+	void it('should apply the same malware SLA regardless of severity', () => {
+		const friday = new Date('2024-10-04');
+
+		assert.strictEqual(daysLeftToFix(friday, 'low', 'malware'), 1);
+		assert.strictEqual(daysLeftToFix(friday, 'medium', 'malware'), 1);
+		assert.strictEqual(daysLeftToFix(friday, 'high', 'malware'), 1);
+		assert.strictEqual(daysLeftToFix(friday, 'critical', 'malware'), 1);
+	});
 });
 
 const MOCK_TODAY = new Date('2024-01-10');

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -4,11 +4,11 @@ import { createAppAuth } from '@octokit/auth-app';
 import type { SNSEvent } from 'aws-lambda';
 import { Octokit } from 'octokit';
 import {
+	generalSLAs,
 	type GitHubAppConfig,
 	type GithubAppSecret,
 	type NonEmptyArray,
 	type Severity,
-	SLAs,
 } from 'common/src/types.js';
 /* eslint-disable @typescript-eslint/no-unsafe-assignment  -- this is not unsafe */
 /* eslint-disable @typescript-eslint/no-unsafe-call  -- this is not unsafe */
@@ -202,7 +202,7 @@ export function daysLeftToFix(
 	alert_date: Date,
 	severity: Severity,
 ): number | undefined {
-	const daysToFix = SLAs[severity];
+	const daysToFix = generalSLAs[severity];
 	if (!daysToFix) {
 		return undefined;
 	}

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -3,6 +3,7 @@ import type { Action } from '@guardian/anghammarad';
 import { createAppAuth } from '@octokit/auth-app';
 import type { SNSEvent } from 'aws-lambda';
 import { Octokit } from 'octokit';
+import type { AlertType } from 'common/src/types.js';
 import {
 	generalSLAs,
 	type GitHubAppConfig,
@@ -198,22 +199,29 @@ function weekendOffset(date: Date): number {
 	}
 }
 
+export const MALWARE_SLA = 1; // all severities of malware have SLA of 1 working day
+
 export function daysLeftToFix(
 	alert_date: Date,
 	severity: Severity,
+	alertType: AlertType = 'general',
 ): number | undefined {
-	const daysToFix = generalSLAs[severity];
+	const daysToFix =
+		alertType === 'malware' ? MALWARE_SLA : generalSLAs[severity];
+
 	if (!daysToFix) {
 		return undefined;
 	}
+
 	const fixDate = new Date(alert_date);
 	fixDate.setDate(fixDate.getDate() + daysToFix);
+
 	const millisecondsInADay = 1000 * 60 * 60 * 24;
 	const daysLeftToFix = Math.ceil(
 		(fixDate.getTime() - new Date().getTime()) / millisecondsInADay,
 	);
 
-	if (severity === 'critical') {
+	if (severity === 'critical' && alertType === 'general') {
 		const weekendOffsetValue = weekendOffset(alert_date);
 		return Math.max(0, daysLeftToFix + weekendOffsetValue);
 	} else {
@@ -227,13 +235,14 @@ export function daysLeftToFix(
 export function isWithinSlaTime(
 	firstObservedAt: Date | null,
 	severity: Severity,
+	alertType: AlertType = 'general',
 ): boolean {
 	if (!firstObservedAt) {
 		console.warn('No first observed date provided');
 		return false;
 	}
 
-	const daysToFix = daysLeftToFix(firstObservedAt, severity);
+	const daysToFix = daysLeftToFix(firstObservedAt, severity, alertType);
 	if (daysToFix === undefined) {
 		return false;
 	}

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -217,10 +217,8 @@ export function daysLeftToFix(
 	if (!daysToFix) {
 		return undefined;
 	}
-
 	const fixDate = new Date(alert_date);
 	fixDate.setDate(fixDate.getDate() + daysToFix);
-
 	const millisecondsInADay = 1000 * 60 * 60 * 24;
 	const daysLeftToFix = Math.ceil(
 		(fixDate.getTime() - new Date().getTime()) / millisecondsInADay,

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -184,55 +184,52 @@ export function stringToSeverity(severity: string): Severity {
 	}
 }
 
-function weekendOffset(date: Date, alertType: AlertType): number {
-	const isFriday = date.getDay() === 5;
-	const isSaturday = date.getDay() === 6;
-	const isSunday = date.getDay() === 0;
-
-	if (alertType === 'general') {
-		if (isSunday) {
-			return 1;
-		}
-		if (isSaturday || isFriday) {
-			return 2;
-		}
-	} else {
-		if (isFriday || isSaturday || isSunday) {
-			return 1;
-		}
-	}
-	return 0;
-}
-
 export const MALWARE_SLA = 1; // all severities of malware have SLA of 1 working day
+
+const WEEKEND_OFFSETS: Record<AlertType, Partial<Record<number, number>>> = {
+	general: {
+		0: 1, // Sunday
+		5: 2, // Friday
+		6: 2, // Saturday
+	},
+	malware: {
+		0: 1, // Sunday
+		5: 3, // Friday
+		6: 2, // Saturday
+	},
+};
+
+/**
+ * Returns the weekend SLA adjustment (in days) for a given alert date and type.
+ *
+ * The value is looked up from `WEEKEND_OFFSETS` using:
+ * - `alertType` (`general` or `malware`)
+ * - `date.getDay()` (0 = Sunday, 5 = Friday, 6 = Saturday)
+ *
+ * If no rule exists for that day/type, returns `0`.
+ */
+function weekendOffset(date: Date, alertType: AlertType): number {
+	return WEEKEND_OFFSETS[alertType][date.getDay()] ?? 0;
+}
 
 export function daysLeftToFix(
 	alert_date: Date,
 	severity: Severity,
 	alertType: AlertType = 'general',
 ): number | undefined {
-	const daysToFix =
-		alertType === 'malware' ? MALWARE_SLA : generalSLAs[severity];
+	const slaDays = alertType === 'malware' ? MALWARE_SLA : generalSLAs[severity];
+	if (slaDays === undefined) return undefined;
 
-	if (!daysToFix) {
-		return undefined;
-	}
 	const fixDate = new Date(alert_date);
-	fixDate.setDate(fixDate.getDate() + daysToFix);
+	fixDate.setDate(fixDate.getDate() + slaDays);
 	const millisecondsInADay = 1000 * 60 * 60 * 24;
-	const daysLeftToFix = Math.ceil(
-		(fixDate.getTime() - new Date().getTime()) / millisecondsInADay,
-	);
+	const baseDaysLeft = Math.ceil((fixDate.getTime() - Date.now()) / millisecondsInADay);
 
-	if (
-		(severity === 'critical' && alertType === 'general') ||
-		alertType === 'malware'
-	) {
-		const weekendOffsetValue = weekendOffset(alert_date, alertType);
-		return Math.max(0, daysLeftToFix + weekendOffsetValue);
-	} else {
-		return Math.max(0, daysLeftToFix);
+	if (alertType === 'malware' || (alertType === 'general' && severity === 'critical')) {
+		return Math.max(0, baseDaysLeft + weekendOffset(alert_date, alertType));
 	}
+
+	return Math.max(0, baseDaysLeft);
 }
 
 /**

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -184,19 +184,24 @@ export function stringToSeverity(severity: string): Severity {
 	}
 }
 
-function weekendOffset(date: Date): number {
+function weekendOffset(date: Date, alertType: AlertType): number {
 	const isFriday = date.getDay() === 5;
 	const isSaturday = date.getDay() === 6;
 	const isSunday = date.getDay() === 0;
 
-	if (isSunday) {
-		return 1;
-	}
-	if (isSaturday || isFriday) {
-		return 2;
+	if (alertType === 'general') {
+		if (isSunday) {
+			return 1;
+		}
+		if (isSaturday || isFriday) {
+			return 2;
+		}
 	} else {
-		return 0;
+		if (isFriday || isSaturday || isSunday) {
+			return 1;
+		}
 	}
+	return 0;
 }
 
 export const MALWARE_SLA = 1; // all severities of malware have SLA of 1 working day
@@ -221,8 +226,11 @@ export function daysLeftToFix(
 		(fixDate.getTime() - new Date().getTime()) / millisecondsInADay,
 	);
 
-	if (severity === 'critical' && alertType === 'general') {
-		const weekendOffsetValue = weekendOffset(alert_date);
+	if (
+		(severity === 'critical' && alertType === 'general') ||
+		alertType === 'malware'
+	) {
+		const weekendOffsetValue = weekendOffset(alert_date, alertType);
 		return Math.max(0, daysLeftToFix + weekendOffsetValue);
 	} else {
 		return Math.max(0, daysLeftToFix);

--- a/packages/common/src/functions.ts
+++ b/packages/common/src/functions.ts
@@ -218,14 +218,21 @@ export function daysLeftToFix(
 	alertType: AlertType = 'general',
 ): number | undefined {
 	const slaDays = alertType === 'malware' ? MALWARE_SLA : generalSLAs[severity];
-	if (slaDays === undefined) return undefined;
+	if (slaDays === undefined) {
+		return undefined;
+	}
 
 	const fixDate = new Date(alert_date);
 	fixDate.setDate(fixDate.getDate() + slaDays);
 	const millisecondsInADay = 1000 * 60 * 60 * 24;
-	const baseDaysLeft = Math.ceil((fixDate.getTime() - Date.now()) / millisecondsInADay);
+	const baseDaysLeft = Math.ceil(
+		(fixDate.getTime() - Date.now()) / millisecondsInADay,
+	);
 
-	if (alertType === 'malware' || (alertType === 'general' && severity === 'critical')) {
+	if (
+		(alertType === 'general' && severity === 'critical') ||
+		alertType === 'malware'
+	) {
 		return Math.max(0, baseDaysLeft + weekendOffset(alert_date, alertType));
 	}
 

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -69,6 +69,8 @@ export type DependencyScope = 'runtime' | 'development';
 
 export type AlertType = 'general' | 'malware';
 
+export type DigestType = 'vulnerability' | 'malware';
+
 export function chooseDependencyScope(
 	scope: string | null | undefined,
 	dependency: string,
@@ -118,7 +120,7 @@ export interface RepositoryWithDepGraphLanguage extends Repository {
 }
 
 // The number of days teams have to fix vulnerabilities of a given severity
-export const SLAs: Record<Severity, number | undefined> = {
+export const generalSLAs: Record<Severity, number | undefined> = {
 	critical: 2,
 	high: 30,
 	medium: undefined,

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -7,7 +7,6 @@ import { logger } from 'common/src/logs.js';
 import type { AlertType } from 'common/src/types.js';
 import {
 	chooseDependencyScope,
-	type NonEmptyArray,
 	type RepocopVulnerability,
 	type Repository,
 } from 'common/src/types.js';
@@ -34,13 +33,11 @@ function prismaToCustomType(
 
 async function getRepocopVulnerabilities(
 	client: PrismaClient,
-): Promise<NonEmptyArray<ObligatronRepocopVulnerability>> {
+): Promise<ObligatronRepocopVulnerability[]> {
 	const rawResponse = await client.repocop_vulnerabilities.findMany({});
-	return toNonEmptyArray(
-		rawResponse
-			.filter((r) => r.alert_type === 'general') // exclude malware alerts
-			.map(prismaToCustomType),
-	);
+	return rawResponse
+		.filter((r) => r.alert_type === 'general') // exclude malware alerts
+		.map(prismaToCustomType);
 }
 
 async function getProductionRepos(client: PrismaClient): Promise<Repository[]> {
@@ -93,6 +90,11 @@ export async function evaluateDependencyVulnerabilityObligation(
 	const vulns = (await getRepocopVulnerabilities(client)).filter(
 		(v) => !v.within_sla,
 	);
+
+	if (vulns.length === 0) {
+		logger.log({ message: 'No dependency vulnerabilities found outside SLA' });
+		return [];
+	}
 
 	const resultsOrUndefined: Array<ObligationResult | undefined> = repos.map(
 		(repo) => {

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.ts
@@ -36,8 +36,11 @@ async function getRepocopVulnerabilities(
 	client: PrismaClient,
 ): Promise<NonEmptyArray<ObligatronRepocopVulnerability>> {
 	const rawResponse = await client.repocop_vulnerabilities.findMany({});
-	// TODO:  filter for alert_type 'general' only
-	return toNonEmptyArray(rawResponse.map(prismaToCustomType));
+	return toNonEmptyArray(
+		rawResponse
+			.filter((r) => r.alert_type === 'general') // exclude malware alerts
+			.map(prismaToCustomType),
+	);
 }
 
 async function getProductionRepos(client: PrismaClient): Promise<Repository[]> {

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -8,7 +8,7 @@ import type {
 } from 'common/prisma-client/client.js';
 import type { RepocopVulnerability, Repository } from 'common/src/types.js';
 import { exampleDependabotAlert } from '../test-data/example-dependabot-alerts.js';
-import type { AwsCloudFormationStack } from '../types.js';
+import type { Alert, AwsCloudFormationStack } from '../types.js';
 import {
 	deduplicateVulnerabilitiesByCve,
 	dependabotAlertToRepocopVulnerability,
@@ -630,6 +630,27 @@ void describe('NO RULE - Dependabot alerts', () => {
 	});
 });
 
+function buildDependabotAlert(
+	createdAt: string,
+	severity: Alert['security_advisory']['severity'],
+	classification: Alert['security_advisory']['classification'],
+): Alert {
+	const baseAlert = exampleDependabotAlert[0];
+	if (!baseAlert) {
+		throw new Error('Missing example Dependabot alert fixture');
+	}
+
+	return {
+		...baseAlert,
+		created_at: createdAt,
+		security_advisory: {
+			...baseAlert.security_advisory,
+			severity,
+			classification,
+		},
+	};
+}
+
 void describe('NO RULE - Vulnerabilities from Dependabot', () => {
 	const fullName = 'guardian/myrepo';
 	const result: RepocopVulnerability[] = exampleDependabotAlert.map((alert) =>
@@ -684,6 +705,85 @@ void describe('NO RULE - Vulnerabilities from Dependabot', () => {
 		const actual = result.map((r) => r.urls)[0];
 		const expected = ['https://github.com/advisories/GHSA-rf4j-j272-fj86'];
 		assert.deepStrictEqual(actual?.slice(0, 1), expected);
+	});
+	void test('marks a new general alert as within SLA', () => {
+		const alert = buildDependabotAlert(
+			new Date().toISOString(),
+			'high',
+			'general',
+		);
+
+		const result = dependabotAlertToRepocopVulnerability(
+			'guardian/some-repo',
+			alert,
+		);
+
+		assert.strictEqual(result.alert_type, 'general');
+		assert.strictEqual(result.within_sla, true);
+	});
+
+	void test('marks an old general alert as outside SLA', () => {
+		const oldDate = new Date();
+		oldDate.setDate(oldDate.getDate() - 31);
+
+		const alert = buildDependabotAlert(
+			oldDate.toISOString(),
+			'high',
+			'general',
+		);
+
+		const result = dependabotAlertToRepocopVulnerability(
+			'guardian/some-repo',
+			alert,
+		);
+
+		assert.strictEqual(result.alert_type, 'general');
+		assert.strictEqual(result.within_sla, false);
+	});
+
+	void test('marks a new malware alert as within SLA', () => {
+		const alert = buildDependabotAlert(
+			new Date().toISOString(),
+			'low',
+			'malware',
+		);
+
+		const result = dependabotAlertToRepocopVulnerability(
+			'guardian/some-repo',
+			alert,
+		);
+
+		assert.strictEqual(result.alert_type, 'malware');
+		assert.strictEqual(result.within_sla, true);
+	});
+
+	void test('marks an old malware alert as outside SLA regardless of severity', () => {
+		const oldDate = new Date();
+		oldDate.setDate(oldDate.getDate() - 2);
+
+		const alert = buildDependabotAlert(
+			oldDate.toISOString(),
+			'high',
+			'malware',
+		);
+
+		const result = dependabotAlertToRepocopVulnerability(
+			'guardian/some-repo',
+			alert,
+		);
+
+		assert.strictEqual(result.alert_type, 'malware');
+		assert.strictEqual(result.within_sla, false);
+	});
+	void test('treats a null classification as a general alert', () => {
+		const alert = buildDependabotAlert(new Date().toISOString(), 'high', null);
+
+		const result = dependabotAlertToRepocopVulnerability(
+			'guardian/some-repo',
+			alert,
+		);
+
+		assert.strictEqual(result.alert_type, 'general');
 	});
 });
 

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -706,7 +706,7 @@ void describe('NO RULE - Vulnerabilities from Dependabot', () => {
 		const expected = ['https://github.com/advisories/GHSA-rf4j-j272-fj86'];
 		assert.deepStrictEqual(actual?.slice(0, 1), expected);
 	});
-	void test('marks a new general alert as within SLA', () => {
+	void test('marks a new dependency vulnerability as within SLA', () => {
 		const alert = buildDependabotAlert(
 			new Date().toISOString(),
 			'high',
@@ -722,7 +722,7 @@ void describe('NO RULE - Vulnerabilities from Dependabot', () => {
 		assert.strictEqual(result.within_sla, true);
 	});
 
-	void test('marks an old general alert as outside SLA', () => {
+	void test('marks an out-of-date dependency vulnerability as outside SLA', () => {
 		const oldDate = new Date();
 		oldDate.setDate(oldDate.getDate() - 31);
 
@@ -775,6 +775,7 @@ void describe('NO RULE - Vulnerabilities from Dependabot', () => {
 		assert.strictEqual(result.alert_type, 'malware');
 		assert.strictEqual(result.within_sla, false);
 	});
+
 	void test('treats a null classification as a general alert', () => {
 		const alert = buildDependabotAlert(new Date().toISOString(), 'high', null);
 

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -759,7 +759,7 @@ void describe('NO RULE - Vulnerabilities from Dependabot', () => {
 
 	void test('marks an old malware alert as outside SLA regardless of severity', () => {
 		const oldDate = new Date();
-		oldDate.setDate(oldDate.getDate() - 2);
+		oldDate.setDate(oldDate.getDate() - 5);
 
 		const alert = buildDependabotAlert(
 			oldDate.toISOString(),

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -5,7 +5,11 @@ import type {
 	repocop_github_repository_rules,
 	view_repo_ownership,
 } from 'common/prisma-client/client.js';
-import { isWithinSlaTime, partition } from 'common/src/functions.js';
+import {
+	isWithinSlaTime,
+	MALWARE_SLA,
+	partition,
+} from 'common/src/functions.js';
 import { chooseDependencyScope, generalSLAs } from 'common/src/types.js';
 import type {
 	AlertType,
@@ -269,13 +273,12 @@ function findArchivedReposWithStacks(
 
 	return archivedReposWithPotentialStacks;
 }
-
+//TODO: remove this function as it's not used
 export function vulnerabilityExceedsSla(
 	date: Date,
 	severity: Severity,
 	alert_type: AlertType,
 ) {
-	const MALWARE_SLA = 1; // all severities of malware have SLA of 1 working day
 	const daysToRemediate =
 		alert_type === 'general' ? generalSLAs[severity] : MALWARE_SLA;
 
@@ -288,6 +291,7 @@ export function vulnerabilityExceedsSla(
 	return date < cutOffDate;
 }
 
+//TODO: remove this function as it's not used
 export function hasOldAlerts(
 	alerts: RepocopVulnerability[],
 	repo: Repository,
@@ -452,7 +456,7 @@ export function evaluateOneRepo(
 	workflowsForRepo: guardian_github_actions_usage[],
 ): EvaluationResult {
 	const vulnerabilities = dependabotAlertsForRepo ?? [];
-	hasOldAlerts(vulnerabilities, repo);
+	hasOldAlerts(vulnerabilities, repo); // TODO: remove as we do nothing with this
 
 	const repocopRules: repocop_github_repository_rules = {
 		full_name: repo.full_name,
@@ -522,7 +526,7 @@ export function dependabotAlertToRepocopVulnerability(
 		alert_issue_date: alertIssueDate,
 		is_patchable: !!alert.security_vulnerability.first_patched_version,
 		cves: CVEs,
-		within_sla: isWithinSlaTime(alertIssueDate, severity),
+		within_sla: isWithinSlaTime(alertIssueDate, severity, alert_type),
 		scope: chooseDependencyScope(
 			alert.dependency.scope,
 			alert.security_vulnerability.package.name,

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -6,8 +6,9 @@ import type {
 	view_repo_ownership,
 } from 'common/prisma-client/client.js';
 import { isWithinSlaTime, partition } from 'common/src/functions.js';
-import { chooseDependencyScope, SLAs } from 'common/src/types.js';
+import { chooseDependencyScope, generalSLAs } from 'common/src/types.js';
 import type {
+	AlertType,
 	DepGraphLanguage,
 	RepocopVulnerability,
 	Repository,
@@ -269,8 +270,14 @@ function findArchivedReposWithStacks(
 	return archivedReposWithPotentialStacks;
 }
 
-export function vulnerabilityExceedsSla(date: Date, severity: Severity) {
-	const daysToRemediate = SLAs[severity];
+export function vulnerabilityExceedsSla(
+	date: Date,
+	severity: Severity,
+	alert_type: AlertType,
+) {
+	const MALWARE_SLA = 1; // all severities of malware have SLA of 1 working day
+	const daysToRemediate =
+		alert_type === 'general' ? generalSLAs[severity] : MALWARE_SLA;
 
 	if (daysToRemediate === undefined) {
 		return false;
@@ -289,7 +296,11 @@ export function hasOldAlerts(
 		return false;
 	}
 	const oldAlerts = alerts.filter((a) =>
-		vulnerabilityExceedsSla(new Date(a.alert_issue_date), a.severity),
+		vulnerabilityExceedsSla(
+			new Date(a.alert_issue_date),
+			a.severity,
+			a.alert_type,
+		),
 	);
 
 	if (oldAlerts.length > 0) {
@@ -527,7 +538,7 @@ export function evaluateRepositories(
 	owners: view_repo_ownership[],
 	repoLanguages: github_languages[],
 	dependabotVulnerabilities: RepocopVulnerability[],
-	productionWorkflowUsages: guardian_github_actions_usage[],
+	workflowUsages: guardian_github_actions_usage[],
 ): EvaluationResult[] {
 	const evaluatedRepos = repositories.map((r) => {
 		const vulnsForRepo = dependabotVulnerabilities.filter(
@@ -536,7 +547,7 @@ export function evaluateRepositories(
 
 		const teamsForRepo = owners.filter((o) => o.full_repo_name === r.full_name);
 		const branchesForRepo = branches.filter((b) => b.repository_id === r.id);
-		const workflowsForRepo = productionWorkflowUsages.filter(
+		const workflowsForRepo = workflowUsages.filter(
 			(repo) => repo.full_name === r.full_name,
 		);
 

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -273,7 +273,7 @@ function findArchivedReposWithStacks(
 
 	return archivedReposWithPotentialStacks;
 }
-//TODO: remove this function as it's not used
+// TODO: remove this helper if/when `hasOldAlerts` (which uses it) is removed.
 export function vulnerabilityExceedsSla(
 	date: Date,
 	severity: Severity,

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -23,6 +23,7 @@ import {
 } from './evaluation/repository.js';
 import { sendToCloudwatch } from './metrics.js';
 import {
+	getDependabotMalware,
 	getDependabotVulnerabilities,
 	getProductionWorkflowUsages,
 	getRepositoryBranches,
@@ -35,9 +36,16 @@ import { applyBranchProtectionAndMessageTeams } from './remediation/branch-prote
 import { sendReposToDependencyGraphIntegrator } from './remediation/dependency_graph-integrator/send-to-sns.js';
 import { sendPotentialInteractives } from './remediation/topics/topic-monitor-interactive.js';
 import { applyProductionTopicAndMessageTeams } from './remediation/topics/topic-monitor-production.js';
-import { createAndSendVulnerabilityDigests } from './remediation/vuln-digest/vuln-digest.js';
+import {
+	createAndSendMalwareDigests,
+	createAndSendVulnerabilityDigests,
+} from './remediation/vuln-digest/vuln-digest.js';
 import type { AwsCloudFormationStack, EvaluationResult } from './types.js';
-import { isProduction } from './utils.js';
+import {
+	generalEvaluationResults,
+	isProduction,
+	malwareEvaluationResults,
+} from './utils.js';
 
 async function writeEvaluationTable(
 	evaluatedRepos: repocop_github_repository_rules[],
@@ -90,12 +98,21 @@ export async function main() {
 	const repoOwners = await getRepoOwnership(prisma);
 
 	const productionRepos = unarchivedRepos.filter((repo) => isProduction(repo));
+
+	// Critical and high Dependabot alerts with alert_type: 'general'
 	const productionDependabotVulnerabilities: RepocopVulnerability[] =
 		await getDependabotVulnerabilities(
 			productionRepos,
 			config.gitHubOrg,
 			octokit,
 		);
+
+	// All severity Dependabot alerts with alert_type: 'malware'
+	const productionDependabotMalware: RepocopVulnerability[] =
+		await getDependabotMalware(productionRepos, config.gitHubOrg, octokit);
+
+	const combinedProdDependabotVulns: RepocopVulnerability[] =
+		productionDependabotVulnerabilities.concat(productionDependabotMalware);
 
 	const productionWorkflowUsages: guardian_github_actions_usage[] =
 		await getProductionWorkflowUsages(prisma, productionRepos);
@@ -105,26 +122,39 @@ export async function main() {
 		branches,
 		repoOwners,
 		repoLanguages,
-		productionDependabotVulnerabilities,
+		combinedProdDependabotVulns,
 		productionWorkflowUsages,
 	);
 
 	const repocopRules = evaluationResults.map((r) => r.repocopRules);
+
 	const severityPredicate = (x: RepocopVulnerability) => x.severity === 'high';
-	const [high, critical] = partition(
-		evaluationResults.flatMap((r) => r.vulnerabilities),
-		severityPredicate,
+
+	const allVulnerabilities = evaluationResults.flatMap(
+		(r) => r.vulnerabilities,
 	);
+	const generalVulnerabilities = allVulnerabilities.filter(
+		(v) => v.alert_type === 'general',
+	);
+	const [high, critical] = partition(generalVulnerabilities, severityPredicate);
 
 	const highPatchable = high.filter((x) => x.is_patchable).length;
 	const criticalPatchable = critical.filter((x) => x.is_patchable).length;
 
 	console.warn(
-		`Found ${high.length} out of date high vulnerabilities, of which ${highPatchable} are patchable`,
+		`Found ${high.length} high dependency vulnerabilities, of which ${highPatchable} are patchable`,
 	);
 	console.warn(
-		`Found ${critical.length} out of date critical vulnerabilities, of which ${criticalPatchable} are patchable`,
+		`Found ${critical.length} critical dependency vulnerabilities, of which ${criticalPatchable} are patchable`,
 	);
+
+	const malwareVulnerabilities = allVulnerabilities.filter(
+		(v) => v.alert_type === 'malware',
+	);
+
+	if (malwareVulnerabilities.length > 0) {
+		console.warn(`Found ${malwareVulnerabilities.length} malware alerts`);
+	}
 
 	function combineVulnWithOwners(
 		vuln: RepocopVulnerability,
@@ -139,13 +169,13 @@ export async function main() {
 	}
 
 	/**
-	 * Create repocop vulnerabilities and write to repocop_vulnerabilities table
+	 * Create repocop vulnerabilities (general and malware) and write to repocop_vulnerabilities table
 	 */
-	const vulnerabilities = evaluationResults
-		.flatMap((result) => result.vulnerabilities)
-		.flatMap((vuln) => combineVulnWithOwners(vuln, repoOwners));
+	const vulnerabilitiesWithOwners = allVulnerabilities.flatMap((vuln) =>
+		combineVulnWithOwners(vuln, repoOwners),
+	);
 
-	await writeVulnerabilitiesTable(vulnerabilities, prisma);
+	await writeVulnerabilitiesTable(vulnerabilitiesWithOwners, prisma);
 
 	const awsConfig = awsClientConfig(config.stage);
 	const cloudwatch = new CloudWatchClient(awsConfig);
@@ -182,6 +212,7 @@ export async function main() {
 	);
 
 	await writeEvaluationTable(repocopRules, prisma);
+
 	if (config.enableMessaging) {
 		await sendPotentialInteractives(repocopRules, config);
 
@@ -197,11 +228,20 @@ export async function main() {
 			(team) => !externalTeams.includes(team.slug),
 		);
 
+		// Message teams about vulnerabilities and malware
+		const generalResults = generalEvaluationResults(evaluationResults);
 		await createAndSendVulnerabilityDigests(
 			config,
 			engineeringTeams,
 			repoOwners,
-			evaluationResults,
+			generalResults,
+		);
+		const malwareResults = malwareEvaluationResults(evaluationResults);
+		await createAndSendMalwareDigests(
+			config,
+			engineeringTeams,
+			repoOwners,
+			malwareResults,
 		);
 
 		await applyProductionTopicAndMessageTeams(

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -229,19 +229,17 @@ export async function main() {
 		);
 
 		// Message teams about vulnerabilities and malware
-		const generalResults = generalEvaluationResults(evaluationResults);
 		await createAndSendVulnerabilityDigests(
 			config,
 			engineeringTeams,
 			repoOwners,
-			generalResults,
+			evaluationResults,
 		);
-		const malwareResults = malwareEvaluationResults(evaluationResults);
 		await createAndSendMalwareDigests(
 			config,
 			engineeringTeams,
 			repoOwners,
-			malwareResults,
+			evaluationResults,
 		);
 
 		await applyProductionTopicAndMessageTeams(

--- a/packages/repocop/src/index.ts
+++ b/packages/repocop/src/index.ts
@@ -41,11 +41,7 @@ import {
 	createAndSendVulnerabilityDigests,
 } from './remediation/vuln-digest/vuln-digest.js';
 import type { AwsCloudFormationStack, EvaluationResult } from './types.js';
-import {
-	generalEvaluationResults,
-	isProduction,
-	malwareEvaluationResults,
-} from './utils.js';
+import { isProduction } from './utils.js';
 
 async function writeEvaluationTable(
 	evaluatedRepos: repocop_github_repository_rules[],

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -77,6 +77,8 @@ async function getAlertsForRepo(
 	octokit: Octokit,
 	orgName: string,
 	repoName: string,
+	classification: string,
+	severities: string,
 ): Promise<Alert[] | undefined> {
 	const prefix = `${orgName}/`;
 	if (repoName.startsWith(prefix)) {
@@ -89,7 +91,8 @@ async function getAlertsForRepo(
 				owner: orgName,
 				repo: repoName,
 				per_page: 100,
-				severity: 'critical,high',
+				classification,
+				severity: severities,
 				state: 'open',
 				sort: 'created',
 				direction: 'asc', //retrieve oldest vulnerabilities first
@@ -112,10 +115,18 @@ export async function getDependabotVulnerabilities(
 	orgName: string,
 	octokit: Octokit,
 ) {
+	const classification = 'general';
+	const severities = 'critical,high';
 	const dependabotVulnerabilities: RepocopVulnerability[] = (
 		await Promise.all(
 			repos.map(async (repo) => {
-				const alerts = await getAlertsForRepo(octokit, orgName, repo.name);
+				const alerts = await getAlertsForRepo(
+					octokit,
+					orgName,
+					repo.name,
+					classification,
+					severities,
+				);
 				if (alerts) {
 					return alerts.map((a) =>
 						dependabotAlertToRepocopVulnerability(repo.full_name, a),
@@ -128,6 +139,39 @@ export async function getDependabotVulnerabilities(
 
 	console.log(
 		`Found ${dependabotVulnerabilities.length} dependabot vulnerabilities across ${repos.length} repos`,
+	);
+
+	return dependabotVulnerabilities;
+}
+export async function getDependabotMalware(
+	repos: Repository[],
+	orgName: string,
+	octokit: Octokit,
+) {
+	const classification = 'malware';
+	const severities = 'critical,high,medium,low';
+	const dependabotVulnerabilities: RepocopVulnerability[] = (
+		await Promise.all(
+			repos.map(async (repo) => {
+				const alerts = await getAlertsForRepo(
+					octokit,
+					orgName,
+					repo.name,
+					classification,
+					severities,
+				);
+				if (alerts) {
+					return alerts.map((a) =>
+						dependabotAlertToRepocopVulnerability(repo.full_name, a),
+					);
+				}
+				return [];
+			}),
+		)
+	).flat();
+
+	console.log(
+		`Found ${dependabotVulnerabilities.length} dependabot malware across ${repos.length} repos`,
 	);
 
 	return dependabotVulnerabilities;

--- a/packages/repocop/src/query.ts
+++ b/packages/repocop/src/query.ts
@@ -150,7 +150,7 @@ export async function getDependabotMalware(
 ) {
 	const classification = 'malware';
 	const severities = 'critical,high,medium,low';
-	const dependabotVulnerabilities: RepocopVulnerability[] = (
+	const dependabotMalware: RepocopVulnerability[] = (
 		await Promise.all(
 			repos.map(async (repo) => {
 				const alerts = await getAlertsForRepo(
@@ -171,10 +171,10 @@ export async function getDependabotMalware(
 	).flat();
 
 	console.log(
-		`Found ${dependabotVulnerabilities.length} dependabot malware across ${repos.length} repos`,
+		`Found ${dependabotMalware.length} dependabot malware across ${repos.length} repos`,
 	);
 
-	return dependabotVulnerabilities;
+	return dependabotMalware;
 }
 
 export async function getProductionWorkflowUsages(

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -107,19 +107,23 @@ function getMessage(value: { message: string } | undefined): string {
 
 function assertSubstringsInOrder(message: string, substrings: string[]): void {
 	let lastIndex = -1;
+	let previousSubstring: string | undefined;
 
 	for (const substring of substrings) {
-		const index = message.indexOf(substring);
+		const index = message.indexOf(substring, lastIndex + 1);
 		assert.notStrictEqual(
 			index,
 			-1,
-			`Expected message to include "${substring}"`,
+			`Expected message to include "${substring}" after "${previousSubstring ?? 'start of message'}"`,
 		);
 		assert.ok(
 			index > lastIndex,
-			`Expected "${substring}" to appear after the previous item`,
+			previousSubstring
+				? `Expected "${substring}" to appear after "${previousSubstring}"`
+				: `Expected "${substring}" to appear after the previous item`,
 		);
 		lastIndex = index;
+		previousSubstring = substring;
 	}
 }
 
@@ -151,19 +155,12 @@ void describe('createDigestForSeverity', () => {
 			package: 'patchableInSLA',
 		};
 
-		const today = new Date();
-		const yesterday = new Date(today);
-		yesterday.setDate(today.getDate() - 1);
-
-		const dayBeforeYesterday = new Date(today);
-		dayBeforeYesterday.setDate(today.getDate() - 2);
-
 		const unpatchableInSLAToday: RepocopVulnerability = {
 			...highRecentVuln,
 			is_patchable: false,
 			within_sla: true,
 			package: 'unpatchableInSLAToday',
-			alert_issue_date: today,
+			alert_issue_date: daysAgo(0),
 		};
 
 		const unpatchableInSLAYesterday: RepocopVulnerability = {
@@ -171,7 +168,7 @@ void describe('createDigestForSeverity', () => {
 			is_patchable: false,
 			within_sla: true,
 			package: 'unpatchableInSLAYesterday',
-			alert_issue_date: yesterday,
+			alert_issue_date: daysAgo(1),
 		};
 
 		const unpatchableInSLADayBeforeYesterday: RepocopVulnerability = {
@@ -179,7 +176,7 @@ void describe('createDigestForSeverity', () => {
 			is_patchable: false,
 			within_sla: true,
 			package: 'unpatchableInSLADayBeforeYesterday',
-			alert_issue_date: dayBeforeYesterday,
+			alert_issue_date: daysAgo(2),
 		};
 
 		const patchableOutsideSLA: RepocopVulnerability = {
@@ -422,6 +419,31 @@ void describe('createDigestForSeverity', () => {
 		assert.match(message, /leftpad/);
 		assert.doesNotMatch(message, /medium-package/);
 	});
+	void it('ignores malware vulnerabilities when passed mixed results', () => {
+		const malwareVuln: RepocopVulnerability = {
+			...highRecentVuln,
+			package: 'bad-package',
+			alert_type: 'malware',
+		};
+
+		const resultWithMixedAlerts: EvaluationResult = {
+			...result,
+			vulnerabilities: [highRecentVuln, malwareVuln],
+		};
+
+		const message = getMessage(
+			createDigestForSeverity(
+				team,
+				'high',
+				[ownershipRecord],
+				[resultWithMixedAlerts],
+				60,
+			),
+		);
+
+		assert.match(message, /leftpad/);
+		assert.doesNotMatch(message, /bad-package/);
+	});
 });
 
 void describe('removeNonRuntimeVulns', () => {
@@ -579,65 +601,6 @@ void describe('createMalwareDigest', () => {
 		assert.doesNotMatch(message, /old-malware/);
 	});
 
-	void it('returns malware in priority order', () => {
-		const today = new Date();
-		const yesterday = new Date(today);
-		yesterday.setDate(today.getDate() - 1);
-
-		const patchableOutsideSLA: RepocopVulnerability = {
-			...recentMalware,
-			package: 'patchableOutsideSLA',
-			is_patchable: true,
-			within_sla: false,
-			alert_issue_date: today,
-		};
-
-		const patchableInSLA: RepocopVulnerability = {
-			...recentMalware,
-			package: 'patchableInSLA',
-			is_patchable: true,
-			within_sla: true,
-			alert_issue_date: today,
-		};
-
-		const unpatchableOutsideSLA: RepocopVulnerability = {
-			...recentMalware,
-			package: 'unpatchableOutsideSLA',
-			is_patchable: false,
-			within_sla: false,
-			alert_issue_date: today,
-		};
-
-		const unpatchableInSLAOlder: RepocopVulnerability = {
-			...recentMalware,
-			package: 'unpatchableInSLAOlder',
-			is_patchable: false,
-			within_sla: true,
-			alert_issue_date: yesterday,
-		};
-
-		const resultWithMalware: EvaluationResult = {
-			...result,
-			vulnerabilities: [
-				unpatchableInSLAOlder,
-				unpatchableOutsideSLA,
-				patchableInSLA,
-				patchableOutsideSLA,
-			],
-		};
-
-		const message = getMessage(
-			createMalwareDigest(team, [ownershipRecord], [resultWithMalware], 60),
-		);
-
-		assertSubstringsInOrder(message, [
-			'patchableOutsideSLA',
-			'patchableInSLA',
-			'unpatchableOutsideSLA',
-			'unpatchableInSLAOlder',
-		]);
-	});
-
 	void it('uses a fallback when there is no CVE', () => {
 		const malwareWithoutCve: RepocopVulnerability = {
 			...recentMalware,
@@ -696,60 +659,5 @@ void describe('createMalwareDigest', () => {
 
 		assert.match(message, /bad-package/);
 		assert.doesNotMatch(message, /not-malware/);
-	});
-
-	void describe('createDigestForSeverity', () => {
-		void it('ignores malware vulnerabilities when passed mixed results', () => {
-			const malwareVuln: RepocopVulnerability = {
-				...highRecentVuln,
-				package: 'bad-package',
-				alert_type: 'malware',
-			};
-
-			const resultWithMixedAlerts: EvaluationResult = {
-				...result,
-				vulnerabilities: [highRecentVuln, malwareVuln],
-			};
-
-			const message = getMessage(
-				createDigestForSeverity(
-					team,
-					'high',
-					[ownershipRecord],
-					[resultWithMixedAlerts],
-					60,
-				),
-			);
-
-			assert.match(message, /leftpad/);
-			assert.doesNotMatch(message, /bad-package/);
-		});
-	});
-
-	void describe('createMalwareDigest', () => {
-		void it('ignores general vulnerabilities when passed mixed results', () => {
-			const nonMalwareVuln: RepocopVulnerability = {
-				...highRecentVuln,
-				package: 'not-malware',
-				alert_type: 'general',
-			};
-
-			const resultWithMixedAlerts: EvaluationResult = {
-				...result,
-				vulnerabilities: [recentMalware, nonMalwareVuln],
-			};
-
-			const message = getMessage(
-				createMalwareDigest(
-					team,
-					[ownershipRecord],
-					[resultWithMixedAlerts],
-					60,
-				),
-			);
-
-			assert.match(message, /bad-package/);
-			assert.doesNotMatch(message, /not-malware/);
-		});
 	});
 });

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -9,6 +9,7 @@ import type { EvaluationResult, Team } from '../../types.js';
 import { removeRepoOwner } from '../shared-utilities.js';
 import {
 	createDigestForSeverity,
+	createMalwareDigest,
 	removeNonRuntimeVulns,
 } from './vuln-digest.js';
 
@@ -56,6 +57,8 @@ const anotherOwnershipRecord: view_repo_ownership = {
 	github_team_name: anotherTeam.name,
 	github_team_id: anotherTeam.id,
 	full_repo_name: anotherFullName,
+	github_team_slug: anotherTeam.slug,
+    short_repo_name: removeRepoOwner(anotherFullName),
 };
 
 const anotherRepocopRuleEvaluation: repocop_github_repository_rules = {
@@ -379,5 +382,217 @@ void describe('removeNonRuntimeVulns', () => {
 
 		const filtered = removeNonRuntimeVulns([resultWithDevVuln]);
 		assert.strictEqual(filtered.length, 0);
+	});
+});
+
+const recentMalware: RepocopVulnerability = {
+	...highRecentVuln,
+	alert_type: 'malware',
+	package: 'bad-package',
+};
+
+void describe('createMalwareDigest', () => {
+	void it('returns undefined when the total malware count is zero', () => {
+		assert.strictEqual(
+			createMalwareDigest(team, [ownershipRecord], [result, anotherResult], 60),
+			undefined,
+		);
+	});
+
+	void it('returns a digest when a result contains malware', () => {
+		const resultWithMalware: EvaluationResult = {
+			...result,
+			vulnerabilities: [recentMalware],
+		};
+
+		const digest = createMalwareDigest(
+			team,
+			[ownershipRecord],
+			[resultWithMalware],
+			60,
+		);
+
+		assert.strictEqual(digest?.teamSlug, team.slug);
+		assert.ok(digest.message.includes('bad-package'));
+		assert.ok(digest.subject.includes(`Malware Digest for ${team.name}`));
+	});
+
+	void it('returns the correct malware digest for the correct team', () => {
+		const resultWithMalware: EvaluationResult = {
+			...result,
+			vulnerabilities: [recentMalware],
+		};
+
+		const anotherMalware: RepocopVulnerability = {
+			...recentMalware,
+			full_name: anotherFullName,
+			package: 'totally-different-package',
+		};
+
+		const anotherResultWithMalware: EvaluationResult = {
+			...anotherResult,
+			vulnerabilities: [anotherMalware],
+		};
+
+		const digest = createMalwareDigest(
+			team,
+			[ownershipRecord, anotherOwnershipRecord],
+			[resultWithMalware, anotherResultWithMalware],
+			60,
+		);
+		assert.strictEqual(digest?.teamSlug, team.slug);
+		assert.ok(digest.message.includes('bad-package'));
+		assert.ok(!digest.message.includes('totally-different-package'));
+
+		const anotherDigest = createMalwareDigest(
+			anotherTeam,
+			[ownershipRecord, anotherOwnershipRecord],
+			[resultWithMalware, anotherResultWithMalware],
+			60,
+		);
+		assert.strictEqual(anotherDigest?.teamSlug, anotherTeam.slug);
+		assert.ok(anotherDigest.message.includes('totally-different-package'));
+		assert.ok(!anotherDigest.message.includes('bad-package'));
+	});
+
+	void it('only returns malware created in the last 60 days', () => {
+		const fiftyNineDaysAgo = new Date();
+		fiftyNineDaysAgo.setDate(fiftyNineDaysAgo.getDate() - 59);
+
+		const sixtyOneDaysAgo = new Date();
+		sixtyOneDaysAgo.setDate(sixtyOneDaysAgo.getDate() - 61);
+
+		const excluded: RepocopVulnerability = {
+			...recentMalware,
+			package: 'old-malware',
+			alert_issue_date: sixtyOneDaysAgo,
+		};
+
+		const included: RepocopVulnerability = {
+			...recentMalware,
+			package: 'recent-malware',
+			alert_issue_date: fiftyNineDaysAgo,
+		};
+
+		const resultWithMalware: EvaluationResult = {
+			...result,
+			vulnerabilities: [excluded, included],
+		};
+
+		const digest = createMalwareDigest(
+			team,
+			[ownershipRecord],
+			[resultWithMalware],
+			60,
+		);
+
+		assert.ok(digest?.message.includes('recent-malware'));
+		assert.ok(!digest?.message.includes('old-malware'));
+	});
+
+	void it('returns a correctly ordered list of malware in the message', () => {
+		const today = new Date();
+		const yesterday = new Date(today);
+		yesterday.setDate(today.getDate() - 1);
+
+		const patchableOutsideSLA: RepocopVulnerability = {
+			...recentMalware,
+			package: 'patchableOutsideSLA',
+			is_patchable: true,
+			within_sla: false,
+			alert_issue_date: today,
+		};
+
+		const patchableInSLA: RepocopVulnerability = {
+			...recentMalware,
+			package: 'patchableInSLA',
+			is_patchable: true,
+			within_sla: true,
+			alert_issue_date: today,
+		};
+
+		const unpatchableOutsideSLA: RepocopVulnerability = {
+			...recentMalware,
+			package: 'unpatchableOutsideSLA',
+			is_patchable: false,
+			within_sla: false,
+			alert_issue_date: today,
+		};
+
+		const unpatchableInSLAOlder: RepocopVulnerability = {
+			...recentMalware,
+			package: 'unpatchableInSLAOlder',
+			is_patchable: false,
+			within_sla: true,
+			alert_issue_date: yesterday,
+		};
+
+		const resultWithMalware: EvaluationResult = {
+			...result,
+			vulnerabilities: [
+				unpatchableInSLAOlder,
+				unpatchableOutsideSLA,
+				patchableInSLA,
+				patchableOutsideSLA,
+			],
+		};
+
+		const message = createMalwareDigest(
+			team,
+			[ownershipRecord],
+			[resultWithMalware],
+			60,
+		)!.message;
+
+		const lines = message
+			.split('\n')
+			.filter((line) => line.includes('contains malware from'));
+
+		assert.ok(lines[0]!.includes('patchableOutsideSLA'));
+		assert.ok(lines[1]!.includes('patchableInSLA'));
+		assert.ok(lines[2]!.includes('unpatchableOutsideSLA'));
+		assert.ok(lines[3]!.includes('unpatchableInSLAOlder'));
+	});
+
+	void it('uses a fallback when there is no CVE', () => {
+		const malwareWithoutCve: RepocopVulnerability = {
+			...recentMalware,
+			cves: [],
+		};
+
+		const resultWithMalware: EvaluationResult = {
+			...result,
+			vulnerabilities: [malwareWithoutCve],
+		};
+
+		assert.ok(
+			createMalwareDigest(
+				team,
+				[ownershipRecord],
+				[resultWithMalware],
+				60,
+			)?.message.includes('No CVE provided'),
+		);
+	});
+
+	void it('uses plain package text when there is no URL', () => {
+		const malwareWithoutUrl: RepocopVulnerability = {
+			...recentMalware,
+			urls: [],
+		};
+
+		const resultWithMalware: EvaluationResult = {
+			...result,
+			vulnerabilities: [malwareWithoutUrl],
+		};
+
+		assert.ok(
+			!createMalwareDigest(
+				team,
+				[ownershipRecord],
+				[resultWithMalware],
+				60,
+			)?.message.includes(`[${malwareWithoutUrl.package}](`),
+		);
 	});
 });

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -94,8 +94,43 @@ const highRecentVuln: RepocopVulnerability = {
 	alert_type: 'general',
 };
 
-void describe('createDigest', () => {
-	void it('returns undefined when the total vuln count is zero', () => {
+const recentMalware: RepocopVulnerability = {
+	...highRecentVuln,
+	alert_type: 'malware',
+	package: 'bad-package',
+};
+
+function getMessage(value: { message: string } | undefined): string {
+	assert.ok(value, 'Expected a digest to be returned');
+	return value.message;
+}
+
+function assertSubstringsInOrder(message: string, substrings: string[]): void {
+	let lastIndex = -1;
+
+	for (const substring of substrings) {
+		const index = message.indexOf(substring);
+		assert.notStrictEqual(
+			index,
+			-1,
+			`Expected message to include "${substring}"`,
+		);
+		assert.ok(
+			index > lastIndex,
+			`Expected "${substring}" to appear after the previous item`,
+		);
+		lastIndex = index;
+	}
+}
+
+function daysAgo(days: number): Date {
+	const value = new Date();
+	value.setDate(value.getDate() - days);
+	return value;
+}
+
+void describe('createDigestForSeverity', () => {
+	void it('returns undefined when the total vulnerability count is zero', () => {
 		assert.strictEqual(
 			createDigestForSeverity(
 				team,
@@ -108,8 +143,8 @@ void describe('createDigest', () => {
 		);
 	});
 
-	void it('returns a correctly ordered list of vulns in the message', () => {
-		const patchableInSLA = {
+	void it('returns vulnerabilities in priority order', () => {
+		const patchableInSLA: RepocopVulnerability = {
 			...highRecentVuln,
 			is_patchable: true,
 			within_sla: true,
@@ -117,46 +152,50 @@ void describe('createDigest', () => {
 		};
 
 		const today = new Date();
-
 		const yesterday = new Date(today);
 		yesterday.setDate(today.getDate() - 1);
 
 		const dayBeforeYesterday = new Date(today);
 		dayBeforeYesterday.setDate(today.getDate() - 2);
 
-		const unpatchableInSLAToday = {
+		const unpatchableInSLAToday: RepocopVulnerability = {
 			...highRecentVuln,
 			is_patchable: false,
 			within_sla: true,
 			package: 'unpatchableInSLAToday',
 			alert_issue_date: today,
 		};
-		const unpatchableInSLAYesterday = {
+
+		const unpatchableInSLAYesterday: RepocopVulnerability = {
 			...highRecentVuln,
 			is_patchable: false,
 			within_sla: true,
 			package: 'unpatchableInSLAYesterday',
 			alert_issue_date: yesterday,
 		};
-		const unpatchableInSLADayBeforeYesterday = {
+
+		const unpatchableInSLADayBeforeYesterday: RepocopVulnerability = {
 			...highRecentVuln,
 			is_patchable: false,
 			within_sla: true,
 			package: 'unpatchableInSLADayBeforeYesterday',
 			alert_issue_date: dayBeforeYesterday,
 		};
-		const patchableOutsideSLA = {
+
+		const patchableOutsideSLA: RepocopVulnerability = {
 			...highRecentVuln,
 			is_patchable: true,
 			within_sla: false,
 			package: 'patchableOutsideSLA',
 		};
-		const unpatchableOutsideSLA = {
+
+		const unpatchableOutsideSLA: RepocopVulnerability = {
 			...highRecentVuln,
 			is_patchable: false,
 			within_sla: false,
 			package: 'unpatchableOutsideSLA',
 		};
+
 		const resultWithVuln: EvaluationResult = {
 			...result,
 			vulnerabilities: [
@@ -168,24 +207,25 @@ void describe('createDigest', () => {
 				patchableOutsideSLA,
 			],
 		};
-		const messages: string = createDigestForSeverity(
-			team,
-			'high',
-			[ownershipRecord],
-			[resultWithVuln],
-			60,
-		)!.message;
-		const messagesAsArray = messages
-			.split('\n')
-			.filter((ss) => ss.includes('contains a high severity vulnerability'));
-		assert.ok(messagesAsArray[0]!.includes('patchableOutsideSLA'));
-		assert.ok(messagesAsArray[1]!.includes('patchableInSLA'));
-		assert.ok(messagesAsArray[2]!.includes('unpatchableOutsideSLA'));
-		assert.ok(
-			messagesAsArray[3]!.includes('unpatchableInSLADayBeforeYesterday'),
+
+		const message = getMessage(
+			createDigestForSeverity(
+				team,
+				'high',
+				[ownershipRecord],
+				[resultWithVuln],
+				60,
+			),
 		);
-		assert.ok(messagesAsArray[4]!.includes('unpatchableInSLAYesterday'));
-		assert.ok(messagesAsArray[5]!.includes('unpatchableInSLAToday'));
+
+		assertSubstringsInOrder(message, [
+			'patchableOutsideSLA',
+			'patchableInSLA',
+			'unpatchableOutsideSLA',
+			'unpatchableInSLADayBeforeYesterday',
+			'unpatchableInSLAYesterday',
+			'unpatchableInSLAToday',
+		]);
 	});
 
 	void it('returns a digest when a result contains a vulnerability', () => {
@@ -193,37 +233,43 @@ void describe('createDigest', () => {
 			...result,
 			vulnerabilities: [highRecentVuln],
 		};
-		assert.ok(
-			createDigestForSeverity(
-				team,
-				'high',
-				[ownershipRecord],
-				[resultWithVuln],
-				60,
-			)?.message.includes('leftpad'),
+
+		const digest = createDigestForSeverity(
+			team,
+			'high',
+			[ownershipRecord],
+			[resultWithVuln],
+			60,
 		);
+
+		assert.ok(digest);
+		assert.match(digest.message, /leftpad/);
 	});
 
-	void it('recognises that a SBT dependency could come from Maven', () => {
+	void it('recognises that an SBT dependency could come from Maven', () => {
 		const vuln: RepocopVulnerability = {
 			...highRecentVuln,
 			package: 'jackson',
 			urls: ['example.com'],
 			ecosystem: 'maven',
 		};
+
 		const resultWithVuln: EvaluationResult = {
 			...result,
 			vulnerabilities: [vuln],
 		};
-		assert.ok(
+
+		const message = getMessage(
 			createDigestForSeverity(
 				team,
 				'high',
 				[ownershipRecord],
 				[resultWithVuln],
 				60,
-			)?.message.includes('sbt or maven'),
+			),
 		);
+
+		assert.match(message, /sbt or maven/);
 	});
 
 	void it('returns the correct digest for the correct team', () => {
@@ -231,25 +277,18 @@ void describe('createDigest', () => {
 			...result,
 			vulnerabilities: [highRecentVuln],
 		};
+
 		const anotherVuln: RepocopVulnerability = {
-			source: 'Dependabot',
-			full_name: fullName,
-			open: true,
-			severity: 'high',
+			...highRecentVuln,
+			full_name: anotherFullName,
 			package: 'rightpad',
-			urls: ['example.com'],
-			ecosystem: 'pip',
-			alert_issue_date: new Date(),
-			is_patchable: true,
-			cves: ['CVE-123'],
-			within_sla: true,
-			scope: 'runtime',
-			alert_type: 'general',
 		};
+
 		const anotherResultWithVuln: EvaluationResult = {
 			...anotherResult,
 			vulnerabilities: [anotherVuln],
 		};
+
 		const digest = createDigestForSeverity(
 			team,
 			'high',
@@ -257,8 +296,11 @@ void describe('createDigest', () => {
 			[resultWithVuln, anotherResultWithVuln],
 			60,
 		);
-		assert.strictEqual(digest?.teamSlug, team.slug);
-		assert.ok(digest.message.includes('leftpad'));
+
+		assert.ok(digest);
+		assert.strictEqual(digest.teamSlug, team.slug);
+		assert.match(digest.message, /leftpad/);
+		assert.doesNotMatch(digest.message, /rightpad/);
 
 		const anotherDigest = createDigestForSeverity(
 			anotherTeam,
@@ -267,25 +309,24 @@ void describe('createDigest', () => {
 			[resultWithVuln, anotherResultWithVuln],
 			60,
 		);
-		assert.strictEqual(anotherDigest?.teamSlug, anotherTeam.slug);
-		assert.ok(anotherDigest.message.includes('rightpad'));
+
+		assert.ok(anotherDigest);
+		assert.strictEqual(anotherDigest.teamSlug, anotherTeam.slug);
+		assert.match(anotherDigest.message, /rightpad/);
+		assert.doesNotMatch(anotherDigest.message, /leftpad/);
 	});
 
-	void it('only returns vulnerabilities created in  the last 60 days', () => {
-		const fiftyNineDaysAgo = new Date();
-		fiftyNineDaysAgo.setDate(fiftyNineDaysAgo.getDate() - 59);
-		const sixtyOneDaysAgo = new Date();
-		sixtyOneDaysAgo.setDate(sixtyOneDaysAgo.getDate() - 61);
+	void it('only returns vulnerabilities created in the last 60 days', () => {
+		const included: RepocopVulnerability = {
+			...highRecentVuln,
+			package: 'rightpad',
+			alert_issue_date: daysAgo(59),
+		};
 
 		const excluded: RepocopVulnerability = {
 			...highRecentVuln,
-			alert_issue_date: sixtyOneDaysAgo,
-		};
-
-		const included = {
-			...excluded,
-			package: 'rightpad',
-			alert_issue_date: fiftyNineDaysAgo,
+			package: 'oldpad',
+			alert_issue_date: daysAgo(61),
 		};
 
 		const resultWithVuln: EvaluationResult = {
@@ -293,103 +334,155 @@ void describe('createDigest', () => {
 			vulnerabilities: [excluded, included],
 		};
 
-		const msg = createDigestForSeverity(
-			team,
-			'high',
-			[ownershipRecord],
-			[resultWithVuln],
-			60,
-		)?.message;
-		console.log(msg);
-
-		assert.ok(msg?.includes(included.package));
-		assert.ok(!msg?.includes(excluded.package));
-	});
-});
-
-void describe('createDigestForSeverity', () => {
-	void it('should take notice when there are no valid CVEs', () => {
-		const noCveVuln: RepocopVulnerability = {
-			...highRecentVuln,
-			cves: [],
-		};
-		const resultWithVuln: EvaluationResult = {
-			...result,
-			vulnerabilities: [noCveVuln],
-		};
-
-		assert.ok(
+		const message = getMessage(
 			createDigestForSeverity(
 				team,
 				'high',
 				[ownershipRecord],
 				[resultWithVuln],
 				60,
-			)?.message.includes('no CVE provided'),
+			),
 		);
-	});
-});
 
-void describe('createDigestForSeverity', () => {
-	void it('should take notice when there are no valid URLs', () => {
-		const noUrlVuln: RepocopVulnerability = {
+		assert.match(message, /rightpad/);
+		assert.doesNotMatch(message, /oldpad/);
+	});
+
+	void it('uses a fallback when there is no CVE', () => {
+		const noCveVuln: RepocopVulnerability = {
 			...highRecentVuln,
-			urls: [],
+			cves: [],
 		};
+
 		const resultWithVuln: EvaluationResult = {
 			...result,
-			vulnerabilities: [noUrlVuln],
+			vulnerabilities: [noCveVuln],
 		};
-		/**  node:test way of determining if the message doesn't include the noUrlVuln.package 
-			 - equivalent of `not.toContain` in Jest  */
-		assert.ok(
-			!createDigestForSeverity(
+
+		const message = getMessage(
+			createDigestForSeverity(
 				team,
 				'high',
 				[ownershipRecord],
 				[resultWithVuln],
 				60,
-			)?.message.includes(`[${noUrlVuln.package}](`),
+			),
 		);
+
+		assert.match(message, /no cve provided/i);
+	});
+
+	void it('uses plain package text when there are no valid URLs', () => {
+		const noUrlVuln: RepocopVulnerability = {
+			...highRecentVuln,
+			urls: [],
+		};
+
+		const resultWithVuln: EvaluationResult = {
+			...result,
+			vulnerabilities: [noUrlVuln],
+		};
+
+		const message = getMessage(
+			createDigestForSeverity(
+				team,
+				'high',
+				[ownershipRecord],
+				[resultWithVuln],
+				60,
+			),
+		);
+
+		assert.doesNotMatch(message, new RegExp(`\\[${noUrlVuln.package}\\]\\(`));
+		assert.match(message, new RegExp(noUrlVuln.package));
+	});
+
+	void it('ignores vulnerabilities with a different severity', () => {
+		const mediumVuln: RepocopVulnerability = {
+			...highRecentVuln,
+			severity: 'medium',
+			package: 'medium-package',
+		};
+
+		const resultWithMixedVulns: EvaluationResult = {
+			...result,
+			vulnerabilities: [highRecentVuln, mediumVuln],
+		};
+
+		const message = getMessage(
+			createDigestForSeverity(
+				team,
+				'high',
+				[ownershipRecord],
+				[resultWithMixedVulns],
+				60,
+			),
+		);
+
+		assert.match(message, /leftpad/);
+		assert.doesNotMatch(message, /medium-package/);
 	});
 });
 
 void describe('removeNonRuntimeVulns', () => {
-	void it('should remove non-runtime vulnerabilities', () => {
+	void it('removes non-runtime vulnerabilities', () => {
 		const runtimeAndDevVulns: RepocopVulnerability[] = [
 			highRecentVuln,
-			{ ...highRecentVuln, scope: 'development' },
+			{ ...highRecentVuln, scope: 'development', package: 'dev-only' },
 		];
+
 		const resultWithVulns: EvaluationResult = {
 			...result,
 			vulnerabilities: runtimeAndDevVulns,
 		};
 
 		const filtered = removeNonRuntimeVulns([resultWithVulns]);
+
 		assert.strictEqual(filtered.length, 1);
 		assert.strictEqual(filtered[0]!.vulnerabilities.length, 1);
 		assert.strictEqual(filtered[0]!.vulnerabilities[0]!.scope, 'runtime');
+		assert.strictEqual(filtered[0]!.vulnerabilities[0]!.package, 'leftpad');
 	});
-	void it('should remove results with no runtime vulnerabilities', () => {
+
+	void it('removes results with no runtime vulnerabilities', () => {
 		const devVuln: RepocopVulnerability = {
 			...highRecentVuln,
 			scope: 'development',
 		};
+
 		const resultWithDevVuln: EvaluationResult = {
 			...result,
 			vulnerabilities: [devVuln],
 		};
 
 		const filtered = removeNonRuntimeVulns([resultWithDevVuln]);
+
 		assert.strictEqual(filtered.length, 0);
 	});
-});
 
-const recentMalware: RepocopVulnerability = {
-	...highRecentVuln,
-	alert_type: 'malware',
-	package: 'bad-package',
-};
+	void it('does not mutate the original results', () => {
+		const runtimeAndDevVulns: RepocopVulnerability[] = [
+			highRecentVuln,
+			{ ...highRecentVuln, scope: 'development', package: 'dev-only' },
+		];
+
+		const resultWithVulns: EvaluationResult = {
+			...result,
+			vulnerabilities: runtimeAndDevVulns,
+		};
+
+		const originalLength = resultWithVulns.vulnerabilities.length;
+
+		void removeNonRuntimeVulns([resultWithVulns]);
+
+		assert.strictEqual(resultWithVulns.vulnerabilities.length, originalLength);
+		assert.strictEqual(resultWithVulns.vulnerabilities[1]!.package, 'dev-only');
+		assert.strictEqual(
+			resultWithVulns.vulnerabilities[1]!.scope,
+			'development',
+		);
+	});
+});
 
 void describe('createMalwareDigest', () => {
 	void it('returns undefined when the total malware count is zero', () => {
@@ -412,9 +505,10 @@ void describe('createMalwareDigest', () => {
 			60,
 		);
 
-		assert.strictEqual(digest?.teamSlug, team.slug);
-		assert.ok(digest.message.includes('bad-package'));
-		assert.ok(digest.subject.includes(`Malware Digest for ${team.name}`));
+		assert.ok(digest);
+		assert.strictEqual(digest.teamSlug, team.slug);
+		assert.match(digest.message, /bad-package/);
+		assert.match(digest.subject, new RegExp(`Malware Digest for ${team.name}`));
 	});
 
 	void it('returns the correct malware digest for the correct team', () => {
@@ -440,9 +534,11 @@ void describe('createMalwareDigest', () => {
 			[resultWithMalware, anotherResultWithMalware],
 			60,
 		);
-		assert.strictEqual(digest?.teamSlug, team.slug);
-		assert.ok(digest.message.includes('bad-package'));
-		assert.ok(!digest.message.includes('totally-different-package'));
+
+		assert.ok(digest);
+		assert.strictEqual(digest.teamSlug, team.slug);
+		assert.match(digest.message, /bad-package/);
+		assert.doesNotMatch(digest.message, /totally-different-package/);
 
 		const anotherDigest = createMalwareDigest(
 			anotherTeam,
@@ -450,28 +546,24 @@ void describe('createMalwareDigest', () => {
 			[resultWithMalware, anotherResultWithMalware],
 			60,
 		);
-		assert.strictEqual(anotherDigest?.teamSlug, anotherTeam.slug);
-		assert.ok(anotherDigest.message.includes('totally-different-package'));
-		assert.ok(!anotherDigest.message.includes('bad-package'));
+
+		assert.ok(anotherDigest);
+		assert.strictEqual(anotherDigest.teamSlug, anotherTeam.slug);
+		assert.match(anotherDigest.message, /totally-different-package/);
+		assert.doesNotMatch(anotherDigest.message, /bad-package/);
 	});
 
 	void it('only returns malware created in the last 60 days', () => {
-		const fiftyNineDaysAgo = new Date();
-		fiftyNineDaysAgo.setDate(fiftyNineDaysAgo.getDate() - 59);
-
-		const sixtyOneDaysAgo = new Date();
-		sixtyOneDaysAgo.setDate(sixtyOneDaysAgo.getDate() - 61);
-
 		const excluded: RepocopVulnerability = {
 			...recentMalware,
 			package: 'old-malware',
-			alert_issue_date: sixtyOneDaysAgo,
+			alert_issue_date: daysAgo(61),
 		};
 
 		const included: RepocopVulnerability = {
 			...recentMalware,
 			package: 'recent-malware',
-			alert_issue_date: fiftyNineDaysAgo,
+			alert_issue_date: daysAgo(59),
 		};
 
 		const resultWithMalware: EvaluationResult = {
@@ -479,18 +571,15 @@ void describe('createMalwareDigest', () => {
 			vulnerabilities: [excluded, included],
 		};
 
-		const digest = createMalwareDigest(
-			team,
-			[ownershipRecord],
-			[resultWithMalware],
-			60,
+		const message = getMessage(
+			createMalwareDigest(team, [ownershipRecord], [resultWithMalware], 60),
 		);
 
-		assert.ok(digest?.message.includes('recent-malware'));
-		assert.ok(!digest?.message.includes('old-malware'));
+		assert.match(message, /recent-malware/);
+		assert.doesNotMatch(message, /old-malware/);
 	});
 
-	void it('returns a correctly ordered list of malware in the message', () => {
+	void it('returns malware in priority order', () => {
 		const today = new Date();
 		const yesterday = new Date(today);
 		yesterday.setDate(today.getDate() - 1);
@@ -537,21 +626,16 @@ void describe('createMalwareDigest', () => {
 			],
 		};
 
-		const message = createMalwareDigest(
-			team,
-			[ownershipRecord],
-			[resultWithMalware],
-			60,
-		)!.message;
+		const message = getMessage(
+			createMalwareDigest(team, [ownershipRecord], [resultWithMalware], 60),
+		);
 
-		const lines = message
-			.split('\n')
-			.filter((line) => line.includes('contains malware from'));
-
-		assert.ok(lines[0]!.includes('patchableOutsideSLA'));
-		assert.ok(lines[1]!.includes('patchableInSLA'));
-		assert.ok(lines[2]!.includes('unpatchableOutsideSLA'));
-		assert.ok(lines[3]!.includes('unpatchableInSLAOlder'));
+		assertSubstringsInOrder(message, [
+			'patchableOutsideSLA',
+			'patchableInSLA',
+			'unpatchableOutsideSLA',
+			'unpatchableInSLAOlder',
+		]);
 	});
 
 	void it('uses a fallback when there is no CVE', () => {
@@ -565,14 +649,11 @@ void describe('createMalwareDigest', () => {
 			vulnerabilities: [malwareWithoutCve],
 		};
 
-		assert.ok(
-			createMalwareDigest(
-				team,
-				[ownershipRecord],
-				[resultWithMalware],
-				60,
-			)?.message.includes('No CVE provided'),
+		const message = getMessage(
+			createMalwareDigest(team, [ownershipRecord], [resultWithMalware], 60),
 		);
+
+		assert.match(message, /no cve provided/i);
 	});
 
 	void it('uses plain package text when there is no URL', () => {
@@ -586,13 +667,89 @@ void describe('createMalwareDigest', () => {
 			vulnerabilities: [malwareWithoutUrl],
 		};
 
-		assert.ok(
-			!createMalwareDigest(
-				team,
-				[ownershipRecord],
-				[resultWithMalware],
-				60,
-			)?.message.includes(`[${malwareWithoutUrl.package}](`),
+		const message = getMessage(
+			createMalwareDigest(team, [ownershipRecord], [resultWithMalware], 60),
 		);
+
+		assert.doesNotMatch(
+			message,
+			new RegExp(`\\[${malwareWithoutUrl.package}\\]\\(`),
+		);
+		assert.match(message, new RegExp(malwareWithoutUrl.package));
+	});
+
+	void it('ignores non-malware vulnerabilities', () => {
+		const nonMalwareVuln: RepocopVulnerability = {
+			...highRecentVuln,
+			package: 'not-malware',
+			alert_type: 'general',
+		};
+
+		const resultWithMixedAlerts: EvaluationResult = {
+			...result,
+			vulnerabilities: [recentMalware, nonMalwareVuln],
+		};
+
+		const message = getMessage(
+			createMalwareDigest(team, [ownershipRecord], [resultWithMixedAlerts], 60),
+		);
+
+		assert.match(message, /bad-package/);
+		assert.doesNotMatch(message, /not-malware/);
+	});
+
+	void describe('createDigestForSeverity', () => {
+		void it('ignores malware vulnerabilities when passed mixed results', () => {
+			const malwareVuln: RepocopVulnerability = {
+				...highRecentVuln,
+				package: 'bad-package',
+				alert_type: 'malware',
+			};
+
+			const resultWithMixedAlerts: EvaluationResult = {
+				...result,
+				vulnerabilities: [highRecentVuln, malwareVuln],
+			};
+
+			const message = getMessage(
+				createDigestForSeverity(
+					team,
+					'high',
+					[ownershipRecord],
+					[resultWithMixedAlerts],
+					60,
+				),
+			);
+
+			assert.match(message, /leftpad/);
+			assert.doesNotMatch(message, /bad-package/);
+		});
+	});
+
+	void describe('createMalwareDigest', () => {
+		void it('ignores general vulnerabilities when passed mixed results', () => {
+			const nonMalwareVuln: RepocopVulnerability = {
+				...highRecentVuln,
+				package: 'not-malware',
+				alert_type: 'general',
+			};
+
+			const resultWithMixedAlerts: EvaluationResult = {
+				...result,
+				vulnerabilities: [recentMalware, nonMalwareVuln],
+			};
+
+			const message = getMessage(
+				createMalwareDigest(
+					team,
+					[ownershipRecord],
+					[resultWithMixedAlerts],
+					60,
+				),
+			);
+
+			assert.match(message, /bad-package/);
+			assert.doesNotMatch(message, /not-malware/);
+		});
 	});
 });

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -58,7 +58,7 @@ const anotherOwnershipRecord: view_repo_ownership = {
 	github_team_id: anotherTeam.id,
 	full_repo_name: anotherFullName,
 	github_team_slug: anotherTeam.slug,
-    short_repo_name: removeRepoOwner(anotherFullName),
+	short_repo_name: removeRepoOwner(anotherFullName),
 };
 
 const anotherRepocopRuleEvaluation: repocop_github_repository_rules = {

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -44,7 +44,11 @@ function createHumanReadableMessage(
 	const ecosystem =
 		vuln.ecosystem === 'maven' ? 'sbt or maven' : vuln.ecosystem;
 
-	const daysToFix = daysLeftToFix(vuln.alert_issue_date, vuln.severity);
+	const daysToFix = daysLeftToFix(
+		vuln.alert_issue_date,
+		vuln.severity,
+		alertType,
+	);
 
 	const vulnHyperlink: string = vuln.urls[0]
 		? `[${vuln.package}](${vuln.urls[0]})`

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -4,7 +4,7 @@ import { awsClientConfig } from 'common/aws.js';
 import type { view_repo_ownership } from 'common/prisma-client/client.js';
 import { daysLeftToFix } from 'common/src/functions.js';
 import { generalSLAs } from 'common/src/types.js';
-import type { DigestType, RepocopVulnerability } from 'common/src/types.js';
+import type { AlertType, DigestType, RepocopVulnerability } from 'common/src/types.js';
 import type { Config } from '../../config.js';
 import type {
 	EvaluationResult,
@@ -47,11 +47,20 @@ function createHumanReadableVulnMessage(vuln: RepocopVulnerability): string {
 There are ${daysToFix} days left to fix this vulnerability. It ${vuln.is_patchable ? 'is ' : 'might not be '}patchable.`;
 }
 
-function createTeamDashboardLinkAction(team: Team, vulnCount: number) {
-	return {
-		cta: `View all ${vulnCount} vulnerabilities on Grafana`,
-		url: `https://metrics.gutools.co.uk/d/fdib3p8l85jwgd?var-REPO_OWNER=${team.slug}&var-SCOPE=runtime`,
-	};
+function createTeamDashboardLinkAction(
+	team: Team,
+	vulnCount: number,
+	alert_type: AlertType,
+) {
+	return alert_type === 'general'
+		? {
+				cta: `View all ${vulnCount} vulnerabilities on Grafana`,
+				url: `https://metrics.gutools.co.uk/d/fdib3p8l85jwgd?var-REPO_OWNER=${team.slug}&var-SCOPE=runtime`,
+			}
+		: {
+				cta: `View all ${vulnCount} malware alerts on Grafana`,
+				url: `https://metrics.gutools.co.uk/d/fdib3p8l85jwgd?var-REPO_OWNER=${team.slug}&var-SCOPE=All`,
+			};
 }
 
 const patchableFirstThenWithinSLAThenDate = (
@@ -123,7 +132,9 @@ Note: DevX only aggregates vulnerability information for runtime dependencies in
 		.join('\n\n');
 
 	const message = `${preamble}\n\n${digestString}`;
-	const actions = [createTeamDashboardLinkAction(team, vulns.length)];
+	const actions = [
+		createTeamDashboardLinkAction(team, vulns.length, 'general'),
+	];
 
 	return {
 		teamSlug: team.slug,
@@ -277,7 +288,9 @@ export function createMalwareDigest(
 		.join('\n\n');
 
 	const message = `${preamble}\n\n${digestString}`;
-	const actions = [createTeamDashboardLinkAction(team, malwareAlerts.length)];
+	const actions = [
+		createTeamDashboardLinkAction(team, malwareAlerts.length, 'malware'),
+	];
 
 	return {
 		teamSlug: team.slug,

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -63,9 +63,9 @@ function createHumanReadableMessage(
 function createTeamDashboardLinkAction(
 	team: Team,
 	vulnCount: number,
-	alert_type: AlertType,
+	alertType: AlertType,
 ) {
-	return alert_type === 'general'
+	return alertType === 'general'
 		? {
 				cta: `View all ${vulnCount} vulnerabilities on Grafana`,
 				url: `https://metrics.gutools.co.uk/d/fdib3p8l85jwgd?var-REPO_OWNER=${team.slug}&var-SCOPE=runtime`,

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -4,7 +4,11 @@ import { awsClientConfig } from 'common/aws.js';
 import type { view_repo_ownership } from 'common/prisma-client/client.js';
 import { daysLeftToFix } from 'common/src/functions.js';
 import { generalSLAs } from 'common/src/types.js';
-import type { AlertType, DigestType, RepocopVulnerability } from 'common/src/types.js';
+import type {
+	AlertType,
+	DigestType,
+	RepocopVulnerability,
+} from 'common/src/types.js';
 import type { Config } from '../../config.js';
 import type {
 	EvaluationResult,

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -3,8 +3,8 @@ import { Anghammarad, RequestedChannel } from '@guardian/anghammarad';
 import { awsClientConfig } from 'common/aws.js';
 import type { view_repo_ownership } from 'common/prisma-client/client.js';
 import { daysLeftToFix } from 'common/src/functions.js';
-import { SLAs } from 'common/src/types.js';
-import type { RepocopVulnerability } from 'common/src/types.js';
+import { generalSLAs } from 'common/src/types.js';
+import type { DigestType, RepocopVulnerability } from 'common/src/types.js';
 import type { Config } from '../../config.js';
 import type {
 	EvaluationResult,
@@ -54,6 +54,37 @@ function createTeamDashboardLinkAction(team: Team, vulnCount: number) {
 	};
 }
 
+const patchableFirstThenWithinSLAThenDate = (
+	a: RepocopVulnerability,
+	b: RepocopVulnerability,
+) => {
+	// Can we patch?  Move it up.
+	if (a.is_patchable && !b.is_patchable) {
+		return -1;
+	}
+	if (!a.is_patchable && b.is_patchable) {
+		return 1;
+	}
+
+	// Is it outside SLA?  Move it up.
+	if (!a.within_sla && b.within_sla) {
+		return -1;
+	}
+	if (a.within_sla && !b.within_sla) {
+		return 1;
+	}
+
+	// Is it older?  Move it up.
+	if (a.alert_issue_date < b.alert_issue_date) {
+		return -1;
+	}
+	if (a.alert_issue_date > b.alert_issue_date) {
+		return 1;
+	}
+
+	return 0;
+};
+
 export function createDigestForSeverity(
 	team: Team,
 	severity: 'critical' | 'high',
@@ -71,37 +102,6 @@ export function createDigestForSeverity(
 	const cutOffDate = new Date();
 	cutOffDate.setDate(cutOffDate.getDate() - cutOffInDays);
 
-	const patchableFirstThenWithinSLAThenDate = (
-		a: RepocopVulnerability,
-		b: RepocopVulnerability,
-	) => {
-		// Can we patch?  Move it up.
-		if (a.is_patchable && !b.is_patchable) {
-			return -1;
-		}
-		if (!a.is_patchable && b.is_patchable) {
-			return 1;
-		}
-
-		// Is it outside SLA?  Move it up.
-		if (!a.within_sla && b.within_sla) {
-			return -1;
-		}
-		if (a.within_sla && !b.within_sla) {
-			return 1;
-		}
-
-		// Is it older?  Move it up.
-		if (a.alert_issue_date < b.alert_issue_date) {
-			return -1;
-		}
-		if (a.alert_issue_date > b.alert_issue_date) {
-			return 1;
-		}
-
-		return 0;
-	};
-
 	const vulnsSinceImplementationDate = vulns
 		.filter(
 			(v) =>
@@ -115,7 +115,7 @@ export function createDigestForSeverity(
 		return undefined;
 	}
 
-	const preamble = String.raw`Found ${totalNewVulnsCount} ${severity} vulnerabilities introduced in the last ${cutOffInDays} days. Teams have ${SLAs[severity]} days to fix these.
+	const preamble = String.raw`Found ${totalNewVulnsCount} ${severity} vulnerabilities introduced in the last ${cutOffInDays} days. Teams have ${generalSLAs[severity]} days to fix these.
 Note: DevX only aggregates vulnerability information for runtime dependencies in repositories with a production topic.`;
 
 	const digestString = vulnsSinceImplementationDate
@@ -136,11 +136,12 @@ Note: DevX only aggregates vulnerability information for runtime dependencies in
 async function sendVulnerabilityDigests(
 	digests: VulnerabilityDigest[],
 	config: Config,
+	digestType: DigestType,
 ) {
 	const snsClient = new SNSClient(awsClientConfig(config.stage));
 	const anghammarad = new Anghammarad(snsClient, config.anghammaradSnsTopic);
 	console.log(
-		`Sending ${digests.length} vulnerability digests: ${digests
+		`Sending ${digests.length} ${digestType} digests: ${digests
 			.map((d) => d.teamSlug)
 			.join(', ')}`,
 	);
@@ -155,7 +156,7 @@ async function sendVulnerabilityDigests(
 					target: { GithubTeamSlug: digest.teamSlug },
 					channel: RequestedChannel.PreferHangouts,
 					sender: `${config.app} ${config.stage}`,
-					threadKey: `vulnerability-digest-${digest.teamSlug}`,
+					threadKey: `${digestType}-digest-${digest.teamSlug}`,
 				}),
 		),
 	);
@@ -165,7 +166,7 @@ export async function createAndSendVulnDigestsForSeverity(
 	config: Config,
 	teams: Team[],
 	repoOwners: view_repo_ownership[],
-	results: EvaluationResult[],
+	generalResults: EvaluationResult[],
 	severity: 'critical' | 'high',
 ) {
 	const digests = teams
@@ -174,16 +175,16 @@ export async function createAndSendVulnDigestsForSeverity(
 				t,
 				severity,
 				repoOwners,
-				results,
+				generalResults,
 				config.cutOffInDays,
 			),
 		)
 		.filter((d): d is VulnerabilityDigest => d !== undefined);
 
-	console.log(`Logging ${severity} vulnerability digests`);
+	console.log(`Sending ${severity} vulnerability digests`);
 	digests.forEach((digest) => console.log(JSON.stringify(digest)));
 	if (config.stage === 'PROD') {
-		await sendVulnerabilityDigests(digests, config);
+		await sendVulnerabilityDigests(digests, config, 'vulnerability');
 	}
 }
 
@@ -206,15 +207,15 @@ export async function createAndSendVulnerabilityDigests(
 	config: Config,
 	teams: Team[],
 	repoOwners: view_repo_ownership[],
-	evaluationResults: EvaluationResult[],
+	generalResults: EvaluationResult[],
 ) {
-	const runtimeEvaluationResults = removeNonRuntimeVulns(evaluationResults);
+	const runtimeGeneralResults = removeNonRuntimeVulns(generalResults);
 
 	await createAndSendVulnDigestsForSeverity(
 		config,
 		teams,
 		repoOwners,
-		runtimeEvaluationResults,
+		runtimeGeneralResults,
 		'critical',
 	);
 
@@ -224,8 +225,91 @@ export async function createAndSendVulnerabilityDigests(
 			config,
 			teams,
 			repoOwners,
-			runtimeEvaluationResults,
+			runtimeGeneralResults,
 			'high',
 		);
+	}
+}
+
+function createHumanReadableMalwareMessage(
+	malware: RepocopVulnerability,
+): string {
+	const malwareHyperlink: string = malware.urls[0]
+		? `[${malware.package}](${malware.urls[0]})`
+		: malware.package;
+
+	const cveHyperlink = malware.cves[0] ?? 'No CVE provided';
+
+	return String.raw`[${removeRepoOwner(malware.full_name)}](https://github.com/${malware.full_name}) contains malware from ${malwareHyperlink}. It ${malware.is_patchable ? 'is ' : 'might not be '}patchable. ${cveHyperlink}`;
+}
+
+export function createMalwareDigest(
+	team: Team,
+	repoOwners: view_repo_ownership[],
+	malwareResults: EvaluationResult[],
+	cutOffInDays: number,
+): VulnerabilityDigest | undefined {
+	const resultsForTeam: EvaluationResult[] = getOwningRepos(
+		team,
+		repoOwners,
+		malwareResults,
+	);
+	const malwareAlerts = resultsForTeam.flatMap((r) => r.vulnerabilities);
+
+	const cutOffDate = new Date();
+	cutOffDate.setDate(cutOffDate.getDate() - cutOffInDays);
+
+	const malwareSinceImplementationDate = malwareAlerts
+		.filter((a) => new Date(a.alert_issue_date) > cutOffDate)
+		.sort(patchableFirstThenWithinSLAThenDate);
+
+	const totalNewMalwareCount = malwareSinceImplementationDate.length;
+
+	if (totalNewMalwareCount === 0) {
+		return undefined;
+	}
+
+	const preamble = String.raw`Found ${totalNewMalwareCount} malware alerts introduced in the last ${cutOffInDays} days. Please address within 1 working day. 
+	Note: Malware information provided is only for repositories with a production topic. Currently the only ecosystem supported by Dependabot is npm.`;
+
+	const digestString = malwareSinceImplementationDate
+		.map((v) => createHumanReadableMalwareMessage(v))
+		.join('\n\n');
+
+	const message = `${preamble}\n\n${digestString}`;
+	const actions = [createTeamDashboardLinkAction(team, malwareAlerts.length)];
+
+	return {
+		teamSlug: team.slug,
+		subject: `Malware Digest for ${team.name}`,
+		message,
+		actions,
+	};
+}
+
+export async function createAndSendMalwareDigests(
+	config: Config,
+	teams: Team[],
+	repoOwners: view_repo_ownership[],
+	malwareResults: EvaluationResult[],
+) {
+	if (malwareResults.length === 0) {
+		return undefined;
+	}
+	const digests = teams
+		.map((team) =>
+			createMalwareDigest(
+				team,
+				repoOwners,
+				malwareResults,
+				config.cutOffInDays,
+			),
+		)
+		.filter((d): d is VulnerabilityDigest => d !== undefined);
+
+	console.log(`Sending malware digests`);
+	digests.forEach((digest) => console.log(JSON.stringify(digest)));
+	if (config.stage === 'PROD') {
+		await sendVulnerabilityDigests(digests, config, 'malware');
 	}
 }

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -56,7 +56,7 @@ function createHumanReadableMessage(
 
 	const cveHyperlink = vuln.cves[0] ?? 'no CVE provided';
 
-	return String.raw`[${removeRepoOwner(vuln.full_name)}](https://github.com/${vuln.full_name}) ${alertType === 'general' ? `contains a ${vuln.severity} severity vulnerability` : 'contains malware'}, ${cveHyperlink}, from ${vulnHyperlink}${alertType === 'general' ? `, introduced via ${ecosystem}` : ''}. There are ${daysToFix} days left to fix this vulnerability. It ${vuln.is_patchable ? 'is ' : 'might not be '}patchable.`;
+	return String.raw`[${removeRepoOwner(vuln.full_name)}](https://github.com/${vuln.full_name}) ${alertType === 'general' ? `contains a ${vuln.severity} severity vulnerability` : 'contains malware'}, ${cveHyperlink}, from ${vulnHyperlink}${alertType === 'general' ? `, introduced via ${ecosystem}` : ''}. There are ${daysToFix} days left to fix this ${alertType === 'general' ? 'vulnerability' : 'malware alert'}. It ${vuln.is_patchable ? 'is ' : 'might not be '}patchable.`;
 }
 
 function createTeamDashboardLinkAction(

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -206,7 +206,7 @@ export async function createAndSendVulnDigestsForSeverity(
 		)
 		.filter((d): d is VulnerabilityDigest => d !== undefined);
 
-	console.log(`Sending ${severity} vulnerability digests`);
+	console.log(`Logging ${severity} vulnerability digests`);
 	digests.forEach((digest) => console.log(JSON.stringify(digest)));
 	if (config.stage === 'PROD') {
 		await sendVulnerabilityDigests(digests, config, 'vulnerability');

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -56,7 +56,7 @@ function createHumanReadableMessage(
 
 	const cveHyperlink = vuln.cves[0] ?? 'no CVE provided';
 
-	return String.raw`[${removeRepoOwner(vuln.full_name)}](https://github.com/${vuln.full_name}) ${alertType === 'general' ? `contains a ${vuln.severity} severity vulnerability` : 'contains malware'}, ${cveHyperlink}, from ${vulnHyperlink}${alertType === 'general' ? `, introduced via ${ecosystem}` : ''}. There are ${daysToFix} days left to fix this ${alertType === 'general' ? 'vulnerability' : 'malware alert'}. It ${vuln.is_patchable ? 'is ' : 'might not be '}patchable.`;
+	return String.raw`[${removeRepoOwner(vuln.full_name)}](https://github.com/${vuln.full_name}) ${alertType === 'general' ? `contains a ${vuln.severity} severity vulnerability` : 'contains malware'}, ${cveHyperlink}, from ${vulnHyperlink}${alertType === 'general' ? `, introduced via ${ecosystem}` : ''}. There are ${daysToFix} days left to ${alertType === 'general' ? 'fix this vulnerability' : 'resolve this malware alert'}. It ${vuln.is_patchable ? 'is ' : 'might not be '}patchable.`;
 }
 
 function createTeamDashboardLinkAction(

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -22,20 +22,20 @@ function getOwningRepos(
 	repoOwners: view_repo_ownership[],
 	results: EvaluationResult[],
 ) {
-	const reposOwnedByTeam = repoOwners.filter(
-		(repoOwner) => repoOwner.github_team_id === team.id,
+	const resultsByFullName = new Map(
+		results.map((result) => [result.fullName, result]),
 	);
 
-	const resultsOwnedByTeam = reposOwnedByTeam
-		.map((repo) => {
-			return results.find((result) => result.fullName === repo.full_repo_name);
-		})
+	return repoOwners
+		.filter((repoOwner) => repoOwner.github_team_id === team.id)
+		.map((repoOwner) => resultsByFullName.get(repoOwner.full_repo_name))
 		.filter((result): result is EvaluationResult => result !== undefined);
-
-	return resultsOwnedByTeam;
 }
 
-function createHumanReadableVulnMessage(vuln: RepocopVulnerability): string {
+function createHumanReadableMessage(
+	vuln: RepocopVulnerability,
+	alertType: AlertType = 'general',
+): string {
 	const ecosystem =
 		vuln.ecosystem === 'maven' ? 'sbt or maven' : vuln.ecosystem;
 
@@ -47,8 +47,8 @@ function createHumanReadableVulnMessage(vuln: RepocopVulnerability): string {
 
 	const cveHyperlink = vuln.cves[0] ?? 'no CVE provided';
 
-	return String.raw`[${removeRepoOwner(vuln.full_name)}](https://github.com/${vuln.full_name}) contains a ${vuln.severity} severity vulnerability, ${cveHyperlink}, from ${vulnHyperlink}, introduced via ${ecosystem}.
-There are ${daysToFix} days left to fix this vulnerability. It ${vuln.is_patchable ? 'is ' : 'might not be '}patchable.`;
+	return String.raw`[${removeRepoOwner(vuln.full_name)}](https://github.com/${vuln.full_name}) ${alertType === 'general' ? `contains a ${vuln.severity} severity vulnerability` : 'contains malware'}, ${cveHyperlink}, from ${vulnHyperlink}${alertType === 'general' ? `, introduced via ${ecosystem}` : ''}.
+		There are ${daysToFix} days left to fix this vulnerability. It ${vuln.is_patchable ? 'is ' : 'might not be '}patchable.`;
 }
 
 function createTeamDashboardLinkAction(
@@ -110,7 +110,9 @@ export function createDigestForSeverity(
 		repoOwners,
 		results,
 	);
-	const vulns = resultsForTeam.flatMap((r) => r.vulnerabilities);
+	const vulns = resultsForTeam
+		.flatMap((r) => r.vulnerabilities)
+		.filter((vuln) => vuln.alert_type === 'general');
 
 	const cutOffDate = new Date();
 	cutOffDate.setDate(cutOffDate.getDate() - cutOffInDays);
@@ -132,7 +134,7 @@ export function createDigestForSeverity(
 Note: DevX only aggregates vulnerability information for runtime dependencies in repositories with a production topic.`;
 
 	const digestString = vulnsSinceImplementationDate
-		.map((v) => createHumanReadableVulnMessage(v))
+		.map((v) => createHumanReadableMessage(v))
 		.join('\n\n');
 
 	const message = `${preamble}\n\n${digestString}`;
@@ -246,30 +248,20 @@ export async function createAndSendVulnerabilityDigests(
 	}
 }
 
-function createHumanReadableMalwareMessage(
-	malware: RepocopVulnerability,
-): string {
-	const malwareHyperlink: string = malware.urls[0]
-		? `[${malware.package}](${malware.urls[0]})`
-		: malware.package;
-
-	const cveHyperlink = malware.cves[0] ?? 'No CVE provided';
-
-	return String.raw`[${removeRepoOwner(malware.full_name)}](https://github.com/${malware.full_name}) contains malware from ${malwareHyperlink}. It ${malware.is_patchable ? 'is ' : 'might not be '}patchable. ${cveHyperlink}`;
-}
-
 export function createMalwareDigest(
 	team: Team,
 	repoOwners: view_repo_ownership[],
-	malwareResults: EvaluationResult[],
+	results: EvaluationResult[],
 	cutOffInDays: number,
 ): VulnerabilityDigest | undefined {
 	const resultsForTeam: EvaluationResult[] = getOwningRepos(
 		team,
 		repoOwners,
-		malwareResults,
+		results,
 	);
-	const malwareAlerts = resultsForTeam.flatMap((r) => r.vulnerabilities);
+	const malwareAlerts = resultsForTeam
+		.flatMap((r) => r.vulnerabilities)
+		.filter((vuln) => vuln.alert_type === 'malware');
 
 	const cutOffDate = new Date();
 	cutOffDate.setDate(cutOffDate.getDate() - cutOffInDays);
@@ -288,7 +280,7 @@ export function createMalwareDigest(
 	Note: Malware information provided is only for repositories with a production topic. Currently the only ecosystem supported by Dependabot is npm.`;
 
 	const digestString = malwareSinceImplementationDate
-		.map((v) => createHumanReadableMalwareMessage(v))
+		.map((mal) => createHumanReadableMessage(mal, 'malware'))
 		.join('\n\n');
 
 	const message = `${preamble}\n\n${digestString}`;

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -26,10 +26,15 @@ function getOwningRepos(
 		results.map((result) => [result.fullName, result]),
 	);
 
-	return repoOwners
-		.filter((repoOwner) => repoOwner.github_team_id === team.id)
+	const reposOwnedByTeam = repoOwners.filter(
+		(repoOwner) => repoOwner.github_team_id === team.id,
+	);
+
+	const resultsOwnedByTeam = reposOwnedByTeam
 		.map((repoOwner) => resultsByFullName.get(repoOwner.full_repo_name))
 		.filter((result): result is EvaluationResult => result !== undefined);
+
+	return resultsOwnedByTeam;
 }
 
 function createHumanReadableMessage(

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.ts
@@ -56,8 +56,7 @@ function createHumanReadableMessage(
 
 	const cveHyperlink = vuln.cves[0] ?? 'no CVE provided';
 
-	return String.raw`[${removeRepoOwner(vuln.full_name)}](https://github.com/${vuln.full_name}) ${alertType === 'general' ? `contains a ${vuln.severity} severity vulnerability` : 'contains malware'}, ${cveHyperlink}, from ${vulnHyperlink}${alertType === 'general' ? `, introduced via ${ecosystem}` : ''}.
-		There are ${daysToFix} days left to fix this vulnerability. It ${vuln.is_patchable ? 'is ' : 'might not be '}patchable.`;
+	return String.raw`[${removeRepoOwner(vuln.full_name)}](https://github.com/${vuln.full_name}) ${alertType === 'general' ? `contains a ${vuln.severity} severity vulnerability` : 'contains malware'}, ${cveHyperlink}, from ${vulnHyperlink}${alertType === 'general' ? `, introduced via ${ecosystem}` : ''}. There are ${daysToFix} days left to fix this vulnerability. It ${vuln.is_patchable ? 'is ' : 'might not be '}patchable.`;
 }
 
 function createTeamDashboardLinkAction(
@@ -285,8 +284,8 @@ export function createMalwareDigest(
 		return undefined;
 	}
 
-	const preamble = String.raw`Found ${totalNewMalwareCount} malware alerts introduced in the last ${cutOffInDays} days. Please address within 1 working day. 
-	Note: Malware information provided is only for repositories with a production topic. Currently the only ecosystem supported by Dependabot is npm.`;
+	const preamble = String.raw`Found ${totalNewMalwareCount} malware alerts introduced in the last ${cutOffInDays} days. Please address within 1 working day.
+Note: Malware information provided is only for repositories with a production topic. Currently the only ecosystem supported by Dependabot is npm.`;
 
 	const digestString = malwareSinceImplementationDate
 		.map((mal) => createHumanReadableMessage(mal, 'malware'))

--- a/packages/repocop/src/utils.ts
+++ b/packages/repocop/src/utils.ts
@@ -1,8 +1,6 @@
 import type { RepocopVulnerability, Repository } from 'common/src/types.js';
 import type { EvaluationResult } from './types.js';
 
-export const MALWARE_SLA = 1; // all severities of malware have SLA of 1 working day
-
 export function isProduction(repo: Repository) {
 	return repo.topics.includes('production') && !repo.archived;
 }

--- a/packages/repocop/src/utils.ts
+++ b/packages/repocop/src/utils.ts
@@ -3,7 +3,6 @@ import type { EvaluationResult } from './types.js';
 
 export const MALWARE_SLA = 1; // all severities of malware have SLA of 1 working day
 
-
 export function isProduction(repo: Repository) {
 	return repo.topics.includes('production') && !repo.archived;
 }

--- a/packages/repocop/src/utils.ts
+++ b/packages/repocop/src/utils.ts
@@ -1,4 +1,8 @@
 import type { RepocopVulnerability, Repository } from 'common/src/types.js';
+import type { EvaluationResult } from './types.js';
+
+export const MALWARE_SLA = 1; // all severities of malware have SLA of 1 working day
+
 
 export function isProduction(repo: Repository) {
 	return repo.topics.includes('production') && !repo.archived;
@@ -20,3 +24,29 @@ export const vulnSortPredicate = (
 		return criticalFirstPredicate(v1);
 	}
 };
+
+export function generalEvaluationResults(
+	results: EvaluationResult[],
+): EvaluationResult[] {
+	return results
+		.map((result) => {
+			const generalVulns = result.vulnerabilities.filter(
+				(vuln) => vuln.alert_type === 'general',
+			);
+			return { ...result, vulnerabilities: generalVulns };
+		})
+		.filter((result) => result.vulnerabilities.length > 0);
+}
+
+export function malwareEvaluationResults(
+	results: EvaluationResult[],
+): EvaluationResult[] {
+	return results
+		.map((result) => {
+			const generalVulns = result.vulnerabilities.filter(
+				(vuln) => vuln.alert_type === 'malware',
+			);
+			return { ...result, vulnerabilities: generalVulns };
+		})
+		.filter((result) => result.vulnerabilities.length > 0);
+}

--- a/packages/repocop/src/utils.ts
+++ b/packages/repocop/src/utils.ts
@@ -1,5 +1,4 @@
 import type { RepocopVulnerability, Repository } from 'common/src/types.js';
-import type { EvaluationResult } from './types.js';
 
 export function isProduction(repo: Repository) {
 	return repo.topics.includes('production') && !repo.archived;
@@ -21,29 +20,3 @@ export const vulnSortPredicate = (
 		return criticalFirstPredicate(v1);
 	}
 };
-
-export function generalEvaluationResults(
-	results: EvaluationResult[],
-): EvaluationResult[] {
-	return results
-		.map((result) => {
-			const generalVulns = result.vulnerabilities.filter(
-				(vuln) => vuln.alert_type === 'general',
-			);
-			return { ...result, vulnerabilities: generalVulns };
-		})
-		.filter((result) => result.vulnerabilities.length > 0);
-}
-
-export function malwareEvaluationResults(
-	results: EvaluationResult[],
-): EvaluationResult[] {
-	return results
-		.map((result) => {
-			const generalVulns = result.vulnerabilities.filter(
-				(vuln) => vuln.alert_type === 'malware',
-			);
-			return { ...result, vulnerabilities: generalVulns };
-		})
-		.filter((result) => result.vulnerabilities.length > 0);
-}


### PR DESCRIPTION
## What does this change?

- Adds separate collection and alerting of Dependabot alerts classified as 'malware'.
  - Makes a separate API call to Github to collect all severities of malware alert.
  - Sends out a separate malware digest to alert teams.
  - Adds tests for the malware digest creation and within_sla derivation.
  - Filters for 'general' alert_type in Obligatron - excludes malware from these results because of the different SLA for malware - do we want this?

## Why has this change been made?

Malware alerts have recently been added to Dependabot (for the npm ecosystem only). This work follows #1969 where we added the `alerts_type` column to the `repocop_vulnerabilities` table in order for us to be able to differentiate between the malware and vulnerability alerts. Dependabot alerts are divided into two categories, 'general', which represent dependency vulnerabilities, and 'malware'. 

There is a different SLA for addressing malware vs dependency vulnerabilities. Malware alerts will be collected regardless of their severity and we will alert on them the next working day. Teams are then expected to address them in one working day.

## Why was this approach chosen?

This approach allows us to piggyback onto Repocop's existing functionality for collecting Dependabot alerts and creating the `repocop_vulnerabilities` table. As malware alerts are a category of Dependabot alert, we are adding them to the `repocop_vulnerabilities` table  as before. Any 'critical' or 'high' malware alerts would have already been collected this way. The difference is now that we are collecting all severities of malware and still only 'critical' and 'high' of 'general' (dependency vulns). 

## How has it been verified?

- [ ] ~~Tested locally~~ (I tried, unable to get dev-environment running successfully)
- [x] Tested by running the repocop lambda on CODE and observing the logs relating to malware. Observed updated results in the `repocop_vulnerabilities` table.
- [x] Tested obligatron lambda on CODE and observing it run successfully. 