### PR TITLE
Fix: collect `github_repositories_sboms` data again

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -19179,7 +19179,7 @@ spec:
     },
     "CloudquerySourceGitHubSbomsScheduledEventRuleCDCF1384": {
       "Properties": {
-        "ScheduleExpression": "cron(0 1 * * ? *)",
+        "ScheduleExpression": "cron(15 1 * * ? *)",
         "State": "ENABLED",
         "Tags": [
           {

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -114,10 +114,10 @@ export function addCloudqueryEcsCluster(
 			config: awsSourceConfigForAccount(GuardianAwsAccounts.DeployTools, {
 				tables:
 					/*
-      Collect all AWS Organisation tables, including account names, and which OU they belong to.
-      A wildcard is used, as there are a lot of tables!
-      See https://www.cloudquery.io/docs/advanced-topics/performance-tuning#use-wildcard-matching
-       */
+	  Collect all AWS Organisation tables, including account names, and which OU they belong to.
+	  A wildcard is used, as there are a lot of tables!
+	  See https://www.cloudquery.io/docs/advanced-topics/performance-tuning#use-wildcard-matching
+	   */
 					filterCloudQueryTables([/^aws_organization.*$/]),
 			}),
 			policies: [
@@ -455,7 +455,7 @@ export function addCloudqueryEcsCluster(
 			name: 'GitHubSboms',
 			description:
 				'Collect GitHub SBOM (Software Bill of Materials) data. Used to track dependencies, which is useful for supply chain attack monitoring.',
-			schedule: Schedule.cron({ minute: '0', hour: '1' }),
+			schedule: Schedule.cron({ minute: '15', hour: '1' }),
 			config: githubSourceConfig({
 				org: gitHubOrgName,
 				tables: ['github_repository_sboms'],


### PR DESCRIPTION
## What does this change?

~~1. Reduces the concurrency of the the `GithubSboms` task by half to 500.~~
2. Moves the schedule to 15 minutes later to allow for rate limit reset to occur. The logs showed that the reset of the rate limit happened at 01:01:56 last time, so this should be plenty.

## Why has this change been made?

The `github_repositories_sboms` table had not synced automatically since 18 May 2025. It was manually synced on 12 June and ran successfully. 

## Why was this approach chosen?

Ultimately we want to implement incremental sync, but until then this is an attempt at getting data in the table updated for users. 

## How has it been verified?

- [x] Tested in CODE by running the task and seeing the table update. However, this does not test the rate limit issue if the rate limit was carried over from the run of the `GitHubRepositories` task.
- [x] Ran the task on main in PROD and it completed successfully. This indicates that it's an issue with the task falling within the rate limit period of the previous task, not that this task has an issue with concurrency.  