### PR TITLE
feat: Add metadata to repocop_vulnerabilities table

### DIFF
--- a/packages/common/prisma/migrations/20260619000000_repocop_vulnerabilities_alert_metadata/migration.sql
+++ b/packages/common/prisma/migrations/20260619000000_repocop_vulnerabilities_alert_metadata/migration.sql
@@ -1,0 +1,41 @@
+-- Add advisory and alert metadata columns to repocop_vulnerabilities.
+-- Keep existing data by adding columns as nullable first, then backfilling.
+-- Epoch defaults are used for historical rows that predate these fields.
+
+BEGIN;
+
+-- Initially add nullable columns
+ALTER TABLE repocop_vulnerabilities
+  ADD COLUMN ingested_at           TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ADD COLUMN advisory_published_at TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN advisory_updated_at   TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN advisory_withdrawn_at TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN alert_updated_at      TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN html_url              TEXT;
+
+-- Set dummy values for existing rows
+
+UPDATE repocop_vulnerabilities
+SET advisory_published_at = TIMESTAMPTZ '1970-01-01 00:00:00+00'
+WHERE advisory_published_at IS NULL;
+
+UPDATE repocop_vulnerabilities
+SET advisory_updated_at = TIMESTAMPTZ '1970-01-01 00:00:00+00'
+WHERE advisory_updated_at IS NULL;
+
+UPDATE repocop_vulnerabilities
+SET alert_updated_at = TIMESTAMPTZ '1970-01-01 00:00:00+00'
+WHERE alert_updated_at IS NULL;
+
+UPDATE repocop_vulnerabilities
+SET html_url = ''
+WHERE html_url IS NULL;
+
+-- Now set columns non-nullable
+ALTER TABLE repocop_vulnerabilities
+  ALTER COLUMN advisory_published_at SET NOT NULL,
+  ALTER COLUMN advisory_updated_at SET NOT NULL,
+  ALTER COLUMN alert_updated_at SET NOT NULL,
+  ALTER COLUMN html_url SET NOT NULL;
+
+COMMIT;

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -657,21 +657,27 @@ model guardian_github_actions_usage {
 }
 
 model repocop_vulnerabilities {
-  source           String
-  full_name        String
-  open             Boolean
-  severity         String
-  package          String
-  urls             String[]
-  ecosystem        String
-  alert_issue_date DateTime
-  is_patchable     Boolean
-  cves             String[]
-  repo_owner       String
-  id               String   @id @default(uuid())
-  within_sla       Boolean
-  scope            String   @default("runtime")
-  alert_type       String
+  source                String
+  full_name             String
+  open                  Boolean
+  severity              String
+  package               String
+  urls                  String[]
+  ecosystem             String
+  alert_issue_date      DateTime
+  is_patchable          Boolean
+  cves                  String[]
+  repo_owner            String
+  id                    String    @id @default(uuid())
+  within_sla            Boolean
+  scope                 String    @default("runtime")
+  alert_type            String
+  ingested_at           DateTime  @default(now()) @db.Timestamptz(6)
+  advisory_published_at DateTime  @db.Timestamptz(6)
+  advisory_updated_at   DateTime  @db.Timestamptz(6)
+  advisory_withdrawn_at DateTime? @db.Timestamptz(6)
+  alert_updated_at      DateTime  @db.Timestamptz(6)
+  html_url              String
 }
 
 /// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -88,7 +88,7 @@ export function chooseDependencyScope(
 
 export type RepocopVulnerability = Omit<
 	repocop_vulnerabilities,
-	'id' | 'repo_owner' | 'severity' | 'scope' | 'alert_type'
+	'id' | 'repo_owner' | 'severity' | 'scope' | 'alert_type' | 'ingested_at'
 > & {
 	severity: Severity;
 	scope: DependencyScope;

--- a/packages/obligatron/src/obligations/dependency-vulnerabilities.test.ts
+++ b/packages/obligatron/src/obligations/dependency-vulnerabilities.test.ts
@@ -34,6 +34,11 @@ void describe('The dependency vulnerabilities obligation', () => {
 		within_sla: false,
 		scope: 'runtime',
 		alert_type: 'general',
+		advisory_published_at: someDate,
+		advisory_updated_at: someDate,
+		advisory_withdrawn_at: null,
+		alert_updated_at: someDate,
+		html_url: 'https://github.com/some/repo/security/dependabot/1',
 	};
 
 	void it('should return something if it finds a vulnerability on a repo', () => {

--- a/packages/repocop/src/evaluation/repository.test.ts
+++ b/packages/repocop/src/evaluation/repository.test.ts
@@ -572,6 +572,11 @@ const oldCriticalDependabotVuln: RepocopVulnerability = {
 	within_sla: false,
 	scope: 'runtime',
 	alert_type: 'general',
+	advisory_published_at: new Date('2026-06-18T00:00:00.000Z'),
+	advisory_updated_at: new Date('2026-06-18T00:00:00.000Z'),
+	advisory_withdrawn_at: null,
+	alert_updated_at: new Date('2026-06-18T00:00:00.000Z'),
+	html_url: 'https://github.com/guardian/some-repo/security/dependabot/1',
 };
 
 const newCriticalDependabotVuln: RepocopVulnerability = {
@@ -677,6 +682,11 @@ void describe('NO RULE - Vulnerabilities from Dependabot', () => {
 			within_sla: false,
 			scope: 'runtime',
 			alert_type: 'general',
+			advisory_published_at: new Date('2018-10-03T21:13:54Z'),
+			advisory_updated_at: new Date('2022-04-26T18:35:37Z'),
+			advisory_withdrawn_at: null,
+			alert_updated_at: new Date('2022-08-23T14:29:47Z'),
+			html_url: 'https://github.com/octo-org/octo-repo/security/dependabot/2',
 		};
 
 		const expected2: RepocopVulnerability = {
@@ -697,6 +707,11 @@ void describe('NO RULE - Vulnerabilities from Dependabot', () => {
 			within_sla: false,
 			scope: 'runtime',
 			alert_type: 'general',
+			advisory_published_at: new Date('2021-06-01T17:38:00Z'),
+			advisory_updated_at: new Date('2021-08-12T23:06:00Z'),
+			advisory_withdrawn_at: null,
+			alert_updated_at: new Date('2022-06-14T15:21:52Z'),
+			html_url: 'https://github.com/octo-org/hello-world/security/dependabot/1',
 		};
 
 		assert.deepStrictEqual(result, [expected1, expected2]);
@@ -786,6 +801,75 @@ void describe('NO RULE - Vulnerabilities from Dependabot', () => {
 
 		assert.strictEqual(result.alert_type, 'general');
 	});
+
+	void test('maps a non-null withdrawn_at ISO timestamp to a Date', () => {
+		const withdrawnAt = '2024-03-15T10:00:00Z';
+		const baseAlert = exampleDependabotAlert[0];
+		if (!baseAlert) {
+			throw new Error('Missing example Dependabot alert fixture');
+		}
+		const alert: Alert = {
+			...baseAlert,
+			security_advisory: {
+				...baseAlert.security_advisory,
+				withdrawn_at: withdrawnAt,
+			},
+		};
+
+		const result = dependabotAlertToRepocopVulnerability(
+			'guardian/some-repo',
+			alert,
+		);
+
+		assert.deepStrictEqual(result.advisory_withdrawn_at, new Date(withdrawnAt));
+	});
+
+	void test('maps advisory and alert metadata fields from the source alert', () => {
+		const baseAlert = exampleDependabotAlert[0];
+		if (!baseAlert) {
+			throw new Error('Missing example Dependabot alert fixture');
+		}
+
+		const result = dependabotAlertToRepocopVulnerability(
+			'guardian/some-repo',
+			baseAlert,
+		);
+
+		assert.deepStrictEqual(
+			result.advisory_published_at,
+			new Date(baseAlert.security_advisory.published_at),
+		);
+		assert.deepStrictEqual(
+			result.advisory_updated_at,
+			new Date(baseAlert.security_advisory.updated_at),
+		);
+		assert.deepStrictEqual(
+			result.alert_updated_at,
+			new Date(baseAlert.updated_at),
+		);
+		assert.strictEqual(result.html_url, baseAlert.html_url);
+	});
+
+	void test('maps a null withdrawn_at to null', () => {
+		const baseAlert = exampleDependabotAlert[0];
+		if (!baseAlert) {
+			throw new Error('Missing example Dependabot alert fixture');
+		}
+		const alert: Alert = {
+			...baseAlert,
+			security_advisory: {
+				...baseAlert.security_advisory,
+				withdrawn_at: null,
+			},
+		};
+
+		const result = dependabotAlertToRepocopVulnerability(
+			'guardian/some-repo',
+			alert,
+		);
+
+		assert.strictEqual(result.advisory_withdrawn_at, null);
+	});
 });
 
 void describe('Deduplication of repocop vulnerabilities', () => {
@@ -804,6 +888,11 @@ void describe('Deduplication of repocop vulnerabilities', () => {
 		within_sla: false,
 		scope: 'runtime',
 		alert_type: 'general',
+		advisory_published_at: new Date('2018-10-03T21:13:54Z'),
+		advisory_updated_at: new Date('2022-04-26T18:35:37Z'),
+		advisory_withdrawn_at: null,
+		alert_updated_at: new Date('2022-06-15T07:43:03Z'),
+		html_url: 'https://github.com/guardian/myrepo/security/dependabot/1',
 	};
 	const vuln2: RepocopVulnerability = {
 		full_name: fullName,
@@ -819,6 +908,11 @@ void describe('Deduplication of repocop vulnerabilities', () => {
 		within_sla: false,
 		scope: 'runtime',
 		alert_type: 'general',
+		advisory_published_at: new Date('2018-10-03T21:13:54Z'),
+		advisory_updated_at: new Date('2022-04-26T18:35:37Z'),
+		advisory_withdrawn_at: null,
+		alert_updated_at: new Date('2022-06-15T07:43:03Z'),
+		html_url: 'https://github.com/guardian/myrepo/security/dependabot/2',
 	};
 	const actual = deduplicateVulnerabilitiesByCve([vuln1, vuln2]);
 	void test('Should happen if two vulnerabilities share the same CVEs', () => {

--- a/packages/repocop/src/evaluation/repository.ts
+++ b/packages/repocop/src/evaluation/repository.ts
@@ -533,6 +533,13 @@ export function dependabotAlertToRepocopVulnerability(
 			fullName,
 		),
 		alert_type,
+		advisory_published_at: new Date(alert.security_advisory.published_at),
+		advisory_updated_at: new Date(alert.security_advisory.updated_at),
+		advisory_withdrawn_at: alert.security_advisory.withdrawn_at
+			? new Date(alert.security_advisory.withdrawn_at)
+			: null,
+		alert_updated_at: new Date(alert.updated_at),
+		html_url: alert.html_url,
 	};
 }
 

--- a/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
+++ b/packages/repocop/src/remediation/vuln-digest/vuln-digest.test.ts
@@ -92,6 +92,11 @@ const highRecentVuln: RepocopVulnerability = {
 	within_sla: true,
 	scope: 'runtime',
 	alert_type: 'general',
+	advisory_published_at: new Date('2026-06-18T00:00:00.000Z'),
+	advisory_updated_at: new Date('2026-06-18T00:00:00.000Z'),
+	advisory_withdrawn_at: null,
+	alert_updated_at: new Date('2026-06-18T00:00:00.000Z'),
+	html_url: 'https://github.com/guardian/some-repo/security/dependabot/1',
 };
 
 const recentMalware: RepocopVulnerability = {

--- a/packages/repocop/src/utils.test.ts
+++ b/packages/repocop/src/utils.test.ts
@@ -42,6 +42,11 @@ void describe('vulnSortingPredicate', () => {
 			within_sla: true,
 			scope: 'runtime',
 			alert_type: 'general',
+			advisory_published_at: new Date('2026-06-18T00:00:00.000Z'),
+			advisory_updated_at: new Date('2026-06-18T00:00:00.000Z'),
+			advisory_withdrawn_at: null,
+			alert_updated_at: new Date('2026-06-18T00:00:00.000Z'),
+			html_url: 'https://github.com/test/test/security/dependabot/1',
 		};
 		const criticalNotPatchable: RepocopVulnerability = {
 			...criticalPatchable,


### PR DESCRIPTION
## What does this change?
This adds some extra metadata to help troubleshoot problems with our vulnerability reports.
Specifically, we report open advisories even when they've been withdrawn. 
In principle a withdrawn advisory should be closed but there's obviously a lag between withdrawing an advisory and Dependabot picking it up.

The extra columns are:
* **ingested_at**: Time of ingestion into our metrics, useful for easy freshness test
* **advisory_published_at**: Obvious
* **advisory_updated_at**: This combined with `advisory_published_at` should help with some problems
* **advisory_withdrawn_at**: Nullable, useful for filtering open but withdrawn alerts
* **alert_updated_at**: Useful troubleshooting info when used with existing `alert_issue_date` column
* **html_url**: Gives us a direct link to the alert

## Why has this change been made?
This gives us more information to reason about in general and it gives us data to filter out of our vulnerability dashboard for this particular problem.

## How has it been verified?
Deployed to Code, ran `repocop` lambda and tested on Code metrics:
```sql
select distinct html_url 
from repocop_vulnerabilities 
where advisory_withdrawn_at is not null
order by html_url
limit 10 
```
This revealed several open but withdrawn advisories (at the time of writing):
* https://github.com/guardian/ad-manager-tools/security/dependabot/58
* https://github.com/guardian/cfn-private-resource-types/security/dependabot/143
* https://github.com/guardian/cfn-private-resource-types/security/dependabot/144
* https://github.com/guardian/consent-management-platform/security/dependabot/241
* https://github.com/guardian/contributions-platform/security/dependabot/81
* https://github.com/guardian/contributions-ticker-calculator/security/dependabot/130
* https://github.com/guardian/contributions-ticker-calculator/security/dependabot/131
* https://github.com/guardian/csnx/security/dependabot/191
* https://github.com/guardian/editorial-wires/security/dependabot/120
* https://github.com/guardian/eventbrite-baton-requests/security/dependabot/72

[Asana ticket](https://app.asana.com/1/1210045093164357/project/1214110347938932/task/1215867526123379?focus=true)