### PR TITLE
split cloudbuster into user report and fsbp report

### DIFF
--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -93,7 +93,7 @@ async function createFsbpTableAndAlerts(
 	);
 }
 
-async function userReport(prisma: PrismaClient) {
+async function breakglassUserReport(prisma: PrismaClient) {
 	const user = await prisma.aws_iam_users.findFirst();
 	const report = await prisma.aws_iam_credential_reports.findFirst();
 
@@ -102,6 +102,7 @@ async function userReport(prisma: PrismaClient) {
 }
 
 export async function main() {
+	logger.log({ message: 'Cloudbuster run starting.' });
 	// *** SETUP ***
 	const config = await getConfig();
 	const prisma = getPrismaClient(config);
@@ -112,6 +113,6 @@ export async function main() {
 	);
 
 	await createFsbpTableAndAlerts(config, prisma, anghammaradClient);
-	await userReport(prisma);
+	await breakglassUserReport(prisma);
 	logger.log({ message: 'Cloudbuster run completed.' });
 }

--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -2,24 +2,28 @@ import { SNSClient } from '@aws-sdk/client-sns';
 import { Anghammarad } from '@guardian/anghammarad';
 import { awsClientConfig } from 'common/aws.js';
 import { logger } from 'common/logs.js';
-import type { cloudbuster_fsbp_vulnerabilities } from 'common/prisma-client/client.js';
+import type {
+	cloudbuster_fsbp_vulnerabilities,
+	PrismaClient,
+} from 'common/prisma-client/client.js';
 import { getFsbpFindings } from 'common/src/database-queries.js';
 import { getPrismaClient } from 'common/src/prisma-client-setup.js';
 import type { SecurityHubSeverity } from 'common/src/types.js';
+import type { Config } from './config.js';
 import { getConfig } from './config.js';
 import { createDigestsFromFindings, sendDigest } from './digests.js';
 import { findingsToGuardianFormat } from './findings.js';
 
-export async function main() {
+async function createFsbpTableAndAlerts(
+	config: Config,
+	prisma: PrismaClient,
+	anghammaradClient: Anghammarad,
+) {
 	const severities: SecurityHubSeverity[] = ['CRITICAL', 'HIGH'];
-
-	// *** SETUP ***
-	const config = await getConfig();
-	const prisma = getPrismaClient(config);
 
 	// *** DATA GATHERING ***
 	logger.log({
-		message: `Starting Cloudbuster. Level of severities that will be scanned: ${severities.join(', ')}`,
+		message: `Level of severities that will be scanned: ${severities.join(', ')}`,
 	});
 
 	const dbResults = await getFsbpFindings(prisma, severities);
@@ -79,19 +83,35 @@ export async function main() {
 			...createDigestsFromFindings(activeFindings, 'HIGH', config.cutOffInDays),
 		);
 	}
-	// *** NOTIFICATION SENDING ***
-	const snsClient = new SNSClient(awsClientConfig(config.stage));
-	const anghammaradClient = new Anghammarad(
-		snsClient,
-		config.anghammaradSnsTopic,
-	);
 
+	// *** NOTIFICATION SENDING ***
 	logger.log({ message: `Sending ${digests.length} digests.` });
 	await Promise.all(
 		digests.map(
 			async (digest) => await sendDigest(anghammaradClient, config, digest),
 		),
 	);
+}
 
+async function userReport(prisma: PrismaClient) {
+	const user = await prisma.aws_iam_users.findFirst();
+	const report = await prisma.aws_iam_credential_reports.findFirst();
+
+	console.log(`User: ${user?.user_name}`);
+	console.log(`Report: ${report?.user}`);
+}
+
+export async function main() {
+	// *** SETUP ***
+	const config = await getConfig();
+	const prisma = getPrismaClient(config);
+	const snsClient = new SNSClient(awsClientConfig(config.stage));
+	const anghammaradClient = new Anghammarad(
+		snsClient,
+		config.anghammaradSnsTopic,
+	);
+
+	await createFsbpTableAndAlerts(config, prisma, anghammaradClient);
+	await userReport(prisma);
 	logger.log({ message: 'Cloudbuster run completed.' });
 }

--- a/packages/common/prisma/migrations/20260706105205_cloudbuster_read/migration.sql
+++ b/packages/common/prisma/migrations/20260706105205_cloudbuster_read/migration.sql
@@ -1,0 +1,8 @@
+-- makes cloudbuster consistent with other DB users in 20240709104714_user_permissions
+BEGIN TRANSACTION;
+    -- Grant read access to all current tables, and views
+    GRANT SELECT ON ALL TABLES IN SCHEMA public TO cloudbuster;
+
+    -- Grant read access to all future tables, and views
+        ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO cloudbuster;
+COMMIT TRANSACTION;

--- a/packages/common/prisma/migrations/20260706105205_cloudbuster_read/migration.sql
+++ b/packages/common/prisma/migrations/20260706105205_cloudbuster_read/migration.sql
@@ -4,5 +4,5 @@ BEGIN TRANSACTION;
     GRANT SELECT ON ALL TABLES IN SCHEMA public TO cloudbuster;
 
     -- Grant read access to all future tables, and views
-        ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO cloudbuster;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO cloudbuster;
 COMMIT TRANSACTION;


### PR DESCRIPTION
## What does this change?

Pull FSBP logic into its own function, `createFsbpTableAndAlerts`. Create a new function,`userReport` for notification of improperly configured breakglass credentials.

In order for the cloudbuster user to read these tables, I've expanded its permissions in line with #1176 

## Why has this change been made?

To simplify cloudbuster maintenance going forward, split the two features into two functions.

## Why was this approach chosen?

The cadence of and permissions of cloudbuster is appropriate for this kind of alert. It makes sense to use the service catalogue and postgres to deliver these messages.

## How has it been verified?

- [x] Cloudbuster still functions on CODE
- [x] Cloudbuster is able to access the new tables
- [ ] Test migration/user report on CODE after approval, before merge