### PR TITLE
chore: Update CQ NS1 plugin from 0.1.18 to 0.1.19

### DIFF
--- a/.env
+++ b/.env
@@ -29,7 +29,7 @@ CQ_GUARDIAN_GALAXIES=2.1.7
 CQ_GITHUB_LANGUAGES=0.0.7
 
 # See https://github.com/guardian/cq-source-ns1
-CQ_NS1=0.1.18
+CQ_NS1=0.1.19
 
 # See https://github.com/guardian/cq-image-packages
 CQ_IMAGE_PACKAGES=1.0.1

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -21733,7 +21733,7 @@ spec:
           },
           {
             "Essential": false,
-            "Image": "ghcr.io/guardian/cq-source-ns1:0.1.18",
+            "Image": "ghcr.io/guardian/cq-source-ns1:0.1.19",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {


### PR DESCRIPTION
See https://github.com/guardian/cq-source-ns1/releases/tag/v0.1.19.