### PR TITLE
refactor: update the start script to improve messaging and timeouts

### DIFF
--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -90,9 +90,37 @@ seed_database() {
   )
 }
 
-start_app_containers() {
-  step "Launching CloudQuery and Grafana"
-  "${COMPOSE_CMD[@]}" up -d --build cloudquery grafana
+start_grafana() {
+  step "Launching Grafana"
+  "${COMPOSE_CMD[@]}" up -d --no-deps grafana
+}
+
+start_cloudquery() {
+  step "Launching CloudQuery"
+  "${COMPOSE_CMD[@]}" up -d --force-recreate --no-deps cloudquery
+
+  local cloudquery_container
+  cloudquery_container=$("${COMPOSE_CMD[@]}" ps -aq cloudquery)
+
+  if [[ -z "$cloudquery_container" ]]; then
+    echo -e "${red}CloudQuery container was not created.${clear}"
+    exit 1
+  fi
+
+  echo "Waiting for CloudQuery to finish..."
+
+  local exit_code
+  exit_code=$(docker wait "$cloudquery_container")
+
+  if [[ "$exit_code" == "0" ]]; then
+    echo "CloudQuery completed successfully."
+  else
+    echo -e "${red}CloudQuery failed.${clear}"
+    echo "CloudQuery exited with code ${exit_code}."
+    echo "Showing recent CloudQuery logs:"
+    "${COMPOSE_CMD[@]}" logs --tail=100 cloudquery || true
+    exit 1
+  fi
 }
 
 main() {
@@ -100,7 +128,8 @@ main() {
   ensure_prisma_available
   start_postgres
   seed_database
-  start_app_containers
+  start_grafana
+  start_cloudquery
 }
 
 main

--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -120,8 +120,7 @@ start_grafana() {
 
 start_cloudquery() {
   step "Launching CloudQuery"
-  "${COMPOSE_CMD[@]}" up -d --force-recreate --no-deps cloudquery
-
+  "${COMPOSE_CMD[@]}" up -d --build --force-recreate --no-deps cloudquery
   local cloudquery_container
   cloudquery_container=$("${COMPOSE_CMD[@]}" ps -aq cloudquery)
 

--- a/packages/dev-environment/script/start
+++ b/packages/dev-environment/script/start
@@ -10,6 +10,7 @@ LOCAL_ENV_FILE=$HOME/.gu/service_catalogue/.env.local
 clear='\033[0m'
 cyan='\033[0;36m'
 yellow="\033[1;33m"
+red='\033[0;31m'
 STEP_COUNT=0
 
 # Build a reusable docker compose command using layered env files.
@@ -51,20 +52,42 @@ ensure_prisma_available() {
 
 start_postgres() {
   step "Launching postgres"
-  "${COMPOSE_CMD[@]}" up -d --build postgres
+  "${COMPOSE_CMD[@]}" up -d postgres
 
   local postgres_container
   postgres_container=$("${COMPOSE_CMD[@]}" ps -q postgres)
+  local postgres_status
+  local wait_seconds=0
+  local max_wait_seconds=60
 
   if [[ -z "$postgres_container" ]]; then
     echo "Postgres container was not created."
     exit 1
   fi
 
-  until [[ "$(docker inspect -f '{{.State.Health.Status}}' "$postgres_container" 2>/dev/null || true)" == "healthy" ]]; do
+  until [[ "$wait_seconds" -ge "$max_wait_seconds" ]]; do
+    postgres_status=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$postgres_container" 2>/dev/null || true)
+
+    if [[ "$postgres_status" == "healthy" ]]; then
+      return
+    fi
+
+    if [[ "$postgres_status" == "unhealthy" || "$postgres_status" == "exited" ]]; then
+      echo -e "${red}Postgres failed to become healthy.${clear}"
+      echo "Showing recent Postgres logs:"
+      "${COMPOSE_CMD[@]}" logs --tail=100 postgres || true
+      exit 1
+    fi
+
     echo "Waiting for postgres to become healthy..."
     sleep 2
+    wait_seconds=$((wait_seconds+2))
   done
+
+  echo -e "${red}Postgres did not become healthy within ${max_wait_seconds} seconds.${clear}"
+  echo "Showing recent Postgres logs:"
+  "${COMPOSE_CMD[@]}" logs --tail=100 postgres || true
+  exit 1
 }
 
 seed_database() {


### PR DESCRIPTION
## What does this change?

* Improves the `start_postgres` function to check both `Health` and `State` for the `postgres` container, adds a timeout, and provides clearer error messages and logs if the container fails to become healthy.
* Splits the previous `start_app_containers` function into two: 
  * `start_grafana`
  * `start_cloudquery`.

## Why has this change been made?

Mainly for improved messaging and error handling - previously, cloudquery would start but there was no user messaging if it ran unsuccessfully. Some build steps were removed as they were unnecessary as both grafana and postgres are image-based services so the build command is redundant.

## Why was this approach chosen?

We can run the cloudquery command without 'build' which would give less noisy output, but I decided to leave it in to ensure a fresh build every time for consistency.

## How has it been verified?

Tested locally. 