### PR TITLE
chore(deps): Update CQ Galaxies plugin from 2.1.7 to 2.1.8

### DIFF
--- a/.env
+++ b/.env
@@ -23,7 +23,7 @@ CQ_GITHUB=15.2.0
 CQ_FASTLY=4.10.3
 
 # See https://github.com/guardian/cq-source-galaxies
-CQ_GUARDIAN_GALAXIES=2.1.7
+CQ_GUARDIAN_GALAXIES=2.1.8
 
 # See https://github.com/guardian/cq-source-github-languages
 CQ_GITHUB_LANGUAGES=0.0.7

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -15502,7 +15502,7 @@ spec:
   name: galaxies
   path: guardian/galaxies
   registry: github
-  version: v2.1.7
+  version: v2.1.8
   destinations:
     - postgresql
   tables:


### PR DESCRIPTION
See https://github.com/guardian/cq-source-galaxies/releases/tag/v2.1.8.