### PR TITLE
find users with no name tag/mfa

### DIFF
--- a/packages/cloudbuster/src/breakglass.test.ts
+++ b/packages/cloudbuster/src/breakglass.test.ts
@@ -217,10 +217,12 @@ void describe('createBreakglassUserReport', () => {
 				credentialReport({
 					user: 'alice',
 					arn: 'arn:aws:iam::111111111111:user/alice',
+					account_id: '111111111111',
 				}),
 				credentialReport({
 					user: 'bob',
 					arn: 'arn:aws:iam::222222222222:user/bob',
+					account_id: '222222222222',
 				}),
 			],
 			[

--- a/packages/cloudbuster/src/breakglass.test.ts
+++ b/packages/cloudbuster/src/breakglass.test.ts
@@ -1,0 +1,175 @@
+import assert from 'assert';
+import { describe, it } from 'node:test';
+import type {
+    aws_accounts,
+    aws_iam_credential_reports,
+    aws_iam_users,
+} from 'common/prisma-client/client.js';
+import { BreakglassUser, createBreakglassUserReport } from './breakglass.js';
+
+function credentialReport(
+    overrides: Partial<aws_iam_credential_reports>,
+): aws_iam_credential_reports {
+    return {
+        cq_sync_time: null,
+        cq_source_name: null,
+        cq_id: 'cq-id',
+        cq_parent_id: null,
+        arn: 'arn:aws:iam::123456789012:user/alice',
+        user_creation_time: null,
+        password_last_changed: null,
+        password_next_rotation: null,
+        access_key_1_last_rotated: null,
+        access_key_2_last_rotated: null,
+        cert_1_last_rotated: null,
+        cert_2_last_rotated: null,
+        access_key_1_last_used_date: null,
+        access_key_2_last_used_date: null,
+        password_last_used: null,
+        password_enabled: 'true',
+        user: 'alice',
+        password_status: null,
+        mfa_active: true,
+        access_key1_active: null,
+        access_key2_active: null,
+        cert1_active: null,
+        cert2_active: null,
+        access_key1_last_used_region: null,
+        access_key1_last_used_service: null,
+        access_key2_last_used_region: null,
+        access_key2_last_used_service: null,
+        account_id: '123456789012',
+        ...overrides,
+    };
+}
+
+function awsAccount(overrides: Partial<aws_accounts>): aws_accounts {
+    return {
+        id: '123456789012',
+        name: 'my-account',
+        email: 'account@example.com',
+        status: 'ACTIVE',
+        joined_timestamp: new Date('2020-01-01'),
+        ancestors: [],
+        is_product_and_engineering: true,
+        ...overrides,
+    };
+}
+
+function iamUser(overrides: Partial<aws_iam_users>): aws_iam_users {
+    return {
+        cq_sync_time: null,
+        cq_source_name: null,
+        cq_id: 'cq-id',
+        cq_parent_id: null,
+        account_id: '123456789012',
+        arn: 'arn:aws:iam::123456789012:user/alice',
+        tags: { GoogleUsername: 'alice.smith' },
+        create_date: null,
+        path: null,
+        user_id: null,
+        user_name: 'alice',
+        password_last_used: null,
+        permissions_boundary: null,
+        ...overrides,
+    };
+}
+
+void describe('createBreakglassUserReport', () => {
+    void it('joins credential reports to accounts and users', () => {
+        const report = createBreakglassUserReport(
+            [credentialReport({})],
+            [awsAccount({})],
+            [iamUser({})],
+        );
+
+        const expected: BreakglassUser = {
+            accountName: 'my-account',
+            user: 'alice',
+            userUrl: 'https://console.aws.amazon.com/iam/home#/users/alice',
+            mfaActive: true,
+            hasUsernameTag: true,
+        };
+
+        assert.deepStrictEqual(report, [expected]);
+    });
+
+    void it('only includes users with passwords', () => {
+        const report = createBreakglassUserReport(
+            [
+                credentialReport({ user: 'alice', password_enabled: 'true' }),
+                credentialReport({
+                    user: 'bob',
+                    arn: 'arn:aws:iam::123456789012:user/bob',
+                    password_enabled: 'false',
+                }),
+            ],
+            [awsAccount({})],
+            [iamUser({})],
+        );
+
+        assert.strictEqual(report.length, 1);
+        assert.strictEqual(report[0]?.user, 'alice');
+    });
+
+    void it('reports hasUsernameTag as false when no matching user is found', () => {
+        const report = createBreakglassUserReport(
+            [credentialReport({})],
+            [awsAccount({})],
+            [],
+        );
+
+        const expected: BreakglassUser = {
+            accountName: 'my-account',
+            user: 'alice',
+            userUrl: 'https://console.aws.amazon.com/iam/home#/users/alice',
+            mfaActive: true,
+            hasUsernameTag: false,
+        };
+
+        assert.deepStrictEqual(report, [expected]);
+    });
+
+    void it('reports hasUsernameTag as false when the user has no GoogleUsername tag', () => {
+        const report = createBreakglassUserReport(
+            [credentialReport({})],
+            [awsAccount({})],
+            [iamUser({ tags: { SomeOtherTag: 'value' } })],
+        );
+
+        const expected: BreakglassUser = {
+            accountName: 'my-account',
+            user: 'alice',
+            userUrl: 'https://console.aws.amazon.com/iam/home#/users/alice',
+            mfaActive: true,
+            hasUsernameTag: false,
+        };
+
+        assert.deepStrictEqual(report, [expected]);
+    });
+
+    void it('sorts the report by account name', () => {
+        const report = createBreakglassUserReport(
+            [
+                credentialReport({
+                    user: 'alice',
+                    arn: 'arn:aws:iam::111111111111:user/alice',
+                }),
+                credentialReport({
+                    user: 'bob',
+                    arn: 'arn:aws:iam::222222222222:user/bob',
+                }),
+            ],
+            [
+                awsAccount({ id: '222222222222', name: 'aardvark-account' }),
+                awsAccount({ id: '111111111111', name: 'zebra-account' }),
+            ],
+            [],
+        );
+
+        assert.deepStrictEqual(
+            report.map((r) => r.accountName),
+            ['aardvark-account', 'zebra-account'],
+        );
+    });
+});

--- a/packages/cloudbuster/src/breakglass.test.ts
+++ b/packages/cloudbuster/src/breakglass.test.ts
@@ -1,237 +1,238 @@
 import assert from 'assert';
 import { describe, it } from 'node:test';
 import type {
-    aws_accounts,
-    aws_iam_credential_reports,
-    aws_iam_users,
+	aws_accounts,
+	aws_iam_credential_reports,
+	aws_iam_users,
 } from 'common/prisma-client/client.js';
-import { BreakglassUser, createBreakglassUserReport } from './breakglass.js';
+import type { BreakglassUser } from './breakglass.js';
+import { createBreakglassUserReport } from './breakglass.js';
 
 function credentialReport(
-    overrides: Partial<aws_iam_credential_reports>,
+	overrides: Partial<aws_iam_credential_reports>,
 ): aws_iam_credential_reports {
-    return {
-        cq_sync_time: null,
-        cq_source_name: null,
-        cq_id: 'cq-id',
-        cq_parent_id: null,
-        arn: 'arn:aws:iam::123456789012:user/alice',
-        user_creation_time: null,
-        password_last_changed: null,
-        password_next_rotation: null,
-        access_key_1_last_rotated: null,
-        access_key_2_last_rotated: null,
-        cert_1_last_rotated: null,
-        cert_2_last_rotated: null,
-        access_key_1_last_used_date: null,
-        access_key_2_last_used_date: null,
-        password_last_used: null,
-        password_enabled: 'true',
-        user: 'alice',
-        password_status: null,
-        mfa_active: true,
-        access_key1_active: null,
-        access_key2_active: null,
-        cert1_active: null,
-        cert2_active: null,
-        access_key1_last_used_region: null,
-        access_key1_last_used_service: null,
-        access_key2_last_used_region: null,
-        access_key2_last_used_service: null,
-        account_id: '123456789012',
-        ...overrides,
-    };
+	return {
+		cq_sync_time: null,
+		cq_source_name: null,
+		cq_id: 'cq-id',
+		cq_parent_id: null,
+		arn: 'arn:aws:iam::123456789012:user/alice',
+		user_creation_time: null,
+		password_last_changed: null,
+		password_next_rotation: null,
+		access_key_1_last_rotated: null,
+		access_key_2_last_rotated: null,
+		cert_1_last_rotated: null,
+		cert_2_last_rotated: null,
+		access_key_1_last_used_date: null,
+		access_key_2_last_used_date: null,
+		password_last_used: null,
+		password_enabled: 'true',
+		user: 'alice',
+		password_status: null,
+		mfa_active: true,
+		access_key1_active: null,
+		access_key2_active: null,
+		cert1_active: null,
+		cert2_active: null,
+		access_key1_last_used_region: null,
+		access_key1_last_used_service: null,
+		access_key2_last_used_region: null,
+		access_key2_last_used_service: null,
+		account_id: '123456789012',
+		...overrides,
+	};
 }
 
 function awsAccount(overrides: Partial<aws_accounts>): aws_accounts {
-    return {
-        id: '123456789012',
-        name: 'my-account',
-        email: 'account@example.com',
-        status: 'ACTIVE',
-        joined_timestamp: new Date('2020-01-01'),
-        ancestors: [],
-        is_product_and_engineering: true,
-        ...overrides,
-    };
+	return {
+		id: '123456789012',
+		name: 'my-account',
+		email: 'account@example.com',
+		status: 'ACTIVE',
+		joined_timestamp: new Date('2020-01-01'),
+		ancestors: [],
+		is_product_and_engineering: true,
+		...overrides,
+	};
 }
 
 function iamUser(overrides: Partial<aws_iam_users>): aws_iam_users {
-    return {
-        cq_sync_time: null,
-        cq_source_name: null,
-        cq_id: 'cq-id',
-        cq_parent_id: null,
-        account_id: '123456789012',
-        arn: 'arn:aws:iam::123456789012:user/alice',
-        tags: { GoogleUsername: 'alice.smith' },
-        create_date: null,
-        path: null,
-        user_id: null,
-        user_name: 'alice',
-        password_last_used: null,
-        permissions_boundary: null,
-        ...overrides,
-    };
+	return {
+		cq_sync_time: null,
+		cq_source_name: null,
+		cq_id: 'cq-id',
+		cq_parent_id: null,
+		account_id: '123456789012',
+		arn: 'arn:aws:iam::123456789012:user/alice',
+		tags: { GoogleUsername: 'alice.smith' },
+		create_date: null,
+		path: null,
+		user_id: null,
+		user_name: 'alice',
+		password_last_used: null,
+		permissions_boundary: null,
+		...overrides,
+	};
 }
 
 void describe('createBreakglassUserReport', () => {
-    void it('joins credential reports to accounts and users', () => {
-        const report = createBreakglassUserReport(
-            [credentialReport({ mfa_active: false })],
-            [awsAccount({})],
-            [iamUser({})],
-        );
+	void it('joins credential reports to accounts and users', () => {
+		const report = createBreakglassUserReport(
+			[credentialReport({ mfa_active: false })],
+			[awsAccount({})],
+			[iamUser({})],
+		);
 
-        const expected: BreakglassUser = {
-            accountName: 'my-account',
-            user: 'alice',
-            userUrl: 'https://console.aws.amazon.com/iam/home#/users/alice',
-            mfaActive: false,
-            hasUsernameTag: true,
-        };
+		const expected: BreakglassUser = {
+			accountName: 'my-account',
+			user: 'alice',
+			userUrl: 'https://console.aws.amazon.com/iam/home#/users/alice',
+			mfaActive: false,
+			hasUsernameTag: true,
+		};
 
-        assert.deepStrictEqual(report, [expected]);
-    });
+		assert.deepStrictEqual(report, [expected]);
+	});
 
-    void it('only includes users with passwords', () => {
-        const report = createBreakglassUserReport(
-            [
-                credentialReport({
-                    user: 'alice',
-                    password_enabled: 'true',
-                    mfa_active: false,
-                }),
-                credentialReport({
-                    user: 'bob',
-                    arn: 'arn:aws:iam::123456789012:user/bob',
-                    password_enabled: 'false',
-                    mfa_active: false,
-                }),
-            ],
-            [awsAccount({})],
-            [iamUser({})],
-        );
+	void it('only includes users with passwords', () => {
+		const report = createBreakglassUserReport(
+			[
+				credentialReport({
+					user: 'alice',
+					password_enabled: 'true',
+					mfa_active: false,
+				}),
+				credentialReport({
+					user: 'bob',
+					arn: 'arn:aws:iam::123456789012:user/bob',
+					password_enabled: 'false',
+					mfa_active: false,
+				}),
+			],
+			[awsAccount({})],
+			[iamUser({})],
+		);
 
-        assert.strictEqual(report.length, 1);
-        assert.strictEqual(report[0]?.user, 'alice');
-    });
+		assert.strictEqual(report.length, 1);
+		assert.strictEqual(report[0]!.user, 'alice');
+	});
 
-    void it('excludes users that have both MFA enabled and a GoogleUsername tag', () => {
-        const report = createBreakglassUserReport(
-            [credentialReport({ mfa_active: true })],
-            [awsAccount({})],
-            [iamUser({ tags: { GoogleUsername: 'alice.smith' } })],
-        );
+	void it('excludes users that have both MFA enabled and a GoogleUsername tag', () => {
+		const report = createBreakglassUserReport(
+			[credentialReport({ mfa_active: true })],
+			[awsAccount({})],
+			[iamUser({ tags: { GoogleUsername: 'alice.smith' } })],
+		);
 
-        assert.deepStrictEqual(report, []);
-    });
+		assert.deepStrictEqual(report, []);
+	});
 
-    void it('includes users that have a GoogleUsername tag but no MFA', () => {
-        const report = createBreakglassUserReport(
-            [credentialReport({ mfa_active: false })],
-            [awsAccount({})],
-            [iamUser({ tags: { GoogleUsername: 'alice.smith' } })],
-        );
+	void it('includes users that have a GoogleUsername tag but no MFA', () => {
+		const report = createBreakglassUserReport(
+			[credentialReport({ mfa_active: false })],
+			[awsAccount({})],
+			[iamUser({ tags: { GoogleUsername: 'alice.smith' } })],
+		);
 
-        assert.strictEqual(report.length, 1);
-        assert.strictEqual(report[0]?.mfaActive, false);
-        assert.strictEqual(report[0]?.hasUsernameTag, true);
-    });
+		assert.strictEqual(report.length, 1);
+		assert.strictEqual(report[0]!.mfaActive, false);
+		assert.strictEqual(report[0]!.hasUsernameTag, true);
+	});
 
-    void it('includes users that have MFA but no GoogleUsername tag', () => {
-        const report = createBreakglassUserReport(
-            [credentialReport({ mfa_active: true })],
-            [awsAccount({})],
-            [iamUser({ tags: { SomeOtherTag: 'value' } })],
-        );
+	void it('includes users that have MFA but no GoogleUsername tag', () => {
+		const report = createBreakglassUserReport(
+			[credentialReport({ mfa_active: true })],
+			[awsAccount({})],
+			[iamUser({ tags: { SomeOtherTag: 'value' } })],
+		);
 
-        assert.strictEqual(report.length, 1);
-        assert.strictEqual(report[0]?.mfaActive, true);
-        assert.strictEqual(report[0]?.hasUsernameTag, false);
-    });
+		assert.strictEqual(report.length, 1);
+		assert.strictEqual(report[0]!.mfaActive, true);
+		assert.strictEqual(report[0]!.hasUsernameTag, false);
+	});
 
-    void it('includes users that have neither MFA nor a GoogleUsername tag', () => {
-        const report = createBreakglassUserReport(
-            [credentialReport({ mfa_active: false })],
-            [awsAccount({})],
-            [iamUser({ tags: { SomeOtherTag: 'value' } })],
-        );
+	void it('includes users that have neither MFA nor a GoogleUsername tag', () => {
+		const report = createBreakglassUserReport(
+			[credentialReport({ mfa_active: false })],
+			[awsAccount({})],
+			[iamUser({ tags: { SomeOtherTag: 'value' } })],
+		);
 
-        assert.strictEqual(report.length, 1);
-        assert.strictEqual(report[0]?.mfaActive, false);
-        assert.strictEqual(report[0]?.hasUsernameTag, false);
-    });
+		assert.strictEqual(report.length, 1);
+		assert.strictEqual(report[0]!.mfaActive, false);
+		assert.strictEqual(report[0]!.hasUsernameTag, false);
+	});
 
-    void it('treats unknown MFA status (null) as missing MFA', () => {
-        const report = createBreakglassUserReport(
-            [credentialReport({ mfa_active: null })],
-            [awsAccount({})],
-            [iamUser({ tags: { GoogleUsername: 'alice.smith' } })],
-        );
+	void it('treats unknown MFA status (null) as missing MFA', () => {
+		const report = createBreakglassUserReport(
+			[credentialReport({ mfa_active: null })],
+			[awsAccount({})],
+			[iamUser({ tags: { GoogleUsername: 'alice.smith' } })],
+		);
 
-        assert.strictEqual(report.length, 1);
-        assert.strictEqual(report[0]?.mfaActive, null);
-    });
+		assert.strictEqual(report.length, 1);
+		assert.strictEqual(report[0]!.mfaActive, null);
+	});
 
-    void it('reports hasUsernameTag as false when no matching user is found', () => {
-        const report = createBreakglassUserReport(
-            [credentialReport({})],
-            [awsAccount({})],
-            [],
-        );
+	void it('reports hasUsernameTag as false when no matching user is found', () => {
+		const report = createBreakglassUserReport(
+			[credentialReport({})],
+			[awsAccount({})],
+			[],
+		);
 
-        const expected: BreakglassUser = {
-            accountName: 'my-account',
-            user: 'alice',
-            userUrl: 'https://console.aws.amazon.com/iam/home#/users/alice',
-            mfaActive: true,
-            hasUsernameTag: false,
-        };
+		const expected: BreakglassUser = {
+			accountName: 'my-account',
+			user: 'alice',
+			userUrl: 'https://console.aws.amazon.com/iam/home#/users/alice',
+			mfaActive: true,
+			hasUsernameTag: false,
+		};
 
-        assert.deepStrictEqual(report, [expected]);
-    });
+		assert.deepStrictEqual(report, [expected]);
+	});
 
-    void it('reports hasUsernameTag as false when the user has no GoogleUsername tag', () => {
-        const report = createBreakglassUserReport(
-            [credentialReport({})],
-            [awsAccount({})],
-            [iamUser({ tags: { SomeOtherTag: 'value' } })],
-        );
+	void it('reports hasUsernameTag as false when the user has no GoogleUsername tag', () => {
+		const report = createBreakglassUserReport(
+			[credentialReport({})],
+			[awsAccount({})],
+			[iamUser({ tags: { SomeOtherTag: 'value' } })],
+		);
 
-        const expected: BreakglassUser = {
-            accountName: 'my-account',
-            user: 'alice',
-            userUrl: 'https://console.aws.amazon.com/iam/home#/users/alice',
-            mfaActive: true,
-            hasUsernameTag: false,
-        };
+		const expected: BreakglassUser = {
+			accountName: 'my-account',
+			user: 'alice',
+			userUrl: 'https://console.aws.amazon.com/iam/home#/users/alice',
+			mfaActive: true,
+			hasUsernameTag: false,
+		};
 
-        assert.deepStrictEqual(report, [expected]);
-    });
+		assert.deepStrictEqual(report, [expected]);
+	});
 
-    void it('sorts the report by account name', () => {
-        const report = createBreakglassUserReport(
-            [
-                credentialReport({
-                    user: 'alice',
-                    arn: 'arn:aws:iam::111111111111:user/alice',
-                }),
-                credentialReport({
-                    user: 'bob',
-                    arn: 'arn:aws:iam::222222222222:user/bob',
-                }),
-            ],
-            [
-                awsAccount({ id: '222222222222', name: 'aardvark-account' }),
-                awsAccount({ id: '111111111111', name: 'zebra-account' }),
-            ],
-            [],
-        );
+	void it('sorts the report by account name', () => {
+		const report = createBreakglassUserReport(
+			[
+				credentialReport({
+					user: 'alice',
+					arn: 'arn:aws:iam::111111111111:user/alice',
+				}),
+				credentialReport({
+					user: 'bob',
+					arn: 'arn:aws:iam::222222222222:user/bob',
+				}),
+			],
+			[
+				awsAccount({ id: '222222222222', name: 'aardvark-account' }),
+				awsAccount({ id: '111111111111', name: 'zebra-account' }),
+			],
+			[],
+		);
 
-        assert.deepStrictEqual(
-            report.map((r) => r.accountName),
-            ['aardvark-account', 'zebra-account'],
-        );
-    });
+		assert.deepStrictEqual(
+			report.map((r) => r.accountName),
+			['aardvark-account', 'zebra-account'],
+		);
+	});
 });

--- a/packages/cloudbuster/src/breakglass.test.ts
+++ b/packages/cloudbuster/src/breakglass.test.ts
@@ -78,7 +78,7 @@ function iamUser(overrides: Partial<aws_iam_users>): aws_iam_users {
 void describe('createBreakglassUserReport', () => {
     void it('joins credential reports to accounts and users', () => {
         const report = createBreakglassUserReport(
-            [credentialReport({})],
+            [credentialReport({ mfa_active: false })],
             [awsAccount({})],
             [iamUser({})],
         );
@@ -87,7 +87,7 @@ void describe('createBreakglassUserReport', () => {
             accountName: 'my-account',
             user: 'alice',
             userUrl: 'https://console.aws.amazon.com/iam/home#/users/alice',
-            mfaActive: true,
+            mfaActive: false,
             hasUsernameTag: true,
         };
 
@@ -97,11 +97,16 @@ void describe('createBreakglassUserReport', () => {
     void it('only includes users with passwords', () => {
         const report = createBreakglassUserReport(
             [
-                credentialReport({ user: 'alice', password_enabled: 'true' }),
+                credentialReport({
+                    user: 'alice',
+                    password_enabled: 'true',
+                    mfa_active: false,
+                }),
                 credentialReport({
                     user: 'bob',
                     arn: 'arn:aws:iam::123456789012:user/bob',
                     password_enabled: 'false',
+                    mfa_active: false,
                 }),
             ],
             [awsAccount({})],
@@ -110,6 +115,63 @@ void describe('createBreakglassUserReport', () => {
 
         assert.strictEqual(report.length, 1);
         assert.strictEqual(report[0]?.user, 'alice');
+    });
+
+    void it('excludes users that have both MFA enabled and a GoogleUsername tag', () => {
+        const report = createBreakglassUserReport(
+            [credentialReport({ mfa_active: true })],
+            [awsAccount({})],
+            [iamUser({ tags: { GoogleUsername: 'alice.smith' } })],
+        );
+
+        assert.deepStrictEqual(report, []);
+    });
+
+    void it('includes users that have a GoogleUsername tag but no MFA', () => {
+        const report = createBreakglassUserReport(
+            [credentialReport({ mfa_active: false })],
+            [awsAccount({})],
+            [iamUser({ tags: { GoogleUsername: 'alice.smith' } })],
+        );
+
+        assert.strictEqual(report.length, 1);
+        assert.strictEqual(report[0]?.mfaActive, false);
+        assert.strictEqual(report[0]?.hasUsernameTag, true);
+    });
+
+    void it('includes users that have MFA but no GoogleUsername tag', () => {
+        const report = createBreakglassUserReport(
+            [credentialReport({ mfa_active: true })],
+            [awsAccount({})],
+            [iamUser({ tags: { SomeOtherTag: 'value' } })],
+        );
+
+        assert.strictEqual(report.length, 1);
+        assert.strictEqual(report[0]?.mfaActive, true);
+        assert.strictEqual(report[0]?.hasUsernameTag, false);
+    });
+
+    void it('includes users that have neither MFA nor a GoogleUsername tag', () => {
+        const report = createBreakglassUserReport(
+            [credentialReport({ mfa_active: false })],
+            [awsAccount({})],
+            [iamUser({ tags: { SomeOtherTag: 'value' } })],
+        );
+
+        assert.strictEqual(report.length, 1);
+        assert.strictEqual(report[0]?.mfaActive, false);
+        assert.strictEqual(report[0]?.hasUsernameTag, false);
+    });
+
+    void it('treats unknown MFA status (null) as missing MFA', () => {
+        const report = createBreakglassUserReport(
+            [credentialReport({ mfa_active: null })],
+            [awsAccount({})],
+            [iamUser({ tags: { GoogleUsername: 'alice.smith' } })],
+        );
+
+        assert.strictEqual(report.length, 1);
+        assert.strictEqual(report[0]?.mfaActive, null);
     });
 
     void it('reports hasUsernameTag as false when no matching user is found', () => {

--- a/packages/cloudbuster/src/breakglass.ts
+++ b/packages/cloudbuster/src/breakglass.ts
@@ -1,15 +1,15 @@
 import type {
-    aws_accounts,
-    aws_iam_credential_reports,
-    aws_iam_users,
+	aws_accounts,
+	aws_iam_credential_reports,
+	aws_iam_users,
 } from 'common/prisma-client/client.js';
 
 export interface BreakglassUser {
-    accountName: string | null;
-    user: string | null;
-    userUrl: string | null;
-    mfaActive: boolean | null;
-    hasUsernameTag: boolean;
+	accountName: string | null;
+	user: string | null;
+	userUrl: string | null;
+	mfaActive: boolean | null;
+	hasUsernameTag: boolean;
 }
 
 /**
@@ -19,7 +19,7 @@ export interface BreakglassUser {
  * E.g. `arn:aws:iam::123456789012:user/alice` -> `123456789012`.
  */
 function accountIdFromArn(arn: string | null): string | null {
-    return arn?.split(':')[4] ?? null;
+	return arn?.split(':')[4] ?? null;
 }
 
 /**
@@ -27,32 +27,31 @@ function accountIdFromArn(arn: string | null): string | null {
  * AWS account and IAM user records, filtering to users that have passwords.
  */
 export function createBreakglassUserReport(
-    credentialReports: aws_iam_credential_reports[],
-    awsAccounts: aws_accounts[],
-    iamUsers: aws_iam_users[],
+	credentialReports: aws_iam_credential_reports[],
+	awsAccounts: aws_accounts[],
+	iamUsers: aws_iam_users[],
 ): BreakglassUser[] {
-    const accountsById = new Map(awsAccounts.map((a) => [a.id, a]));
-    const usersByArn = new Map(iamUsers.map((u) => [u.arn, u]));
+	const accountsById = new Map(awsAccounts.map((a) => [a.id, a]));
+	const usersByArn = new Map(iamUsers.map((u) => [u.arn, u]));
 
-    return credentialReports
-        .filter((cr) => cr.password_enabled === 'true')
-        .map((cr) => {
-            const accountId = accountIdFromArn(cr.arn);
-            const account = accountId ? accountsById.get(accountId) : undefined;
-            const user = cr.arn ? usersByArn.get(cr.arn) : undefined;
-            const tags = user?.tags as Record<string, string> | null | undefined;
+	return credentialReports
+		.filter((cr) => cr.password_enabled === 'true')
+		.map((cr) => {
+			const accountId = accountIdFromArn(cr.arn);
+			const account = accountId ? accountsById.get(accountId) : undefined;
+			const user = cr.arn ? usersByArn.get(cr.arn) : undefined;
+			const tags = user?.tags as Record<string, string> | null | undefined;
 
-            return {
-                accountName: account?.name ?? null,
-                user: cr.user,
-                userUrl: cr.user
-                    ? `https://console.aws.amazon.com/iam/home#/users/${cr.user}`
-                    : null,
-                mfaActive: cr.mfa_active,
-                hasUsernameTag: tags?.['GoogleUsername'] != null,
-            };
-        })
-        .sort((a, b) =>
-            (a.accountName ?? '').localeCompare(b.accountName ?? ''),
-        ).filter((user) => !user.hasUsernameTag || !user.mfaActive);
+			return {
+				accountName: account?.name ?? null,
+				user: cr.user,
+				userUrl: cr.user
+					? `https://console.aws.amazon.com/iam/home#/users/${cr.user}`
+					: null,
+				mfaActive: cr.mfa_active,
+				hasUsernameTag: tags?.['GoogleUsername'] != null,
+			};
+		})
+		.sort((a, b) => (a.accountName ?? '').localeCompare(b.accountName ?? ''))
+		.filter((user) => !user.hasUsernameTag || !user.mfaActive);
 }

--- a/packages/cloudbuster/src/breakglass.ts
+++ b/packages/cloudbuster/src/breakglass.ts
@@ -1,0 +1,58 @@
+import type {
+    aws_accounts,
+    aws_iam_credential_reports,
+    aws_iam_users,
+} from 'common/prisma-client/client.js';
+
+export interface BreakglassUser {
+    accountName: string | null;
+    user: string | null;
+    userUrl: string | null;
+    mfaActive: boolean | null;
+    hasUsernameTag: boolean;
+}
+
+/**
+ * Extracts the 12-digit AWS account id from an IAM ARN.
+ * ARNs have the form `arn:aws:iam::<account-id>:<resource>`, so the account id
+ * is the 5th colon-delimited segment.
+ * E.g. `arn:aws:iam::123456789012:user/alice` -> `123456789012`.
+ */
+function accountIdFromArn(arn: string | null): string | null {
+    return arn?.split(':')[4] ?? null;
+}
+
+/**
+ * Builds the breakglass user report by joining IAM credential reports to their
+ * AWS account and IAM user records, filtering to users that have passwords.
+ */
+export function createBreakglassUserReport(
+    credentialReports: aws_iam_credential_reports[],
+    awsAccounts: aws_accounts[],
+    iamUsers: aws_iam_users[],
+): BreakglassUser[] {
+    const accountsById = new Map(awsAccounts.map((a) => [a.id, a]));
+    const usersByArn = new Map(iamUsers.map((u) => [u.arn, u]));
+
+    return credentialReports
+        .filter((cr) => cr.password_enabled === 'true')
+        .map((cr) => {
+            const accountId = accountIdFromArn(cr.arn);
+            const account = accountId ? accountsById.get(accountId) : undefined;
+            const user = cr.arn ? usersByArn.get(cr.arn) : undefined;
+            const tags = user?.tags as Record<string, string> | null | undefined;
+
+            return {
+                accountName: account?.name ?? null,
+                user: cr.user,
+                userUrl: cr.user
+                    ? `https://console.aws.amazon.com/iam/home#/users/${cr.user}`
+                    : null,
+                mfaActive: cr.mfa_active,
+                hasUsernameTag: tags?.['GoogleUsername'] != null,
+            };
+        })
+        .sort((a, b) =>
+            (a.accountName ?? '').localeCompare(b.accountName ?? ''),
+        ).filter((user) => !user.hasUsernameTag || !user.mfaActive);
+}

--- a/packages/cloudbuster/src/breakglass.ts
+++ b/packages/cloudbuster/src/breakglass.ts
@@ -13,16 +13,6 @@ export interface BreakglassUser {
 }
 
 /**
- * Extracts the 12-digit AWS account id from an IAM ARN.
- * ARNs have the form `arn:aws:iam::<account-id>:<resource>`, so the account id
- * is the 5th colon-delimited segment.
- * E.g. `arn:aws:iam::123456789012:user/alice` -> `123456789012`.
- */
-function accountIdFromArn(arn: string | null): string | null {
-	return arn?.split(':')[4] ?? null;
-}
-
-/**
  * Builds the breakglass user report by joining IAM credential reports to their
  * AWS account and IAM user records, filtering to users that have passwords.
  */
@@ -37,7 +27,7 @@ export function createBreakglassUserReport(
 	return credentialReports
 		.filter((cr) => cr.password_enabled === 'true')
 		.map((cr) => {
-			const accountId = accountIdFromArn(cr.arn);
+			const accountId = cr.account_id;
 			const account = accountId ? accountsById.get(accountId) : undefined;
 			const user = cr.arn ? usersByArn.get(cr.arn) : undefined;
 			const tags = user?.tags as Record<string, string> | null | undefined;

--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -112,12 +112,13 @@ async function breakglassUserReport(prisma: PrismaClient) {
 		iamUsers,
 	);
 
-
 	logger.log({
-		message: report.map((r) => ({
-			accountName: r.accountName,
-			user: r.user,
-		})).toLocaleString(),
+		message: JSON.stringify(
+			report.map((r) => ({
+				accountName: r.accountName,
+				user: r.user,
+			})),
+		),
 	});
 
 	return report;

--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -6,9 +6,15 @@ import type {
 	cloudbuster_fsbp_vulnerabilities,
 	PrismaClient,
 } from 'common/prisma-client/client.js';
-import { getFsbpFindings } from 'common/src/database-queries.js';
+import {
+	getAwsAccounts,
+	getFsbpFindings,
+	getIamCredentialReports,
+	getIamUsers,
+} from 'common/src/database-queries.js';
 import { getPrismaClient } from 'common/src/prisma-client-setup.js';
 import type { SecurityHubSeverity } from 'common/src/types.js';
+import { createBreakglassUserReport } from './breakglass.js';
 import type { Config } from './config.js';
 import { getConfig } from './config.js';
 import { createDigestsFromFindings, sendDigest } from './digests.js';
@@ -94,11 +100,27 @@ async function createFsbpTableAndAlerts(
 }
 
 async function breakglassUserReport(prisma: PrismaClient) {
-	const user = await prisma.aws_iam_users.findFirst();
-	const report = await prisma.aws_iam_credential_reports.findFirst();
+	const [credentialReports, awsAccounts, iamUsers] = await Promise.all([
+		getIamCredentialReports(prisma),
+		getAwsAccounts(prisma),
+		getIamUsers(prisma),
+	]);
 
-	console.log(`User: ${user?.user_name}`);
-	console.log(`Report: ${report?.user}`);
+	const report = createBreakglassUserReport(
+		credentialReports,
+		awsAccounts,
+		iamUsers,
+	);
+
+
+	logger.log({
+		message: report.map((r) => ({
+			accountName: r.accountName,
+			user: r.user,
+		})).toLocaleString(),
+	});
+
+	return report;
 }
 
 export async function main() {

--- a/packages/common/src/database-queries.ts
+++ b/packages/common/src/database-queries.ts
@@ -1,4 +1,7 @@
 import type {
+	aws_accounts,
+	aws_iam_credential_reports,
+	aws_iam_users,
 	aws_securityhub_findings,
 	PrismaClient,
 	view_repo_ownership,
@@ -69,4 +72,22 @@ export async function getExternalTeams(
 ): Promise<string[]> {
 	const teams = await client.guardian_non_p_and_e_github_teams.findMany();
 	return toNonEmptyArray(teams.map((t) => t.team_name));
+}
+
+export async function getIamCredentialReports(
+	client: PrismaClient,
+): Promise<aws_iam_credential_reports[]> {
+	return await client.aws_iam_credential_reports.findMany();
+}
+
+export async function getIamUsers(
+	client: PrismaClient,
+): Promise<aws_iam_users[]> {
+	return await client.aws_iam_users.findMany();
+}
+
+export async function getAwsAccounts(
+	client: PrismaClient,
+): Promise<aws_accounts[]> {
+	return await client.aws_accounts.findMany();
 }


### PR DESCRIPTION
## What does this change?

Implements the core logic for identifying users with at least one of

- No MFA
- No google username tag

## Why has this change been made?

As part of keeping Janus resilient, we need to make sure that AWS breakglass users are compliant, and findable.

## Why was this approach chosen?

We could message users directly if they don't have MFA set up, but this introduces some problems

1. Setting up email infrastructure is fiddly, and requires collaboration across departments which significantly slows things down.
2. If the user has no email, we don't know who we are meant to contact in the first place
3. Account health is a whole-team responsibility, not just the responsibility of the breakglass user
4. If the breakglass user has left, the email will just bounce

Extending via cloudbuster has the following benefits

1. We can plug into an existing messaging system
2. We can reach the entire team, which mitigates challenges 2-4 above
3. We can follow the same cadence that cloudbuster uses.

## How has it been verified?

Added unit tests. Verified on CODE, except for last commit

In the next PR, I'll add some end-to-end tests, making use of our seeded local db!
