### PR TITLE
Set up test data for local integration testing of cloudbuster user report

### DIFF
--- a/packages/cloudbuster/src/breakglass.test.ts
+++ b/packages/cloudbuster/src/breakglass.test.ts
@@ -1,9 +1,9 @@
 import assert from 'assert';
 import { describe, it } from 'node:test';
 import type {
-	aws_accounts,
 	aws_iam_credential_reports,
 	aws_iam_users,
+	aws_organizations_accounts,
 } from 'common/prisma-client/client.js';
 import type { BreakglassUser } from './breakglass.js';
 import { createBreakglassUserReport } from './breakglass.js';
@@ -44,15 +44,24 @@ function credentialReport(
 	};
 }
 
-function awsAccount(overrides: Partial<aws_accounts>): aws_accounts {
+function awsAccount(
+	overrides: Partial<aws_organizations_accounts>,
+): aws_organizations_accounts {
 	return {
+		cq_sync_time: null,
+		cq_source_name: null,
+		cq_id: 'cq-id',
+		cq_parent_id: null,
+		request_account_id: null,
+		tags: null,
+		arn: 'arn:aws:organizations::123456789012:account/o-example/123456789012',
 		id: '123456789012',
 		name: 'my-account',
 		email: 'account@example.com',
-		status: 'ACTIVE',
+		joined_method: null,
 		joined_timestamp: new Date('2020-01-01'),
-		ancestors: [],
-		is_product_and_engineering: true,
+		status: 'ACTIVE',
+		state: null,
 		...overrides,
 	};
 }

--- a/packages/cloudbuster/src/breakglass.ts
+++ b/packages/cloudbuster/src/breakglass.ts
@@ -1,7 +1,7 @@
 import type {
-	aws_accounts,
 	aws_iam_credential_reports,
 	aws_iam_users,
+	aws_organizations_accounts,
 } from 'common/prisma-client/client.js';
 
 export interface BreakglassUser {
@@ -18,7 +18,7 @@ export interface BreakglassUser {
  */
 export function createBreakglassUserReport(
 	credentialReports: aws_iam_credential_reports[],
-	awsAccounts: aws_accounts[],
+	awsAccounts: aws_organizations_accounts[],
 	iamUsers: aws_iam_users[],
 ): BreakglassUser[] {
 	const accountsById = new Map(awsAccounts.map((a) => [a.id, a]));

--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -112,14 +112,13 @@ async function breakglassUserReport(prisma: PrismaClient) {
 		iamUsers,
 	);
 
-	logger.log({
-		message: JSON.stringify(
-			report.map((r) => ({
-				accountName: r.accountName,
-				user: r.user,
-			})),
-		),
-	});
+	console.table(
+		report.map(({ user, mfaActive, hasUsernameTag }) => ({
+			user,
+			mfaActive,
+			hasUsernameTag,
+		})),
+	);
 
 	return report;
 }

--- a/packages/common/prisma/schema.prisma
+++ b/packages/common/prisma/schema.prisma
@@ -186,8 +186,6 @@ model aws_organizations_accounts {
   name               String?
   status             String?
   state              String?
-
-  @@ignore
 }
 
 model aws_organizations_organizational_units {

--- a/packages/common/prisma/seed.ts
+++ b/packages/common/prisma/seed.ts
@@ -10,12 +10,16 @@
  */
 import { PrismaPg } from '@prisma/adapter-pg';
 import { type Prisma, PrismaClient } from '../prisma-client/client.js';
-import { buildSeedData } from './seed/seed-assembly.js';
+import { buildGitHubSeedData } from './seed/seed-assembly.js';
+import {
+	type BreakglassSeedData,
+	buildBreakglassSeedData,
+} from './seed/seed-breakglass.js';
 import { createTeam } from './seed/seed-builders.js';
 import { cqSourceName, orgName } from './seed/seed-constants.js';
 import { repoDefinitions, teamDefinitions } from './seed/seed-data.js';
 import { createManyIfAny } from './seed/seed-helpers.js';
-import type { SeedData, SeedFilter } from './seed/seed-types.js';
+import type { GitHubSeedData, SeedFilter } from './seed/seed-types.js';
 
 const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {
@@ -79,6 +83,10 @@ async function clearExistingSeedData(
 	await tx.github_repositories.deleteMany(seedFilter);
 	await tx.github_teams.deleteMany(seedFilter);
 
+	await tx.aws_iam_credential_reports.deleteMany(seedFilter);
+	await tx.aws_iam_users.deleteMany(seedFilter);
+	await tx.aws_organizations_accounts.deleteMany(seedFilter);
+
 	// runtime/output tables: always clear for reproducible local runs
 	await tx.guardian_github_actions_usage.deleteMany({
 		where: {
@@ -98,30 +106,45 @@ async function clearExistingSeedData(
 async function insertSeedData(
 	tx: Prisma.TransactionClient,
 	teams: Prisma.github_teamsCreateManyInput[],
-	seedData: SeedData,
+	gitHubSeedData: GitHubSeedData,
+	breakglassReportSeedData: BreakglassSeedData,
 ): Promise<void> {
 	await tx.github_teams.createMany({ data: teams });
-	await tx.github_repositories.createMany({ data: seedData.repos });
+	await tx.github_repositories.createMany({ data: gitHubSeedData.repos });
 
-	await createManyIfAny(seedData.githubWorkflows, (data) =>
+	await createManyIfAny(gitHubSeedData.githubWorkflows, (data) =>
 		tx.github_workflows.createMany({ data }),
 	);
 
-	await createManyIfAny(seedData.githubActionsUsages, (data) =>
+	await createManyIfAny(gitHubSeedData.githubActionsUsages, (data) =>
 		tx.guardian_github_actions_usage.createMany({ data }),
 	);
 
-	await tx.github_languages.createMany({ data: seedData.languages });
-	await tx.github_team_repositories.createMany({ data: seedData.teamRepos });
-	await tx.github_repository_branches.createMany({ data: seedData.branches });
+	await tx.github_languages.createMany({ data: gitHubSeedData.languages });
+	await tx.github_team_repositories.createMany({
+		data: gitHubSeedData.teamRepos,
+	});
+	await tx.github_repository_branches.createMany({
+		data: gitHubSeedData.branches,
+	});
 
-	await createManyIfAny(seedData.cloudFormationStacks, (data) =>
+	await createManyIfAny(gitHubSeedData.cloudFormationStacks, (data) =>
 		tx.aws_cloudformation_stacks.createMany({ data }),
 	);
 
-	await createManyIfAny(seedData.customProperties, (data) =>
+	await createManyIfAny(gitHubSeedData.customProperties, (data) =>
 		tx.github_repository_custom_properties.createMany({ data }),
 	);
+
+	await tx.aws_organizations_accounts.createMany({
+		data: breakglassReportSeedData.organizationsAccounts,
+	});
+	await tx.aws_iam_users.createMany({
+		data: breakglassReportSeedData.iamUsers,
+	});
+	await tx.aws_iam_credential_reports.createMany({
+		data: breakglassReportSeedData.iamCredentialReports,
+	});
 }
 
 /**
@@ -151,7 +174,8 @@ async function main(): Promise<void> {
 
 	const teams = teamDefinitions.map(({ id, slug }) => createTeam(id, slug));
 
-	const seedData = buildSeedData();
+	const gitHubSeedData = buildGitHubSeedData();
+	const breakglassReportSeedData = buildBreakglassSeedData();
 
 	console.log(
 		'Seeding teams, repos, workflows, languages, and related records...',
@@ -159,7 +183,7 @@ async function main(): Promise<void> {
 
 	await prisma.$transaction(async (tx) => {
 		await clearExistingSeedData(tx, seedFilter, seededRepoFullNames);
-		await insertSeedData(tx, teams, seedData);
+		await insertSeedData(tx, teams, gitHubSeedData, breakglassReportSeedData);
 	});
 
 	console.log('Seeding complete!');

--- a/packages/common/prisma/seed/seed-assembly.ts
+++ b/packages/common/prisma/seed/seed-assembly.ts
@@ -27,7 +27,7 @@ import {
 	teamDefinitions,
 } from './seed-data.js';
 import { createSeedMetadata } from './seed-helpers.js';
-import type { SeedData, TeamSlug } from './seed-types.js';
+import type { GitHubSeedData, TeamSlug } from './seed-types.js';
 
 /**
  * Builds the intentionally invalid workflow row used by local testing scenarios.
@@ -49,12 +49,12 @@ function createInvalidGithubWorkflow(
 /**
  * Expands repository fixture definitions into the full persisted seed payload.
  */
-export function buildSeedData(): SeedData {
+export function buildGitHubSeedData(): GitHubSeedData {
 	const teamIdsBySlug = new Map<TeamSlug, bigint>(
 		teamDefinitions.map(({ id, slug }) => [slug, BigInt(id)] as const),
 	);
 
-	return repoDefinitions.reduce<SeedData>((acc, definition) => {
+	return repoDefinitions.reduce<GitHubSeedData>((acc, definition) => {
 		const repoBundle = createRepoAndChildren(
 			definition.id,
 			definition.name,

--- a/packages/common/prisma/seed/seed-breakglass.ts
+++ b/packages/common/prisma/seed/seed-breakglass.ts
@@ -1,0 +1,117 @@
+/**
+ * Seed fixtures for exercising cloudbuster's breakglass user report locally.
+ *
+ * Produces IAM users and credential reports covering the report's decision
+ * matrix:
+ *   - correctly configured (GoogleUsername tag + MFA)  → excluded from report
+ *   - missing GoogleUsername tag                        → included
+ *   - missing MFA                                       → included
+ *   - missing both                                      → included
+ *
+ * A single `aws_organizations_accounts` row is seeded so the report can look
+ * up an account name for the credential reports.
+ */
+import { Prisma } from '../../prisma-client/client.js';
+import { createSeedMetadata } from './seed-helpers.js';
+
+const breakglassAccountId = '000000000001';
+const breakglassAccountName = 'service-catalogue-dev-account';
+const breakglassAccountEmail = 'service-catalogue-dev@example.com';
+
+interface BreakglassUserFixture {
+	userName: string;
+	hasGoogleUsernameTag: boolean;
+	mfaActive: boolean;
+}
+
+const breakglassUserFixtures: readonly BreakglassUserFixture[] = [
+	{
+		userName: 'alice-correctly-configured',
+		hasGoogleUsernameTag: true,
+		mfaActive: true,
+	},
+	{
+		userName: 'bob-missing-googleusername-tag',
+		hasGoogleUsernameTag: false,
+		mfaActive: true,
+	},
+	{
+		userName: 'charlie-missing-mfa',
+		hasGoogleUsernameTag: true,
+		mfaActive: false,
+	},
+	{
+		userName: 'dave-missing-tag-and-mfa',
+		hasGoogleUsernameTag: false,
+		mfaActive: false,
+	},
+];
+
+const userArn = (userName: string): string =>
+	`arn:aws:iam::${breakglassAccountId}:user/${userName}`;
+
+function createIamUser(
+	fixture: BreakglassUserFixture,
+): Prisma.aws_iam_usersCreateManyInput {
+	const tags: Prisma.InputJsonValue = fixture.hasGoogleUsernameTag
+		? { GoogleUsername: `${fixture.userName}@example.com` }
+		: { SomeOtherTag: 'value' };
+
+	return {
+		...createSeedMetadata(),
+		account_id: breakglassAccountId,
+		arn: userArn(fixture.userName),
+		user_name: fixture.userName,
+		user_id: `AIDA${fixture.userName.toUpperCase().replace(/[^A-Z0-9]/g, '')}`,
+		path: '/',
+		create_date: new Date('2023-01-01T00:00:00Z'),
+		tags,
+		password_last_used: null,
+		permissions_boundary: Prisma.DbNull,
+	};
+}
+
+function createIamCredentialReport(
+	fixture: BreakglassUserFixture,
+): Prisma.aws_iam_credential_reportsCreateManyInput {
+	return {
+		...createSeedMetadata(),
+		account_id: breakglassAccountId,
+		arn: userArn(fixture.userName),
+		user: fixture.userName,
+		password_enabled: 'true',
+		mfa_active: fixture.mfaActive,
+		user_creation_time: new Date('2023-01-01T00:00:00Z'),
+	};
+}
+
+function createOrganizationsAccount(): Prisma.aws_organizations_accountsCreateManyInput {
+	return {
+		...createSeedMetadata(),
+		request_account_id: breakglassAccountId,
+		arn: `arn:aws:organizations::${breakglassAccountId}:account/o-seed/${breakglassAccountId}`,
+		id: breakglassAccountId,
+		name: breakglassAccountName,
+		email: breakglassAccountEmail,
+		status: 'ACTIVE',
+		joined_timestamp: new Date('2023-01-01T00:00:00Z'),
+	};
+}
+
+export interface BreakglassSeedData {
+	iamUsers: Prisma.aws_iam_usersCreateManyInput[];
+	iamCredentialReports: Prisma.aws_iam_credential_reportsCreateManyInput[];
+	organizationsAccounts: Prisma.aws_organizations_accountsCreateManyInput[];
+}
+
+/**
+ * Builds Prisma createMany payloads for the seeded IAM users, credential
+ * reports and organisations account used by the breakglass report.
+ */
+export function buildBreakglassSeedData(): BreakglassSeedData {
+	return {
+		iamUsers: breakglassUserFixtures.map(createIamUser),
+		iamCredentialReports: breakglassUserFixtures.map(createIamCredentialReport),
+		organizationsAccounts: [createOrganizationsAccount()],
+	};
+}

--- a/packages/common/prisma/seed/seed-builders.ts
+++ b/packages/common/prisma/seed/seed-builders.ts
@@ -15,10 +15,10 @@ import {
 } from './seed-constants.js';
 import { createSeedMetadata } from './seed-helpers.js';
 import type {
+	GitHubSeedData,
 	RepoBundle,
 	RepoDefinition,
 	RoleName,
-	GitHubSeedData,
 	TeamSlug,
 } from './seed-types.js';
 

--- a/packages/common/prisma/seed/seed-builders.ts
+++ b/packages/common/prisma/seed/seed-builders.ts
@@ -18,7 +18,7 @@ import type {
 	RepoBundle,
 	RepoDefinition,
 	RoleName,
-	SeedData,
+	GitHubSeedData,
 	TeamSlug,
 } from './seed-types.js';
 
@@ -374,7 +374,7 @@ export function createGithubActionsUsage(
  * Adds optional seeded records declared by a repository fixture definition.
  */
 export function addOptionalSeedData(
-	acc: SeedData,
+	acc: GitHubSeedData,
 	definition: RepoDefinition,
 ): void {
 	if (definition.cloudFormation === true) {
@@ -389,7 +389,7 @@ export function addOptionalSeedData(
 /**
  * Creates an empty mutable seed payload accumulator.
  */
-export function createEmptySeedData(): SeedData {
+export function createEmptySeedData(): GitHubSeedData {
 	return {
 		repos: [],
 		languages: [],

--- a/packages/common/prisma/seed/seed-types.ts
+++ b/packages/common/prisma/seed/seed-types.ts
@@ -19,7 +19,7 @@ export interface RepoDefinition {
 }
 
 /** Persisted seed payload assembled before insertion into the database. */
-export interface SeedData {
+export interface GitHubSeedData {
 	repos: Prisma.github_repositoriesCreateManyInput[];
 	languages: Prisma.github_languagesCreateManyInput[];
 	branches: Prisma.github_repository_branchesCreateManyInput[];

--- a/packages/common/src/database-queries.ts
+++ b/packages/common/src/database-queries.ts
@@ -1,7 +1,7 @@
 import type {
-	aws_accounts,
 	aws_iam_credential_reports,
 	aws_iam_users,
+	aws_organizations_accounts,
 	aws_securityhub_findings,
 	PrismaClient,
 	view_repo_ownership,
@@ -88,6 +88,6 @@ export async function getIamUsers(
 
 export async function getAwsAccounts(
 	client: PrismaClient,
-): Promise<aws_accounts[]> {
-	return await client.aws_accounts.findMany();
+): Promise<aws_organizations_accounts[]> {
+	return await client.aws_organizations_accounts.findMany();
 }


### PR DESCRIPTION
### #1993 must be merged before this PR

## What does this change?

1. Switches cloudbuster's breakglass user report from using `aws_accounts` to `aws_organization_accounts`
2. Creates seed data for testing the user report locally, renaming the existing seeds to be explicitly GitHub related

## Why has this change been made?

1. `aws_accounts` is a [view](https://github.com/guardian/service-catalogue/tree/main/packages/common/prisma/migrations/20231026134216_view_aws_accounts/migration.sql). In order to populate it we would need to seed three separate tables: `aws_organizations_accounts`, `aws_organizations_account_parents`, `aws_organizations_organizational_units`. To simplify this, (and probably improve performance very slightly), The AWS account name now comes from `aws_organizations_accounts` instead, meaning we only have to seed one table.
2. One issue with repocop is that it's been difficult to test from end to end, due to the many db calls it makes. Seeding (introduced in #1978 ), helps solve this problem, as we can put deterministic test data in a local db, and then run it however we like (in docker, in an action job, etc). Here, we are creating test data to verify that the breakglass user report correctly identifies IAM users that are missing certain configurations.
## How has it been verified?

Ran `npm run start -w cloudbuster` locally, observed expected output

## What doesn't it do?

To limit scope, this deliberately doesn't introduce an e2e testing framework, or a way to run these tests in CI etc. The rest of cloudbuster, and maybe other parts of the service catalogue, can be tested like this in future PRs