### PR TITLE
feat: Run `AwsResourcesForAvailabilityDashboard` as a singleton

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -12700,6 +12700,10 @@ spec:
                 "Condition": "HEALTHY",
                 "ContainerName": "CloudquerySource-AwsResourcesForAvailabilityDashboardAWSOTELCollector",
               },
+              {
+                "Condition": "SUCCESS",
+                "ContainerName": "CloudquerySource-AwsResourcesForAvailabilityDashboardAwsCli",
+              },
             ],
             "DockerLabels": {
               "App": "service-catalogue",
@@ -12844,6 +12848,31 @@ spec:
                 "Protocol": "tcp",
               },
             ],
+            "ReadonlyRootFilesystem": true,
+          },
+          {
+            "Command": [
+              "/bin/bash",
+              "-c",
+              "ECS_CLUSTER=$(curl -s $ECS_CONTAINER_METADATA_URI/task | jq -r '.Cluster');ECS_FAMILY=$(curl -s $ECS_CONTAINER_METADATA_URI/task | jq -r '.Family');ECS_TASK_ARN=$(curl -s $ECS_CONTAINER_METADATA_URI/task | jq -r '.TaskARN');RUNNING=$(aws ecs list-tasks --cluster $ECS_CLUSTER --family $ECS_FAMILY | jq '.taskArns | length');[[ \${RUNNING} > 1 ]] && exit 114 || exit 0",
+            ],
+            "EntryPoint": [
+              "",
+            ],
+            "Essential": false,
+            "Image": "ghcr.io/guardian/service-catalogue/singleton:stable",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": "eu-west-1",
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-AwsResourcesForAvailabilityDashboardAwsCli",
             "ReadonlyRootFilesystem": true,
           },
           {
@@ -32373,6 +32402,21 @@ spec:
       "Properties": {
         "PolicyDocument": {
           "Statement": [
+            {
+              "Action": "ecs:ListTasks",
+              "Condition": {
+                "StringEquals": {
+                  "ecs:cluster": {
+                    "Fn::GetAtt": [
+                      "servicecatalogueCluster5FC34DC5",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+            },
             {
               "Action": [
                 "kinesis:Describe*",

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -230,6 +230,7 @@ export function addCloudqueryEcsCluster(
 				],
 			}),
 			policies: [listOrgsPolicy, cloudqueryAccess('*')],
+			runAsSingleton: true,
 		},
 		{
 			name: 'AwsOrgWideCertificates',


### PR DESCRIPTION
## What does this change?
This task runs every 30 minutes. The last two invocations overlapped a little:

<img width="1121" height="200" alt="image" src="https://github.com/user-attachments/assets/c0f7370f-d902-4c50-9bff-a9d22e87a305" />

When this happens there's an opportunity for database locking. Run as a singleton to avoid this; when the second task starts, it'll check if there's one running and exit if so. See also https://github.com/guardian/service-catalogue/pull/484.

## How has it been verified?
N/A.