### PR TITLE
Expand prisma update group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       prisma:
         patterns:
           - 'prisma'
-          - '@prisma/client'
+          - '@prisma/*'
       code-quality:
         patterns:
           - '@guardian/eslint-config'


### PR DESCRIPTION
## What does this change?

As of the upgrade to prisma v7, we are now pulling in a library called `@prisma/adapter-pg`. I've modified the dependabot config to ensure that, and any future prisma related libraries are included in prsima dependency updates automatically

## Why has this change been made?

Prisma library versions falling out of sync can cause weird errors

## Notes

This change is not particularly risky, so please rebase if necessary, and let auto-merge do its thing
