### PR TITLE
chore: Configure Dependabot to update all Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,7 +41,9 @@ updates:
           - patch
 
   - package-ecosystem: 'github-actions'
-    directory: '/'
+    directories:
+      - '/.github/workflows'
+      - '/.github/actions'
     schedule:
       interval: 'quarterly'
     cooldown:


### PR DESCRIPTION
## What does this change?
The Actions used in [`npm-run`](https://github.com/guardian/service-catalogue/tree/main/.github/actions/npm-run) haven't been updated since being added in https://github.com/guardian/service-catalogue/pull/1156. This change updates the Dependabot configuration to include it.