### PR TITLE
chore: Tweak Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,7 +43,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directories:
       - '/.github/workflows'
-      - '/.github/actions'
+      - '/.github/actions/**'
     schedule:
       interval: 'quarterly'
     cooldown:


### PR DESCRIPTION
## What does this change?
The changes in #2000 didn't work as expected. No updates were seen for `.github/actions/npm-run/action.yml` (see https://github.com/guardian/service-catalogue/pull/2001). The logs from https://github.com/guardian/service-catalogue/actions/runs/29331244651/job/87079442952 confirm this.

Reading https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#directories-or-directory--, it looks like the default behaviour is to look for files in the immediate directory, i.e. `.github/actions/action.yml`. We have `.github/actions/npm-run/action.yml`. This change tweaks the config to look at all child directories.