### PR TITLE
chore: Update Dependabot config again!

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,7 +43,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directories:
       - '/.github/workflows'
-      - '/.github/actions/**'
+      - '/.github/actions/npm-run'
     schedule:
       interval: 'quarterly'
     cooldown:


### PR DESCRIPTION
## What does this change?
The changes in https://github.com/guardian/service-catalogue/pull/2006 still didn't update `.github/actions/npm-run`.

This change updates the config to name the directory explicitly. This is similar to https://github.com/guardian/dotcom-rendering/blob/916bd87001a798c4dd0e7ae2b03ea5022c721cc3/.github/dependabot.yml#L70.
