### PR TITLE
refactor: show prisma migrate task in service catalogue app logs

### DIFF
--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -82,6 +82,12 @@ You can apply a migration to CODE or PROD using the [CLI](../packages/cli)):
 npm -w cli start run-task -- --stage [CODE|PROD] --name prisma-migrate-task
 ```
 
+#### Viewing migration logs
+
+> [!NOTE]
+> Although the ECS task is named `prisma-migrate-task`, its shipped logs are attributed to `service-catalogue` in Kibana.
+> To narrow to a specific migration run, use the ECS task ARN from the CLI log link.
+
 See also:
 
 - https://www.prisma.io/docs/orm/prisma-client/deployment/deploy-database-changes-with-prisma-migrate
@@ -118,6 +124,9 @@ prismaMigrate: ContainerImage.fromRegistry(
 ### 3. Deploy to CODE and observe
 
 Deploy to CODE and observe the ECS task logs to verify your changes work as expected.
+
+> [!NOTE]
+> See [Viewing migration logs](#viewing-migration-logs).
 
 ### 4. Revert the image reference
 

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -27197,7 +27197,7 @@ spec:
               },
               {
                 "Name": "APP",
-                "Value": "prisma-migrate-task",
+                "Value": "service-catalogue",
               },
               {
                 "Name": "GU_REPO",
@@ -27235,7 +27235,7 @@ spec:
           },
           {
             "DockerLabels": {
-              "App": "prisma-migrate-task",
+              "App": "service-catalogue",
               "Stack": "deploy",
               "Stage": "PROD",
             },

--- a/packages/cdk/lib/prisma-migrate-task.ts
+++ b/packages/cdk/lib/prisma-migrate-task.ts
@@ -39,6 +39,8 @@ export function addPrismaMigrateTask(
 	}: PrismaMigrateTaskProps,
 ) {
 	const app = 'prisma-migrate-task';
+	// Keep ECS identity distinct while grouping migrate logs under the main app in Kibana
+	const logApp = 'service-catalogue';
 	const { stack, stage, region } = scope;
 
 	const roleName = `${app}-${stage}`;
@@ -84,7 +86,7 @@ export function addPrismaMigrateTask(
 			environment: {
 				STACK: stack,
 				STAGE: stage,
-				APP: app,
+				APP: logApp,
 				GU_REPO: 'guardian/service-catalogue',
 				TASK_NAME: app,
 			},
@@ -147,7 +149,8 @@ export function addPrismaMigrateTask(
 		dockerLabels: {
 			Stack: stack,
 			Stage: stage,
-			App: app,
+			// Match FireLens APP metadata so container labels and shipped logs agree
+			App: logApp,
 		},
 		logging: fireLensLogDriver,
 		readonlyRootFilesystem: true,


### PR DESCRIPTION
## What does this change?

- Updates the `APP` environment variable and the `App` Docker label in `addPrismaMigrateTask` to use `service-catalogue` instead of `prisma-migrate-task`.
- Adds a note to the migration README to reflect this change.

## Why has this change been made?

Currently, when the task is started via the cli, a link is created to ECS to view the logs. The url sets sets `app.keyword:"service-catalogue"` which means that the logs don't show up for the migrate task, as this has the `app.keyword:"prisma-migrate-task"`. This change should fix that and the link should work.

[Asana ticket](https://app.asana.com/1/1210045093164357/project/1214110347938932/task/1214980667159868)

## Why was this approach chosen?

The issue was limited to Kibana log attribution, so only the logging metadata has changed, not the task identity itself. This avoids altering task family naming, IAM/resource naming, task discovery conventions, and other infrastructure metadata. 

## How has it been verified?

- [x] Tested locally by deploying this branch to CODE and running the cli task (`npm -w cli start run-task -- --stage CODE --name prisma-migrate-task`) and observing the link correctly displaying the [logs](https://logs.gutools.co.uk/s/devx/app/r/s/AOnD1).