### PR TITLE
Report noncompliant breakglass user count to cloudwatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14524,7 +14524,10 @@
       }
     },
     "packages/cloudbuster": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dependencies": {
+        "@aws-sdk/client-cloudwatch": "^3.1075.0"
+      }
     },
     "packages/cloudquery-tables": {
       "version": "0.0.0",

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -25115,6 +25115,16 @@ spec:
               },
             },
             {
+              "Action": "cloudwatch:PutMetricData",
+              "Condition": {
+                "StringEquals": {
+                  "cloudwatch:namespace": "cloudbuster",
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
               "Action": "rds-db:connect",
               "Effect": "Allow",
               "Resource": {

--- a/packages/cdk/lib/cloudbuster.ts
+++ b/packages/cdk/lib/cloudbuster.ts
@@ -8,6 +8,7 @@ import type { GuSecurityGroup } from '@guardian/cdk/lib/constructs/ec2';
 import { Duration } from 'aws-cdk-lib';
 import type { IVpc } from 'aws-cdk-lib/aws-ec2';
 import type { Schedule } from 'aws-cdk-lib/aws-events';
+import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Architecture, LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
 import type { DatabaseInstance } from 'aws-cdk-lib/aws-rds';
 import type { ITopic } from 'aws-cdk-lib/aws-sns';
@@ -37,6 +38,16 @@ export class CloudBuster {
 		} = props;
 		const app = 'cloudbuster';
 
+		const cloudwatchWrite = new PolicyStatement({
+			actions: ['cloudwatch:PutMetricData'],
+			resources: ['*'],
+			conditions: {
+				StringEquals: {
+					'cloudwatch:namespace': app,
+				},
+			},
+		});
+
 		const lambda = new GuScheduledLambda(stack, 'cloudbuster', {
 			app,
 			vpc,
@@ -59,7 +70,7 @@ export class CloudBuster {
 			rules: [{ schedule }],
 		});
 		anghammaradTopic.grantPublish(lambda);
-
+		lambda.addToRolePolicy(cloudwatchWrite);
 		db.grantConnect(lambda, 'cloudbuster');
 	}
 }

--- a/packages/cloudbuster/package.json
+++ b/packages/cloudbuster/package.json
@@ -2,6 +2,9 @@
 	"name": "cloudbuster",
 	"version": "1.0.0",
 	"type": "module",
+	"dependencies": {
+		"@aws-sdk/client-cloudwatch": "^3.1075.0"
+	},
 	"scripts": {
 		"build": "esbuild src/index.ts --bundle --platform=node --target=node24 --outdir=dist --external:@aws-sdk --external:@prisma/client --external:prisma  --format=esm --banner:js=\"import { createRequire } from 'module'; const require = createRequire(import.meta.url);\"",
 		"postbuild": "cp package.json dist/package.json",

--- a/packages/cloudbuster/src/breakglass/index.ts
+++ b/packages/cloudbuster/src/breakglass/index.ts
@@ -1,9 +1,13 @@
+import type { MetricDatum } from '@aws-sdk/client-cloudwatch';
+import { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
+import { PutMetricDataCommand } from '@aws-sdk/client-cloudwatch';
 import type {
 	Anghammarad,
 	AnghammaradNotification,
 	Target,
 } from '@guardian/anghammarad';
 import { RequestedChannel } from '@guardian/anghammarad';
+import type { AwsClientConfig } from 'common/aws.js';
 import {
 	getAwsAccounts,
 	getIamCredentialReports,
@@ -15,8 +19,38 @@ import { formatMessage } from './digests.js';
 import { createBreakglassUserReport } from './findings.js';
 import type { BreakglassUser } from './types.js';
 
+async function createBreakglassUserMetric(
+	noncompliantUsers: BreakglassUser[],
+	config: Config,
+	awsClientConfig: AwsClientConfig,
+) {
+	const client = new CloudWatchClient(awsClientConfig);
+	const [stack, stage, app] = [config.stack, config.stage, config.app];
+	const Dimensions = [
+		{ Name: 'Stack', Value: stack },
+		{ Name: 'Stage', Value: stage },
+		{ Name: 'App', Value: app },
+	];
+
+	const metric: MetricDatum = {
+		MetricName: 'NoncompliantBreakglassUsers',
+		Value: noncompliantUsers.length,
+		Dimensions,
+	};
+
+	console.log('Sending metrics to Cloudwatch');
+
+	await client.send(
+		new PutMetricDataCommand({
+			Namespace: config.app,
+			MetricData: [metric],
+		}),
+	);
+}
+
 export async function sendBreakglassUserAlerts(
 	config: Config,
+	awsConfig: AwsClientConfig,
 	prisma: PrismaClient,
 	anghammaradClient: Anghammarad,
 ) {
@@ -32,7 +66,7 @@ export async function sendBreakglassUserAlerts(
 		iamUsers,
 	);
 
-	//TODO store user count as a cloudwatch metric
+	await createBreakglassUserMetric(report, config, awsConfig);
 
 	console.table(
 		report.map(({ user, mfaActive, hasUsernameTag }) => ({

--- a/packages/cloudbuster/src/breakglass/index.ts
+++ b/packages/cloudbuster/src/breakglass/index.ts
@@ -69,8 +69,9 @@ export async function sendBreakglassUserAlerts(
 	await createBreakglassUserMetric(report, config, awsConfig);
 
 	console.table(
-		report.map(({ user, mfaActive, hasUsernameTag }) => ({
+		report.map(({ user, accountName, mfaActive, hasUsernameTag }) => ({
 			user,
+			accountName,
 			mfaActive,
 			hasUsernameTag,
 		})),

--- a/packages/cloudbuster/src/config.ts
+++ b/packages/cloudbuster/src/config.ts
@@ -8,6 +8,14 @@ import type { PrismaConfig } from 'common/src/database-setup.js';
 
 export interface Config extends PrismaConfig {
 	/**
+	 * The stack name.
+	 */
+	stack: string;
+	/**
+	 * The name of the application.
+	 */
+	app: string;
+	/**
 	 * The stage of the application, e.g. DEV, CODE, PROD.
 	 */
 	stage: string;
@@ -26,7 +34,9 @@ export interface Config extends PrismaConfig {
 }
 
 export async function getConfig(): Promise<Config> {
+	const stack = getEnvOrThrow('STACK');
 	const stage = getEnvOrThrow('STAGE');
+	const app = getEnvOrThrow('APP');
 	const anghammaradSnsTopic: string = getEnvOrThrow('ANGHAMMARAD_SNS_ARN');
 
 	const isDev = stage === 'DEV';
@@ -35,7 +45,9 @@ export async function getConfig(): Promise<Config> {
 		? await getDevDatabaseConfig()
 		: await getDatabaseConfig(stage, 'cloudbuster');
 	return {
+		stack,
 		stage,
+		app,
 		databaseConnectionString: getDatabaseConnectionString(databaseConfig),
 		withQueryLogging: isDev,
 		enableMessaging: !isDev,

--- a/packages/cloudbuster/src/index.ts
+++ b/packages/cloudbuster/src/index.ts
@@ -9,18 +9,23 @@ import { createFsbpTableAndAlerts } from './fsbp/index.js';
 
 export async function main() {
 	logger.log({ message: 'Cloudbuster run starting.' });
-
-	const config = await getConfig();
-	const prisma = getPrismaClient(config);
-	const snsClient = new SNSClient(awsClientConfig(config.stage));
+	const cloudbusterConfig = await getConfig();
+	const awsConfig = awsClientConfig(cloudbusterConfig.stage);
+	const prisma = getPrismaClient(cloudbusterConfig);
+	const snsClient = new SNSClient(awsConfig);
 	const anghammaradClient = new Anghammarad(
 		snsClient,
-		config.anghammaradSnsTopic,
+		cloudbusterConfig.anghammaradSnsTopic,
 	);
 
 	await Promise.all([
-		createFsbpTableAndAlerts(config, prisma, anghammaradClient),
-		sendBreakglassUserAlerts(config, prisma, anghammaradClient),
+		createFsbpTableAndAlerts(cloudbusterConfig, prisma, anghammaradClient),
+		sendBreakglassUserAlerts(
+			cloudbusterConfig,
+			awsConfig,
+			prisma,
+			anghammaradClient,
+		),
 	]);
 
 	logger.log({ message: 'Cloudbuster run completed.' });

--- a/packages/common/src/aws.ts
+++ b/packages/common/src/aws.ts
@@ -6,7 +6,7 @@ import {
 } from '@aws-sdk/credential-providers';
 import type { AwsCredentialIdentityProvider } from '@smithy/types';
 
-interface AwsClientConfig {
+export interface AwsClientConfig {
 	region: string;
 	credentials?: AwsCredentialIdentityProvider;
 }


### PR DESCRIPTION
## What does this change?

- Grant cloudbuster permission to `PutMetrics` in the `cloudbuster` namespace.
- Track the number of noncompliant breakglass users on every invocation.

## Why has this change been made?

I think it's interesting to track our compliance over time.

## How has it been verified?

Tested on CODE, observed expected results
