### PR TITLE
More strictly enforce booleans in credential reports

### DIFF
--- a/packages/cloudbuster/src/breakglass/digests.ts
+++ b/packages/cloudbuster/src/breakglass/digests.ts
@@ -54,12 +54,13 @@ export async function sendAnghammaradNotification(
 				actions: [
 					{
 						cta: 'View breakglass user report',
-						url: `https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/var-account_name=${account.name}`,
+						url: `https://metrics.gutools.co.uk/d/bdn97cui5rbi8f?var-account_name=${encodeURIComponent(account.name)}`,
 					},
 				],
 				target,
 				sender: `Cloudbuster ${config.stage}`,
 				channel: RequestedChannel.PreferHangouts,
+				threadKey: `breakglass-${new Date().toISOString().split('T')[0]}`,
 			};
 			await anghammaradClient.notify(notification);
 		}),

--- a/packages/cloudbuster/src/breakglass/digests.ts
+++ b/packages/cloudbuster/src/breakglass/digests.ts
@@ -1,3 +1,11 @@
+import type {
+	Anghammarad,
+	AnghammaradNotification,
+	Target,
+} from '@guardian/anghammarad';
+import { RequestedChannel } from '@guardian/anghammarad';
+import type { AwsOrganizationsAccounts } from 'common/types.js';
+import type { Config } from '../config.js';
 import type { BreakglassUser } from './types.js';
 
 function formatUser(user: BreakglassUser): string {
@@ -10,4 +18,50 @@ function formatUser(user: BreakglassUser): string {
 
 export function formatMessage(users: BreakglassUser[]): string {
 	return users.map(formatUser).join('\n');
+}
+
+export async function sendAnghammaradNotification(
+	config: Config,
+	awsAccounts: AwsOrganizationsAccounts[],
+	report: BreakglassUser[],
+	anghammaradClient: Anghammarad,
+) {
+	const usersPerAccount = awsAccounts
+		.map(({ name }) => ({
+			name,
+			users: report.filter((user) => user.accountName === name),
+		}))
+		.filter(({ users }) => users.length > 0);
+
+	console.table(
+		usersPerAccount.map(({ name, users }) => ({
+			name,
+			numUsers: users.length,
+			users: users.map((u) => u.user).join(', '),
+		})),
+	);
+
+	const target: Target =
+		config.stage === 'PROD'
+			? { Stack: 'security' }
+			: { Stack: 'testing-alerts' };
+
+	await Promise.all(
+		usersPerAccount.map(async (account) => {
+			const notification: AnghammaradNotification = {
+				subject: `Breakglass User Report: ${account.name}`,
+				message: `${account.users.length} breakglass users are missing security configuration\n\n${formatMessage(account.users)}`,
+				actions: [
+					{
+						cta: 'View breakglass user report',
+						url: `https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/var-account_name=${account.name}`,
+					},
+				],
+				target,
+				sender: `Cloudbuster ${config.stage}`,
+				channel: RequestedChannel.PreferHangouts,
+			};
+			await anghammaradClient.notify(notification);
+		}),
+	);
 }

--- a/packages/cloudbuster/src/breakglass/findings.test.ts
+++ b/packages/cloudbuster/src/breakglass/findings.test.ts
@@ -13,7 +13,7 @@ function credentialReport(
 ): AwsIamCredentialReport {
 	return {
 		arn: 'arn:aws:iam::123456789012:user/alice',
-		password_enabled: 'true',
+		password_enabled: true,
 		user: 'alice',
 		mfa_active: true,
 		account_id: '123456789012',
@@ -65,13 +65,13 @@ void describe('createBreakglassUserReport', () => {
 			[
 				credentialReport({
 					user: 'alice',
-					password_enabled: 'true',
+					password_enabled: true,
 					mfa_active: false,
 				}),
 				credentialReport({
 					user: 'bob',
 					arn: 'arn:aws:iam::123456789012:user/bob',
-					password_enabled: 'false',
+					password_enabled: false,
 					mfa_active: false,
 				}),
 			],

--- a/packages/cloudbuster/src/breakglass/findings.ts
+++ b/packages/cloudbuster/src/breakglass/findings.ts
@@ -18,7 +18,7 @@ export function createBreakglassUserReport(
 	const usersByArn = new Map(iamUsers.map((u) => [u.arn, u]));
 
 	return credentialReports
-		.filter((cr) => cr.password_enabled === 'true')
+		.filter((cr) => cr.password_enabled)
 		.map((cr) => {
 			const accountId = cr.account_id;
 			const account = accountId ? accountsById.get(accountId) : undefined;

--- a/packages/cloudbuster/src/breakglass/index.ts
+++ b/packages/cloudbuster/src/breakglass/index.ts
@@ -3,12 +3,7 @@ import {
 	CloudWatchClient,
 	PutMetricDataCommand,
 } from '@aws-sdk/client-cloudwatch';
-import type {
-	Anghammarad,
-	AnghammaradNotification,
-	Target,
-} from '@guardian/anghammarad';
-import { RequestedChannel } from '@guardian/anghammarad';
+import type { Anghammarad } from '@guardian/anghammarad';
 import type { AwsClientConfig } from 'common/aws.js';
 import {
 	getAwsAccounts,
@@ -16,9 +11,8 @@ import {
 	getIamUsers,
 } from 'common/database-queries.js';
 import type { PrismaClient } from 'common/prisma-client/client.js';
-import type { AwsOrganizationsAccounts } from 'common/types.js';
 import type { Config } from '../config.js';
-import { formatMessage } from './digests.js';
+import { sendAnghammaradNotification } from './digests.js';
 import { createBreakglassUserReport } from './findings.js';
 import type { BreakglassUser } from './types.js';
 
@@ -47,52 +41,6 @@ async function createBreakglassUserMetric(
 		new PutMetricDataCommand({
 			Namespace: app,
 			MetricData: [metric],
-		}),
-	);
-}
-
-async function sendAnghammaradNotification(
-	config: Config,
-	awsAccounts: AwsOrganizationsAccounts[],
-	report: BreakglassUser[],
-	anghammaradClient: Anghammarad,
-) {
-	const usersPerAccount = awsAccounts
-		.map(({ name }) => ({
-			name,
-			users: report.filter((user) => user.accountName === name),
-		}))
-		.filter(({ users }) => users.length > 0);
-
-	console.table(
-		usersPerAccount.map(({ name, users }) => ({
-			name,
-			numUsers: users.length,
-			users: users.map((u) => u.user).join(', '),
-		})),
-	);
-
-	const target: Target =
-		config.stage === 'PROD'
-			? { Stack: 'security' }
-			: { Stack: 'testing-alerts' };
-
-	await Promise.all(
-		usersPerAccount.map(async (account) => {
-			const notification: AnghammaradNotification = {
-				subject: `Breakglass User Report: ${account.name}`,
-				message: `${account.users.length} breakglass users are missing security configuration\n\n${formatMessage(account.users)}`,
-				actions: [
-					{
-						cta: 'View breakglass user report',
-						url: `https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/var-account_name=${account.name}`,
-					},
-				],
-				target,
-				sender: `Cloudbuster ${config.stage}`,
-				channel: RequestedChannel.PreferHangouts,
-			};
-			await anghammaradClient.notify(notification);
 		}),
 	);
 }

--- a/packages/cloudbuster/src/breakglass/index.ts
+++ b/packages/cloudbuster/src/breakglass/index.ts
@@ -72,14 +72,10 @@ export async function sendBreakglassUserAlerts(
 		})),
 	);
 
-	await createBreakglassUserMetric(report, config, awsConfig);
-
-	await sendAnghammaradNotification(
-		config,
-		awsAccounts,
-		report,
-		anghammaradClient,
-	);
+	await Promise.all([
+		createBreakglassUserMetric(report, config, awsConfig),
+		sendAnghammaradNotification(config, awsAccounts, report, anghammaradClient),
+	]);
 
 	return report;
 }

--- a/packages/cloudbuster/src/breakglass/index.ts
+++ b/packages/cloudbuster/src/breakglass/index.ts
@@ -1,6 +1,8 @@
 import type { MetricDatum } from '@aws-sdk/client-cloudwatch';
-import { CloudWatchClient } from '@aws-sdk/client-cloudwatch';
-import { PutMetricDataCommand } from '@aws-sdk/client-cloudwatch';
+import {
+	CloudWatchClient,
+	PutMetricDataCommand,
+} from '@aws-sdk/client-cloudwatch';
 import type {
 	Anghammarad,
 	AnghammaradNotification,
@@ -14,6 +16,7 @@ import {
 	getIamUsers,
 } from 'common/database-queries.js';
 import type { PrismaClient } from 'common/prisma-client/client.js';
+import type { AwsOrganizationsAccounts } from 'common/types.js';
 import type { Config } from '../config.js';
 import { formatMessage } from './digests.js';
 import { createBreakglassUserReport } from './findings.js';
@@ -25,7 +28,7 @@ async function createBreakglassUserMetric(
 	awsClientConfig: AwsClientConfig,
 ) {
 	const client = new CloudWatchClient(awsClientConfig);
-	const [stack, stage, app] = [config.stack, config.stage, config.app];
+	const { stack, stage, app } = config;
 	const Dimensions = [
 		{ Name: 'Stack', Value: stack },
 		{ Name: 'Stage', Value: stage },
@@ -42,8 +45,54 @@ async function createBreakglassUserMetric(
 
 	await client.send(
 		new PutMetricDataCommand({
-			Namespace: config.app,
+			Namespace: app,
 			MetricData: [metric],
+		}),
+	);
+}
+
+async function sendAnghammaradNotification(
+	config: Config,
+	awsAccounts: AwsOrganizationsAccounts[],
+	report: BreakglassUser[],
+	anghammaradClient: Anghammarad,
+) {
+	const usersPerAccount = awsAccounts
+		.map(({ name }) => ({
+			name,
+			users: report.filter((user) => user.accountName === name),
+		}))
+		.filter(({ users }) => users.length > 0);
+
+	console.table(
+		usersPerAccount.map(({ name, users }) => ({
+			name,
+			numUsers: users.length,
+			users: users.map((u) => u.user).join(', '),
+		})),
+	);
+
+	const target: Target =
+		config.stage === 'PROD'
+			? { Stack: 'security' }
+			: { Stack: 'testing-alerts' };
+
+	await Promise.all(
+		usersPerAccount.map(async (account) => {
+			const notification: AnghammaradNotification = {
+				subject: `Breakglass User Report: ${account.name}`,
+				message: `${account.users.length} breakglass users are missing security configuration\n\n${formatMessage(account.users)}`,
+				actions: [
+					{
+						cta: 'View breakglass user report',
+						url: `https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/var-account_name=${account.name}`,
+					},
+				],
+				target,
+				sender: `Cloudbuster ${config.stage}`,
+				channel: RequestedChannel.PreferHangouts,
+			};
+			await anghammaradClient.notify(notification);
 		}),
 	);
 }
@@ -60,13 +109,11 @@ export async function sendBreakglassUserAlerts(
 		getIamUsers(prisma),
 	]);
 
-	const report: BreakglassUser[] = createBreakglassUserReport(
+	const report = createBreakglassUserReport(
 		credentialReports,
 		awsAccounts,
 		iamUsers,
 	);
-
-	await createBreakglassUserMetric(report, config, awsConfig);
 
 	console.table(
 		report.map(({ user, accountName, mfaActive, hasUsernameTag }) => ({
@@ -77,52 +124,13 @@ export async function sendBreakglassUserAlerts(
 		})),
 	);
 
-	interface UsersPerAccount {
-		acctId: string;
-		acctName: string;
-		users: BreakglassUser[];
-	}
+	await createBreakglassUserMetric(report, config, awsConfig);
 
-	const usersPerAccount: UsersPerAccount[] = awsAccounts
-		.map((account) => ({
-			acctId: account.id,
-			acctName: account.name,
-			users: report
-				.filter((user) => user.accountName === account.name)
-				.map((user) => user),
-		}))
-		.filter((account) => account.users.length > 0);
-
-	console.table(
-		usersPerAccount.map(({ acctName, users }) => ({
-			acctName,
-			numUsers: users.length,
-			users: users.map((u) => u.user).join(', '),
-		})),
-	);
-
-	const target: Target =
-		config.stage === 'PROD'
-			? { Stack: 'security' }
-			: { Stack: 'testing-alerts' };
-
-	await Promise.all(
-		usersPerAccount.map(async (account) => {
-			const notification: AnghammaradNotification = {
-				subject: `Breakglass User Report: ${account.acctName}`,
-				message: `${account.users.length} breakglass users are missing security configuration\n\n${formatMessage(account.users)}`,
-				actions: [
-					{
-						cta: 'View breakglass user report',
-						url: `https://metrics.gutools.co.uk/d/bdn97cui5rbi8f?var-account_name=${encodeURIComponent(account.acctName)}`,
-					},
-				],
-				target,
-				sender: `Cloudbuster ${config.stage}`,
-				channel: RequestedChannel.PreferHangouts,
-			};
-			await anghammaradClient.notify(notification);
-		}),
+	await sendAnghammaradNotification(
+		config,
+		awsAccounts,
+		report,
+		anghammaradClient,
 	);
 
 	return report;

--- a/packages/common/prisma/seed/seed-breakglass.ts
+++ b/packages/common/prisma/seed/seed-breakglass.ts
@@ -20,6 +20,7 @@ const breakglassAccountEmail = 'service-catalogue-dev@example.com';
 
 interface BreakglassUserFixture {
 	userName: string;
+	hasPassword: boolean;
 	hasGoogleUsernameTag: boolean;
 	mfaActive: boolean;
 }
@@ -27,21 +28,31 @@ interface BreakglassUserFixture {
 const breakglassUserFixtures: readonly BreakglassUserFixture[] = [
 	{
 		userName: 'alice-correctly-configured',
+		hasPassword: true,
 		hasGoogleUsernameTag: true,
 		mfaActive: true,
 	},
 	{
 		userName: 'bob-missing-googleusername-tag',
+		hasPassword: true,
 		hasGoogleUsernameTag: false,
 		mfaActive: true,
 	},
 	{
 		userName: 'charlie-missing-mfa',
+		hasPassword: true,
 		hasGoogleUsernameTag: true,
 		mfaActive: false,
 	},
 	{
 		userName: 'dave-missing-tag-and-mfa',
+		hasPassword: true,
+		hasGoogleUsernameTag: false,
+		mfaActive: false,
+	},
+	{
+		userName: 'eve-the-robot',
+		hasPassword: false, //robots don't need passwords
 		hasGoogleUsernameTag: false,
 		mfaActive: false,
 	},
@@ -66,7 +77,9 @@ function createIamUser(
 		path: '/',
 		create_date: new Date('2023-01-01T00:00:00Z'),
 		tags,
-		password_last_used: null,
+		password_last_used: fixture.hasPassword
+			? new Date('2023-01-01T00:00:00Z')
+			: null,
 		permissions_boundary: Prisma.DbNull,
 	};
 }
@@ -79,7 +92,7 @@ function createIamCredentialReport(
 		account_id: breakglassAccountId,
 		arn: userArn(fixture.userName),
 		user: fixture.userName,
-		password_enabled: 'true',
+		password_enabled: fixture.hasPassword ? 'true' : 'false',
 		mfa_active: fixture.mfaActive,
 		user_creation_time: new Date('2023-01-01T00:00:00Z'),
 	};

--- a/packages/common/src/database-queries.ts
+++ b/packages/common/src/database-queries.ts
@@ -78,7 +78,9 @@ export async function getIamCredentialReports(
 	client: PrismaClient,
 ): Promise<AwsIamCredentialReport[]> {
 	const reports = await client.aws_iam_credential_reports.findMany();
-	return toNonEmptyArray(reports.map((r) => r as AwsIamCredentialReport));
+	return toNonEmptyArray(
+		reports.map((r) => r as unknown as AwsIamCredentialReport),
+	);
 }
 
 export async function getIamUsers(client: PrismaClient): Promise<AwsIamUser[]> {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -176,13 +176,13 @@ export interface AwsOrganizationsAccounts extends AwsOrganizationsAccountsFields
 
 type AwsIamCredentialReports = Pick<
 	aws_iam_credential_reports,
-	'account_id' | 'user' | 'arn' | 'password_enabled' | 'mfa_active'
+	'account_id' | 'user' | 'arn'
 >;
 
 export interface AwsIamCredentialReport extends AwsIamCredentialReports {
 	account_id: NonNullable<AwsIamCredentialReports['account_id']>;
 	user: NonNullable<AwsIamCredentialReports['user']>;
 	arn: NonNullable<AwsIamCredentialReports['arn']>;
-	password_enabled: NonNullable<AwsIamCredentialReports['password_enabled']>;
-	mfa_active: NonNullable<AwsIamCredentialReports['mfa_active']>;
+	password_enabled: boolean;
+	mfa_active: boolean;
 }


### PR DESCRIPTION
## What does this change?

Some db columns appear to be optional strings, but in reality are only ever boolean values. We're enforcing this more strictly within TS

## Why has this change been made?

Potential bug, fix WIP


## Why was this approach chosen?

<!-- If the change is non-trivial, please discuss why this approach was chosen over alternatives, and any trade-offs considered. If it's very large, consider an ADR instead. -->

## How has it been verified?

- [ ] Tested locally
- [ ] Tested on CODE
