### PR TITLE
fix: Use ARN in links to Kibana

### DIFF
--- a/docs/database-migrations.md
+++ b/docs/database-migrations.md
@@ -74,7 +74,6 @@ Prerequisite:
 
 1. You have an approved Pull Request
 2. You have `deployTools` credentials from Janus
-3. You are connected to the VPN
 
 You can apply a migration to CODE or PROD using the [CLI](../packages/cli)):
 

--- a/packages/cli/src/aws.ts
+++ b/packages/cli/src/aws.ts
@@ -8,7 +8,7 @@ import {
 } from '@aws-sdk/client-ecs';
 import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
 import { awsClientConfig } from 'common/aws.js';
-import { getCentralElkLink } from 'common/logs.js';
+import { getEcsTaskLogsLink } from 'common/logs.js';
 import terminalLink from 'terminal-link';
 
 interface EcsResourceTags {
@@ -256,7 +256,7 @@ export const runOneTask = async (
 		?.map((t) => t.taskArn)
 		.filter(Boolean) as string[];
 
-	taskArns.map((taskArn) => printLogsUrl(app, stage, taskArn));
+	taskArns.map((taskArn) => printLogsUrl(stage, taskArn));
 };
 
 export const runAllTasks = async (
@@ -317,16 +317,13 @@ export const runAllTasks = async (
 		.flatMap((r) => r.tasks?.map((t) => t.taskArn))
 		.filter(Boolean) as string[];
 
-	taskArns.map((taskArn) => printLogsUrl(app, stage, taskArn));
+	taskArns.map((taskArn) => printLogsUrl(stage, taskArn));
 };
 
-function printLogsUrl(app: string, stage: string, taskDefinition: string) {
-	const url = getCentralElkLink({
-		filters: {
-			app,
-			stage,
-			ecs_task_arn: taskDefinition,
-		},
+function printLogsUrl(stage: string, taskDefinition: string) {
+	const url = getEcsTaskLogsLink({
+		stage,
+		ecsTaskArn: taskDefinition,
 		columns: ['table', 'resources', 'errors', 'client', 'message', 'error'],
 	});
 

--- a/packages/common/src/logs.test.ts
+++ b/packages/common/src/logs.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { describe, it } from 'node:test';
-import { getCentralElkLink } from './logs.js';
+import { getCentralElkLink, getEcsTaskLogsLink } from './logs.js';
 
 void describe('getCentralElkUrl', () => {
 	void it('should form a valid link', () => {
@@ -27,6 +27,29 @@ void describe('getCentralElkUrl', () => {
 		});
 		const expected =
 			"https://logs.gutools.co.uk/s/devx/app/discover#/?_g=(filters:!((query:(match_phrase:(stack:'deploy'))),(query:(match_phrase:(stage:'CODE'))),(query:(match_phrase:(app:'service-catalogue')))))&_a=(columns:!(message))";
+		assert.strictEqual(actual, expected);
+	});
+});
+
+void describe('getEcsTaskLogsLink', () => {
+	void it('should form a valid link without app', () => {
+		const actual = getEcsTaskLogsLink({
+			stage: 'CODE',
+			ecsTaskArn: 'arn:aws:ecs:eu-west-1:123456789012:task/cluster-name/abc123',
+		});
+		const expected =
+			"https://logs.gutools.co.uk/s/devx/app/discover#/?_g=(filters:!((query:(match_phrase:(stage:'CODE'))),(query:(match_phrase:(ecs_task_arn:'arn:aws:ecs:eu-west-1:123456789012:task/cluster-name/abc123')))))";
+		assert.strictEqual(actual, expected);
+	});
+
+	void it('should form a valid link with columns', () => {
+		const actual = getEcsTaskLogsLink({
+			stage: 'CODE',
+			ecsTaskArn: 'arn:aws:ecs:eu-west-1:123456789012:task/cluster-name/abc123',
+			columns: ['message'],
+		});
+		const expected =
+			"https://logs.gutools.co.uk/s/devx/app/discover#/?_g=(filters:!((query:(match_phrase:(stage:'CODE'))),(query:(match_phrase:(ecs_task_arn:'arn:aws:ecs:eu-west-1:123456789012:task/cluster-name/abc123')))))&_a=(columns:!(message))";
 		assert.strictEqual(actual, expected);
 	});
 });

--- a/packages/common/src/logs.ts
+++ b/packages/common/src/logs.ts
@@ -10,6 +10,12 @@ interface CentralElkProps {
 	columns?: string[];
 }
 
+interface EcsTaskLogsProps {
+	stage: string;
+	ecsTaskArn: string;
+	columns?: string[];
+}
+
 /**
  * Builds a deep link to the logs within Central ELK.
  */
@@ -36,6 +42,20 @@ export function getCentralElkLink(props: CentralElkProps): string {
 		.join('&');
 
 	return `${base}?${queryString}`;
+}
+
+/**
+ * Builds a deep link to the logs for a single ECS task run within Central ELK.
+ */
+export function getEcsTaskLogsLink({
+	stage,
+	ecsTaskArn,
+	columns,
+}: EcsTaskLogsProps): string {
+	return getCentralElkLink({
+		filters: { stage, ecs_task_arn: ecsTaskArn },
+		columns,
+	});
 }
 
 interface LogLine {


### PR DESCRIPTION
## What does this change?

- Adds a function to build the log link using the task ARN rather than the app name. 
- Adds tests for the new function.
- Drive-by removes a reference to the VPN requirement in migration docs.

Note: The service catalogue log linking is unaffected, as this still calls the original function directly. 

## Why has this change been made?

Currently, when the task is started via the cli, a link is created to ECS to view the logs. The url sets sets app.keyword:"service-catalogue" which means that the logs don't show up for the migrate task, as this has the app.keyword:"prisma-migrate-task". This change should fix that and the link should work.

[Asana ticket](https://app.asana.com/1/1210045093164357/project/1214110347938932/task/1214980667159868)

## Why was this approach chosen?

In the [previous PR](#2008) to address this, it was suggested that we just change the link rather than the task. Now, we use the ARN to build the link so it always goes to the right place. 

## How has it been verified?

- [x] Tested locally by running the cli task (`npm -w cli start run-task -- --stage CODE --name prisma-migrate-task`) and observing the link correctly displaying the [logs](https://logs.gutools.co.uk/s/devx/app/r/s/xsTHn).