### PR TITLE
Exclude root users from credential report

### DIFF
--- a/packages/cloudbuster/src/breakglass/findings.test.ts
+++ b/packages/cloudbuster/src/breakglass/findings.test.ts
@@ -191,4 +191,34 @@ void describe('createBreakglassUserReport', () => {
 			['aardvark-account', 'zebra-account'],
 		);
 	});
+	void it('excludes root users from the report', () => {
+		const report = createBreakglassUserReport(
+			[
+				credentialReport({
+					user: '<root_account>',
+					arn: 'arn:aws:iam::123456789012:root',
+					account_id: '123456789012',
+					mfa_active: false,
+				}),
+				credentialReport({
+					user: 'alice',
+					arn: 'arn:aws:iam::123456789012:user/alice',
+					account_id: '123456789012',
+					mfa_active: false,
+				}),
+			],
+			[awsAccount({})],
+			[
+				iamUser({}),
+				iamUser({
+					user_name: '<root_account>',
+					arn: 'arn:aws:iam::123456789012:root',
+					tags: {},
+				}),
+			],
+		);
+
+		assert.strictEqual(report.length, 1);
+		assert.strictEqual(report[0]!.user, 'alice');
+	});
 });

--- a/packages/cloudbuster/src/breakglass/findings.ts
+++ b/packages/cloudbuster/src/breakglass/findings.ts
@@ -18,7 +18,9 @@ export function createBreakglassUserReport(
 	const usersByArn = new Map(iamUsers.map((u) => [u.arn, u]));
 
 	return credentialReports
-		.filter((cr) => cr.password_enabled === 'true')
+		.filter(
+			(cr) => cr.password_enabled === 'true' && cr.user !== '<root_account>',
+		)
 		.map((cr) => {
 			const accountId = cr.account_id;
 			const account = accountId ? accountsById.get(accountId) : undefined;


### PR DESCRIPTION
## What does this change?

This process is meant to deal with breakglass users. Root users are not breakglass users, and have different requirements/policies, and so should be handled separately. When commenting on this PR, please be mindful that this repo is public

## Why has this change been made?

The original dashboard excludes root users. So should we.

## Why was this approach chosen?

Root users are out of scope for this work

## How has it been verified?

Added a unit test to verify that root users are not included in the breakglass reports. Verified the unit test passes
