### PR TITLE
Add a script for quickly testing the deps-graph-integrator on CODE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13267,6 +13267,8 @@
     },
     "node_modules/terminal-link": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-5.0.0.tgz",
+      "integrity": "sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14552,7 +14554,8 @@
         "yaml": "^2.9.0"
       },
       "devDependencies": {
-        "@types/aws-lambda": "^8.10.162"
+        "@types/aws-lambda": "^8.10.162",
+        "terminal-link": "^5.0.0"
       }
     },
     "packages/dev-environment": {

--- a/packages/dependency-graph-integrator/README.md
+++ b/packages/dependency-graph-integrator/README.md
@@ -89,7 +89,20 @@ In non-production environments, such as CODE, or when running locally, the depen
 
 The lambda can safely be invoked in the CODE environment, as it will only attempt to create a PR if the `STAGE` environment variable is set to `PROD`. Additionally, there are no GitHub credentials available to the CODE lambda - any attempt to instantiate a GitHub client will fail.
 
-The format of input to the lambda on the CODE environment is that of an SNS message. It's not trivial to construct, so some sample events have been provided in the Test tab of the lambda in the AWS console.
+The format of input to the lambda on the CODE environment is that of an SNS message. You can send a test message to the CODE environment using the provided script in [`test-code.ts`](./src/test-code.ts) by running `npm run send-test-event -w dependency-graph-integrator`. There are also some sample events which have been provided in the Test tab of the lambda in the AWS console.
+
+You can control which workflow template is used by setting the `language` field in the test message defined in the script:
+
+- `'Scala'` → sbt workflow
+- `'Kotlin'` → Gradle workflow
+
+```ts
+const message: DependencyGraphIntegratorEvent = {
+	name: 'service-catalogue',
+	language: 'Scala',
+	admins: ['devx-security'],
+};
+```
 
 #### DEV
 
@@ -97,22 +110,7 @@ The format of input to the lambda on the CODE environment is that of an SNS mess
 
 The lambda can be invoked locally by running `npm run start -w dependency-graph-integrator` from the root of the repo, or `npm run start` from the root of the dependency-graph-integrator package.
 
-You can preview the generated YAML and PR body locally by setting the language in [`run-locally.ts`](./src/run-locally.ts). This controls which workflow template is used:
-
-- Scala → sbt workflow
-- Kotlin → Gradle workflow
-
-Example:
-
-```ts
-if (isMain) {
-	void main({
-		name: 'service-catalogue', // repo name
-		language: 'Scala', // 'Scala' or 'Kotlin'
-		admins: ['my-team-slug'], // optional, use [] if none
-	});
-}
-```
+As described above for the CODE script, you can preview the generated YAML and PR body locally by setting the language in [`run-locally.ts`](./src/run-locally.ts).
 
 The package uses snapshot tests to verify the generated workflow YAML and PR body formatting.
 

--- a/packages/dependency-graph-integrator/README.md
+++ b/packages/dependency-graph-integrator/README.md
@@ -89,7 +89,7 @@ In non-production environments, such as CODE, or when running locally, the depen
 
 The lambda can safely be invoked in the CODE environment, as it will only attempt to create a PR if the `STAGE` environment variable is set to `PROD`. Additionally, there are no GitHub credentials available to the CODE lambda - any attempt to instantiate a GitHub client will fail.
 
-The format of input to the lambda on the CODE environment is that of an SNS message. You can send a test message to the CODE environment using the provided script in [`test-code.ts`](./src/test-code.ts) by running `npm run send-test-event -w dependency-graph-integrator`. There are also some sample events which have been provided in the Test tab of the lambda in the AWS console.
+The format of input to the lambda on the CODE environment is that of an SNS message. You can send a test message to the CODE environment using the provided script in [`test-code.ts`](./src/test-code.ts) by running `npm run invoke-code -w dependency-graph-integrator`. There are also some sample events which have been provided in the Test tab of the lambda in the AWS console.
 
 You can control which workflow template is used by setting the `language` field in the test message defined in the script:
 

--- a/packages/dependency-graph-integrator/package.json
+++ b/packages/dependency-graph-integrator/package.json
@@ -12,7 +12,7 @@
 		"postbuild": "cp package.json dist/package.json",
 		"prestart": "npm run copy-templates",
 		"start": "tsx src/run-locally.ts",
-		"send-test-event": "tsx src/test-code.ts",
+		"invoke-code": "tsx src/test-code.ts",
 		"pretest": "npm run copy-templates",
 		"test": "node --import tsx --test **/*.test.ts",
 		"test:update": "UPDATE_SNAPSHOTS=true node --import tsx --test **/*.test.ts",

--- a/packages/dependency-graph-integrator/package.json
+++ b/packages/dependency-graph-integrator/package.json
@@ -12,6 +12,7 @@
 		"postbuild": "cp package.json dist/package.json",
 		"prestart": "npm run copy-templates",
 		"start": "tsx src/run-locally.ts",
+		"send-test-event": "tsx src/test-code.ts",
 		"pretest": "npm run copy-templates",
 		"test": "node --import tsx --test **/*.test.ts",
 		"test:update": "UPDATE_SNAPSHOTS=true node --import tsx --test **/*.test.ts",

--- a/packages/dependency-graph-integrator/package.json
+++ b/packages/dependency-graph-integrator/package.json
@@ -3,7 +3,8 @@
 	"version": "1.0.0",
 	"type": "module",
 	"devDependencies": {
-		"@types/aws-lambda": "^8.10.162"
+		"@types/aws-lambda": "^8.10.162",
+		"terminal-link": "^5.0.0"
 	},
 	"scripts": {
 		"copy-templates": "cp ../../.github/workflows/template_dep_submission_gradle.yaml src/template_dep_submission_gradle.yaml && cp ../../.github/workflows/template_dep_submission_sbt.yaml src/template_dep_submission_sbt.yaml",

--- a/packages/dependency-graph-integrator/src/test-code.ts
+++ b/packages/dependency-graph-integrator/src/test-code.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
 import { getEnvOrThrow } from 'common/functions.js';
 import { awsClientConfig } from 'common/src/aws.js';
+import { getCentralElkLink } from 'common/src/logs.js';
 import type { DependencyGraphIntegratorEvent } from 'common/types.js';
 
 loadEnvFile(`${homedir()}/.gu/service_catalogue/.env.local`);
@@ -35,4 +36,11 @@ if (isMain) {
 	console.log(
 		"Test event sent to CODE dependency-graph-integrator's input topic.",
 	);
+	const logLink = getCentralElkLink({
+		filters: {
+			stage: 'CODE',
+			app: 'dependency-graph-integrator',
+		},
+	});
+	console.log(`View the logs at ${logLink}`);
 }

--- a/packages/dependency-graph-integrator/src/test-code.ts
+++ b/packages/dependency-graph-integrator/src/test-code.ts
@@ -1,0 +1,38 @@
+import { homedir } from 'node:os';
+import { loadEnvFile } from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { PublishCommand, SNSClient } from '@aws-sdk/client-sns';
+import { getEnvOrThrow } from 'common/functions.js';
+import { awsClientConfig } from 'common/src/aws.js';
+import type { DependencyGraphIntegratorEvent } from 'common/types.js';
+
+loadEnvFile(`${homedir()}/.gu/service_catalogue/.env.local`);
+
+/**
+ * checks if the current module is the entry point script - replaces the CommonJs `require.main === module` check
+ * `import.meta.url` represents the URL of the current module file, e.g. run-locally.ts
+ * `process.argv[1]` represents the path to the script that was executed - it's the second
+argument in the process's argument vector (the first being the Node executable).
+*/
+const isMain = fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
+	const snsClient = new SNSClient(awsClientConfig('DEV'));
+
+	const message: DependencyGraphIntegratorEvent = {
+		name: 'service-catalogue',
+		language: 'Scala',
+		admins: ['devx-security'],
+	};
+
+	const publish = new PublishCommand({
+		Message: JSON.stringify(message),
+		TopicArn: getEnvOrThrow('DEPENDENCY_GRAPH_INPUT_TOPIC_ARN'),
+	});
+
+	await snsClient.send(publish);
+
+	console.log(
+		"Test event sent to CODE dependency-graph-integrator's input topic.",
+	);
+}

--- a/packages/dependency-graph-integrator/src/test-code.ts
+++ b/packages/dependency-graph-integrator/src/test-code.ts
@@ -6,6 +6,7 @@ import { getEnvOrThrow } from 'common/functions.js';
 import { awsClientConfig } from 'common/src/aws.js';
 import { getCentralElkLink } from 'common/src/logs.js';
 import type { DependencyGraphIntegratorEvent } from 'common/types.js';
+import terminalLink from 'terminal-link';
 
 loadEnvFile(`${homedir()}/.gu/service_catalogue/.env.local`);
 
@@ -42,6 +43,5 @@ if (isMain) {
 			app: 'dependency-graph-integrator',
 		},
 	});
-	console.log('View the logs at:');
-	console.log(`  "${logLink}"`);
+	console.log(terminalLink('View the logs here', logLink));
 }

--- a/packages/dependency-graph-integrator/src/test-code.ts
+++ b/packages/dependency-graph-integrator/src/test-code.ts
@@ -42,5 +42,6 @@ if (isMain) {
 			app: 'dependency-graph-integrator',
 		},
 	});
-	console.log(`View the logs at ${logLink}`);
+	console.log('View the logs at:');
+	console.log(`  "${logLink}"`);
 }


### PR DESCRIPTION
## What does this change?

Adds a script which sends a test event onto the dependency-graph-integrator's input topic on CODE. 

## Why has this change been made?

Makes it quicker and easier to send a test event, without having to enter & navigate the AWS console each time.

## Why was this approach chosen?

We chose to send the test event via the SNS topic, as it avoids having to create the SNS event wrapper and fill it with fake data, plus it tests that the topic is correctly set up to invoke the lambda.

## How has it been verified?

The DGI has been run on CODE using this script.