### PR TITLE
add breakglass setup guide to CTAs

### DIFF
--- a/packages/cloudbuster/src/breakglass/digests.ts
+++ b/packages/cloudbuster/src/breakglass/digests.ts
@@ -53,8 +53,12 @@ export async function sendAnghammaradNotification(
 				message: `${account.users.length} breakglass users are missing security configuration\n\n${formatMessage(account.users)}`,
 				actions: [
 					{
-						cta: 'View breakglass user report',
+						cta: 'Full breakglass user report',
 						url: `https://metrics.gutools.co.uk/d/bdn97cui5rbi8f?var-account_name=${encodeURIComponent(account.name)}`,
+					},
+					{
+						cta: 'Breakglass user setup guide',
+						url: 'https://docs.google.com/document/d/1Jyx51PcBR-H8quAv944fC5eKLNsI9iLWQDG6Le0sGHQ',
 					},
 				],
 				target,


### PR DESCRIPTION
## What does this change?

Adds setup guide to breakglass CTAs

## Why has this change been made?

To make it easier for teams to understand how these users are meant to be set up