### PR TITLE
use incremental sync on AWS inspector table

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -2253,6 +2253,724 @@ spec:
       },
       "Type": "AWS::IAM::Policy",
     },
+    "CloudquerySourceAwsIncrementalInspector2FindingsScheduledEventRuleBBCC5C30": {
+      "Properties": {
+        "ScheduleExpression": "cron(0 21 * * ? *)",
+        "State": "ENABLED",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "deploy::service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "servicecatalogueCluster5FC34DC5",
+                "Arn",
+              ],
+            },
+            "EcsParameters": {
+              "LaunchType": "FARGATE",
+              "NetworkConfiguration": {
+                "AwsVpcConfiguration": {
+                  "AssignPublicIp": "DISABLED",
+                  "SecurityGroups": [
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresAccessSecurityGroupServicecatalogue03C78F14",
+                        "GroupId",
+                      ],
+                    },
+                  ],
+                  "Subnets": {
+                    "Ref": "PrivateSubnets",
+                  },
+                },
+              },
+              "PropagateTags": "TASK_DEFINITION",
+              "TaskCount": 1,
+              "TaskDefinitionArn": {
+                "Ref": "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionF007F7CE",
+              },
+            },
+            "Id": "Target0",
+            "Input": "{}",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionEventsRole9E421F15",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionCloudquerySourceAwsIncrementalInspector2FindingsFirelensLogGroup89A74EE2": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "RetentionInDays": 1,
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "deploy::service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "AwsIncrementalInspector2Findings",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionEventsRole9E421F15": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "deploy::service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "AwsIncrementalInspector2Findings",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionEventsRoleDefaultPolicyBC9BA6DA": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "ecs:RunTask",
+              "Condition": {
+                "ArnEquals": {
+                  "ecs:cluster": {
+                    "Fn::GetAtt": [
+                      "servicecatalogueCluster5FC34DC5",
+                      "Arn",
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionF007F7CE",
+              },
+            },
+            {
+              "Action": "ecs:TagResource",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ecs:eu-west-1:*:task/",
+                    {
+                      "Ref": "servicecatalogueCluster5FC34DC5",
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionExecutionRole2E7AA756",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "iam:PassRole",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "servicecataloguePRODtaskAwsIncrementalInspector2Findings7F797066",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionEventsRoleDefaultPolicyBC9BA6DA",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionEventsRole9E421F15",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionExecutionRole2E7AA756": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "deploy::service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "AwsIncrementalInspector2Findings",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionExecutionRoleDefaultPolicy6274B612": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "cloudqueryapikeyCCF82F53",
+              },
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionCloudquerySourceAwsIncrementalInspector2FindingsFirelensLogGroup89A74EE2",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": "ecr:GetAuthorizationToken",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+              ],
+              "Effect": "Allow",
+              "Resource": "arn:aws:ecr:eu-west-1:694911143906:repository/aws-guardduty-agent-fargate",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionExecutionRoleDefaultPolicy6274B612",
+        "Roles": [
+          {
+            "Ref": "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionExecutionRole2E7AA756",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionF007F7CE": {
+      "Properties": {
+        "ContainerDefinitions": [
+          {
+            "Command": [
+              "/bin/sh",
+              "-c",
+              "printf 'kind: source
+spec:
+  name: aws
+  path: cloudquery/aws
+  version: v32.47.1
+  tables:
+    - aws_inspector2_findings
+  skip_dependent_tables: true
+  destinations:
+    - postgresql
+  otel_endpoint: 0.0.0.0:4318
+  otel_endpoint_insecure: true
+  backend_options:
+    table_name: cq-state-aws
+    connection: '\\''@@plugins.postgresql.connection'\\''
+  spec:
+    concurrency: 2000
+    accounts:
+      - id: cq-for-000000000015
+        role_arn: arn:aws:iam::000000000015:role/service-catalogue-access
+    table_options:
+      aws_inspector2_findings:
+        list_findings:
+          - filter_criteria:
+              finding_status:
+                - comparison: EQUALS
+                  value: ACTIVE
+              severity:
+                - comparison: EQUALS
+                  value: CRITICAL
+                - comparison: EQUALS
+                  value: HIGH
+' > /usr/share/cloudquery/source.yaml;printf 'kind: destination
+spec:
+  name: postgresql
+  registry: cloudquery
+  path: cloudquery/postgresql
+  version: v8.13.0
+  write_mode: overwrite-delete-stale
+  migrate_mode: forced
+  send_sync_summary: true
+  spec:
+    connection_string: >-
+      user=\${DB_USERNAME} password=\${DB_PASSWORD} host=\${DB_HOST} port=5432
+      dbname=postgres sslmode=verify-full
+' > /usr/share/cloudquery/destination.yaml;/app/cloudquery sync /usr/share/cloudquery/source.yaml /usr/share/cloudquery/destination.yaml --log-format json --log-console --no-log-file --log-level \${CLOUDQUERY_LOG_LEVEL}",
+            ],
+            "DependsOn": [
+              {
+                "Condition": "HEALTHY",
+                "ContainerName": "CloudquerySource-AwsIncrementalInspector2FindingsAWSOTELCollector",
+              },
+            ],
+            "DockerLabels": {
+              "App": "service-catalogue",
+              "Name": "AwsIncrementalInspector2Findings",
+              "Stack": "deploy",
+              "Stage": "PROD",
+            },
+            "EntryPoint": [
+              "",
+            ],
+            "Environment": [
+              {
+                "Name": "GOMEMLIMIT",
+                "Value": "1638MiB",
+              },
+              {
+                "Name": "CLOUDQUERY_LOG_LEVEL",
+                "Value": "info",
+              },
+            ],
+            "Essential": true,
+            "Image": "ghcr.io/guardian/service-catalogue/cloudquery:stable",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": "eu-west-1",
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/usr/share/cloudquery",
+                "ReadOnly": false,
+                "SourceVolume": "config-volume",
+              },
+              {
+                "ContainerPath": "/app/.cq",
+                "ReadOnly": false,
+                "SourceVolume": "cloudquery-volume",
+              },
+              {
+                "ContainerPath": "/tmp",
+                "ReadOnly": false,
+                "SourceVolume": "tmp-volume",
+              },
+            ],
+            "Name": "CloudquerySource-AwsIncrementalInspector2FindingsContainer",
+            "ReadonlyRootFilesystem": true,
+            "Secrets": [
+              {
+                "Name": "DB_USERNAME",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_HOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "DB_PASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "CLOUDQUERY_API_KEY",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "cloudqueryapikeyCCF82F53",
+                      },
+                      ":api-key::",
+                    ],
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            "Command": [
+              "--config=/etc/ecs/ecs-xray.yaml",
+            ],
+            "Essential": true,
+            "HealthCheck": {
+              "Command": [
+                "CMD",
+                "/healthcheck",
+              ],
+              "Interval": 5,
+              "Retries": 3,
+              "Timeout": 5,
+            },
+            "Image": "public.ecr.aws/aws-observability/aws-otel-collector:v0.35.0",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": "eu-west-1",
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-AwsIncrementalInspector2FindingsAWSOTELCollector",
+            "PortMappings": [
+              {
+                "ContainerPort": 4318,
+                "Protocol": "tcp",
+              },
+            ],
+            "ReadonlyRootFilesystem": true,
+          },
+          {
+            "Command": [
+              "/bin/sh",
+              "-c",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_inspector2_findings', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
+            ],
+            "DockerLabels": {
+              "App": "service-catalogue",
+              "Name": "AwsIncrementalInspector2Findings",
+              "Stack": "deploy",
+              "Stage": "PROD",
+            },
+            "EntryPoint": [
+              "",
+            ],
+            "Essential": false,
+            "Image": "public.ecr.aws/docker/library/postgres:18.3-alpine3.23@sha256:1b13c640ae11f2f165d1e89667e5862b0017baf4c80fec2fb7377d86319859ba",
+            "LogConfiguration": {
+              "LogDriver": "awsfirelens",
+              "Options": {
+                "Name": "kinesis_streams",
+                "region": "eu-west-1",
+                "retry_limit": "2",
+                "stream": {
+                  "Ref": "LoggingStreamName",
+                },
+              },
+            },
+            "Name": "CloudquerySource-AwsIncrementalInspector2FindingsPostgresContainer",
+            "ReadonlyRootFilesystem": true,
+            "Secrets": [
+              {
+                "Name": "PGUSER",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":username::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "PGHOST",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":host::",
+                    ],
+                  ],
+                },
+              },
+              {
+                "Name": "PGPASSWORD",
+                "ValueFrom": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                      },
+                      ":password::",
+                    ],
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            "Environment": [
+              {
+                "Name": "STACK",
+                "Value": "deploy",
+              },
+              {
+                "Name": "STAGE",
+                "Value": "PROD",
+              },
+              {
+                "Name": "APP",
+                "Value": "service-catalogue",
+              },
+              {
+                "Name": "GU_REPO",
+                "Value": "guardian/service-catalogue",
+              },
+              {
+                "Name": "TASK_NAME",
+                "Value": "AwsIncrementalInspector2Findings",
+              },
+            ],
+            "Essential": true,
+            "FirelensConfiguration": {
+              "Type": "fluentbit",
+            },
+            "Image": "ghcr.io/guardian/devx-logs:2.1.0",
+            "LogConfiguration": {
+              "LogDriver": "awslogs",
+              "Options": {
+                "awslogs-group": {
+                  "Ref": "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionCloudquerySourceAwsIncrementalInspector2FindingsFirelensLogGroup89A74EE2",
+                },
+                "awslogs-region": "eu-west-1",
+                "awslogs-stream-prefix": "deploy/PROD/service-catalogue",
+              },
+            },
+            "MountPoints": [
+              {
+                "ContainerPath": "/init",
+                "ReadOnly": false,
+                "SourceVolume": "firelens-volume",
+              },
+            ],
+            "Name": "CloudquerySource-AwsIncrementalInspector2FindingsFirelens",
+            "ReadonlyRootFilesystem": true,
+          },
+        ],
+        "Cpu": "1024",
+        "ExecutionRoleArn": {
+          "Fn::GetAtt": [
+            "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionExecutionRole2E7AA756",
+            "Arn",
+          ],
+        },
+        "Family": "AwsIncrementalInspector2Findings",
+        "Memory": "2048",
+        "NetworkMode": "awsvpc",
+        "RequiresCompatibilities": [
+          "FARGATE",
+        ],
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "deploy::service-catalogue",
+          },
+          {
+            "Key": "Name",
+            "Value": "AwsIncrementalInspector2Findings",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "TaskRoleArn": {
+          "Fn::GetAtt": [
+            "servicecataloguePRODtaskAwsIncrementalInspector2Findings7F797066",
+            "Arn",
+          ],
+        },
+        "Volumes": [
+          {
+            "Name": "config-volume",
+          },
+          {
+            "Name": "cloudquery-volume",
+          },
+          {
+            "Name": "tmp-volume",
+          },
+          {
+            "Name": "firelens-volume",
+          },
+        ],
+      },
+      "Type": "AWS::ECS::TaskDefinition",
+    },
     "CloudquerySourceAwsLambdaScheduledEventRuleC1529FB1": {
       "Properties": {
         "ScheduleExpression": "cron(10 1 * * ? *)",
@@ -27821,6 +28539,104 @@ spec:
       },
       "Type": "AWS::Events::Rule",
     },
+    "refreshmaterializedviewlambdatriggerAwsIncrementalInspector2Findings3772C284": {
+      "Properties": {
+        "EventPattern": {
+          "detail": {
+            "clusterArn": [
+              {
+                "Fn::GetAtt": [
+                  "servicecatalogueCluster5FC34DC5",
+                  "Arn",
+                ],
+              },
+            ],
+            "containers.exitCode": [
+              {
+                "numeric": [
+                  "=",
+                  0,
+                ],
+              },
+            ],
+            "containers.name": [
+              "CloudquerySource-AwsIncrementalInspector2FindingsContainer",
+            ],
+            "lastStatus": [
+              "STOPPED",
+            ],
+            "stopCode": [
+              "EssentialContainerExited",
+            ],
+            "taskDefinitionArn": [
+              {
+                "Ref": "CloudquerySourceAwsIncrementalInspector2FindingsTaskDefinitionF007F7CE",
+              },
+            ],
+          },
+          "detail-type": [
+            "ECS Task State Change",
+          ],
+          "source": [
+            "aws.ecs",
+          ],
+        },
+        "State": "ENABLED",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "deploy::service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "RefreshMaterializedViewF0E38938",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "refreshmaterializedviewlambdatriggerAwsIncrementalInspector2FindingsAllowEventRuleServiceCatalogueRefreshMaterializedViewA9EE9448C1869BC7": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "RefreshMaterializedViewF0E38938",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "refreshmaterializedviewlambdatriggerAwsIncrementalInspector2Findings3772C284",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
     "refreshmaterializedviewlambdatriggerAwsLambda026DCBB2": {
       "Properties": {
         "EventPattern": {
@@ -30401,6 +31217,138 @@ spec:
         "Roles": [
           {
             "Ref": "servicecataloguePRODtaskAwsDelegatedToSecurityAccountD81B6FBC",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "servicecataloguePRODtaskAwsIncrementalInspector2Findings7F797066": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "ecs-tasks.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/AWSXrayWriteOnlyAccess",
+              ],
+            ],
+          },
+        ],
+        "RoleName": "service-catalogue-PROD-task-AwsIncrementalInspector2Findings",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/service-catalogue",
+          },
+          {
+            "Key": "gu:riff-raff:project",
+            "Value": "deploy::service-catalogue",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "servicecataloguePRODtaskAwsIncrementalInspector2FindingsDefaultPolicy3BE2E9E4": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":kinesis:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": "arn:aws:iam::000000000015:role/service-catalogue-access",
+            },
+            {
+              "Action": "rds-db:connect",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":rds-db:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":dbuser:",
+                    {
+                      "Fn::GetAtt": [
+                        "PostgresInstance16DE4286E",
+                        "DbiResourceId",
+                      ],
+                    },
+                    "/{{resolve:secretsmanager:",
+                    {
+                      "Ref": "PostgresInstance1SecretAttachmentBA0D257D",
+                    },
+                    ":SecretString:username::}}",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "servicecataloguePRODtaskAwsIncrementalInspector2FindingsDefaultPolicy3BE2E9E4",
+        "Roles": [
+          {
+            "Ref": "servicecataloguePRODtaskAwsIncrementalInspector2Findings7F797066",
           },
         ],
       },

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -1598,7 +1598,6 @@ spec:
     - aws_guardduty_detector_members
     - aws_guardduty_detector_publishing_destinations
     - aws_guardduty_detectors
-    - aws_inspector2_findings
     - aws_securityhub_enabled_standards
     - aws_securityhub_findings
     - aws_securityhub_hubs
@@ -1630,17 +1629,6 @@ spec:
                 - comparison: EQUALS
                   value: Security Hub
               severity_label:
-                - comparison: EQUALS
-                  value: CRITICAL
-                - comparison: EQUALS
-                  value: HIGH
-      aws_inspector2_findings:
-        list_findings:
-          - filter_criteria:
-              finding_status:
-                - comparison: EQUALS
-                  value: ACTIVE
-              severity:
                 - comparison: EQUALS
                   value: CRITICAL
                 - comparison: EQUALS
@@ -1815,7 +1803,7 @@ spec:
             "Command": [
               "/bin/sh",
               "-c",
-              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_accessanalyzer_analyzer_findings', 86400000),('aws_accessanalyzer_analyzer_findings_v2', 86400000),('aws_accessanalyzer_analyzers', 86400000),('aws_guardduty_detector_filters', 86400000),('aws_guardduty_detector_findings', 86400000),('aws_guardduty_detector_members', 86400000),('aws_guardduty_detector_publishing_destinations', 86400000),('aws_guardduty_detectors', 86400000),('aws_inspector2_findings', 86400000),('aws_securityhub_enabled_standards', 86400000),('aws_securityhub_findings', 86400000),('aws_securityhub_hubs', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
+              "psql -c "INSERT INTO cloudquery_table_frequency VALUES ('aws_accessanalyzer_analyzer_findings', 86400000),('aws_accessanalyzer_analyzer_findings_v2', 86400000),('aws_accessanalyzer_analyzers', 86400000),('aws_guardduty_detector_filters', 86400000),('aws_guardduty_detector_findings', 86400000),('aws_guardduty_detector_members', 86400000),('aws_guardduty_detector_publishing_destinations', 86400000),('aws_guardduty_detectors', 86400000),('aws_securityhub_enabled_standards', 86400000),('aws_securityhub_findings', 86400000),('aws_securityhub_hubs', 86400000) ON CONFLICT (table_name) DO UPDATE SET frequency = 86400000"",
             ],
             "DockerLabels": {
               "App": "service-catalogue",

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -124,6 +124,39 @@ describe('Config generation, and converting to YAML', () => {
 	`);
 	});
 
+	it('Should create an AWS source configuration for a single account with incremental sync', () => {
+		const config = awsSourceConfigForAccount(
+			GuardianAwsAccounts.Security,
+			{
+				tables: ['aws_securityhub_findings'],
+			},
+			{},
+			true,
+		);
+		expect(dump(config)).toMatchInlineSnapshot(`
+		"kind: source
+		spec:
+		  name: aws
+		  path: cloudquery/aws
+		  version: v32.47.1
+		  tables:
+		    - aws_securityhub_findings
+		  skip_dependent_tables: true
+		  destinations:
+		    - postgresql
+		  otel_endpoint: 0.0.0.0:4318
+		  otel_endpoint_insecure: true
+		  backend_options:
+		    table_name: cq-state-aws
+		    connection: '@@plugins.postgresql.connection'
+		  spec:
+		    accounts:
+		      - id: cq-for-000000000015
+		        role_arn: arn:aws:iam::000000000015:role/service-catalogue-access
+		"
+	`);
+	});
+
 	it('Should create a GitHub source configuration', () => {
 		const config = githubSourceConfig({
 			tables: ['github_repositories'],
@@ -140,6 +173,42 @@ describe('Config generation, and converting to YAML', () => {
 		  skip_dependent_tables: true
 		  destinations:
 		    - postgresql
+		  spec:
+		    concurrency: 1000
+		    orgs:
+		      - guardian
+		    app_auth:
+		      - org: guardian
+		        private_key_path: /usr/share/cloudquery/github-private-key
+		        app_id: \${file:/usr/share/cloudquery/github-app-id}
+		        installation_id: \${file:/usr/share/cloudquery/github-installation-id}
+		    include_archived_repos: true
+		"
+	`);
+	});
+
+	it('Should create a GitHub source configuration with incremental sync', () => {
+		const config = githubSourceConfig(
+			{
+				tables: ['github_repositories'],
+				org: 'guardian',
+			},
+			true,
+		);
+		expect(dump(config)).toMatchInlineSnapshot(`
+		"kind: source
+		spec:
+		  name: github
+		  path: cloudquery/github
+		  version: v15.2.0
+		  tables:
+		    - github_repositories
+		  skip_dependent_tables: true
+		  destinations:
+		    - postgresql
+		  backend_options:
+		    table_name: cq-state-github
+		    connection: '@@plugins.postgresql.connection'
 		  spec:
 		    concurrency: 1000
 		    orgs:

--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -131,7 +131,7 @@ describe('Config generation, and converting to YAML', () => {
 				tables: ['aws_securityhub_findings'],
 			},
 			{},
-			true,
+			'incremental',
 		);
 		expect(dump(config)).toMatchInlineSnapshot(`
 		"kind: source
@@ -193,7 +193,7 @@ describe('Config generation, and converting to YAML', () => {
 				tables: ['github_repositories'],
 				org: 'guardian',
 			},
-			true,
+			'incremental',
 		);
 		expect(dump(config)).toMatchInlineSnapshot(`
 		"kind: source

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -14,6 +14,10 @@ export type CloudQuerySourceConfig = {
 		tables: readonly CloudQueryTableToSync[];
 		[k: string]: unknown;
 	};
+	backend_options?: {
+		table_name: `cq-state-${string}`;
+		connection: '@@plugins.postgresql.connection';
+	};
 	[k: string]: unknown;
 };
 
@@ -121,8 +125,16 @@ export function postgresDestinationConfig(
 export function awsSourceConfig(
 	tableConfig: CloudqueryTableConfig,
 	extraConfig: Record<string, unknown> = {},
+	incremental?: boolean,
 ): CloudQuerySourceConfig {
 	const { tables, concurrency } = tableConfig;
+
+	const backendTableOptions = incremental
+		? {
+				table_name: `cq-state-aws`,
+				connection: '@@plugins.postgresql.connection',
+			}
+		: undefined;
 
 	return {
 		kind: 'source',
@@ -135,6 +147,7 @@ export function awsSourceConfig(
 			destinations: ['postgresql'],
 			otel_endpoint: '0.0.0.0:4318',
 			otel_endpoint_insecure: true,
+			backend_options: backendTableOptions,
 			spec: {
 				concurrency,
 				...extraConfig,
@@ -177,22 +190,35 @@ export function awsSourceConfigForAccount(
 	accountNumber: string,
 	tableConfig: CloudqueryTableConfig,
 	extraConfig: Record<string, unknown> = {},
+	incremental?: boolean,
 ): CloudQuerySourceConfig {
-	return awsSourceConfig(tableConfig, {
-		accounts: [
-			{
-				id: `cq-for-${accountNumber}`,
-				role_arn: `arn:aws:iam::${accountNumber}:role/service-catalogue-access`,
-			},
-		],
-		...extraConfig,
-	});
+	return awsSourceConfig(
+		tableConfig,
+		{
+			accounts: [
+				{
+					id: `cq-for-${accountNumber}`,
+					role_arn: `arn:aws:iam::${accountNumber}:role/service-catalogue-access`,
+				},
+			],
+			...extraConfig,
+		},
+		incremental,
+	);
 }
 
 export function githubSourceConfig(
 	tableConfig: GitHubCloudqueryTableConfig,
+	incremental?: boolean,
 ): CloudQuerySourceConfig {
 	const { tables, org, includeArchivedRepos } = tableConfig;
+
+	const backendTableOptions = incremental
+		? {
+				table_name: `cq-state-github`,
+				connection: '@@plugins.postgresql.connection',
+			}
+		: undefined;
 
 	return {
 		kind: 'source',
@@ -203,6 +229,7 @@ export function githubSourceConfig(
 			tables,
 			skip_dependent_tables: true,
 			destinations: ['postgresql'],
+			backend_options: backendTableOptions,
 			spec: {
 				concurrency: 1000, // TODO what's the ideal value here?!
 				orgs: [org],

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -8,16 +8,33 @@ import { riffraffTables } from 'cloudquery-tables/riffraff';
 import { CloudQueryPluginVersions } from 'cloudquery-tables/versions';
 import { dump } from 'js-yaml';
 
+export type SyncMode = 'default' | 'incremental';
+
+type BackendOptions = {
+	table_name: `cq-state-${string}`;
+	connection: '@@plugins.postgresql.connection';
+};
+
+function backendOptions(
+	platform: 'aws' | 'github',
+	mode?: SyncMode,
+): BackendOptions | undefined {
+	if (mode === 'incremental') {
+		return {
+			table_name: `cq-state-${platform}`,
+			connection: '@@plugins.postgresql.connection',
+		};
+	}
+	return undefined;
+}
+
 export type CloudQuerySourceConfig = {
 	kind: 'source';
 	spec: {
 		tables: readonly CloudQueryTableToSync[];
 		[k: string]: unknown;
 	};
-	backend_options?: {
-		table_name: `cq-state-${string}`;
-		connection: '@@plugins.postgresql.connection';
-	};
+	backend_options?: BackendOptions;
 	[k: string]: unknown;
 };
 
@@ -125,16 +142,9 @@ export function postgresDestinationConfig(
 export function awsSourceConfig(
 	tableConfig: CloudqueryTableConfig,
 	extraConfig: Record<string, unknown> = {},
-	incremental?: boolean,
+	mode?: SyncMode,
 ): CloudQuerySourceConfig {
 	const { tables, concurrency } = tableConfig;
-
-	const backendTableOptions = incremental
-		? {
-				table_name: `cq-state-aws`,
-				connection: '@@plugins.postgresql.connection',
-			}
-		: undefined;
 
 	return {
 		kind: 'source',
@@ -147,7 +157,7 @@ export function awsSourceConfig(
 			destinations: ['postgresql'],
 			otel_endpoint: '0.0.0.0:4318',
 			otel_endpoint_insecure: true,
-			backend_options: backendTableOptions,
+			backend_options: backendOptions('aws', mode),
 			spec: {
 				concurrency,
 				...extraConfig,
@@ -190,7 +200,7 @@ export function awsSourceConfigForAccount(
 	accountNumber: string,
 	tableConfig: CloudqueryTableConfig,
 	extraConfig: Record<string, unknown> = {},
-	incremental?: boolean,
+	syncMode?: SyncMode,
 ): CloudQuerySourceConfig {
 	return awsSourceConfig(
 		tableConfig,
@@ -203,22 +213,15 @@ export function awsSourceConfigForAccount(
 			],
 			...extraConfig,
 		},
-		incremental,
+		syncMode,
 	);
 }
 
 export function githubSourceConfig(
 	tableConfig: GitHubCloudqueryTableConfig,
-	incremental?: boolean,
+	syncMode?: SyncMode,
 ): CloudQuerySourceConfig {
 	const { tables, org, includeArchivedRepos } = tableConfig;
-
-	const backendTableOptions = incremental
-		? {
-				table_name: `cq-state-github`,
-				connection: '@@plugins.postgresql.connection',
-			}
-		: undefined;
 
 	return {
 		kind: 'source',
@@ -229,7 +232,7 @@ export function githubSourceConfig(
 			tables,
 			skip_dependent_tables: true,
 			destinations: ['postgresql'],
-			backend_options: backendTableOptions,
+			backend_options: backendOptions('github', syncMode),
 			spec: {
 				concurrency: 1000, // TODO what's the ideal value here?!
 				orgs: [org],

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -137,16 +137,37 @@ export function addCloudqueryEcsCluster(
 						/^aws_accessanalyzer_.*$/,
 						/^aws_securityhub_.*$/,
 						/^aws_guardduty_.*$/,
-						/^aws_inspector2_findings$/,
+						/^aws_inspector2_findings$/, //TODO remove
 					]),
 					concurrency: 2000,
 				},
 				{
 					table_options: {
 						aws_securityhub_findings: securityHubTableOptions,
+						aws_inspector2_findings: inspector2TableOptions, //TODO remove
+					},
+				},
+			),
+			policies: [cloudqueryAccess(GuardianAwsAccounts.Security)],
+			memoryLimitMiB: 2048,
+			cpu: 1024,
+		},
+		{
+			name: 'AwsIncrementalInspector2Findings',
+			description: 'Collect inspector 2 findings incrementally',
+			schedule: Schedule.cron({ minute: '0', hour: '21' }),
+			config: awsSourceConfigForAccount(
+				GuardianAwsAccounts.Security,
+				{
+					tables: ['aws_inspector2_findings'],
+					concurrency: 2000,
+				},
+				{
+					table_options: {
 						aws_inspector2_findings: inspector2TableOptions,
 					},
 				},
+				true, //incremental sync
 			),
 			policies: [cloudqueryAccess(GuardianAwsAccounts.Security)],
 			memoryLimitMiB: 2048,

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -167,7 +167,7 @@ export function addCloudqueryEcsCluster(
 						aws_inspector2_findings: inspector2TableOptions,
 					},
 				},
-				true, //incremental sync
+				'incremental',
 			),
 			policies: [cloudqueryAccess(GuardianAwsAccounts.Security)],
 			memoryLimitMiB: 2048,

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -137,14 +137,12 @@ export function addCloudqueryEcsCluster(
 						/^aws_accessanalyzer_.*$/,
 						/^aws_securityhub_.*$/,
 						/^aws_guardduty_.*$/,
-						/^aws_inspector2_findings$/, //TODO remove
 					]),
 					concurrency: 2000,
 				},
 				{
 					table_options: {
 						aws_securityhub_findings: securityHubTableOptions,
-						aws_inspector2_findings: inspector2TableOptions, //TODO remove
 					},
 				},
 			),

--- a/packages/cdk/lib/cloudquery/task.ts
+++ b/packages/cdk/lib/cloudquery/task.ts
@@ -238,8 +238,8 @@ export class ScheduledCloudqueryTask extends ScheduledFargateTask {
 				'-c',
 				[
 					...additionalCommands,
-					`printf '${renderCloudquerySourceConfig(sourceConfig)}' > ${serviceCatalogueConfigDirectory}/source.yaml`,
-					`printf '${dump(destinationConfig)}' > ${serviceCatalogueConfigDirectory}/destination.yaml`,
+					`printf '${renderCloudquerySourceConfig(sourceConfig).replaceAll("'", "'\\''")}' > ${serviceCatalogueConfigDirectory}/source.yaml`,
+					`printf '${dump(destinationConfig).replaceAll("'", "'\\''")}' > ${serviceCatalogueConfigDirectory}/destination.yaml`,
 					`/app/cloudquery sync ${serviceCatalogueConfigDirectory}/source.yaml ${serviceCatalogueConfigDirectory}/destination.yaml --log-format json --log-console --no-log-file --log-level \${CLOUDQUERY_LOG_LEVEL}`,
 				].join(';'),
 			],


### PR DESCRIPTION
## What does this change?

Runs `aws_inspector2_findings` as an incremental sync.


## Why has this change been made?

To reduce the duration of syncs, the number of rows we consume, and improve reliability by reducing rate limiting.

## Why was this approach chosen?

The `@` symbol used in the `backend_options` breaks the yaml construction, as it's a reserved character, so we need to do some slightly fancier escaping in order to surround that value in quotes. The snapshot tests make sure that the existing serialisation is conserved, and we add two new tests to make sure the new fields act how they should

## How has it been verified?

It won't be possible to verify if this saves us _time_, because the CODE DB is smaller than the PROD one, and so the bottleneck is DB throughput rather than cloudquery, but we should be able to get an idea of the number of rows we save from one sync to the next

- [x] Run on CODE (confirm new config works)
- [x] Run on CODE again about 24 hours later (observe multiple cursors)
- [x] Try to observe ratio of new vs old rows, and calculate a rough % saving per day

After running the jobs 16 hours apart (the normal gap is 24), I observed a drop in row consumption of about 65%. Which is promising number for one table that's about 15% of our overall CloudQuery usage. We'll have to observe the drop over a few days to get a fuller picture of the row/cost savings by consulting the Cloudquery Paid Usage dashboard

## Anything else

We should be careful about how we roll out incremental sync, as it's available on a table-by-table basis. Only a few AWS/GitHub tables have this option, but they tend to be the bigger ones