### PR TITLE
only send messages under certain conditions

### DIFF
--- a/packages/cloudbuster/src/breakglass/digests.ts
+++ b/packages/cloudbuster/src/breakglass/digests.ts
@@ -104,6 +104,7 @@ export async function sendAnghammaradNotification(
 	const variableFields: VariableAnghammaradFields[] =
 		groupUsersAndCreateNotifications(report, awsAccounts);
 
+	// Avoid Mondays (Bank Holidays), Fridays (weekends) and Tuesdays (used for other notifications)
 	const isThursday = new Date().getDay() === 4;
 
 	if (config.enableMessaging && isThursday) {

--- a/packages/cloudbuster/src/breakglass/digests.ts
+++ b/packages/cloudbuster/src/breakglass/digests.ts
@@ -4,6 +4,7 @@ import type {
 	Target,
 } from '@guardian/anghammarad';
 import { RequestedChannel } from '@guardian/anghammarad';
+import { logger } from 'common/logs.js';
 import type { AwsOrganizationsAccounts } from 'common/types.js';
 import type { Config } from '../config.js';
 import type { BreakglassUser } from './types.js';
@@ -44,8 +45,7 @@ function groupUsersByAccount(
 	console.table(
 		usersPerAccount.map(({ name, users }) => ({
 			name,
-			numUsers: users.length,
-			users: users.map((u) => u.user).join(', '),
+			nonCompliantUsers: users.length,
 		})),
 	);
 
@@ -104,13 +104,21 @@ export async function sendAnghammaradNotification(
 	const variableFields: VariableAnghammaradFields[] =
 		groupUsersAndCreateNotifications(report, awsAccounts);
 
-	await Promise.all(
-		variableFields.map(async (fields) => {
-			const notification: AnghammaradNotification = {
-				...fixedFields,
-				...fields,
-			};
-			await anghammaradClient.notify(notification);
-		}),
-	);
+	const isThursday = new Date().getDay() === 4;
+
+	if (config.enableMessaging && isThursday) {
+		await Promise.all(
+			variableFields.map(async (fields) => {
+				const notification: AnghammaradNotification = {
+					...fixedFields,
+					...fields,
+				};
+				await anghammaradClient.notify(notification);
+			}),
+		);
+	} else {
+		logger.log({
+			message: `Skipping sending breakglass user notifications. Is Thursday: ${isThursday}, enableMessaging: ${config.enableMessaging}`,
+		});
+	}
 }


### PR DESCRIPTION
### Only merge after #2023 

## What does this change?

Only sends anghammarad notifications if both of the following are true

- ENABLE_MESSAGING is on
- It's Thursday

## Why has this change been made?

Sometimes we want to be able to control whether or not we send a notification, especially if we need to test an issue that shows up in PROD but not CODE. We do this with the cloudbuster FSBP report, and also should apply this to the breakglass report.

I'm restricting this message to once a week, as every day seems excessive. I've chosen a different day to the FSBP/repocop notifications to spread things out a bit

## How has it been verified?

Tested locally, observed expected behaviour