### PR TITLE
fix: Remove base branch parameter from dependency graph integrator (DGI)

### DIFF
--- a/packages/dependency-graph-integrator/src/pull-requests.test.ts
+++ b/packages/dependency-graph-integrator/src/pull-requests.test.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import { describe, it } from 'node:test';
-import { generateBranchName } from './pull-requests.js';
+import type { Octokit } from 'octokit';
+import { createPullRequest, generateBranchName } from './pull-requests.js';
 
 void describe('generateBranchName', () => {
 	void it('does not produce the same branch name twice', () => {
@@ -8,5 +9,94 @@ void describe('generateBranchName', () => {
 		const branch1 = generateBranchName(prefix);
 		const branch2 = generateBranchName(prefix);
 		assert.notStrictEqual(branch1, branch2);
+	});
+});
+
+void describe('createPullRequest', () => {
+	void it('uses the repository default branch when no base branch is supplied', async () => {
+		const requests: Array<{
+			route: string;
+			parameters: Record<string, unknown>;
+		}> = [];
+
+		const request = (
+			route: string,
+			parameters: Record<string, unknown> = {},
+		) => {
+			requests.push({ route, parameters });
+
+			switch (route) {
+				case 'GET /repos/{owner}/{repo}':
+					return {
+						data: {
+							default_branch: 'trunk',
+							permissions: { push: true },
+						},
+						headers: {},
+					};
+				case 'GET /repos/{owner}/{repo}/commits':
+					return {
+						data: [
+							{
+								sha: 'base-commit-sha',
+								commit: { tree: { sha: 'base-tree-sha' } },
+							},
+						],
+					};
+				case 'POST /repos/{owner}/{repo}/git/commits':
+					return { data: { sha: 'new-commit-sha' } };
+				case 'POST /repos/{owner}/{repo}/git/refs':
+					return { data: {} };
+				case 'POST /repos/{owner}/{repo}/pulls':
+					return {
+						data: {
+							html_url: 'https://github.com/owner/repo/pull/123',
+							number: 123,
+						},
+					};
+				case 'POST /repos/{owner}/{repo}/issues/{number}/labels':
+					return { data: [] };
+				default:
+					throw new Error(`Unexpected GitHub request: ${route}`);
+			}
+		};
+
+		const octokit = {
+			request,
+			graphql: () => ({
+				repository: { ref: null },
+			}),
+			log: { warn: () => undefined },
+		} as unknown as Octokit;
+
+		const pullRequest = await createPullRequest(octokit, {
+			repoName: 'repo',
+			owner: 'owner',
+			title: 'Add dependency graph workflow',
+			body: 'Test PR body',
+			branchName: 'dependency-graph-test',
+			changes: [
+				{
+					commitMessage: 'Add workflow',
+					files: {},
+				},
+			],
+			admins: [],
+		});
+
+		assert.deepStrictEqual(pullRequest, {
+			html_url: 'https://github.com/owner/repo/pull/123',
+			number: 123,
+		});
+
+		const commitLookup = requests.find(
+			({ route }) => route === 'GET /repos/{owner}/{repo}/commits',
+		);
+		assert.strictEqual(commitLookup?.parameters.sha, 'trunk');
+
+		const createPullRequestRequest = requests.find(
+			({ route }) => route === 'POST /repos/{owner}/{repo}/pulls',
+		);
+		assert.strictEqual(createPullRequestRequest?.parameters.base, 'trunk');
 	});
 });

--- a/packages/dependency-graph-integrator/src/pull-requests.ts
+++ b/packages/dependency-graph-integrator/src/pull-requests.ts
@@ -37,15 +37,7 @@ export async function createPullRequest(
 	octokit: Octokit,
 	props: CreatePullRequestOptions,
 ): Promise<UrlAndNumber | undefined> {
-	const {
-		repoName,
-		owner,
-		title,
-		body,
-		branchName,
-		baseBranch = 'main',
-		changes,
-	} = props;
+	const { repoName, owner, title, body, branchName, changes } = props;
 
 	const response = await composeCreatePullRequest(octokit, {
 		owner,
@@ -53,7 +45,6 @@ export async function createPullRequest(
 		title,
 		body,
 		head: branchName,
-		base: baseBranch,
 		labels: ['maintenance'],
 		changes: changes.map(({ commitMessage, files }) => ({
 			commit: commitMessage,

--- a/packages/dependency-graph-integrator/src/pull-requests.ts
+++ b/packages/dependency-graph-integrator/src/pull-requests.ts
@@ -15,7 +15,6 @@ interface CreatePullRequestOptions {
 	title: string;
 	body: string;
 	branchName: string;
-	baseBranch?: string;
 	changes: Change[];
 	admins: string[];
 }


### PR DESCRIPTION
## What does this change?

- Removes the `base` parameter from `composeCreatePullRequest` function in the DGI.
- Adds a unit test to ensure the plugin correctly defaults to the `default-branch` of the repo.

## Why has this change been made?

The base branch was set to `main` which caused the DGI to fail on a repo which does not have `main` as its default branch.

## Why was this approach chosen?

The `octokit-plugin-create-pull-request` plugin [automatically uses a repo's default branch if `base` is not specified](https://github.com/gr2m/octokit-plugin-create-pull-request/blob/main/README.md). 

## How has it been verified?

- [x] Ran unit test for the plugin successfully.
- [x] Merged this PR and ran the DGI against `test-repocop-prs` which now has the default branch `notmain`. Observed the PR creation. PR: https://github.com/guardian/test-repocop-prs/pull/47