### PR TITLE
make github issues collection incremental

### DIFF
--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -17255,7 +17255,7 @@ spec:
   registry: cloudquery
   path: cloudquery/postgresql
   version: v8.13.0
-  write_mode: overwrite-delete-stale
+  write_mode: overwrite
   migrate_mode: forced
   send_sync_summary: true
   spec:

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -17236,6 +17236,9 @@ spec:
   skip_dependent_tables: true
   destinations:
     - postgresql
+  backend_options:
+    table_name: cq-state-github
+    connection: '\\''@@plugins.postgresql.connection'\\''
   spec:
     concurrency: 1000
     orgs:

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -533,6 +533,7 @@ export function addCloudqueryEcsCluster(
 			secrets: githubSecrets,
 			additionalCommands: additionalGithubCommands,
 			memoryLimitMiB: 2048,
+			writeMode: CloudqueryWriteMode.Overwrite,
 		},
 		{
 			name: 'GitHubSecretScanningAlerts',

--- a/packages/cdk/lib/cloudquery/index.ts
+++ b/packages/cdk/lib/cloudquery/index.ts
@@ -523,10 +523,13 @@ export function addCloudqueryEcsCluster(
 			name: 'GitHubIssues',
 			description: 'Collect GitHub issue data (PRs and Issues)',
 			schedule: Schedule.cron({ minute: '0', hour: '2' }),
-			config: githubSourceConfig({
-				org: gitHubOrgName,
-				tables: ['github_issues'],
-			}),
+			config: githubSourceConfig(
+				{
+					org: gitHubOrgName,
+					tables: ['github_issues'],
+				},
+				'incremental',
+			),
 			secrets: githubSecrets,
 			additionalCommands: additionalGithubCommands,
 			memoryLimitMiB: 2048,


### PR DESCRIPTION
## What does this change?

`github_issues` supports incremental sync, and is one of our busiest tables (in rows/month), so let's try it out

## Why has this change been made?

To reduce rate limiting, and reduce row consumption towards a finite limit. Hopefully this will allow us to sync some more tables, or increase the regularity of syncs

## How has it been verified?

- [ ] Verify on CODE
