### PR TITLE
change state table casing

### DIFF
--- a/packages/cdk/lib/cloudquery/config.test.ts
+++ b/packages/cdk/lib/cloudquery/config.test.ts
@@ -147,7 +147,7 @@ describe('Config generation, and converting to YAML', () => {
 		  otel_endpoint: 0.0.0.0:4318
 		  otel_endpoint_insecure: true
 		  backend_options:
-		    table_name: cq-state-aws
+		    table_name: cq_state_aws
 		    connection: '@@plugins.postgresql.connection'
 		  spec:
 		    accounts:
@@ -207,7 +207,7 @@ describe('Config generation, and converting to YAML', () => {
 		  destinations:
 		    - postgresql
 		  backend_options:
-		    table_name: cq-state-github
+		    table_name: cq_state_github
 		    connection: '@@plugins.postgresql.connection'
 		  spec:
 		    concurrency: 1000

--- a/packages/cdk/lib/cloudquery/config.ts
+++ b/packages/cdk/lib/cloudquery/config.ts
@@ -11,7 +11,7 @@ import { dump } from 'js-yaml';
 export type SyncMode = 'default' | 'incremental';
 
 type BackendOptions = {
-	table_name: `cq-state-${string}`;
+	table_name: `cq_state_${string}`;
 	connection: '@@plugins.postgresql.connection';
 };
 
@@ -21,7 +21,7 @@ function backendOptions(
 ): BackendOptions | undefined {
 	if (mode === 'incremental') {
 		return {
-			table_name: `cq-state-${platform}`,
+			table_name: `cq_state_${platform}`,
 			connection: '@@plugins.postgresql.connection',
 		};
 	}

--- a/packages/common/prisma/migrations/20260723162405_drop_state_tables/migration.sql
+++ b/packages/common/prisma/migrations/20260723162405_drop_state_tables/migration.sql
@@ -1,0 +1,4 @@
+BEGIN TRANSACTION;
+    DROP TABLE IF EXISTS "cq-state-aws";
+    DROP TABLE IF EXISTS "cq-state-github";
+COMMIT TRANSACTION;


### PR DESCRIPTION
## What does this change?

The table for holding state cursors were kebab-cased. This PR switches them to snake_case. We've also stopped syncing incrementally. When we switch this on again, these tables are likely to cause confusion, so we should just get rid of them.

## Why has this change been made?

In SQL, this means the table has to be quoted, so we must write queries like this - `select * from "cq-state-aws"`. This is annoying. Let's switch to a more idiomatic form, in keeping with the rest of our tables

