### PR TITLE
chore(deps): Update Galaxies and NS1 CQ source plugins

### DIFF
--- a/.env
+++ b/.env
@@ -29,7 +29,7 @@ CQ_GUARDIAN_GALAXIES=2.1.9
 CQ_GITHUB_LANGUAGES=0.0.7
 
 # See https://github.com/guardian/cq-source-ns1
-CQ_NS1=0.1.19
+CQ_NS1=0.1.20
 
 # See https://github.com/guardian/cq-image-packages
 CQ_IMAGE_PACKAGES=1.0.1

--- a/.env
+++ b/.env
@@ -23,7 +23,7 @@ CQ_GITHUB=15.2.0
 CQ_FASTLY=4.10.3
 
 # See https://github.com/guardian/cq-source-galaxies
-CQ_GUARDIAN_GALAXIES=2.1.8
+CQ_GUARDIAN_GALAXIES=2.1.9
 
 # See https://github.com/guardian/cq-source-github-languages
 CQ_GITHUB_LANGUAGES=0.0.7

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -16234,7 +16234,7 @@ spec:
   name: galaxies
   path: guardian/galaxies
   registry: github
-  version: v2.1.8
+  version: v2.1.9
   destinations:
     - postgresql
   tables:

--- a/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
+++ b/packages/cdk/lib/__snapshots__/service-catalogue.test.ts.snap
@@ -22465,7 +22465,7 @@ spec:
           },
           {
             "Essential": false,
-            "Image": "ghcr.io/guardian/cq-source-ns1:0.1.19",
+            "Image": "ghcr.io/guardian/cq-source-ns1:0.1.20",
             "LogConfiguration": {
               "LogDriver": "awsfirelens",
               "Options": {


### PR DESCRIPTION
## What does this change?
Updates Galaxies and NS1 CQ source plugins following vulnerability patching. See:
- https://github.com/guardian/cq-source-galaxies/releases/tag/v2.1.9
- https://github.com/guardian/cq-source-ns1/releases/tag/v0.1.20
